### PR TITLE
fix: complete Makefile figure deps for technical report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,16 @@ COMPANION_FIGS  := content/figures/fig_breakpoints.png content/figures/fig_alluv
 
 TECHREP_FIGS    := content/figures/fig_alluvial_core.png \
                    content/figures/fig_bimodality_core.png \
-                   content/figures/fig_kde.png
+                   content/figures/fig_bimodality_lexical_core.png \
+                   content/figures/fig_bimodality_keywords_core.png \
+                   content/figures/fig_bimodality_lexical.png \
+                   content/figures/fig_bimodality_keywords.png \
+                   content/figures/fig_kde.png \
+                   content/figures/fig_traditions.png \
+                   content/figures/fig_communities.png \
+                   content/figures/fig_semantic.png \
+                   content/figures/fig_semantic_lang.png \
+                   content/figures/fig_semantic_period.png
 
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(COMPANION_FIGS) $(TECHREP_FIGS)
 
@@ -291,6 +300,8 @@ content/figures/fig_breaks.png: scripts/plot_fig2_breaks.py scripts/plot_style.p
 
 # Bimodality tests (co-produced)
 content/figures/fig_bimodality.png \
+content/figures/fig_bimodality_lexical.png \
+content/figures/fig_bimodality_keywords.png \
 content/tables/tab_bimodality.csv content/tables/tab_axis_detection.csv \
 content/tables/tab_pole_papers.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(REFINED)
@@ -334,10 +345,22 @@ content/figures/fig_alluvial_core.png: \
 
 # Bimodality core variant (co-produced)
 content/figures/fig_bimodality_core.png \
+content/figures/fig_bimodality_lexical_core.png \
+content/figures/fig_bimodality_keywords_core.png \
 content/tables/tab_bimodality_core.csv content/tables/tab_axis_detection_core.csv \
 content/tables/tab_pole_papers_core.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(REFINED)
 	uv run python $< --core-only --no-pdf
+
+# Pre-2007 co-citation traditions network
+content/figures/fig_traditions.png: scripts/plot_fig_traditions.py scripts/plot_style.py scripts/utils.py $(REFINED)
+	uv run python $<
+
+# Co-citation communities (network + community assignments)
+content/figures/fig_communities.png \
+content/tables/tab_community_summary.csv &: \
+		scripts/analyze_cocitation.py scripts/utils.py $(REFINED_CIT)
+	uv run python $<
 
 # KDE supplementary
 content/figures/fig_kde.png: scripts/plot_figS_kde.py scripts/plot_style.py scripts/utils.py \
@@ -389,7 +412,7 @@ output/content/manuscript.pdf: $(SRC) $(BIB) $(CSL) $(MANUSCRIPT_FIGS) $(PROJECT
 output/content/manuscript.docx: $(SRC) $(BIB) $(CSL) $(MANUSCRIPT_FIGS) $(PROJECT_INCLUDES) content/manuscript-vars.yml
 	quarto render $< --to docx
 
-output/content/technical-report.pdf: content/technical-report.qmd $(PROJECT_INCLUDES) $(BIB) $(STATS)
+output/content/technical-report.pdf: content/technical-report.qmd $(PROJECT_INCLUDES) $(BIB) $(STATS) $(TECHREP_FIGS) $(COMPANION_FIGS) lexical-figures
 	quarto render $< --to pdf
 
 output/content/data-paper.pdf: content/data-paper.qmd $(PROJECT_INCLUDES) $(BIB) $(STATS)

--- a/scripts/compute_vars.py
+++ b/scripts/compute_vars.py
@@ -211,7 +211,7 @@ def corpus_stats(v):
     # Raw (pre-filter) count from unified_works.csv
     unified_path = os.path.join(CATALOGS_DIR, "unified_works.csv")
     if os.path.isfile(unified_path):
-        unified_n = len(pd.read_csv(unified_path, usecols=["id"]))
+        unified_n = len(pd.read_csv(unified_path, usecols=["source"]))
         v["corpus_raw"] = _int(unified_n)
         v["corpus_removal_pct"] = _pct(100 * (unified_n - n) / unified_n)
 


### PR DESCRIPTION
## Summary
- `TECHREP_FIGS` was missing 8 of 23 figures referenced by the tech report
- Bimodality rules now declare all 3 co-produced figures (was only declaring 1)
- New rule for `fig_communities.png` via `analyze_cocitation.py`
- Tech report target now depends on `COMPANION_FIGS` + `lexical-figures` too
- Fix `compute_vars.py`: `unified_works.csv` has no `id` column, use `source`

## Test plan
- [x] `make -n output/content/technical-report.pdf` shows complete dependency chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)