### PR TITLE
docs: workflow improvements from Makefile idempotency session

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -17,6 +17,18 @@ Consult this file when writing or modifying Python scripts, pipeline steps, or b
 - House style: `docs/oeconomia-style.md` (eyeballed from 15-4 samples)
 - **Logging, not print.** All scripts MUST use `from utils import get_logger; log = get_logger("script_name")` — never bare `print()`. The `get_logger()` factory configures a shared `pipeline` root logger with `StreamHandler` (auto-flush to stderr, `HH:MM:SS LEVEL message` format). Use `log.info()` for progress, `log.warning()` for retries/rate-limits, `log.error()` for failures.
 
+## Makefile conventions
+
+- **One output per rule.** Each Make target should produce a known file so timestamps work.
+- **Sentinel stamps for dynamic outputs.** When a script produces filenames that depend on data (e.g., one figure per detected break year), Make can't declare them as static targets. Use a stamp file instead:
+  ```makefile
+  .my_target.stamp: scripts/my_script.py input.csv
+  	uv run python $< --no-pdf
+  	@touch $@
+  ```
+  Add `*.stamp` to `.gitignore`. The stamp sits at the repo root (not under `content/figures/` which is gitignored).
+- **No `.PHONY` for real work.** `.PHONY` targets always re-run — use them only for aliases (`figures`, `stats`, `clean`), never for recipes that produce files.
+
 ## Script hygiene
 
 - **No `sys.path` hacks.** Never `sys.path.insert(0, ...)`. Make scripts importable through proper packaging (`pyproject.toml`), not path manipulation in every file.

--- a/runbooks/on-start.md
+++ b/runbooks/on-start.md
@@ -22,6 +22,8 @@ Read `STATE.md` and `ROADMAP.md`.
 
 Infer the DD phase from context, create or checkout the working branch,
 then announce. The pre-commit hook blocks all commits on main, no exceptions.
+**Branch immediately** — even for "small" fixes. Don't start editing files
+on main and discover the hook at commit time.
 
 | Context | Phase | Branch |
 |---------|-------|--------|

--- a/runbooks/pre-commit.md
+++ b/runbooks/pre-commit.md
@@ -2,6 +2,19 @@
 
 Run before every commit.
 
+## DVC lock sanity
+
+If `dvc.lock` is staged, verify the recorded hashes exist in the local cache:
+```bash
+uv run dvc status --show-json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+bad = [s for s, v in d.items() if any('not in cache' in str(v) for _ in [v])]
+if bad: print(f'WARNING: dvc.lock references uncached outputs: {bad}'); sys.exit(1)
+"
+```
+If any stage shows "not in cache", the lock file contains phantom hashes — do not commit it. Run `dvc repro <stage>` or `dvc commit <stage>` first.
+
 ## Stale check
 
 Re-read any project file you modified or relied on. If it contains outdated numbers, stale status, or dead references, fix them in the same commit. The commit is the quality gate — nothing stale gets versioned.


### PR DESCRIPTION
## Summary
- **coding-guidelines.md**: document sentinel stamp pattern for dynamic Make outputs, warn against `.PHONY` for real work
- **pre-commit runbook**: add DVC lock sanity check to catch phantom hashes before they reach main
- **on-start runbook**: emphasize branching immediately, not after editing on main

## Context
All three came up during today's `make papers` idempotency fixes (PR #400 + `fix-makefile-idempotent`).

## Test plan
- [x] Documentation review — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)