### PR TITLE
feat: make corpus auto-commits dvc.lock (#458)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,30 @@ all: manuscript papers
 #   make figures && make manuscript  # Phase 2 + 3 (no DVC needed)
 
 # Full pipeline — run on padme only (GPU, API access).
+# After dvc repro + push, auto-commits dvc.lock if it's the only change.
 corpus:
 	@[ "$$(hostname)" = "padme" ] || { echo "error: make corpus runs on padme only. Use 'make corpus-sync' on $$(hostname)."; exit 1; }
 	@uv run dvc version >/dev/null 2>&1 || { echo "error: dvc not found. Install with: uv tool install 'dvc[ssh]'"; exit 1; }
 	uv run dvc repro; ret=$$?; uv run dvc push; \
-	echo ""; echo "DVC lock and pool files staged, ready to commit."; \
-	exit $$ret
+	if [ $$ret -ne 0 ]; then exit $$ret; fi; \
+	changed=$$(git diff --name-only); \
+	if [ -z "$$changed" ]; then \
+		echo "dvc.lock unchanged, nothing to commit."; \
+	elif [ "$$changed" = "dvc.lock" ]; then \
+		echo "Auto-committing dvc.lock..."; \
+		branch="housekeeping-dvclock-$$(date +%Y%m%d-%H%M%S)"; \
+		git checkout -b "$$branch" && \
+		git add dvc.lock && \
+		git commit -m "data: update dvc.lock after pipeline re-run" && \
+		git checkout main && \
+		git merge --no-ff -m "Merge $$branch: DVC lock update" "$$branch" && \
+		git branch -d "$$branch" && \
+		git push origin main && \
+		echo "dvc.lock committed and pushed."; \
+	else \
+		echo ""; echo "WARNING: files other than dvc.lock changed:"; echo "$$changed"; \
+		echo "Stage and commit manually."; \
+	fi
 
 # Sync data from padme — run on doudou (never pushes).
 corpus-sync:


### PR DESCRIPTION
## Summary
- After `dvc repro` + `dvc push`, auto-commits `dvc.lock` if it's the only changed file
- Creates housekeeping branch → merge → delete → push (same pattern as manual)
- Guards: warns if other files changed, skips if nothing changed

## Test plan
- [x] `make check-fast` passes (549 tests)
- [ ] Run `make corpus` on padme — verify auto-commit works

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)