### PR TITLE
fix: harden make corpus auto-commit (#458 review)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,19 +145,20 @@ all: manuscript papers
 corpus:
 	@[ "$$(hostname)" = "padme" ] || { echo "error: make corpus runs on padme only. Use 'make corpus-sync' on $$(hostname)."; exit 1; }
 	@uv run dvc version >/dev/null 2>&1 || { echo "error: dvc not found. Install with: uv tool install 'dvc[ssh]'"; exit 1; }
+	@[ "$$(git rev-parse --abbrev-ref HEAD)" = "main" ] || { echo "error: make corpus must run on main (currently on $$(git rev-parse --abbrev-ref HEAD))."; exit 1; }
 	uv run dvc repro; ret=$$?; uv run dvc push; \
 	if [ $$ret -ne 0 ]; then exit $$ret; fi; \
-	changed=$$(git diff --name-only); \
+	changed=$$(git status --porcelain); \
 	if [ -z "$$changed" ]; then \
 		echo "dvc.lock unchanged, nothing to commit."; \
-	elif [ "$$changed" = "dvc.lock" ]; then \
+	elif [ "$$(echo "$$changed" | sed 's/^...//')" = "dvc.lock" ]; then \
 		echo "Auto-committing dvc.lock..."; \
 		branch="housekeeping-dvclock-$$(date +%Y%m%d-%H%M%S)"; \
 		git checkout -b "$$branch" && \
 		git add dvc.lock && \
 		git commit -m "data: update dvc.lock after pipeline re-run" && \
 		git checkout main && \
-		git merge --no-ff -m "Merge $$branch: DVC lock update" "$$branch" && \
+		git merge "$$branch" && \
 		git branch -d "$$branch" && \
 		git push origin main && \
 		echo "dvc.lock committed and pushed."; \

--- a/README.md
+++ b/README.md
@@ -108,10 +108,8 @@ Example paths: `/home/user/data/projets/Oeconomia-Climate-finance/dvc-cache` (do
 fast network to APIs). Doudou only pulls data — never pushes.
 
 ```bash
-# On padme — run the corpus pipeline and push:
-make corpus                              # runs dvc repro (slow, API calls)
-uv run dvc push                          # upload results to shared store
-git add dvc.lock && git commit -m "data: update dvc.lock" && git push
+# On padme — run the corpus pipeline (auto-pushes data, auto-commits dvc.lock):
+make corpus
 
 # On doudou — sync and use:
 git pull                                 # get updated .dvc pointers


### PR DESCRIPTION
## Summary
- Branch guard: `make corpus` refuses to run unless on `main`
- `git status --porcelain` catches staged + unstaged changes (was `git diff --name-only`)
- Fast-forward merge instead of `--no-ff` — no commit on main, no hook bypass needed
- README: padme workflow simplified to single `make corpus`

Follow-up to #459 (merged without review fixes).

## Test plan
- [x] `make check-fast` passes (549 tests)
- [ ] Run `make corpus` on padme — verify auto-commit works

🤖 Generated with [Claude Code](https://claude.com/claude-code)