### PR TITLE
fix: missing import sys in prepare_deposit.py

### DIFF
--- a/scripts/prepare_deposit.py
+++ b/scripts/prepare_deposit.py
@@ -13,6 +13,7 @@ Usage:
 
 import argparse
 import os
+import sys
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- `sys.exit(1)` on line 118 called without `import sys` — would crash with NameError on validation failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)