### PR TITLE
security: pin litellm<=1.82.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pytest-timeout",
     "requests-mock",
     "python-dotenv>=1.2.2",
-    "litellm>=1.30.0",
+    "litellm>=1.30.0,<=1.82.6",
     "rich>=13.0",
 ]
 
@@ -54,6 +54,7 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests that require network access or external data (deselect with '-m \"not slow\"')",
+    "integration: marks tests that spawn subprocesses or use sleep-based timing (deselect with '-m \"not integration\"')",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Pin litellm upper bound to <=1.82.6 to block compromised versions 1.82.7–1.82.8
- TeamPCP supply chain attack via Trivy CI compromise (2026-03-24)
- PyPI quarantined the malicious releases; this pin is a belt-and-suspenders safeguard

## Action needed
Relax the cap once upstream publishes a verified clean release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)