### PR TITLE
edit: macOS coreutils note in Makefile.datapaper

### DIFF
--- a/Makefile.datapaper
+++ b/Makefile.datapaper
@@ -6,6 +6,7 @@
 #   make corpus  — rebuild the corpus incrementally (uses caches, needs internet)
 #
 # Prerequisites: Python >= 3.10, uv, quarto
+# macOS: brew install coreutils (for md5sum in make verify)
 
 .DEFAULT_GOAL := help
 .PHONY: help verify papers corpus


### PR DESCRIPTION
## Summary
- `md5sum` is GNU coreutils, not available on macOS by default
- Added prerequisite note: `brew install coreutils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)