### PR TITLE
fix: Zenodo README — 2 archives → 1

### DIFF
--- a/release/2026-03-26 Zenodo/README.md
+++ b/release/2026-03-26 Zenodo/README.md
@@ -5,12 +5,14 @@
 - Git tag: v1.1-rdj-submitted (to be created at freeze)
 - Submission branch: submission/rdj-data-paper (to be sprouted from tag)
 
-### Archives
+### Archive
 
-1. **climate-finance-corpus.tar.gz** — v1.1 corpus data files:
-   climate_finance_corpus.csv, embeddings.npz, citations.csv,
-   per-source catalogs, config files.
+Single archive: **climate-finance-datapaper.tar.gz**
 
-2. **climate-finance-pipeline.tar.gz** — reproducibility archive:
-   scripts/, dvc.yaml, dvc.lock, pyproject.toml, config/,
-   content/data-paper.qmd, bibliography/.
+Built by `make archive-datapaper`. Contains:
+
+- `code/` — full pipeline source (git archive of HEAD), plus pre-built
+  figures and tables for rendering. Includes `Makefile.datapaper` with
+  three targets: `make verify`, `make papers`, `make corpus`.
+- `data/` — v1.1 deposit files: climate_finance_corpus.csv (abstracts
+  stripped), embeddings.npz, citations.csv, per-source catalogs.


### PR DESCRIPTION
## Summary
- README described two separate tarballs; we produce one (climate-finance-datapaper.tar.gz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)