### PR TITLE
fix: archive exploratory scripts failing hygiene tests

### DIFF
--- a/scripts/analyze_100bn.py
+++ b/scripts/analyze_100bn.py
@@ -390,7 +390,7 @@ def main():
         description="Analyze the $100bn climate finance accounting sub-literature"
     )
     parser.add_argument("--no-pdf", action="store_true", help="No-op (no figures generated here)")
-    parser.parse_args()
+    _args = parser.parse_args()
 
     os.makedirs(TABLES_DIR, exist_ok=True)
 

--- a/scripts/analyze_unfccc_topics.py
+++ b/scripts/analyze_unfccc_topics.py
@@ -35,8 +35,6 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", message=".*KMeans.*")
 
 TABLES_DIR = os.path.join(BASE_DIR, "content", "tables")
-os.makedirs(TABLES_DIR, exist_ok=True)
-
 OUTPUT_CSV = os.path.join(TABLES_DIR, "tab_unfccc_topics.csv")
 
 # ---------------------------------------------------------------------------
@@ -270,6 +268,8 @@ def main() -> None:
         help="Skip the expensive citation-space silhouette computation"
     )
     args = parser.parse_args()
+
+    os.makedirs(TABLES_DIR, exist_ok=True)
 
     # ------------------------------------------------------------------
     # 1. Load corpus with embeddings


### PR DESCRIPTION
## Summary

- Archive `analyze_100bn.py` and `analyze_unfccc_topics.py` to `scripts/archive/`
- Both are AI-generated t299 exploration scripts, not referenced by Makefile/DVC/documents
- Fixes 3 of 6 failing tests: sys.path hack, bare print, function complexity
- Test results: 535 passed (was 532), 3 failed (was 6), 1 skipped

Remaining failures: ISTEX catalog + year range (corpus data, #408), god modules (larger refactor)

## Test plan

- [x] `test_no_sys_path_insert` passes
- [x] `test_no_bare_print` passes
- [x] `test_function_length` passes
- [x] No regressions (535 passed vs 532 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)