### PR TITLE
Update manuscript title (#27)

### DIFF
--- a/content/manuscript.qmd
+++ b/content/manuscript.qmd
@@ -1,6 +1,6 @@
 ---
-title: "Counting Climate Finance. How Economists Made a Governable Object (1990–2025)"
-subtitle: "*Compter la finance climat. Comment les économistes ont fabriqué un objet gouvernable (1990–2025)*"
+title: "Inventing Climate Finance. From Incremental Costs to Strategic Ambiguity"
+subtitle: "*Inventer la finance climat. Des coûts incrémentaux à l'ambiguïté stratégique*"
 author: "Minh Ha-Duong"
 keywords:
   - climate finance


### PR DESCRIPTION
## Summary
- New title: **Inventing Climate Finance. From Incremental Costs to Strategic Ambiguity**
- French subtitle: *Inventer la finance climat. Des coûts incrémentaux à l'ambiguïté stratégique*
- Selected via round-robin tournament (32 candidates, 2 rounds) optimizing for Oeconomia conventions and manuscript argument

## Rationale
Traces the paper's intellectual arc — from Article 4.3's "agreed full incremental costs" to deliberate post-Copenhagen vagueness. "Inventing" signals constructivism; dot-separated format matches Oeconomia house style.

## Test plan
- [ ] Verify `make manuscript` renders correctly with new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)