### PR TITLE
docs(#46): sync alluvial includes with modular script architecture

### DIFF
--- a/content/_includes/alluvial-diagram.md
+++ b/content/_includes/alluvial-diagram.md
@@ -1,6 +1,6 @@
 ## 5. Alluvial Diagram
 
-**Script:** `scripts/analyze_alluvial.py` (same script as breakpoint detection)
+**Scripts:** `scripts/compute_alluvial.py` + `scripts/plot_fig_alluvial.py`
 
 ### Period assignment
 

--- a/content/_includes/core-vs-full.md
+++ b/content/_includes/core-vs-full.md
@@ -8,7 +8,7 @@ The broad landscape of "scholarship around climate finance." This includes not o
 
 ### Core subset (~{{< var corpus_core >}} papers, cited_by_count >= {{< var corpus_core_threshold >}})
 
-The influential intellectual core. These are the papers that have shaped the field's concepts, debates, and categories. The core subset is analyzed separately by passing `--core-only` to `analyze_alluvial.py`.
+The influential intellectual core. These are the papers that have shaped the field's concepts, debates, and categories. The core subset is analyzed separately by passing `--core-only` to `compute_alluvial.py` and the corresponding plotting scripts.
 
 ### Key differences
 

--- a/content/_includes/reproducibility.md
+++ b/content/_includes/reproducibility.md
@@ -44,7 +44,9 @@ See `AGENTS.md` for individual script invocations and the `Makefile` for full de
 | `corpus_refine.py --extend` | `enriched_works.csv`, `citations.csv`*, `embeddings.npz`* | `extended_works.csv` |
 | `corpus_refine.py --filter` | `extended_works.csv` | `refined_works.csv`, `corpus_audit.csv` |
 | `analyze_embeddings.py` | `refined_works.csv` | `embeddings.npz` (incremental cache), `semantic_clusters.csv` |
-| `analyze_alluvial.py` | `refined_works.csv`, `embeddings.npz` | `fig_breakpoints`, `fig_composition`, `tab_*.csv`, `cluster_labels.json` |
+| `compute_alluvial.py` | `refined_works.csv`, `embeddings.npz` | `tab_alluvial.csv`, `tab_breakpoints.csv`, `tab_breakpoint_robustness.csv`, `cluster_labels.json`, `tab_core_shares.csv`, `tab_lexical_tfidf.csv` |
+| `plot_fig_breakpoints.py` | `tab_breakpoints.csv`, `tab_breakpoint_robustness.csv`, `tab_alluvial.csv` | `fig_breakpoints.png` |
+| `plot_fig_alluvial.py` | `tab_alluvial.csv`, `cluster_labels.json` | `fig_alluvial.png`, `fig_alluvial.html` |
 | `analyze_bimodality.py` | `refined_works.csv`, `embeddings.npz` | `fig_bimodality*`, `tab_bimodality.csv`, `tab_pole_papers.csv`, `tab_axis_detection.csv` |
 | `analyze_genealogy.py` | `refined_works.csv`, `citations.csv`, `semantic_clusters.csv`, `tab_pole_papers.csv` | `fig_genealogy`, `tab_lineages.csv` |
 | `plot_fig45_pca_scatter.py` | `refined_works.csv`, `embeddings.npz` | `fig_seed_axis_core`, `fig_pca_scatter`, `tab_*.csv` |

--- a/content/_includes/structural-breaks.md
+++ b/content/_includes/structural-breaks.md
@@ -1,6 +1,6 @@
 ## 4. Structural Break Detection
 
-**Script:** `scripts/analyze_alluvial.py`
+**Scripts:** `scripts/compute_alluvial.py` + `scripts/plot_fig_breakpoints.py`
 
 This analysis detects endogenous structural breaks in the temporal evolution of the corpus's thematic composition. Rather than imposing external periodizations from COP milestones or policy events, we ask: at what years did the *semantic structure* of climate finance scholarship shift most sharply?
 


### PR DESCRIPTION
Summary: documentation sync for the alluvial modular split.

Changes:
- structural-breaks include now references compute_alluvial.py + plot_fig_breakpoints.py
- alluvial-diagram include now references compute_alluvial.py + plot_fig_alluvial.py
- reproducibility include replaces the old analyze_alluvial.py row with modular compute/plot rows
- core-vs-full include updates --core-only usage to modular compute/plot flow

Scope: docs only; no behavioral code changes.

Closes #46 (documentation alignment).