### PR TITLE
docs(#56): update Phase 1 contract documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,13 @@ The pipeline has three phases with a strict contract between them:
 
 **Phase 1 — Corpus building** (slow, API-dependent, run rarely):
 - Scripts: `catalog_*`, `enrich_*`, `qa_*`, `qc_*`, `corpus_*`
-- Outputs (the contract): `refined_works.csv`, `embeddings.npz`, `citations.csv`
-- Run with: `make corpus`
+- Four steps with intermediate artifacts in `$CLIMATE_FINANCE_DATA/catalogs/`:
+  1. **corpus-discover**: merge sources → `unified_works.csv`
+  2. **corpus-enrich**: enrich DOIs/abstracts/citations on `unified_works.csv` → `enriched_works.csv`
+  3. **corpus-extend**: flag all works (no rows removed) → `extended_works.csv`
+  4. **corpus-filter**: apply policy, audit → `refined_works.csv` (final Phase 1 output)
+- Phase 1 → Phase 2 **contract**: `refined_works.csv`, `embeddings.npz`, `citations.csv`
+- Run with: `make corpus` (all four steps) or individual targets
 
 **Phase 2 — Analysis & figures** (fast, deterministic, run often):
 - Scripts: `analyze_*`, `plot_*`, `compute_*`, `export_*`, `summarize_*`, `build_het_core.py`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ All sources searched for: `"climate finance" OR "finance climat" OR "finance cli
 | `catalogs/scispsace_works.csv` | 663 | SciSpace AI-curated corpus (RIS + CSV, deduplicated) |
 | `catalogs/grey_works.csv` | 213 | 16 curated seed entries + 200 World Bank OKR API |
 | `catalogs/unified_works.csv` | 12,372 | Deduplicated merge of all sources (474 multi-source) |
+| `catalogs/enriched_works.csv` | 12,372 | After DOI/abstract/citation enrichment (Phase 1b output) |
+| `catalogs/extended_works.csv` | 12,372 | All works with quality flags, no rows removed (Phase 1c output) |
 | `catalogs/citations.csv` | 232,218 | Crossref citation links (176K with DOIs, from 4,710 source DOIs) |
 
 ### CSV schema

--- a/content/_includes/corpus-construction.md
+++ b/content/_includes/corpus-construction.md
@@ -56,28 +56,33 @@ A `source_count` field tracks how many sources contributed to each record. The o
 
 ### Pipeline overview
 
-The full corpus pipeline runs in three phases:
+The full corpus pipeline runs in four steps (Makefile targets: `corpus-discover`,
+`corpus-enrich`, `corpus-extend`, `corpus-filter`):
 
 ```
-  7 sources ──→ merge ──→ unified_works.csv
+  7 sources ──→ merge ──→ unified_works.csv   [corpus-discover]
                                │
                                ▼
-                        cheap filter (flags 1-3)
-                               │
-                    ┌──────────┴──────────┐
-                    ▼                     ▼
-             enrich abstracts      enrich citations
-              (OA, S2, ISTEX)      (Crossref, OA refs)
-                    │                     │
-                    ▼                     │
-             generate embeddings          │
-                    │                     │
-                    └──────────┬──────────┘
-                               ▼
-                        full refine (flags 1-6)
+                        enrich DOIs / abstracts / citations
                                │
                                ▼
-                        refined_works.csv
+                        enriched_works.csv      [corpus-enrich]
+                               │
+                               ▼
+                        flag all works (flags 1-6, no rows removed)
+                               │
+                               ▼
+                        extended_works.csv      [corpus-extend]
+                               │
+                               ▼
+                        apply policy → audit → refined_works.csv  [corpus-filter]
 ```
 
-A cheap pre-filter (flags 1–3: missing metadata, irrelevant titles, blacklisted terms) removes obvious junk before the expensive enrichment phase. Abstract and citation enrichment run independently; embedding generation requires abstracts. The full refinement pass then applies all six flags, including citation isolation (flag 4), semantic outlier detection (flag 5), and LLM relevance scoring (flag 6). See §2 (Corpus Enrichment) and §3 (Corpus Refinement) for details.
+Enrichment (DOIs via OpenAlex, abstracts from OA/S2/ISTEX, citations from
+Crossref and OpenAlex) runs on the full `unified_works.csv` so that all
+metadata is available when the flagging rules are evaluated. The extend step
+computes six quality flags for every work without removing any rows; the
+filter step then applies the retention policy and writes the final
+`refined_works.csv` together with `corpus_audit.csv`. See §2 (Corpus
+Enrichment) and §3 (Corpus Refinement) for details.
+

--- a/content/_includes/reproducibility.md
+++ b/content/_includes/reproducibility.md
@@ -21,6 +21,15 @@ make manuscript  # Phase 3: render PDF + DOCX
 The Phase 1 → Phase 2 contract is three files in `$CLIMATE_FINANCE_DATA/catalogs/`:
 `refined_works.csv`, `embeddings.npz`, `citations.csv`.
 
+Phase 1 itself has four steps and three intermediate artifacts:
+
+| Step | Make target | Reads | Writes |
+|---|---|---|---|
+| Discover | `corpus-discover` | source catalogs | `unified_works.csv` |
+| Enrich | `corpus-enrich` | `unified_works.csv` | `enriched_works.csv` |
+| Extend | `corpus-extend` | `enriched_works.csv` | `extended_works.csv` |
+| Filter | `corpus-filter` | `extended_works.csv` | `refined_works.csv` |
+
 See `AGENTS.md` for individual script invocations and the `Makefile` for full dependency graph.
 
 ### Data dependencies
@@ -28,7 +37,12 @@ See `AGENTS.md` for individual script invocations and the `Makefile` for full de
 | Script | Reads | Writes |
 |---|---|---|
 | `catalog_merge.py` | `*_works.csv` | `unified_works.csv` |
-| `corpus_refine.py` | `unified_works.csv`, `citations.csv`*, `embeddings.npz`* | `refined_works.csv`, `corpus_audit.csv` |
+| `enrich_dois.py` | `unified_works.csv` | `enriched_works.csv` |
+| `enrich_abstracts.py` | `enriched_works.csv` | `enriched_works.csv` (in-place) |
+| `enrich_citations_batch.py` | `enriched_works.csv` | `citations.csv` (append) |
+| `enrich_citations_openalex.py` | `enriched_works.csv` | `citations.csv` (append) |
+| `corpus_refine.py --extend` | `enriched_works.csv`, `citations.csv`*, `embeddings.npz`* | `extended_works.csv` |
+| `corpus_refine.py --filter` | `extended_works.csv` | `refined_works.csv`, `corpus_audit.csv` |
 | `analyze_embeddings.py` | `refined_works.csv` | `embeddings.npz` (incremental cache), `semantic_clusters.csv` |
 | `analyze_alluvial.py` | `refined_works.csv`, `embeddings.npz` | `fig_breakpoints`, `fig_composition`, `tab_*.csv`, `cluster_labels.json` |
 | `analyze_bimodality.py` | `refined_works.csv`, `embeddings.npz` | `fig_bimodality*`, `tab_bimodality.csv`, `tab_pole_papers.csv`, `tab_axis_detection.csv` |

--- a/tests/test_doc_contract_consistency.py
+++ b/tests/test_doc_contract_consistency.py
@@ -1,0 +1,154 @@
+"""Tests for #56: Documentation consistency with Phase 1 contract.
+
+The canonical Phase 1 pipeline artifacts are:
+  unified_works.csv  → enriched_works.csv → extended_works.csv → refined_works.csv
+
+Makefile targets:
+  corpus-discover → corpus-enrich → corpus-extend → corpus-filter
+
+Docs must:
+  1. Name all four intermediate artifacts
+  2. Name all four Make targets
+  3. Not refer to a 'cheap' pre-filter step occurring before enrichment
+  4. Describe Phase 1 as having four steps/phases (not two)
+"""
+
+import os
+import re
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+AGENTS_MD = os.path.join(ROOT, "AGENTS.md")
+README_MD = os.path.join(ROOT, "README.md")
+CORPUS_CONSTRUCTION_MD = os.path.join(ROOT, "content", "_includes", "corpus-construction.md")
+REPRODUCIBILITY_MD = os.path.join(ROOT, "content", "_includes", "reproducibility.md")
+
+
+def read(path):
+    with open(path) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# AGENTS.md
+# ---------------------------------------------------------------------------
+
+class TestAgentsMd:
+    def test_all_four_artifacts_mentioned(self):
+        """AGENTS.md must mention all four Phase 1 intermediate artifacts."""
+        text = read(AGENTS_MD)
+        for artifact in ["unified_works.csv", "enriched_works.csv",
+                         "extended_works.csv", "refined_works.csv"]:
+            assert artifact in text, \
+                f"AGENTS.md missing artifact: {artifact}"
+
+    def test_all_four_make_targets_mentioned(self):
+        """AGENTS.md must mention all four corpus Makefile targets."""
+        text = read(AGENTS_MD)
+        for target in ["corpus-discover", "corpus-enrich", "corpus-extend", "corpus-filter"]:
+            assert target in text, \
+                f"AGENTS.md missing Makefile target: {target}"
+
+    def test_no_cheap_prefilter_as_pipeline_step(self):
+        """AGENTS.md must not describe 'cheap filter' as a step before enrichment."""
+        text = read(AGENTS_MD)
+        # Acceptable: mentioning '--cheap' flag if historical/deprecated context
+        # Unacceptable: prose saying cheap filter runs in Phase 1a before enrichment
+        assert "cheap filter" not in text.lower(), \
+            "AGENTS.md still describes 'cheap filter' as a pipeline step"
+
+    def test_phase1_has_four_steps(self):
+        """AGENTS.md Phase 1 section should describe four steps (discover/enrich/extend/filter)."""
+        text = read(AGENTS_MD)
+        phase1_section = re.search(
+            r"Phase 1.*?(?=Phase 2|##|\Z)", text, re.DOTALL | re.IGNORECASE
+        )
+        assert phase1_section, "AGENTS.md must have a Phase 1 section"
+        section_text = phase1_section.group(0)
+        steps_found = sum(
+            1 for step in ["discover", "enrich", "extend", "filter"]
+            if step in section_text.lower()
+        )
+        assert steps_found >= 4, (
+            f"AGENTS.md Phase 1 section mentions only {steps_found}/4 pipeline steps "
+            f"(discover, enrich, extend, filter)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# corpus-construction.md
+# ---------------------------------------------------------------------------
+
+class TestCorpusConstructionMd:
+    def test_all_four_artifacts_in_diagram_or_prose(self):
+        """corpus-construction.md must mention all four Phase 1 intermediate artifacts."""
+        text = read(CORPUS_CONSTRUCTION_MD)
+        for artifact in ["unified_works.csv", "enriched_works.csv",
+                         "extended_works.csv", "refined_works.csv"]:
+            assert artifact in text, \
+                f"corpus-construction.md missing artifact: {artifact}"
+
+    def test_no_cheap_filter_before_enrich(self):
+        """corpus-construction.md must not describe cheap filter as a step before enrichment."""
+        text = read(CORPUS_CONSTRUCTION_MD)
+        # The old pipeline had:  unified → cheap filter → enrichment → refined
+        # The new pipeline has:  unified → enrichment → extend (flag) → filter
+        assert "cheap filter" not in text.lower(), \
+            "corpus-construction.md still describes 'cheap filter' before enrichment"
+
+    def test_pipeline_diagram_has_four_stages(self):
+        """Pipeline diagram/description must include all four stages."""
+        text = read(CORPUS_CONSTRUCTION_MD)
+        stages_found = sum(
+            1 for stage in ["discover", "enrich", "extend", "filter"]
+            if stage in text.lower()
+        )
+        assert stages_found >= 4, (
+            f"corpus-construction.md mentions only {stages_found}/4 pipeline stages"
+        )
+
+
+# ---------------------------------------------------------------------------
+# reproducibility.md
+# ---------------------------------------------------------------------------
+
+class TestReproducibilityMd:
+    def test_artifact_table_has_extended_works(self):
+        """reproducibility.md artifact/script table must include extended_works.csv."""
+        text = read(REPRODUCIBILITY_MD)
+        assert "extended_works.csv" in text, \
+            "reproducibility.md artifact table missing extended_works.csv"
+
+    def test_artifact_table_has_enriched_works(self):
+        """reproducibility.md artifact/script table must include enriched_works.csv."""
+        text = read(REPRODUCIBILITY_MD)
+        assert "enriched_works.csv" in text, \
+            "reproducibility.md artifact table missing enriched_works.csv"
+
+    def test_corpus_refine_shows_split_modes(self):
+        """reproducibility.md must show corpus_refine.py --extend and --filter modes."""
+        text = read(REPRODUCIBILITY_MD)
+        assert "--extend" in text or "extend" in text, \
+            "reproducibility.md must document corpus_refine.py --extend mode"
+        assert "--filter" in text or ("corpus_refine" in text and "filter" in text), \
+            "reproducibility.md must document corpus_refine.py --filter mode"
+
+
+# ---------------------------------------------------------------------------
+# README.md
+# ---------------------------------------------------------------------------
+
+class TestReadmeMd:
+    def test_artifact_table_has_enriched_works(self):
+        """README.md artifact table must include enriched_works.csv."""
+        text = read(README_MD)
+        assert "enriched_works.csv" in text, \
+            "README.md artifact table missing enriched_works.csv"
+
+    def test_artifact_table_has_extended_works(self):
+        """README.md artifact table must include extended_works.csv."""
+        text = read(README_MD)
+        assert "extended_works.csv" in text, \
+            "README.md artifact table missing extended_works.csv"


### PR DESCRIPTION
Replace the stale two-phase (cheap-filter + enrich) description with the
canonical four-step pipeline:
  corpus-discover  → unified_works.csv
  corpus-enrich    → enriched_works.csv
  corpus-extend    → extended_works.csv
  corpus-filter    → refined_works.csv

Files updated:
- AGENTS.md: Phase 1 section now lists all four steps and Make targets
- content/_includes/corpus-construction.md: pipeline diagram replaced;
  'cheap filter before enrichment' removed
- content/_includes/reproducibility.md: Phase 1 step table added;
  data dependencies table split by script mode
- README.md: artifact table gains enriched_works.csv and extended_works.csv

Tests: 12 new doc-consistency checks (test_doc_contract_consistency.py),
48 total pass
