### PR TITLE
docs: Dreaming on a branch — eager branching workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Interactive discussion with the user on an `explore-{topic}` branch. Imagine spe
 Generate portfolio of options with their probabilities. Go beyond conventional habits to explore new approaches. Take the high road.
 Act as my high-level advisor. Challenge my thinking, question my assumptions, and expose blind spots. Stop defaulting to agreement. If my reasoning is weak, break it down and show me why.
 
-Commits are optional workspace artifacts (notes, analysis, braindumps) — not production code. Deliverable: a shared vision, plus one of:
+Commits are workspace artifacts (notes, analysis, braindumps) unless the conversation produces a small fix (see below). Deliverable: a shared vision, plus one of:
 
 - **Tickets** — non-trivial work gets one ticket per action item, for future Doing conversations.
 - **Small fix** — if the fix fits in one red/green/refactor cycle and doesn't need a fresh context, do it on the explore branch. TDD still applies. Rationale goes in the commit message (why this change) and the PR description (the Dreaming context that led to it). If during the fix you realize it's bigger than expected, stop — open a ticket, start fresh.

--- a/runbooks/on-start.md
+++ b/runbooks/on-start.md
@@ -1,6 +1,6 @@
 # On start — conversation start trigger
 
-Run at the start of every conversation, before the first response.
+Runs after the user's first message, before the agent's first response.
 
 ## 1. Setup
 
@@ -35,8 +35,8 @@ then announce. **Never edit files while on main.**
 | Context | Phase | Branch |
 |---------|-------|--------|
 | Active feature branch + open PR | `[→ Doing]` | Checkout existing branch |
-| Ticket reference but no branch | `[→ Planning]` | Create `t{N}-short-description` |
-| Fresh conversation, no ticket | `[→ Dreaming]` | Create `explore-{topic}` from first user message |
+| Ticket reference but no branch | `[→ Planning]` | Stay on `explore-{topic}`; `start-ticket` creates the `t{N}` branch when Doing begins |
+| Fresh conversation, no ticket | `[→ Dreaming]` | Create `explore-{topic}` (name inferred from user's opening message) |
 
 If the conversation turns out to be a quick question with no file edits,
 the branch is harmless — delete it at session end if empty.


### PR DESCRIPTION
## Summary
- Rewrite `runbooks/on-start.md`: eager branch creation at conversation start, main is read-only (except STATE housekeeping)
- Update `AGENTS.md` Dreaming section: branch-first, three outcomes (tickets / small fix / nothing)
- Update conversation scope: Dreaming may produce zero or many tickets; Doing is still one-ticket
- Planning stays on explore branch; `start-ticket` creates the `t{N}` branch when Doing begins

Split from PR #386 (DMP) to keep concerns separate.

## Test plan
- [ ] Verify on-start.md and AGENTS.md are internally consistent
- [ ] Verify no collision between on-start branch creation and start-ticket branch creation
- [ ] Check that Dreaming/Planning/Doing phase descriptions are coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)