### PR TITLE
fix: stale title + DOI in checklist/cover letter + Makefile.datapaper rewrite

### DIFF
--- a/Makefile.datapaper
+++ b/Makefile.datapaper
@@ -1,62 +1,38 @@
 # Data paper reproducibility — Climate Finance Corpus
 #
-# Two verification levels:
-#   Level 1 (fast, offline): verify pre-built outputs against checksums
-#   Level 2 (slow, online):  rebuild corpus from APIs and compare
+# Three targets:
+#   make verify  — verify shipped data against checksums (fast, offline)
+#   make papers  — render the data paper PDF from frozen vars + figures
+#   make corpus  — rebuild the corpus incrementally (uses caches, needs internet)
 #
-# Prerequisites: Python >= 3.10, uv
-# Usage:
-#   make verify-quick    # Level 1: checksums only (~1 min)
-#   make verify-rebuild  # Level 2: full rebuild + compare (~4-6 hours, needs internet)
+# Prerequisites: Python >= 3.10, uv, quarto
 
-export PYTHONHASHSEED := 0
-export SOURCE_DATE_EPOCH := 0
-
-DATA := data/catalogs
-
-.DEFAULT_GOAL := verify-quick
-.PHONY: verify-quick verify-rebuild corpus stats help
+.DEFAULT_GOAL := help
+.PHONY: help verify papers corpus
 
 help:
 	@echo "Targets:"
-	@echo "  verify-quick    Check pre-built outputs against checksums (fast, offline)"
-	@echo "  verify-rebuild  Rebuild corpus from APIs and compare (slow, needs internet)"
-	@echo "  corpus          Run full corpus building pipeline"
-	@echo "  stats           Regenerate computed statistics"
+	@echo "  make verify  Verify shipped data checksums (fast, offline)"
+	@echo "  make papers  Render data-paper.pdf from frozen vars + figures"
+	@echo "  make corpus  Rebuild corpus incrementally (slow, needs internet)"
 
-# ── Level 1: checksum verification (fast, offline) ────────
-# Verifies that the shipped data files are bitwise identical to the
-# author's outputs. No Python, no network, no API keys needed.
-verify-quick:
-	@echo "=== Level 1: Verifying shipped outputs against checksums ==="
-	md5sum -c checksums-data.md5
-	@echo "=== Level 1: PASS — all checksums match ==="
+# ── verify: check data checksums ─────────────────────────
+verify:
+	@echo "=== Verifying data checksums ==="
+	cd ../data && md5sum -c ../code/checksums-data.md5
+	@echo "=== PASS ==="
 
-# ── Level 2: full rebuild and comparison (slow) ───────────
-# Rebuilds the corpus from source APIs and compares row counts and
-# key statistics against the shipped reference. Exact byte-identity
-# is NOT expected because:
-#   - API responses may include new publications added since the harvest date
-#   - Crossref metadata updates continuously
-#   - OpenAlex citation counts change daily
-# Instead, we verify structural equivalence: schema, row-count tolerance,
-# and statistical similarity.
-verify-rebuild: corpus
-	@echo "=== Level 2: Comparing rebuilt corpus against reference ==="
-	uv run python verify_corpus.py
-	@echo "=== Level 2: DONE — see comparison report above ==="
+# ── papers: render the data paper only ───────────────────
+papers: output/content/data-paper.pdf
+	@echo "=== Data paper rendered ==="
 
-# ── Corpus building ───────────────────────────────────────
+output/content/data-paper.pdf: content/data-paper.qmd content/data-paper-vars.yml \
+                               content/bibliography/main.bib
+	quarto render $< --to pdf
+
+# ── corpus: incremental rebuild via DVC ──────────────────
 corpus:
-	@echo "=== Building corpus from source APIs ==="
-	@echo "WARNING: This takes 4-6 hours and requires internet access."
-	@echo "API keys: set OPENALEX_PREMIUM_KEY in .env for faster OpenAlex harvest."
-	@echo ""
+	@echo "=== Rebuilding corpus (incremental, uses caches) ==="
 	uv sync --group corpus --extra cpu
