### PR TITLE
docs: submission branch lifecycle runbook (#404)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ The agent must always know and declare its current DD phase.
 
 ## Git discipline
 
-- **Always work on a branch.** Branch naming: `t{N}-short-description` (Doing) or `explore-{topic}` (Dreaming). Main is read-only except for STATE housekeeping (see `runbooks/celebrate-day.md` step 7).
+- **Always work on a branch.** Branch naming: `t{N}-short-description` (Doing), `explore-{topic}` (Dreaming), or `submission/{journal}-{document}` (long-lived submission tracking, see `runbooks/submission-branch.md`). Main is read-only except for STATE housekeeping (see `runbooks/celebrate-day.md` step 7).
 - **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers.
 - **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees (scripts need it for data paths).
 - **Git hooks** live in `hooks/`. After cloning: `make setup`. Agents: set automatically by `on-start` trigger.

--- a/runbooks/submission-branch.md
+++ b/runbooks/submission-branch.md
@@ -19,17 +19,15 @@ relevant to the paper under review.
 
 ### 1. Sprout
 
-When ready to submit:
+**Gate**: run `runbooks/submission-readiness.md` checklist before proceeding.
+
+#### Create the branch
 
 ```bash
 git checkout -b submission/{journal}-{document} main
 ```
 
-Verify the paper builds cleanly:
-
-```bash
-make output/content/{document}.pdf
-```
+Verify the paper builds cleanly (use the actual target, e.g., `make output/content/manuscript.pdf`).
 
 Tag the submission point:
 
@@ -54,7 +52,14 @@ git push -u origin submission/{journal}-{document}
 
 ### 2. Freeze
 
-The submission branch is now frozen. No changes except:
+The submission branch is now frozen. What was frozen:
+
+- **Git tag** marks the exact submission commit
+- **Pinned vars** in `content/{document}-vars.yml` (counts, percentages cited in prose)
+- **Reference data** in `config/` (cluster labels, identifier lists, alluvial tables)
+- **Reproducibility archives** on Zenodo (code + data tarballs, tested on two machines)
+
+No changes on this branch except:
 
 - Errata (errors discovered after submission)
 - Reviewer responses
@@ -98,7 +103,7 @@ git checkout submission/{journal}-{document}
 
 After addressing all reviewer points:
 
-1. Rebuild the paper: `make output/content/{document}.pdf`
+1. Rebuild the paper (e.g., `make output/content/manuscript.pdf`)
 2. Prepare a diff/track-changes document if required
 3. Add resubmission artifacts to `release/`
 4. Commit: `release: resubmit {document} to {journal} (revision 1)`
@@ -129,24 +134,7 @@ If rejected:
    current one) or abandon (leave the branch as historical record)
 3. Cherry-pick any improvements worth keeping back to main
 
-## Catching up an existing submission
+## Apply tickets
 
-If a submission was made before this workflow existed (e.g., Oeconomia):
-
-```bash
-# Create the submission branch from the submission tag
-git checkout -b submission/oeconomia-manuscript v1.0-submission
-# Cherry-pick errata and post-submission fixes
-git cherry-pick <errata-commits>
-git push -u origin submission/oeconomia-manuscript
-```
-
-## Starting right (for data paper)
-
-Before submitting the data paper to RDJ4HSS:
-
-1. Ensure all data paper dependencies build cleanly on main
-2. Sprout: `git checkout -b submission/rdj-data-paper main`
-3. Freeze immediately after adding submission artifacts
-4. Main continues with corpus improvements — cherry-pick to the
-   submission branch only if they affect the data paper's claims
+- **Oeconomia catch-up**: #376 (create branch from `v1.0-submission`, cherry-pick errata)
+- **Data paper branch**: #421 (sprout `submission/rdj-data-paper` when ready)

--- a/runbooks/submission-readiness.md
+++ b/runbooks/submission-readiness.md
@@ -1,0 +1,39 @@
+# Submission readiness — pre-sprout gate
+
+Run this checklist before creating a submission branch (`runbooks/submission-branch.md`).
+Every item must pass. If one fails, fix it before sprouting.
+
+## Build
+
+- [ ] Paper builds cleanly: e.g., `make output/content/manuscript.pdf`
+- [ ] Full test suite passes: `make check`
+- [ ] No warnings or missing references in the build log
+
+## Data freeze
+
+- [ ] Computed variables pinned in `content/{document}-vars.yml`
+- [ ] Reference data snapshots saved in `config/` (e.g., `config/v1_*` files)
+- [ ] Manuscript decoupled from live corpus — re-running `dvc repro` does not change the paper
+- [ ] Provenance column links current corpus rows to the frozen version
+
+## Reproducibility
+
+- [ ] Reproducibility archive(s) built (code tarball + data tarball)
+- [ ] Archive tested on a second machine — builds from scratch, produces identical output
+- [ ] Zenodo deposit created (or deposit plan documented with target DOI)
+- [ ] HAL deposit created (or planned)
+
+## Submission artifacts
+
+- [ ] Cover letter in `release/`
+- [ ] AI disclosure statement in `release/`
+- [ ] Journal-specific files prepared (anonymized PDF, figures at required resolution, metadata)
+- [ ] `release/release-journal.md` entry drafted
+
+## Prior art
+
+The v1.0 Oeconomia submission established this pattern:
+- Frozen `config/v1_cluster_labels.json`, `config/v1_tab_alluvial.csv`, `config/v1_identifiers.txt.gz`
+- Pinned `content/manuscript-vars.yml`
+- Zenodo tarballs (analysis 56 MB + manuscript 683 KB), tested on two independent machines
+- `release/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF


### PR DESCRIPTION
## Summary

- `runbooks/submission-branch.md`: lifecycle workflow for long-running submission branches
  - Sprout → freeze → errata → revision → resubmission → acceptance/rejection
  - Branch naming: `submission/{journal}-{document}`
  - Cherry-pick from main (not merge) to avoid pulling unrelated changes
  - Pre-sprout gate references `runbooks/submission-readiness.md`
  - Freeze section specifies what gets frozen (tag, pinned vars, config/ data, Zenodo archives)
- `runbooks/submission-readiness.md`: pre-sprout checklist (build, data freeze, reproducibility, artifacts)
- `AGENTS.md`: added `submission/` branch naming to Git discipline section
- Apply tasks split to #376 (Oeconomia catch-up) and #421 (data paper branch)

Addresses #404.

## Test plan

- [x] Runbook covers all lifecycle phases
- [x] Readiness checklist codifies the v1.0 pattern
- [x] Apply tasks tracked in dedicated tickets