### PR TITLE
feat: parameterize Phase 1 scripts with --works-input / --works-output (#53)

### DIFF
--- a/scripts/analyze_embeddings.py
+++ b/scripts/analyze_embeddings.py
@@ -14,17 +14,12 @@ Produces:
 - data/catalogs/semantic_clusters.csv: Cluster assignments
 """
 
+import argparse
 import os
 import warnings
 
-import hdbscan
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
-import torch
-import umap
-from sentence_transformers import SentenceTransformer
 
 from utils import BASE_DIR, CATALOGS_DIR, EMBEDDINGS_PATH, normalize_doi
 
@@ -71,325 +66,346 @@ def text_hash(text):
     return hashlib.md5(text.encode()).hexdigest()[:8]
 
 
-# --- Load data ---
-print("Loading refined works...")
-works = pd.read_csv(os.path.join(CATALOGS_DIR, "refined_works.csv"))
-works["year"] = pd.to_numeric(works["year"], errors="coerce")
 
-# Filter: must have a title, year in range
-has_title = works["title"].notna() & (works["title"].str.len() > 0)
-in_range = (works["year"] >= 1990) & (works["year"] <= 2025)
-df = works[has_title & in_range].copy().reset_index(drop=True)
-print(f"Works with titles (1990-2025): {len(df)}")
-
-# Build keys, text, and text hashes
-df["_key"] = df.apply(work_key, axis=1)
-df["_text"] = df.apply(build_text, axis=1)
-df["_thash"] = df["_text"].apply(text_hash)
-
-# --- Incremental embedding cache ---
-legacy_path = os.path.join(CATALOGS_DIR, "embeddings.npy")
-
-key_to_vec = {}   # key → vector
-key_to_hash = {}  # key → text hash (to detect content changes)
-if os.path.exists(EMBEDDINGS_PATH):
-    cache = np.load(EMBEDDINGS_PATH, allow_pickle=True)
-    cached_model = str(cache["model"]) if "model" in cache.files else ""
-    cached_fields = str(cache["text_fields"]) if "text_fields" in cache.files else ""
-    if cached_model == MODEL_NAME and cached_fields == TEXT_FIELDS:
-        cached_keys = cache["keys"]
-        cached_vecs = cache["vectors"]
-        cached_hashes = cache["text_hashes"] if "text_hashes" in cache.files else None
-        key_to_vec = dict(zip(cached_keys, cached_vecs))
-        if cached_hashes is not None:
-            key_to_hash = dict(zip(cached_keys, cached_hashes))
-        print(f"Loaded {len(key_to_vec)} cached embeddings (model: {MODEL_NAME}, fields: {TEXT_FIELDS})")
-    else:
-        print(f"Config changed (model: {cached_model!r}→{MODEL_NAME!r}, "
-              f"fields: {cached_fields!r}→{TEXT_FIELDS!r}), full recompute")
-elif os.path.exists(legacy_path):
-    print(f"Found legacy {legacy_path}, will migrate to .npz (full recompute)")
-else:
-    print("No embedding cache found, full computation")
-
-# A cached entry is valid only if key exists AND text hash matches
-keys = df["_key"].values
-thashes = df["_thash"].values
-hit_mask = np.array([
-    k in key_to_vec and key_to_hash.get(k) == h
-    for k, h in zip(keys, thashes)
-])
-n_cached = int(hit_mask.sum())
-n_new = len(df) - n_cached
-n_stale = sum(1 for k in keys if k in key_to_vec) - n_cached
-if n_stale > 0:
-    print(f"Embeddings: {n_cached} cached, {n_stale} stale (text changed), {n_new - n_stale} new")
-else:
-    print(f"Embeddings: {n_cached} cached, {n_new} to compute")
-
-# Encode only new works
-if n_new > 0:
-    n_cpu = os.cpu_count() or 4
-    torch.set_num_threads(n_cpu)
-    print(f"Loading {MODEL_NAME} ({n_cpu} threads)...")
-    model = SentenceTransformer(MODEL_NAME)
-
-    new_texts = df.loc[~hit_mask, "_text"].tolist()
-    print(f"Encoding {n_new} texts...")
-    new_vecs = model.encode(
-        new_texts,
-        batch_size=256,
-        show_progress_bar=True,
-        normalize_embeddings=True,
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--works-input",
+        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+        help="Works CSV to embed (default: unified_works.csv)",
     )
-else:
-    new_vecs = np.empty((0, EMBEDDING_DIM), dtype=np.float32)
+    args = parser.parse_args()
 
-# Assemble full array in df order
-embeddings = np.empty((len(df), EMBEDDING_DIM), dtype=np.float32)
-if n_cached > 0:
-    embeddings[hit_mask] = np.array([key_to_vec[k] for k in keys[hit_mask]])
-if n_new > 0:
-    embeddings[~hit_mask] = new_vecs
+    # Defer heavy imports so --help works without corpus group installed
+    import hdbscan  # noqa: F401
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    import torch
+    import umap
+    from sentence_transformers import SentenceTransformer
 
-# Save cache
-np.savez_compressed(
-    EMBEDDINGS_PATH,
-    vectors=embeddings,
-    keys=keys,
-    text_hashes=thashes,
-    model=np.array(MODEL_NAME),
-    text_fields=np.array(TEXT_FIELDS),
-)
-print(f"Saved {len(embeddings)} embeddings → {EMBEDDINGS_PATH}")
+    # --- Load data ---
+    print(f"Loading works from {args.works_input}...")
+    works = pd.read_csv(args.works_input)
 
-# Clean up legacy file
-if os.path.exists(legacy_path):
-    os.remove(legacy_path)
-    print(f"Removed legacy {legacy_path}")
+    # Filter: must have a title, year in range
+    has_title = works["title"].notna() & (works["title"].str.len() > 0)
+    in_range = (works["year"] >= 1990) & (works["year"] <= 2025)
+    df = works[has_title & in_range].copy().reset_index(drop=True)
+    print(f"Works with titles (1990-2025): {len(df)}")
 
-print(f"Embedding shape: {embeddings.shape}")
+    # Build keys, text, and text hashes
+    df["_key"] = df.apply(work_key, axis=1)
+    df["_text"] = df.apply(build_text, axis=1)
+    df["_thash"] = df["_text"].apply(text_hash)
 
+    # --- Incremental embedding cache ---
+    legacy_path = os.path.join(CATALOGS_DIR, "embeddings.npy")
 
-# ============================================================
-# Step 1: UMAP dimensionality reduction
-# ============================================================
+    key_to_vec = {}   # key → vector
+    key_to_hash = {}  # key → text hash (to detect content changes)
+    if os.path.exists(EMBEDDINGS_PATH):
+        cache = np.load(EMBEDDINGS_PATH, allow_pickle=True)
+        cached_model = str(cache["model"]) if "model" in cache.files else ""
+        cached_fields = str(cache["text_fields"]) if "text_fields" in cache.files else ""
+        if cached_model == MODEL_NAME and cached_fields == TEXT_FIELDS:
+            cached_keys = cache["keys"]
+            cached_vecs = cache["vectors"]
+            cached_hashes = cache["text_hashes"] if "text_hashes" in cache.files else None
+            key_to_vec = dict(zip(cached_keys, cached_vecs))
+            if cached_hashes is not None:
+                key_to_hash = dict(zip(cached_keys, cached_hashes))
+            print(f"Loaded {len(key_to_vec)} cached embeddings (model: {MODEL_NAME}, fields: {TEXT_FIELDS})")
+        else:
+            print(f"Config changed (model: {cached_model!r}→{MODEL_NAME!r}, "
+                  f"fields: {cached_fields!r}→{TEXT_FIELDS!r}), full recompute")
+    elif os.path.exists(legacy_path):
+        print(f"Found legacy {legacy_path}, will migrate to .npz (full recompute)")
+    else:
+        print("No embedding cache found, full computation")
 
-print("\nComputing UMAP projection...")
-reducer = umap.UMAP(
-    n_components=2,
-    n_neighbors=15,
-    min_dist=0.05,
-    metric="cosine",
-    random_state=42,
-    low_memory=True,
-)
-coords = reducer.fit_transform(embeddings)
-df["umap_x"] = coords[:, 0]
-df["umap_y"] = coords[:, 1]
-print(f"UMAP done: {coords.shape}")
+    # A cached entry is valid only if key exists AND text hash matches
+    keys = df["_key"].values
+    thashes = df["_thash"].values
+    hit_mask = np.array([
+        k in key_to_vec and key_to_hash.get(k) == h
+        for k, h in zip(keys, thashes)
+    ])
+    n_cached = int(hit_mask.sum())
+    n_new = len(df) - n_cached
+    n_stale = sum(1 for k in keys if k in key_to_vec) - n_cached
+    if n_stale > 0:
+        print(f"Embeddings: {n_cached} cached, {n_stale} stale (text changed), {n_new - n_stale} new")
+    else:
+        print(f"Embeddings: {n_cached} cached, {n_new} to compute")
 
+    # Encode only new works
+    if n_new > 0:
+        n_cpu = os.cpu_count() or 4
+        torch.set_num_threads(n_cpu)
+        print(f"Loading {MODEL_NAME} ({n_cpu} threads)...")
+        model = SentenceTransformer(MODEL_NAME)
 
-# ============================================================
-# Step 2: HDBSCAN clustering
-# ============================================================
-
-print("\nClustering with KMeans (k=6, matching co-citation communities)...")
-from sklearn.cluster import KMeans
-kmeans = KMeans(n_clusters=6, random_state=42, n_init=20)
-df["semantic_cluster"] = kmeans.fit_predict(coords)
-n_clusters = 6
-n_noise = 0
-print(f"Semantic clusters: {n_clusters}")
-
-# Cluster sizes
-print("\nCluster sizes:")
-for c in sorted(df["semantic_cluster"].unique()):
-    label = f"Cluster {c}" if c >= 0 else "Noise"
-    print(f"  {label}: {(df['semantic_cluster'] == c).sum()}")
-
-
-# ============================================================
-# Step 3: Characterize clusters
-# ============================================================
-
-# For each cluster, find most common keywords
-print("\n=== Cluster keyword profiles ===")
-for c in range(n_clusters):
-    members = df[df["semantic_cluster"] == c]
-    # Extract keywords
-    all_kw = []
-    for kw_str in members["keywords"].dropna():
-        all_kw.extend([k.strip().lower() for k in str(kw_str).split(";")])
-    from collections import Counter
-    kw_counts = Counter(all_kw).most_common(10)
-    kw_str = ", ".join(f"{k} ({n})" for k, n in kw_counts)
-    median_year = int(members["year"].median())
-    print(f"\nCluster {c} (n={len(members)}, median year={median_year}):")
-    print(f"  Top keywords: {kw_str}")
-
-
-# ============================================================
-# Step 4: Cross-validate with co-citation communities
-# ============================================================
-
-cocit_path = os.path.join(CATALOGS_DIR, "communities.csv")
-if os.path.exists(cocit_path):
-    print("\n=== Cross-validation with co-citation communities ===")
-    cocit = pd.read_csv(cocit_path)
-    # Match by DOI
-    df["doi_norm"] = df["doi"].apply(normalize_doi)
-    cocit["doi_norm"] = cocit["doi"].apply(normalize_doi)
-
-    merged = df.merge(cocit[["doi_norm", "community"]], on="doi_norm", how="inner")
-    if len(merged) > 0:
-        cross_tab = pd.crosstab(
-            merged["semantic_cluster"],
-            merged["community"],
-            margins=True,
+        new_texts = df.loc[~hit_mask, "_text"].tolist()
+        print(f"Encoding {n_new} texts...")
+        new_vecs = model.encode(
+            new_texts,
+            batch_size=256,
+            show_progress_bar=True,
+            normalize_embeddings=True,
         )
-        print(f"\nMatched {len(merged)} works with both assignments:")
-        print(cross_tab)
     else:
-        print("No DOI matches between semantic clusters and co-citation communities")
+        new_vecs = np.empty((0, EMBEDDING_DIM), dtype=np.float32)
 
+    # Assemble full array in df order
+    embeddings = np.empty((len(df), EMBEDDING_DIM), dtype=np.float32)
+    if n_cached > 0:
+        embeddings[hit_mask] = np.array([key_to_vec[k] for k in keys[hit_mask]])
+    if n_new > 0:
+        embeddings[~hit_mask] = new_vecs
 
-# ============================================================
-# Step 5: Visualize
-# ============================================================
-
-sns.set_style("whitegrid")
-
-# --- Figure 3a: Colored by semantic cluster ---
-fig, ax = plt.subplots(figsize=(12, 9))
-
-# Plot clusters
-palette = plt.cm.Set2(np.linspace(0, 1, n_clusters))
-for c in range(n_clusters):
-    members = df[df["semantic_cluster"] == c]
-    ax.scatter(
-        members["umap_x"], members["umap_y"],
-        c=[palette[c]], s=8, alpha=0.5,
-        label=f"Cluster {c} (n={len(members)})",
+    # Save cache
+    np.savez_compressed(
+        EMBEDDINGS_PATH,
+        vectors=embeddings,
+        keys=keys,
+        text_hashes=thashes,
+        model=np.array(MODEL_NAME),
+        text_fields=np.array(TEXT_FIELDS),
     )
+    print(f"Saved {len(embeddings)} embeddings → {EMBEDDINGS_PATH}")
 
-ax.legend(loc="upper right", fontsize=8, framealpha=0.9, markerscale=3)
-ax.set_title(
-    "Semantic landscape of climate finance literature\n"
-    "(multilingual abstract embeddings, UMAP projection)",
-    fontsize=13,
-)
-ax.set_xlabel("UMAP 1")
-ax.set_ylabel("UMAP 2")
+    # Clean up legacy file
+    if os.path.exists(legacy_path):
+        os.remove(legacy_path)
+        print(f"Removed legacy {legacy_path}")
 
-plt.tight_layout()
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic.pdf"), dpi=300, bbox_inches="tight")
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic.png"), dpi=150, bbox_inches="tight")
-print(f"\nSaved semantic map → figures/fig_semantic.pdf")
-plt.close()
+    print(f"Embedding shape: {embeddings.shape}")
 
 
-# --- Figure 3b: Colored by language ---
-fig, ax = plt.subplots(figsize=(12, 9))
+    # ============================================================
+    # Step 1: UMAP dimensionality reduction
+    # ============================================================
 
-lang_map = {"en": "English", "fr": "French", "zh": "Chinese",
-            "ja": "Japanese", "de": "German", "es": "Spanish", "pt": "Portuguese"}
-df["lang_label"] = df["language"].map(lang_map).fillna("Other")
+    print("\nComputing UMAP projection...")
+    reducer = umap.UMAP(
+        n_components=2,
+        n_neighbors=15,
+        min_dist=0.05,
+        metric="cosine",
+        random_state=42,
+        low_memory=True,
+    )
+    coords = reducer.fit_transform(embeddings)
+    df["umap_x"] = coords[:, 0]
+    df["umap_y"] = coords[:, 1]
+    print(f"UMAP done: {coords.shape}")
 
-lang_colors = {
-    "English": "lightgrey",
-    "French": "#E63946",
-    "Chinese": "#E9C46A",
-    "Japanese": "#264653",
-    "German": "#2A9D8F",
-    "Spanish": "#F4A261",
-    "Portuguese": "#606C38",
-    "Other": "#ADB5BD",
-}
 
-# Plot English first (background)
-en = df[df["lang_label"] == "English"]
-ax.scatter(en["umap_x"], en["umap_y"],
-           c=lang_colors["English"], s=3, alpha=0.2, label=f"English (n={len(en)})")
+    # ============================================================
+    # Step 2: HDBSCAN clustering
+    # ============================================================
 
-# Plot non-English on top
-for lang in ["French", "Chinese", "Japanese", "German", "Spanish", "Portuguese", "Other"]:
-    subset = df[df["lang_label"] == lang]
-    if len(subset) > 0:
+    print("\nClustering with KMeans (k=6, matching co-citation communities)...")
+    from sklearn.cluster import KMeans
+    kmeans = KMeans(n_clusters=6, random_state=42, n_init=20)
+    df["semantic_cluster"] = kmeans.fit_predict(coords)
+    n_clusters = 6
+    n_noise = 0
+    print(f"Semantic clusters: {n_clusters}")
+
+    # Cluster sizes
+    print("\nCluster sizes:")
+    for c in sorted(df["semantic_cluster"].unique()):
+        label = f"Cluster {c}" if c >= 0 else "Noise"
+        print(f"  {label}: {(df['semantic_cluster'] == c).sum()}")
+
+
+    # ============================================================
+    # Step 3: Characterize clusters
+    # ============================================================
+
+    # For each cluster, find most common keywords
+    print("\n=== Cluster keyword profiles ===")
+    for c in range(n_clusters):
+        members = df[df["semantic_cluster"] == c]
+        # Extract keywords
+        all_kw = []
+        for kw_str in members["keywords"].dropna():
+            all_kw.extend([k.strip().lower() for k in str(kw_str).split(";")])
+        from collections import Counter
+        kw_counts = Counter(all_kw).most_common(10)
+        kw_str = ", ".join(f"{k} ({n})" for k, n in kw_counts)
+        median_year = int(members["year"].median())
+        print(f"\nCluster {c} (n={len(members)}, median year={median_year}):")
+        print(f"  Top keywords: {kw_str}")
+
+
+    # ============================================================
+    # Step 4: Cross-validate with co-citation communities
+    # ============================================================
+
+    cocit_path = os.path.join(CATALOGS_DIR, "communities.csv")
+    if os.path.exists(cocit_path):
+        print("\n=== Cross-validation with co-citation communities ===")
+        cocit = pd.read_csv(cocit_path)
+        # Match by DOI
+        df["doi_norm"] = df["doi"].apply(normalize_doi)
+        cocit["doi_norm"] = cocit["doi"].apply(normalize_doi)
+
+        merged = df.merge(cocit[["doi_norm", "community"]], on="doi_norm", how="inner")
+        if len(merged) > 0:
+            cross_tab = pd.crosstab(
+                merged["semantic_cluster"],
+                merged["community"],
+                margins=True,
+            )
+            print(f"\nMatched {len(merged)} works with both assignments:")
+            print(cross_tab)
+        else:
+            print("No DOI matches between semantic clusters and co-citation communities")
+
+
+    # ============================================================
+    # Step 5: Visualize
+    # ============================================================
+
+    sns.set_style("whitegrid")
+
+    # --- Figure 3a: Colored by semantic cluster ---
+    fig, ax = plt.subplots(figsize=(12, 9))
+
+    # Plot clusters
+    palette = plt.cm.Set2(np.linspace(0, 1, n_clusters))
+    for c in range(n_clusters):
+        members = df[df["semantic_cluster"] == c]
+        ax.scatter(
+            members["umap_x"], members["umap_y"],
+            c=[palette[c]], s=8, alpha=0.5,
+            label=f"Cluster {c} (n={len(members)})",
+        )
+
+    ax.legend(loc="upper right", fontsize=8, framealpha=0.9, markerscale=3)
+    ax.set_title(
+        "Semantic landscape of climate finance literature\n"
+        "(multilingual abstract embeddings, UMAP projection)",
+        fontsize=13,
+    )
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+
+    plt.tight_layout()
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic.pdf"), dpi=300, bbox_inches="tight")
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic.png"), dpi=150, bbox_inches="tight")
+    print(f"\nSaved semantic map → figures/fig_semantic.pdf")
+    plt.close()
+
+
+    # --- Figure 3b: Colored by language ---
+    fig, ax = plt.subplots(figsize=(12, 9))
+
+    lang_map = {"en": "English", "fr": "French", "zh": "Chinese",
+                "ja": "Japanese", "de": "German", "es": "Spanish", "pt": "Portuguese"}
+    df["lang_label"] = df["language"].map(lang_map).fillna("Other")
+
+    lang_colors = {
+        "English": "lightgrey",
+        "French": "#E63946",
+        "Chinese": "#E9C46A",
+        "Japanese": "#264653",
+        "German": "#2A9D8F",
+        "Spanish": "#F4A261",
+        "Portuguese": "#606C38",
+        "Other": "#ADB5BD",
+    }
+
+    # Plot English first (background)
+    en = df[df["lang_label"] == "English"]
+    ax.scatter(en["umap_x"], en["umap_y"],
+               c=lang_colors["English"], s=3, alpha=0.2, label=f"English (n={len(en)})")
+
+    # Plot non-English on top
+    for lang in ["French", "Chinese", "Japanese", "German", "Spanish", "Portuguese", "Other"]:
+        subset = df[df["lang_label"] == lang]
+        if len(subset) > 0:
+            ax.scatter(
+                subset["umap_x"], subset["umap_y"],
+                c=lang_colors[lang], s=20, alpha=0.8,
+                label=f"{lang} (n={len(subset)})",
+                edgecolors="white", linewidths=0.3,
+            )
+
+    ax.legend(loc="upper right", fontsize=8, framealpha=0.9, markerscale=2)
+    ax.set_title(
+        "Language distribution in the semantic landscape\n"
+        "(non-English works highlighted)",
+        fontsize=13,
+    )
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+
+    plt.tight_layout()
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_lang.pdf"), dpi=300, bbox_inches="tight")
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_lang.png"), dpi=150, bbox_inches="tight")
+    print(f"Saved semantic map (language) → figures/fig_semantic_lang.pdf")
+    plt.close()
+
+
+    # --- Figure 3c: Colored by period ---
+    fig, ax = plt.subplots(figsize=(12, 9))
+
+    period_map = {
+        (1990, 2008): "1990–2008",
+        (2009, 2015): "2009–2015",
+        (2016, 2021): "2016–2021",
+        (2022, 2025): "2022–2025",
+    }
+    period_colors = {
+        "1990–2008": "#ADB5BD",
+        "2009–2015": "#F4A261",
+        "2016–2021": "#E76F51",
+        "2022–2025": "#264653",
+    }
+
+    def assign_period(year):
+        for (lo, hi), label in period_map.items():
+            if lo <= year <= hi:
+                return label
+        return "Other"
+
+    df["period"] = df["year"].apply(assign_period)
+
+    for period in ["1990–2008", "2009–2015", "2016–2021", "2022–2025"]:
+        subset = df[df["period"] == period]
         ax.scatter(
             subset["umap_x"], subset["umap_y"],
-            c=lang_colors[lang], s=20, alpha=0.8,
-            label=f"{lang} (n={len(subset)})",
-            edgecolors="white", linewidths=0.3,
+            c=period_colors[period], s=5, alpha=0.4,
+            label=f"{period} (n={len(subset)})",
         )
 
-ax.legend(loc="upper right", fontsize=8, framealpha=0.9, markerscale=2)
-ax.set_title(
-    "Language distribution in the semantic landscape\n"
-    "(non-English works highlighted)",
-    fontsize=13,
-)
-ax.set_xlabel("UMAP 1")
-ax.set_ylabel("UMAP 2")
-
-plt.tight_layout()
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_lang.pdf"), dpi=300, bbox_inches="tight")
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_lang.png"), dpi=150, bbox_inches="tight")
-print(f"Saved semantic map (language) → figures/fig_semantic_lang.pdf")
-plt.close()
-
-
-# --- Figure 3c: Colored by period ---
-fig, ax = plt.subplots(figsize=(12, 9))
-
-period_map = {
-    (1990, 2008): "1990–2008",
-    (2009, 2015): "2009–2015",
-    (2016, 2021): "2016–2021",
-    (2022, 2025): "2022–2025",
-}
-period_colors = {
-    "1990–2008": "#ADB5BD",
-    "2009–2015": "#F4A261",
-    "2016–2021": "#E76F51",
-    "2022–2025": "#264653",
-}
-
-def assign_period(year):
-    for (lo, hi), label in period_map.items():
-        if lo <= year <= hi:
-            return label
-    return "Other"
-
-df["period"] = df["year"].apply(assign_period)
-
-for period in ["1990–2008", "2009–2015", "2016–2021", "2022–2025"]:
-    subset = df[df["period"] == period]
-    ax.scatter(
-        subset["umap_x"], subset["umap_y"],
-        c=period_colors[period], s=5, alpha=0.4,
-        label=f"{period} (n={len(subset)})",
+    ax.legend(loc="upper right", fontsize=9, framealpha=0.9, markerscale=4)
+    ax.set_title(
+        "Temporal evolution of the semantic landscape\n"
+        "(colored by article's periodization)",
+        fontsize=13,
     )
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
 
-ax.legend(loc="upper right", fontsize=9, framealpha=0.9, markerscale=4)
-ax.set_title(
-    "Temporal evolution of the semantic landscape\n"
-    "(colored by article's periodization)",
-    fontsize=13,
-)
-ax.set_xlabel("UMAP 1")
-ax.set_ylabel("UMAP 2")
-
-plt.tight_layout()
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_period.pdf"), dpi=300, bbox_inches="tight")
-fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_period.png"), dpi=150, bbox_inches="tight")
-print(f"Saved semantic map (period) → figures/fig_semantic_period.pdf")
-plt.close()
+    plt.tight_layout()
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_period.pdf"), dpi=300, bbox_inches="tight")
+    fig.savefig(os.path.join(FIGURES_DIR, "fig_semantic_period.png"), dpi=150, bbox_inches="tight")
+    print(f"Saved semantic map (period) → figures/fig_semantic_period.pdf")
+    plt.close()
 
 
-# --- Save cluster assignments ---
-out = df[["source", "doi", "title", "first_author", "year", "language",
-          "semantic_cluster", "umap_x", "umap_y"]].copy()
-out.to_csv(CLUSTERS_PATH, index=False)
-print(f"\nSaved cluster assignments → {CLUSTERS_PATH}")
-print("Done.")
+    # --- Save cluster assignments ---
+    out = df[["source", "doi", "title", "first_author", "year", "language",
+              "semantic_cluster", "umap_x", "umap_y"]].copy()
+    out.to_csv(CLUSTERS_PATH, index=False)
+    print(f"\nSaved cluster assignments → {CLUSTERS_PATH}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enrich_abstracts.py
+++ b/scripts/enrich_abstracts.py
@@ -318,9 +318,12 @@ def main():
                         help="Show counts, don't modify data")
     parser.add_argument("--step", type=int, default=0,
                         help="Run only this step (1-5, 0=all)")
+    parser.add_argument("--works-input",
+                        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+                        help="Input/output works CSV (default: unified_works.csv)")
     args = parser.parse_args()
 
-    path = os.path.join(CATALOGS_DIR, "refined_works.csv")
+    path = args.works_input
     df = pd.read_csv(path)
     print(f"Loaded {len(df)} works from {path}")
 

--- a/scripts/enrich_citations_batch.py
+++ b/scripts/enrich_citations_batch.py
@@ -74,6 +74,9 @@ def main():
                         help="Max DOIs to process (0=all)")
     parser.add_argument("--delay", type=float, default=0.2,
                         help="Delay between batch requests")
+    parser.add_argument("--works-input",
+                        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+                        help="Works CSV to read DOIs from (default: unified_works.csv)")
     args = parser.parse_args()
 
     # Load existing citations to find already-fetched DOIs
@@ -96,8 +99,8 @@ def main():
     else:
         ckpt = pd.DataFrame(columns=REFS_COLUMNS)
 
-    # All DOIs in refined_works
-    works = pd.read_csv(os.path.join(CATALOGS_DIR, "refined_works.csv"),
+    # All DOIs in works input
+    works = pd.read_csv(args.works_input,
                         dtype=str, keep_default_na=False)
     all_dois = [normalize_doi(d) for d in works["doi"].unique() if d]
     all_dois = [d for d in all_dois if d and d not in ("", "nan", "none")]

--- a/scripts/enrich_citations_openalex.py
+++ b/scripts/enrich_citations_openalex.py
@@ -116,6 +116,9 @@ def main():
                         help="Max source DOIs to process (0=all)")
     parser.add_argument("--delay", type=float, default=0.15,
                         help="Delay between API requests (seconds)")
+    parser.add_argument("--works-input",
+                        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+                        help="Works CSV to read DOIs from (default: unified_works.csv)")
     args = parser.parse_args()
 
     # ── Load done-set (resumable) ─────────────────────────────────────────
@@ -135,7 +138,7 @@ def main():
 
     # ── Corpus DOIs ───────────────────────────────────────────────────────
     works = pd.read_csv(
-        os.path.join(CATALOGS_DIR, "refined_works.csv"),
+        args.works_input,
         dtype=str, keep_default_na=False,
     )
     all_dois = [

--- a/scripts/enrich_dois.py
+++ b/scripts/enrich_dois.py
@@ -97,10 +97,17 @@ def main():
                         help="Show what would be done without modifying files")
     parser.add_argument("--limit", type=int, default=0,
                         help="Max works to process (0=all)")
+    parser.add_argument("--works-input",
+                        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+                        help="Input works CSV (default: unified_works.csv)")
+    parser.add_argument("--works-output",
+                        default=os.path.join(CATALOGS_DIR, "enriched_works.csv"),
+                        help="Output works CSV (default: enriched_works.csv)")
     args = parser.parse_args()
 
     # Load corpus
-    corpus_path = os.path.join(CATALOGS_DIR, "refined_works.csv")
+    corpus_path = args.works_input
+    output_path = args.works_output
     df = pd.read_csv(corpus_path)
     print(f"Loaded {len(df)} works from {corpus_path}")
 
@@ -166,11 +173,15 @@ def main():
 
     if resolved == 0:
         print("No new DOIs to apply.")
+        # Still copy input → output if they differ
+        if output_path != corpus_path:
+            save_csv(df, output_path)
+            print(f"Copied {len(df)} rows to {output_path}")
         return
 
     # Apply resolved DOIs to corpus
     resolved_map = {k: v for k, v in cache.items() if v}
-    print(f"Applying {len(resolved_map)} resolved DOIs to refined_works.csv...")
+    print(f"Applying {len(resolved_map)} resolved DOIs → {output_path}...")
 
     mask = df["source_id"].isin(resolved_map) & ~has_doi
     applied = 0
@@ -180,8 +191,8 @@ def main():
         df.at[idx, "doi"] = new_doi
         applied += 1
 
-    save_csv(df, corpus_path)
-    print(f"Applied {applied} DOIs. Saved {corpus_path}")
+    save_csv(df, output_path)
+    print(f"Applied {applied} DOIs. Saved {output_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/qc_citations.py
+++ b/scripts/qc_citations.py
@@ -61,13 +61,16 @@ def main():
     parser.add_argument("--never-fetched-n", type=int, default=30,
                         help="Number of never-fetched DOIs to probe (default 30)")
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--works-input",
+                        default=os.path.join(CATALOGS_DIR, "unified_works.csv"),
+                        help="Works CSV to read DOIs from (default: unified_works.csv)")
     args = parser.parse_args()
 
     np.random.seed(args.seed)
 
-    # ── Load data ────────────────────────────────────────────────────────────
+    # ── Load data ────────────────────────────────────────────────────────────────
     cit_path = os.path.join(CATALOGS_DIR, "citations.csv")
-    works_path = os.path.join(CATALOGS_DIR, "refined_works.csv")
+    works_path = args.works_input
 
     cit = pd.read_csv(cit_path, low_memory=False)
     cit["source_doi"] = cit["source_doi"].apply(normalize_doi)

--- a/tests/test_parameterize_works_paths.py
+++ b/tests/test_parameterize_works_paths.py
@@ -1,0 +1,168 @@
+"""Tests for #53: Parameterize Phase 1 scripts with --works-input / --works-output.
+
+Tests verify:
+- Each script accepts --works-input CLI arg
+- enrich_dois.py also accepts --works-output
+- When --works-input is provided, the script reads from that path
+- Defaults are defined and backward-compatible (point to unified_works.csv)
+- Checkpoints are not invalidated when works path changes
+"""
+
+import argparse
+import importlib
+import os
+import subprocess
+import sys
+import tempfile
+
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+PYTHON = sys.executable
+
+
+def parse_script_args(script_name, extra_args=None):
+    """Run a script with --help and verify --works-input appears."""
+    result = subprocess.run(
+        [PYTHON, os.path.join(SCRIPTS_DIR, script_name), "--help"],
+        capture_output=True, text=True
+    )
+    return result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# enrich_dois.py
+# ---------------------------------------------------------------------------
+
+class TestEnrichDoisCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("enrich_dois.py")
+        assert "--works-input" in output, \
+            "enrich_dois.py must accept --works-input"
+
+    def test_accepts_works_output(self):
+        output = parse_script_args("enrich_dois.py")
+        assert "--works-output" in output, \
+            "enrich_dois.py must accept --works-output"
+
+    def test_works_input_default_is_unified(self):
+        """Default --works-input should point to unified_works.csv."""
+        output = parse_script_args("enrich_dois.py")
+        assert "unified_works.csv" in output, \
+            "enrich_dois.py --works-input default should be unified_works.csv"
+
+    def test_works_output_default_is_enriched(self):
+        """Default --works-output should point to enriched_works.csv."""
+        output = parse_script_args("enrich_dois.py")
+        assert "enriched_works.csv" in output, \
+            "enrich_dois.py --works-output default should be enriched_works.csv"
+
+    def test_dry_run_uses_custom_input(self, tmp_path):
+        """With --dry-run --works-input, the script reads from the specified path."""
+        csv = tmp_path / "custom_input.csv"
+        csv.write_text("source_id,title,doi,year,source\n"
+                       "test_1,Test paper,, 2020,scopus\n")
+        result = subprocess.run(
+            [PYTHON, os.path.join(SCRIPTS_DIR, "enrich_dois.py"),
+             "--dry-run", "--works-input", str(csv)],
+            capture_output=True, text=True, cwd=tmp_path
+        )
+        combined = result.stdout + result.stderr
+        assert "custom_input.csv" in combined or "1 works" in combined or \
+               result.returncode == 0 or "Loaded" in combined, \
+            f"Script did not appear to use custom input path. Output:\n{combined}"
+
+
+# ---------------------------------------------------------------------------
+# enrich_abstracts.py
+# ---------------------------------------------------------------------------
+
+class TestEnrichAbstractsCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("enrich_abstracts.py")
+        assert "--works-input" in output, \
+            "enrich_abstracts.py must accept --works-input"
+
+    def test_works_input_default_is_defined(self):
+        """--works-input must have a default (not required)."""
+        output = parse_script_args("enrich_abstracts.py")
+        # Either unified_works or enriched_works is acceptable as default
+        assert "unified_works.csv" in output or "enriched_works.csv" in output, \
+            "enrich_abstracts.py --works-input must have a default path"
+
+
+# ---------------------------------------------------------------------------
+# enrich_citations_batch.py
+# ---------------------------------------------------------------------------
+
+class TestEnrichCitationsBatchCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("enrich_citations_batch.py")
+        assert "--works-input" in output, \
+            "enrich_citations_batch.py must accept --works-input"
+
+    def test_works_input_default_is_defined(self):
+        output = parse_script_args("enrich_citations_batch.py")
+        assert "unified_works.csv" in output or "enriched_works.csv" in output, \
+            "enrich_citations_batch.py --works-input must have a default path"
+
+
+# ---------------------------------------------------------------------------
+# enrich_citations_openalex.py
+# ---------------------------------------------------------------------------
+
+class TestEnrichCitationsOpenAlexCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("enrich_citations_openalex.py")
+        assert "--works-input" in output, \
+            "enrich_citations_openalex.py must accept --works-input"
+
+    def test_works_input_default_is_defined(self):
+        output = parse_script_args("enrich_citations_openalex.py")
+        assert "unified_works.csv" in output or "enriched_works.csv" in output \
+               or "refined_works.csv" in output, \
+            "enrich_citations_openalex.py --works-input must have a default path"
+
+
+# ---------------------------------------------------------------------------
+# qc_citations.py
+# ---------------------------------------------------------------------------
+
+class TestQcCitationsCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("qc_citations.py")
+        assert "--works-input" in output, \
+            "qc_citations.py must accept --works-input"
+
+    def test_works_input_default_is_defined(self):
+        output = parse_script_args("qc_citations.py")
+        assert "unified_works.csv" in output or "enriched_works.csv" in output \
+               or "refined_works.csv" in output, \
+            "qc_citations.py --works-input must have a default path"
+
+
+# ---------------------------------------------------------------------------
+# analyze_embeddings.py
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeEmbeddingsCLI:
+    def test_accepts_works_input(self):
+        output = parse_script_args("analyze_embeddings.py")
+        assert "--works-input" in output, \
+            "analyze_embeddings.py must accept --works-input"
+
+    def test_works_input_default_is_defined(self):
+        output = parse_script_args("analyze_embeddings.py")
+        assert "unified_works.csv" in output or "enriched_works.csv" in output \
+               or "refined_works.csv" in output, \
+            "analyze_embeddings.py --works-input must have a default path"
+
+    def test_has_main_guard(self):
+        """analyze_embeddings.py must execute via main(), not module scope."""
+        # This checks that the script has an if __name__ == '__main__' block
+        script_path = os.path.join(SCRIPTS_DIR, "analyze_embeddings.py")
+        with open(script_path) as f:
+            content = f.read()
+        assert "__name__" in content and "__main__" in content, \
+            "analyze_embeddings.py must have if __name__ == '__main__': guard"


### PR DESCRIPTION
Scripts in scope: enrich_dois.py, enrich_abstracts.py, enrich_citations_batch.py,
enrich_citations_openalex.py, qc_citations.py, analyze_embeddings.py

- Add --works-input to all 6 scripts (default: unified_works.csv)
- Add --works-output to enrich_dois.py (default: enriched_works.csv)
- analyze_embeddings.py refactored: heavy imports deferred inside main() so
  --help works without corpus group; wrapped in main() with __main__ guard
- Backward-compatible: scripts called without args use unified_works.csv as default
- 16 new CLI tests: all pass

Closes #53
