### PR TITLE
Add catalog_bibcnrs as DVC stage, track data/exports (#134)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,7 @@ content/bibliography/*.pdf
 .env
 
 # Data directory — DVC manages catalog/pool artifacts (*.dvc files tracked by git)
-# Non-DVC subdirs (exports/, raw/, syllabi/) gitignored here
-data/exports/
+# Non-DVC subdirs (raw/, syllabi/) gitignored here; exports/ managed by data/exports.dvc
 data/raw/
 data/syllabi/
 # Script checkpoint files (resume state, not source of truth)

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,2 @@
 /pool
+/exports

--- a/data/catalogs/bibcnrs_works.csv.dvc
+++ b/data/catalogs/bibcnrs_works.csv.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: aad79a049076761e7943646c5e732feb
-  size: 53677
-  hash: md5
-  path: bibcnrs_works.csv

--- a/data/exports.dvc
+++ b/data/exports.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: e4ee27a6fea54a81bf590ee04a1c12ae.dir
+  size: 154608
+  nfiles: 5
+  hash: md5
+  path: exports

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -8,6 +8,18 @@
 # Do not run casually — use `dvc repro --dry` to preview what would run.
 
 stages:
+  # Phase 1a-pre: Parse bibCNRS RIS exports → bibcnrs_works.csv
+  # Hand-exported from bib.cnrs.fr (CNRS credentials required); conversion is
+  # deterministic so it lives in the pipeline rather than as a pre-placed artifact.
+  catalog_bibcnrs:
+    cmd: uv run python scripts/catalog_bibcnrs.py
+    deps:
+      - scripts/catalog_bibcnrs.py
+      - scripts/utils.py
+      - data/exports
+    outs:
+      - data/catalogs/bibcnrs_works.csv
+
   # Phase 1a: Discovery + merge → unified_works.csv
   # Catalog scripts query APIs (ISTEX, OpenAlex, Semantic Scholar) and merge
   # all per-source CSVs into a single unified catalog. No filtering here.
@@ -34,8 +46,8 @@ stages:
       - config/openalex_queries.yaml
       - config/grey_sources.yaml
       - config/teaching_sources.yaml
-      # Hand-curated inputs (pre-placed, not produced by pipeline)
       - data/catalogs/bibcnrs_works.csv
+      # Hand-curated input (pre-placed, not produced by pipeline)
       - data/catalogs/scispsace_works.csv
     outs:
       - data/catalogs/istex_works.csv


### PR DESCRIPTION
## Summary

- Adds `catalog_bibcnrs` stage to `dvc.yaml`: deterministic RIS→CSV conversion belongs in the pipeline, not as a pre-placed artifact
- Removes `data/catalogs/bibcnrs_works.csv.dvc` (replaced by stage output)
- Tracks `data/exports/` via `dvc add` → `data/exports.dvc` (makes RIS files syncable to padme)
- Updates `.gitignore`: `data/exports/` entry removed (now managed by DVC)

DAG is coherent: `data/exports.dvc → catalog_bibcnrs → discover → enrich → extend → filter → align`

`scispsace_works.csv` remains a hand-placed dep of `discover` (no equivalent conversion script).

Closes #134.

## Test plan

- [x] `make check-fast`: 194 passed, 1 skipped
- [x] `dvc dag` shows correct dependency chain