### PR TITLE
dreaming: AGENTS.md size guard, roadmap sequencing, harness tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,19 @@ Submitted to Oeconomia (Varia) on 2026-03-18. Waiting for referee reports (~3 mo
 - [ ] Continue Tier 1 reading plan (defence against reviewer questions)
 - [ ] Companion methods paper (Scientometrics/QSS): parked for post-acceptance
 
+## Next milestone: Data paper
+
+Submit data paper to RDJ4HSS (diamond OA). Immediate priority.
+
+- [ ] Finalize and submit data paper (PDF ready at `output/content/data-paper.pdf`)
+
+## Then: Transfer to AEDIST
+
+Before this repo can serve the AEDIST project, the reusable harness must be split out.
+
+- [ ] Extract harness into standalone repo (#391)
+- [ ] Offline ticket system — good to have (PR #385)
+
 ## Post-submission improvements
 
 - [x] Split embeddings encoding (Phase 1) from UMAP+clustering (Phase 2) (#189)

--- a/STATE.md
+++ b/STATE.md
@@ -85,6 +85,6 @@ None.
 - #26: Human proofread of full manuscript
 - #158: Third paper (agentic workflow)
 - #223: Worktrees start without DVC data
-- #236–240: Harness extraction
+- #391: Harness extraction (prior art: PR #224)
 - #253: LLM audit on Padme
 - #262: Continuous relevance score

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -1,0 +1,38 @@
+"""AGENTS.md size guard.
+
+AGENTS.md is loaded into every Claude Code conversation via CLAUDE.md.
+Anthropic recommends keeping CLAUDE.md under 200 lines.
+
+When the harness is extracted (PR #224), this test travels with it.
+"""
+
+import os
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+AGENTS_MD = os.path.join(ROOT, "AGENTS.md")
+
+SMELL_THRESHOLD = 150  # lines — time to trim
+HARD_CEILING = 200  # Anthropic recommended limit
+
+
+def _line_count():
+    with open(AGENTS_MD) as f:
+        return len(f.readlines())
+
+
+def test_under_smell_threshold():
+    """AGENTS.md above the smell threshold — consider trimming."""
+    lines = _line_count()
+    assert lines <= SMELL_THRESHOLD, (
+        f"AGENTS.md is {lines} lines (smell threshold: {SMELL_THRESHOLD}). "
+        f"Consider extracting sections to docs/ or runbooks/."
+    )
+
+
+def test_under_hard_ceiling():
+    """AGENTS.md must stay under the hard ceiling (Anthropic limit)."""
+    lines = _line_count()
+    assert lines <= HARD_CEILING, (
+        f"AGENTS.md is {lines} lines — exceeds the {HARD_CEILING}-line ceiling. "
+        f"Claude Code truncates beyond this."
+    )


### PR DESCRIPTION
## Summary

- Add `tests/test_agents_md.py`: 150-line smell threshold, 200-line hard ceiling (Anthropic limit)
- ROADMAP: sequence data paper → AEDIST harness extraction → offline tickets
- STATE: fix phantom #236–240 → real #391
- GitHub annotations: created #391, commented on PR #224 and PR #385

## Context

Dreaming session exploring hooks (Claude Code, Git, GitHub, agentic harness) that led to harness extraction tracking cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)