### PR TITLE
housekeeping: remove stale GitHub mirrors from STATE.md, decouple from gh

### DIFF
--- a/.agent/runbooks/celebrate.md
+++ b/.agent/runbooks/celebrate.md
@@ -5,7 +5,7 @@ Run this sequence after completing a task. Do not skip steps.
 ## `[Doing → Celebrating]`
 
 1. **Reflect**: what worked, what didn't, what was surprising.
-2. **Update STATE.md**: refresh stats, remove resolved blockers.
+2. **Update STATE.md**: refresh stats, remove resolved blockers. Do not maintain PR/issue lists — the ticket system is the source of truth.
 3. **Update ROADMAP.md**: check off completed items, note new ones that emerged.
 4. **Update technical-report.qmd** if pipeline, data contract, or methodology changed.
 5. **Save persistent memory** (`$CLAUDE_MEMORY_DIR/MEMORY.md` or equivalent): save durable lessons from this task. No sweep here — sweeps happen at session end (`.agent/runbooks/celebrate-day.md`).
@@ -13,35 +13,24 @@ Run this sequence after completing a task. Do not skip steps.
 
 ## Close and clean up
 
-7. **Merge to main**: `git checkout main && git merge --no-ff -m "..." <branch>`.
+7. **Merge to main**: feature work goes through a PR in the ticket system. Chores (dvc.lock, housekeeping) merge locally via short-lived branch + fast-forward.
 8. **Push** and **clean up**: delete local and remote branch.
-9. **Close** the GitHub issue if one exists.
-10. **Check for tracking issue** (integration review): if the closed issue has a parent, check whether all sibling sub-issues are now closed:
-    ```bash
-    gh issue view <PARENT> --json subIssues
-    ```
-    - If any sibling is still open: do nothing — tracking issue stays open.
-    - If all siblings are now closed, run integration review on the tracking issue:
+9. **Close** the ticket if still open.
+10. **Check for tracking ticket** (integration review): if the closed ticket has a parent, check whether all sibling sub-tickets are now closed
+    - If any sibling is still open: do nothing — tracker stays open.
+    - If all siblings are now closed, run integration review on the tracking ticket:
       1. Re-read all child PR diffs: for each child, find the PR with `gh pr list --search "closes:#<child>"`, then read it with `gh pr diff <PR#>`.
       2. Run tests: `make check`
-      3. Check the tracking issue's exit criteria — are they all met?
-      4. If gaps remain: open new sub-issues on the tracking issue, leave it open.
-      5. If all criteria met: close the tracking issue with a summary comment.
+      3. Check the tracking ticket's exit criteria — are they all met?
+      4. If gaps remain: open new sub-tickets on the tracking ticket, leave it open.
+      5. If all criteria met: close the tracking ticket with a summary comment.
 11. **Verify hygiene** — no stale artifacts left behind:
     - `git worktree list` → only main (or active work)
     - `git branch -a` → no stale remote branches from merged PRs
-    - `gh issue list` → no orphan issues from completed work
+    - No orphan tickets from completed work
     - `gh pr list` → no stale PRs from merged/superseded branches
 12. **Log celebration** — record structured session metrics (skip if harness not installed):
     ```bash
-    ~/.agent/bin/log-celebration '{"project":"oeconomia","session_type":"task","commits":N,"prs_merged":N,"deliverables":[...],"surprises":[...],"next":[...]}'
+    ~/.agent/log/log-celebration '{"project":"oeconomia","session_type":"task","commits":N,"prs_merged":N,"deliverables":[...],"surprises":[...],"next":[...]}'
     ```
 13. **Offer** to work on AGENTS.md if the workflow can be improved.
-
-## Merge message format
-
-```
-Merge <branch>: <one-line summary>
-
-<Tactical detail: architecture decisions, cross-file impacts, residual debt.>
-```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ The agent must always know and declare its current DD phase.
 - **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees (scripts need it for data paths).
 - **Git hooks** live in `hooks/`. After cloning: `make setup`. Agents: set automatically by `on-start` trigger.
 - **Agent identity**: set at conversation start by the `on-start` trigger. The machine user is `HDMX-coding-agent` (GitHub account). Credentials (`AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`) are project-specific secrets, deployed per-machine in `.env` (gitignored).
