### PR TITLE
Update Makefile contract tests to match DVC-delegated structure (#129)

### DIFF
--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -1,16 +1,19 @@
-"""Tests for Phase 1 Makefile contract — #52.
+"""Tests for Phase 1 Makefile contract — #52, updated for DVC delegation (#129).
 
 Tests verify:
 - Phase 1 target definitions exist in correct order
-- Each phase declares only its contract outputs
-- Fail-fast checks for missing handoff artifacts are present
+- corpus meta-target delegates to DVC (dvc repro)
+- Artifact dependency contracts are expressed in dvc.yaml (not Makefile recipes)
 - The old cheap pre-filter is absent from corpus-discover
 """
 
 import os
 import re
 
+import yaml
+
 MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
+DVC_YAML = os.path.join(os.path.dirname(__file__), "..", "dvc.yaml")
 
 
 def read_makefile():
@@ -44,14 +47,18 @@ class TestTargetPresence:
             "corpus-filter target missing (new Phase 1d)"
 
     def test_corpus_target_chains_all_phases(self):
-        """The 'corpus' meta-target must chain discover -> enrich -> extend -> filter -> manifest."""
+        """The 'corpus' meta-target must delegate to DVC (dvc repro).
+
+        Since DVC now owns the dependency graph (dvc.yaml), the Makefile
+        corpus target simply calls 'dvc repro' rather than chaining individual
+        phase targets. Each stage's artifact dependencies are declared in dvc.yaml.
+        """
         mk = read_makefile()
-        # Find corpus: line and check all four phases appear as prereqs
         m = re.search(r"^corpus\s*:(.*?)(?=\n\S|\Z)", mk, re.MULTILINE | re.DOTALL)
         assert m, "corpus meta-target not found"
         body = m.group(0)
-        for phase in ("corpus-discover", "corpus-enrich", "corpus-extend", "corpus-filter"):
-            assert phase in body, f"{phase} not chained in corpus meta-target"
+        assert "dvc repro" in body, \
+            "corpus meta-target must delegate to 'dvc repro' (DVC owns the pipeline DAG)"
 
 
 # ---------------------------------------------------------------------------
@@ -110,42 +117,53 @@ class TestContractVariables:
 
 
 # ---------------------------------------------------------------------------
-# Fail-fast artifact checks
+# Artifact dependency checks (now in dvc.yaml, not Makefile recipes)
 # ---------------------------------------------------------------------------
+
+def read_dvc_yaml():
+    with open(DVC_YAML) as f:
+        return yaml.safe_load(f)
+
 
 class TestFailFastChecks:
     def test_corpus_enrich_checks_for_unified(self):
-        """corpus-enrich recipe must fail-fast if unified_works.csv is absent."""
-        mk = read_makefile()
-        m = re.search(
-            r"^corpus-enrich\s*:.*?\n((?:\t.*\n?)*)",
-            mk, re.MULTILINE
-        )
-        assert m, "corpus-enrich target not found"
-        recipe = m.group(1)
-        assert "unified_works.csv" in recipe or "UNIFIED" in recipe, \
-            "corpus-enrich must reference UNIFIED/unified_works.csv (fail-fast check)"
+        """dvc.yaml enrich stage must declare unified_works.csv as a dependency.
+
+        Previously the Makefile corpus-enrich recipe contained a fail-fast check.
+        Now DVC owns the dependency graph: the contract is expressed in dvc.yaml
+        deps, which DVC enforces before running the stage.
+        """
+        dvc = read_dvc_yaml()
+        assert "enrich" in dvc.get("stages", {}), "enrich stage missing from dvc.yaml"
+        deps = dvc["stages"]["enrich"].get("deps", [])
+        dep_paths = [str(d) for d in deps]
+        assert any("unified_works.csv" in p for p in dep_paths), \
+            "dvc.yaml enrich stage must list unified_works.csv in deps"
 
     def test_corpus_extend_checks_for_enriched(self):
-        """corpus-extend recipe must fail-fast if enriched_works.csv is absent."""
-        mk = read_makefile()
-        m = re.search(
-            r"^corpus-extend\s*:.*?\n((?:\t.*\n?)*)",
-            mk, re.MULTILINE
-        )
-        assert m, "corpus-extend target not found"
-        recipe = m.group(1)
-        assert "enriched_works.csv" in recipe or "ENRICHED" in recipe, \
-            "corpus-extend must reference ENRICHED/enriched_works.csv (fail-fast check)"
+        """dvc.yaml extend stage must declare enriched_works.csv as a dependency.
+
+        Previously the Makefile corpus-extend recipe contained a fail-fast check.
+        Now DVC owns the dependency graph: the contract is expressed in dvc.yaml
+        deps, which DVC enforces before running the stage.
+        """
+        dvc = read_dvc_yaml()
+        assert "extend" in dvc.get("stages", {}), "extend stage missing from dvc.yaml"
+        deps = dvc["stages"]["extend"].get("deps", [])
+        dep_paths = [str(d) for d in deps]
+        assert any("enriched_works.csv" in p for p in dep_paths), \
+            "dvc.yaml extend stage must list enriched_works.csv in deps"
 
     def test_corpus_filter_checks_for_extended(self):
-        """corpus-filter recipe must fail-fast if extended_works.csv is absent."""
-        mk = read_makefile()
-        m = re.search(
-            r"^corpus-filter\s*:.*?\n((?:\t.*\n?)*)",
-            mk, re.MULTILINE
-        )
-        assert m, "corpus-filter target not found"
-        recipe = m.group(1)
-        assert "extended_works.csv" in recipe or "EXTENDED" in recipe, \
-            "corpus-filter must reference EXTENDED/extended_works.csv (fail-fast check)"
+        """dvc.yaml filter stage must declare extended_works.csv as a dependency.
+
+        Previously the Makefile corpus-filter recipe contained a fail-fast check.
+        Now DVC owns the dependency graph: the contract is expressed in dvc.yaml
+        deps, which DVC enforces before running the stage.
+        """
+        dvc = read_dvc_yaml()
+        assert "filter" in dvc.get("stages", {}), "filter stage missing from dvc.yaml"
+        deps = dvc["stages"]["filter"].get("deps", [])
+        dep_paths = [str(d) for d in deps]
+        assert any("extended_works.csv" in p for p in dep_paths), \
+            "dvc.yaml filter stage must list extended_works.csv in deps"

--- a/tests/test_phase1_contract.py
+++ b/tests/test_phase1_contract.py
@@ -7,7 +7,7 @@ Covers:
 - load_refined_embeddings() and load_refined_citations() raise on missing file
 - corpus_align.py CLI: --dry-run works without writing files
 - corpus_align.py: alignment is correct given synthetic fixture data
-- Makefile declares corpus-align target chained into corpus meta-target
+- Makefile declares corpus-align target; dvc.yaml align stage lists refined_works.csv in deps
 """
 
 import os
@@ -15,12 +15,15 @@ import sys
 import subprocess
 import tempfile
 
+import yaml
+
 import numpy as np
 import pandas as pd
 import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
+DVC_YAML = os.path.join(os.path.dirname(__file__), "..", "dvc.yaml")
 sys.path.insert(0, SCRIPTS_DIR)
 
 
@@ -351,12 +354,17 @@ class TestMakefileContract:
             "corpus-align target missing from Makefile"
 
     def test_corpus_meta_target_includes_corpus_align(self):
-        import re
-        mk = self._read_makefile()
-        m = re.search(r"^corpus\s*:(.*?)(?=\n\S|\Z)", mk, re.MULTILINE | re.DOTALL)
-        assert m, "corpus meta-target not found"
-        assert "corpus-align" in m.group(0), \
-            "corpus-align not chained in corpus meta-target"
+        """dvc.yaml must define an align stage (corpus-align delegates to dvc repro align).
+
+        Previously the test checked the Makefile corpus meta-target listed
+        corpus-align as a prerequisite. Now DVC owns the pipeline DAG:
+        the align stage is declared in dvc.yaml, and corpus-align in the
+        Makefile simply calls 'dvc repro align'.
+        """
+        with open(DVC_YAML) as f:
+            dvc = yaml.safe_load(f)
+        assert "align" in dvc.get("stages", {}), \
+            "align stage missing from dvc.yaml (corpus-align delegates to 'dvc repro align')"
 
     def test_refined_embeddings_variable_declared(self):
         import re
@@ -371,14 +379,17 @@ class TestMakefileContract:
             "REFINED_CIT variable not declared in Makefile"
 
     def test_corpus_align_checks_for_refined(self):
-        """corpus-align recipe must fail-fast if refined_works.csv is absent."""
-        import re
-        mk = self._read_makefile()
-        m = re.search(
-            r"^corpus-align\s*:.*?\n((?:\t.*\n?)*)",
-            mk, re.MULTILINE,
-        )
-        assert m, "corpus-align target not found"
-        recipe = m.group(1)
-        assert "refined_works.csv" in recipe or "REFINED" in recipe, \
-            "corpus-align must reference REFINED/refined_works.csv (fail-fast check)"
+        """dvc.yaml align stage must declare refined_works.csv as a dependency.
+
+        Previously the Makefile corpus-align recipe contained a fail-fast check
+        for the presence of refined_works.csv. Now DVC owns the dependency graph:
+        the contract is expressed in dvc.yaml deps, which DVC enforces before
+        running the align stage.
+        """
+        with open(DVC_YAML) as f:
+            dvc = yaml.safe_load(f)
+        assert "align" in dvc.get("stages", {}), "align stage missing from dvc.yaml"
+        deps = dvc["stages"]["align"].get("deps", [])
+        dep_paths = [str(d) for d in deps]
+        assert any("refined_works.csv" in p for p in dep_paths), \
+            "dvc.yaml align stage must list refined_works.csv in deps"


### PR DESCRIPTION
## Summary

- The Makefile was previously simplified to delegate Phase 1 to DVC (`dvc repro <stage>`), but six tests still reflected the old structure where the Makefile contained inline fail-fast checks and chained corpus phase targets.
- Updated `test_corpus_target_chains_all_phases` to assert `dvc repro` appears in the `corpus` recipe instead of checking for chained phase prerequisites.
- Updated `test_corpus_enrich/extend/filter_checks_for_*` to parse `dvc.yaml` and verify the expected artifact appears in the relevant stage's `deps` list (DVC now owns the dependency contract).
- Updated `test_corpus_meta_target_includes_corpus_align` to check `dvc.yaml` has an `align` stage.
- Updated `test_corpus_align_checks_for_refined` to verify `dvc.yaml` align stage lists `refined_works.csv` in its `deps`.

## Test plan

- [x] All 6 previously failing tests now pass: `uv run pytest tests/test_makefile_contract.py tests/test_phase1_contract.py -v`
- [x] `make check-fast` passes with no new regressions (2 pre-existing failures in `test_phase1_migration.py` are unchanged and unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)