### PR TITLE
fix: stale Zenodo DOI in data paper §3

### DIFF
--- a/content/data-paper.qmd
+++ b/content/data-paper.qmd
@@ -97,7 +97,7 @@ Users should be aware of several potential biases. The literature on climate fin
 
 ## 3. Data {#sec-data}
 
-- Climate finance corpus --- DOI: [10.5281/zenodo.19097045](https://doi.org/10.5281/zenodo.19097045)
+- Climate finance corpus --- DOI: [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130)
 - Temporal coverage: 1990--2024
 
 The Zenodo deposit is a reproducibility archive in two parts: the pipeline source code (scripts, configuration, and DVC definitions) and the v1.1 corpus data files described below. All CSV files use UTF-8 encoding with standard comma-separated format; identifiers are opaque string keys.


### PR DESCRIPTION
## Summary
- Line 100 of data-paper.qmd pointed to the Oeconomia deposit (19097045) instead of the data paper deposit (19236130)
- Lines 37 and 129 were already correct — this was the only stale reference

## Test plan
- [x] `grep -n zenodo content/data-paper.qmd` shows consistent DOI

🤖 Generated with [Claude Code](https://claude.com/claude-code)