-- **One change per commit.** Message explains *why this change and not another*: tactical-level details: alternatives considered, local design choices made.
-- **Merge commits** (`git merge --no-ff -m`): strategic-level detail — architecture decisions, cross-file impacts, residual debt. Readable via `git log --merges`.
+- **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
+- **Merge commits**: strategic-level detail — architecture decisions, cross-file impacts, residual debt. Readable via `git log --merges`. Feature merges go through PRs; chores (dvc.lock, housekeeping) merge locally via short-lived branch + fast-forward.
 - **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`. In doubt, check older versions.
 - **Use worktrees** for feature branches — work in isolated copies via `git worktree`, not `git stash`/`git checkout`.
 - **Create PR** for each ticket to review changes before merging.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ Before this repo can serve the AEDIST project, the reusable harness must be spli
 - Œconomia house style, AI-tell sweep, code audit, PDF+ODT build clean
 - Doc restructuring: separated concerns (AGENTS → workflow only, domain guidance → docs/), added Dragon Dreaming + TDD + git hooks
 - Agent-agnostic skills: .agent/runbooks/, make check, AGENTS.md works with any AI assistant
+- Harness consolidation (#457): `docs/` guidelines + `runbooks/` → `.agent/guidelines/` + `.agent/runbooks/`
 - Agent identity (#109): machine user `HDMX-coding-agent`, classic PAT in `.env`, convention documented in AGENTS.md
 - DVC integration (#101–#104, #109): data versioning, pipeline DAG, repro archives, external cache, bidirectional sync
 - Source normalized to 1NF (#113): pipe-separated source → boolean from_* columns

--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-Last updated: 2026-03-25
+Last updated: 2026-03-26
 
 ## Status: SUBMITTED + ERRATA 1
 
@@ -49,37 +49,9 @@ Submitted to Oeconomia (Varia) on 2026-03-18. Under double-blind review.
 
 None.
 
-## Active PRs
-
-- #385: docs: landscape analysis of distributed issue trackers (#237)
-- #453: ✅ merged — fix from_scispace flag never set (#452): source name derived from filename, not CSV content
-
-## Recent (2026-03-25)
-
-- #447: ✅ merged — security: pin litellm<=1.82.6 (supply chain attack)
-- #450: ✅ merged — variabilize hardcoded filter counts in data paper
-- #449: ✅ closed — embedding/filter mismatch resolved by corpus regen
-- Branch cleanup: 12 stale remote branches deleted
-- Test suite: 637 tests (547 unit, 90 integration/slow). `check-fast` runs unit tests in ~21 s, `check` runs all.
-
 ## Next actions
 
 - Data paper submission (RDJ4HSS) — PDF ready; needs re-render after SciSpace fix (#452)
 - Send Errata 1 to Oeconomia editor
 - Finalize DMP on OPIDoR (after v1.1 counts stabilize)
 - ESHET-HES conference slides (Nice, May 26–29)
-- Harness consolidation: move agentic-harness → ~/.agent/, reorganize project .agent/
-
-## Open tickets (publication path)
-
-- #421: Create data paper submission branch (submission/rdj-data-paper)
-- #403: Make targets for reproducibility archive and archival datasets
-- #404: Document long-running submission branch workflow
-
-## Open tickets (tooling)
-
-- #376: Setup: rename repo, create oeconomia release branch
-- #391: Extract harness into standalone repo
-- #405: Makefile modularity: include modules instead of duplicating for archives
-- #428: Normalize enrichment tables (join stage instead of in-place mutation)
-- #288: Add progress bars, ETA, stuck detection, and desktop notifications to pipeline scripts


### PR DESCRIPTION
STATE.md had Active PRs, Recent, and Open tickets sections that duplicated GitHub and went stale after every merge. Removed them — the ticket system is the source of truth. Also updated celebrate runbook and AGENTS.md to reflect: feature merges via PRs, chores via local fast-forward.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>