-	uv run make -f Makefile corpus
-	@echo "=== Corpus build complete ==="
-
-# ── Statistics ────────────────────────────────────────────
-stats:
-	uv run python scripts/compute_vars.py
-	uv run python scripts/export_corpus_table.py
+	uv run dvc repro
+	@echo "=== Corpus rebuild complete ==="

--- a/release/cover-letter-rdj.txt
+++ b/release/cover-letter-rdj.txt
@@ -1,6 +1,6 @@
 **To:** Editors, Research Data Journal for the Humanities and Social Sciences
 **From:** Minh Ha-Duong, CIRED/CNRS
-**Re:** Data paper submission — "A Curated Corpus of Climate Finance Literature, 1990–2024: Six Sources, Eight Languages"
+**Re:** Data paper submission — "A Curated Corpus of Climate Finance Literature, 1990–2024: Six Sources, Multilingual Retrieval, and Grey Literature"
 
 Dear Editors,
 
@@ -10,7 +10,7 @@ I am pleased to submit a data paper describing a multilingual bibliometric corpu
 
 **Why this dataset matters for HSS.** Climate finance is a contested category at the intersection of economics, political science, development studies, and environmental governance. Existing bibliometric studies of this literature rely on single databases, cover English only, and do not publish reusable datasets. Our corpus addresses these limitations by combining academic and institutional sources, including the grey literature that has shaped the very categories of the debate. The multilingual design — targeting French, Chinese, Japanese, and German alongside English — supports cross-linguistic studies that monolingual corpora cannot.
 
-**Data deposit.** The dataset is deposited in Zenodo at https://doi.org/10.5281/zenodo.19097045 under CC BY 4.0. All pipeline scripts are publicly available.
+**Data deposit.** The dataset is deposited in Zenodo at https://doi.org/10.5281/zenodo.19236130 under CC BY 4.0. All pipeline scripts are publicly available.
 
 **Companion study.** The corpus was constructed to support a history-of-economic-thought study of how climate finance crystallised as a category of economic governance. That companion paper is currently under review at Œconomia. The data paper stands independently: it describes the dataset's construction, validation, and reuse potential without depending on the companion study's analytical conclusions.
 

--- a/release/rdj-submission-checklist.md
+++ b/release/rdj-submission-checklist.md
@@ -1,7 +1,7 @@
 # RDJ4HSS Submission Checklist
 
 ## Manuscript
-- [x] Title: "A Curated Corpus of Climate Finance Literature, 1990–2024: Six Sources, Eight Languages"
+- [x] Title: "A Curated Corpus of Climate Finance Literature, 1990–2024: Six Sources, Multilingual Retrieval, and Grey Literature"
 - [x] Sections follow RDJ4HSS structure: Abstract, Keywords, Related dataset, 1. Introduction, 2. Method (2.1 Sources, 2.2 Data Structure, 2.3 Quality/Biases), 3. Data, 4. Concluding Remarks, Acknowledgements, References
 - [ ] Word count ≤ 2,500 (body sections 1–4) — verify after final edits
 - [x] Author-date citations (APA-like)
@@ -11,7 +11,7 @@
 - [x] Table included (tab_corpus_sources.md)
 
 ## Data deposit
-- [x] Zenodo DOI: 10.5281/zenodo.19097045
+- [x] Zenodo DOI: 10.5281/zenodo.19236130
 - [ ] Update Zenodo deposit with v1.1 data files
 - [x] CC BY 4.0 license
 - [x] Suggested citation in paper


### PR DESCRIPTION
## Summary
- Fix stale title "Eight Languages" → "Multilingual Retrieval, and Grey Literature" in checklist + cover letter
- Fix stale Zenodo DOI 19097045 → 19236130 in checklist + cover letter
- Rewrite Makefile.datapaper: 3 targets (verify, papers, corpus), consistent naming with siblings

## Test plan
- [x] `grep -n "Eight Languages" release/` returns nothing
- [x] `grep -n 19097045 release/rdj-submission-checklist.md release/cover-letter-rdj.txt` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)