### PR TITLE
fix: override PYTEST_ADDOPTS to unblock make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ check-manuscript-data:
 	$$ok || { echo "Run 'uv run dvc pull' to sync data, or 'make corpus' to rebuild."; exit 1; }
 
 corpus-validate: $(REFINED)
-	uv run pytest tests/test_corpus_acceptance.py -v -s --tb=long
+	PYTEST_ADDOPTS="" uv run pytest tests/test_corpus_acceptance.py -v -s --tb=long
 
 # ── Corpus reporting (Phase 2 — reads only refined data) ──
 content/tables/tab_citation_coverage.md: scripts/export_citation_coverage.py scripts/utils.py $(REFINED)
@@ -571,11 +571,11 @@ archive-datapaper: check-corpus
 
 # ── All checks (tests + lint) ────────────────────────────
 check: lint-prose
-	uv run pytest tests/ -v --tb=short
+	PYTEST_ADDOPTS="" uv run pytest tests/ -v --tb=short
 
 # Fast subset: unit tests only (no corpus data or network needed, < 30s).
 check-fast: lint-prose
-	uv run pytest tests/ -v --tb=short -m "not slow"
+	PYTEST_ADDOPTS="" uv run pytest tests/ -v --tb=short -m "not slow"
 
 # ── Prose linting (AI-tell detection) ─────────────────────
 lint-prose:


### PR DESCRIPTION
## Summary

- `make check` and `make check-fast` were broken on padme: `PYTEST_ADDOPTS=--cache-dir=...` injected by system env, but pytest 9.x has no `--cache-dir` flag
- Override `PYTEST_ADDOPTS=""` in all 3 Makefile pytest invocations
- Tests now run: 532 passed, 6 failed (pre-existing), 1 skipped

## Test plan

- [x] `make check` completes (was erroring before collection)
- [x] `make check-fast` completes
- [x] `make corpus-validate` completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)