### PR TITLE
Create bin/log-celebration for session telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ output/
 *~
 *.swp
 
+# Local telemetry
+docs/local-ai/celebrations.jsonl
+
 # Claude Code config
 .claude/
 

--- a/bin/log-celebration
+++ b/bin/log-celebration
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Append a celebration record to docs/local-ai/celebrations.jsonl
+# Usage: bin/log-celebration '{"project":"oeconomia","session_type":"task",...}'
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+LOG_FILE="$REPO_ROOT/docs/local-ai/celebrations.jsonl"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 '<json>'" >&2
+    exit 1
+fi
+
+json="$1"
+
+# Validate JSON
+if ! echo "$json" | python3 -m json.tool > /dev/null 2>&1; then
+    echo "Error: invalid JSON" >&2
+    exit 1
+fi
+
+# Add timestamp and write
+record=$(echo "$json" | python3 -c "
+import json, sys
+from datetime import datetime, timezone
+obj = json.load(sys.stdin)
+obj['timestamp'] = datetime.now(timezone.utc).isoformat()
+print(json.dumps(obj, ensure_ascii=False))
+")
+
+echo "$record" >> "$LOG_FILE"
+echo "Logged to $LOG_FILE"

--- a/runbooks/celebrate-day.md
+++ b/runbooks/celebrate-day.md
@@ -30,7 +30,7 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
 8. **Memory sweep** — follow `runbooks/memory.md` (includes runbook cross-reference).
 9. **Log celebration** — record structured session metrics:
     ```bash
-    ~/CNRS/code/agentic-harness/telemetry/bin/log-celebration '{"project":"oeconomia","session_type":"day","commits":N,"prs_merged":N,"memories_saved":N,"deliverables":[...],"feedback_memories":[...],"surprises":[...],"next":[...]}'
+    bin/log-celebration '{"project":"oeconomia","session_type":"day","commits":N,"prs_merged":N,"memories_saved":N,"deliverables":[...],"feedback_memories":[...],"surprises":[...],"next":[...]}'
     ```
 10. **Autonomous session** — if the user wants to launch an autonomous session,
     hand off to `runbooks/autonomous-session.md`. The end-of-day celebration is the

--- a/runbooks/celebrate.md
+++ b/runbooks/celebrate.md
@@ -34,7 +34,7 @@ Run this sequence after completing a task. Do not skip steps.
     - `gh pr list` → no stale PRs from merged/superseded branches
 12. **Log celebration** — record structured session metrics:
     ```bash
-    ~/CNRS/code/agentic-harness/telemetry/bin/log-celebration '{"project":"oeconomia","session_type":"task","commits":N,"prs_merged":N,"deliverables":[...],"surprises":[...],"next":[...]}'
+    bin/log-celebration '{"project":"oeconomia","session_type":"task","commits":N,"prs_merged":N,"deliverables":[...],"surprises":[...],"next":[...]}'
     ```
 13. **Offer** to work on AGENTS.md if the workflow can be improved.
 


### PR DESCRIPTION
## Summary

- Created `bin/log-celebration` — appends timestamped JSON lines to `docs/local-ai/celebrations.jsonl`
- Replaced broken path (`~/CNRS/code/agentic-harness/telemetry/bin/log-celebration`) in both `runbooks/celebrate.md` and `runbooks/celebrate-day.md`
- Added `celebrations.jsonl` to `.gitignore` (local telemetry, not project content)

## Test plan

- [x] `bin/log-celebration '{"project":"oeconomia","session_type":"task","commits":1}'` succeeds
- [ ] Invalid JSON is rejected
- [ ] Verify runbooks reference `bin/log-celebration` not old path

🤖 Generated with [Claude Code](https://claude.com/claude-code)