### PR TITLE
Agent identity: commit and gh calls as HDMX-coding-agent (#109)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ Follow `runbooks/housekeeping.md` at each trigger point.
 - **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers.
 - **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees (scripts need it for data paths).
 - **Hooks** live in `hooks/`. After cloning: `git config core.hooksPath hooks`.
+- **Agent identity**: at the start of every agent session, load `.env` and apply the machine-user identity so commits and `gh` calls are attributed to the agent, not the human:
+  ```bash
+  set -a && source .env && set +a
+  git config user.name  "$AGENT_GIT_NAME"
+  git config user.email "$AGENT_GIT_EMAIL"
+  export GH_TOKEN="$AGENT_GH_TOKEN"
+  ```
+  The machine user is `HDMX-coding-agent` (GitHub account). The token is in `.env` as `AGENT_GH_TOKEN` (gitignored, machine-specific).
 - **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
 - **Merge commits** (`git merge --no-ff -m`): tactical-level detail — architecture decisions, cross-file impacts, residual debt. Readable via `git log --merges`.
 - **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`. In doubt, check older versions.


### PR DESCRIPTION
## Summary

- Documents agent identity convention in `AGENTS.md`: agents must load `.env` and apply `AGENT_GIT_NAME`/`AGENT_GIT_EMAIL`/`AGENT_GH_TOKEN` at session start
- Machine user `HDMX-coding-agent` created as GitHub collaborator (Write access)
- Classic PAT stored in `.env` (gitignored) — authenticates `gh` calls as the machine user
- Fine-grained PAT was tried first but doesn't support collaborator-owned repos as resource owner; classic PAT used instead

## Test plan

- [x] `GH_TOKEN=$AGENT_GH_TOKEN gh api user` returns `HDMX-coding-agent`
- [ ] After merging, agent commits show `HDMX-coding-agent` in `git log`
- [ ] `make check-fast` passes (no hooks broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)