### PR TITLE
Add make check-fast target for offline/unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ TECHREP_FIGS    := content/figures/fig_alluvial_core.png \
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(COMPANION_FIGS) $(TECHREP_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep stats check-corpus corpus corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-refine corpus-tables corpus-validate deploy-corpus lint-prose clean rebuild archive-manuscript archive-datapaper
+.PHONY: all manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep stats check check-fast check-corpus corpus corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-refine corpus-tables corpus-validate deploy-corpus lint-prose clean rebuild archive-manuscript archive-datapaper
 
 .DEFAULT_GOAL := manuscript
 
@@ -430,6 +430,10 @@ archive-datapaper: check-corpus
 # ── All checks (tests + lint) ────────────────────────────
 check: lint-prose
 	uv run pytest tests/ -v --tb=short
+
+# Fast subset: unit tests only (no corpus data needed, < 30s).
+check-fast: lint-prose
+	uv run pytest tests/ -v --tb=short -m "not slow"
 
 # ── Prose linting (AI-tell detection) ─────────────────────
 lint-prose:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests that require corpus data or network access (deselect with '-m \"not slow\"')",
+]
+
 [tool.uv.sources]
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }

--- a/tests/test_corpus_acceptance.py
+++ b/tests/test_corpus_acceptance.py
@@ -18,6 +18,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+# Whole module requires corpus data files — skip with `pytest -m "not slow"`.
+pytestmark = pytest.mark.slow
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from refine_flags import _has_safe_words, _load_config
 from utils import (

--- a/tests/test_parameterize_works_paths.py
+++ b/tests/test_parameterize_works_paths.py
@@ -18,6 +18,9 @@ import tempfile
 import pandas as pd
 import pytest
 
+# Whole module spawns enrichment-script subprocesses — skip with `-m "not slow"`.
+pytestmark = pytest.mark.slow
+
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 PYTHON = sys.executable
 

--- a/tests/test_phase1_migration.py
+++ b/tests/test_phase1_migration.py
@@ -13,6 +13,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+# Whole module spawns corpus_refine.py subprocesses — skip with `-m "not slow"`.
+pytestmark = pytest.mark.slow
+
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -18,6 +18,9 @@ import time
 import pandas as pd
 import pytest
 
+# Whole module spawns enrichment-script subprocesses — skip with `-m "not slow"`.
+pytestmark = pytest.mark.slow
+
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 

--- a/tests/test_split_corpus_refine.py
+++ b/tests/test_split_corpus_refine.py
@@ -17,6 +17,9 @@ import tempfile
 import pandas as pd
 import pytest
 
+# Whole module runs corpus_refine.py subprocesses — skip with `-m "not slow"`.
+pytestmark = pytest.mark.slow
+
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 PYTHON = sys.executable
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")


### PR DESCRIPTION
Closes #119

## Summary
- Register `slow` pytest marker in `pyproject.toml`
- Mark 5 test modules as slow: `test_corpus_acceptance`, `test_split_corpus_refine`, `test_robustness_observability`, `test_parameterize_works_paths`, `test_phase1_migration`
- Add `make check-fast` target that runs `uv run pytest -m "not slow"` (110 tests in ~14s)
- Existing `make check` unchanged (runs full suite)

## Test plan
- [ ] `make check-fast` completes in under 30 seconds
- [ ] `make check` still runs the full suite (241 tests)
- [ ] No pytest warnings about unknown markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)