### PR TITLE
Fix integration tests failing without torch (#130)

### DIFF
--- a/scripts/refine_flags.py
+++ b/scripts/refine_flags.py
@@ -383,8 +383,14 @@ def _reranker_streaming(df, config, *, already_flagged):
     Cache is checkpointed after each batch, so interrupting preserves progress.
     Yields (indices, partial_series) for Flag 6 candidates only.
     """
-    import torch
-    from sentence_transformers import CrossEncoder
+    try:
+        import torch  # noqa: F401
+        from sentence_transformers import CrossEncoder
+    except ImportError as exc:
+        raise RuntimeError(
+            "Flag 6 requires torch and sentence-transformers — "
+            "run on padme or install the corpus extras group"
+        ) from exc
 
     llm_cfg = config["llm_relevance"]
     candidates_mask, doi_norm = _identify_candidates(df, config, already_flagged)

--- a/tests/test_phase1_migration.py
+++ b/tests/test_phase1_migration.py
@@ -59,13 +59,18 @@ class TestPhase1Integration:
         env["CLIMATE_FINANCE_DATA"] = str(temp_catalogs.parent)
         
         result = subprocess.run(
-            ["python", os.path.join(SCRIPTS_DIR, "corpus_refine.py"), "--apply"],
+            [
+                "python", os.path.join(SCRIPTS_DIR, "corpus_refine.py"),
+                "--apply", "--skip-llm", "--skip-citation-flag",
+                "--works-input", str(temp_catalogs / "unified_works.csv"),
+                "--works-output", str(temp_catalogs / "refined_works.csv"),
+            ],
             cwd=str(temp_catalogs),
             capture_output=True,
             text=True,
             env=env,
         )
-        
+
         assert result.returncode == 0, (
             f"corpus_refine.py --apply failed:\nstdout: {result.stdout}\n"
             f"stderr: {result.stderr}"
@@ -89,24 +94,19 @@ class TestIncrementiality:
         env = os.environ.copy()
         env["CLIMATE_FINANCE_DATA"] = str(temp_catalogs.parent)
         
+        cmd = [
+            "python", os.path.join(SCRIPTS_DIR, "corpus_refine.py"),
+            "--apply", "--skip-llm", "--skip-citation-flag",
+            "--works-input", str(temp_catalogs / "unified_works.csv"),
+            "--works-output", str(temp_catalogs / "refined_works.csv"),
+        ]
+
         # First run
-        subprocess.run(
-            ["python", os.path.join(SCRIPTS_DIR, "corpus_refine.py"), "--apply"],
-            cwd=str(temp_catalogs),
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+        subprocess.run(cmd, cwd=str(temp_catalogs), capture_output=True, text=True, env=env)
         run1 = (temp_catalogs / "refined_works.csv").read_text()
-        
+
         # Second run
-        subprocess.run(
-            ["python", os.path.join(SCRIPTS_DIR, "corpus_refine.py"), "--apply"],
-            cwd=str(temp_catalogs),
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+        subprocess.run(cmd, cwd=str(temp_catalogs), capture_output=True, text=True, env=env)
         run2 = (temp_catalogs / "refined_works.csv").read_text()
         
         assert run1 == run2, "corpus_refine --apply is not idempotent"


### PR DESCRIPTION
## Summary

- **tests/test_phase1_migration.py**: both `test_corpus_refine_apply_works` and `test_corpus_refine_idempotent` now pass `--skip-llm`, `--skip-citation-flag`, `--works-input`, and `--works-output` to the subprocess, so the tests exercise flags 1–3 only and use the temp fixture paths (not the hardcoded `CATALOGS_DIR`).
- **scripts/refine_flags.py**: `_reranker_streaming()` now wraps `import torch` and `from sentence_transformers import CrossEncoder` in `try/except ImportError`, raising `RuntimeError` with a clear message ("run on padme or install the corpus extras group") instead of a bare `ModuleNotFoundError`.

## Test plan

- [x] `uv run pytest tests/test_phase1_migration.py -v` — all 6 tests pass (was 2 failures)
- [x] `make check-fast` — 187 pass, 1 skipped, 6 pre-existing Makefile/DVC failures unchanged (verified identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)