### PR TITLE
Remove all ALLOW_* bypass mechanisms from pre-commit hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Reflect on lessons learned. Generalize new skills. Update MEMORY.md with durable
 ## Git discipline
 
 - **Always work on a branch.** Branch naming: `t{N}-short-description`.
-- **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers. Each check has an `ALLOW_*=1` override.
+- **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers.
 - **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees (scripts need it for data paths).
 - **Hooks** live in `hooks/`. After cloning: `git config core.hooksPath hooks`.
 - **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,12 +1,10 @@
 #!/bin/sh
-# Pre-commit guards — keep the repo clean
-# Override any check: ALLOW_MAIN=1, ALLOW_SECRETS=1, ALLOW_LARGE=1
+# Pre-commit guards — keep the repo clean. No overrides.
 
 # 1. No commits on main
 branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$branch" = "main" ] && [ "$ALLOW_MAIN" != "1" ]; then
+if [ "$branch" = "main" ]; then
     echo "ERROR: Direct commits to main are not allowed. Work on a branch." >&2
-    echo "  Override: ALLOW_MAIN=1 git commit ..." >&2
     exit 1
 fi
 
@@ -17,31 +15,25 @@ if git diff --cached --name-only | grep -qx 'CLAUDE.md'; then
 fi
 
 # 3. No secrets
-if [ "$ALLOW_SECRETS" != "1" ]; then
-    secrets=$(git diff --cached --name-only | grep -iE '\.env$|\.env\.|credentials|secret|api.?key|\.pem$|\.key$' || true)
-    if [ -n "$secrets" ]; then
-        echo "ERROR: Possible secrets staged:" >&2
-        echo "$secrets" >&2
-        echo "  Override: ALLOW_SECRETS=1 git commit ..." >&2
-        exit 1
-    fi
+secrets=$(git diff --cached --name-only | grep -iE '\.env$|\.env\.|credentials|secret|api.?key|\.pem$|\.key$' || true)
+if [ -n "$secrets" ]; then
+    echo "ERROR: Possible secrets staged:" >&2
+    echo "$secrets" >&2
+    exit 1
 fi
 
 # 4. No large files (>500KB)
-if [ "$ALLOW_LARGE" != "1" ]; then
-    large=""
-    for file in $(git diff --cached --name-only --diff-filter=d); do
-        size=$(wc -c < "$file" 2>/dev/null || echo 0)
-        if [ "$size" -gt 512000 ]; then
-            large="$large  $file ($(( size / 1024 ))KB)\n"
-        fi
-    done
-    if [ -n "$large" ]; then
-        echo "ERROR: Large files staged (>500KB):" >&2
-        printf "$large" >&2
-        echo "  Override: ALLOW_LARGE=1 git commit ..." >&2
-        exit 1
+large=""
+for file in $(git diff --cached --name-only --diff-filter=d); do
+    size=$(wc -c < "$file" 2>/dev/null || echo 0)
+    if [ "$size" -gt 512000 ]; then
+        large="$large  $file ($(( size / 1024 ))KB)\n"
     fi
+done
+if [ -n "$large" ]; then
+    echo "ERROR: Large files staged (>500KB):" >&2
+    printf '%s' "$large" >&2
+    exit 1
 fi
 
 # 5. No conflict markers


### PR DESCRIPTION
## Summary
- Remove ALLOW_MAIN, ALLOW_SECRETS, ALLOW_LARGE env var overrides from pre-commit hook
- All guards now block unconditionally — the only way to commit to main is `git merge`
- Update AGENTS.md to drop the "override" mention

## Test plan
- [ ] `git checkout main && echo test > /tmp/test && git add /tmp/test && git commit` → blocked
- [ ] `ALLOW_MAIN=1 git commit` → still blocked (no bypass)
- [ ] Commit on a feature branch → works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)