### PR TITLE
fix: Planning row in on-start creates explore branch

### DIFF
--- a/runbooks/on-start.md
+++ b/runbooks/on-start.md
@@ -26,7 +26,7 @@ blocks all commits on main, no exceptions.
 | Context | Phase | Branch |
 |---------|-------|--------|
 | Active feature branch + open PR | `[→ Doing]` | Checkout existing branch |
-| Ticket reference but no branch | `[→ Planning]` | Stay on `explore-{topic}`; `start-ticket` creates the `t{N}` branch when Doing begins |
+| Ticket reference but no branch | `[→ Planning]` | Create `explore-{topic}`; `start-ticket` creates the `t{N}` branch when Doing begins |
 | Fresh conversation, no ticket | `[→ Dreaming]` | Create `explore-{topic}` (name inferred from user's opening message) |
 
 If the conversation turns out to be a quick question with no file edits,


### PR DESCRIPTION
## Summary
- Planning may start in a fresh conversation with no prior Dreaming branch
- Changed "Stay on" to "Create" — same as Dreaming row
- `start-ticket` still creates the `t{N}` branch when Doing begins

One-word fix from review of PR #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)