### PR TITLE
fix: archive generates checksums-data.md5, drops dead .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,8 @@ archive-datapaper: check-corpus
 		cp -r content/tables/* $(DPAPER_TMP)/code/content/tables/; \
 	fi
 	cp content/*-vars.yml $(DPAPER_TMP)/code/content/ 2>/dev/null || true
-	echo 'CLIMATE_FINANCE_DATA=data' > $(DPAPER_TMP)/code/.env
+	@echo "  Computing data checksums..."
+	cd $(DPAPER_TMP)/data && md5sum * > $(DPAPER_TMP)/code/checksums-data.md5
 	@echo "=== Creating tarball ==="
 	tar czf $(DPAPER_ARCHIVE).tar.gz -C /tmp \
 		--exclude='__pycache__' --exclude='.venv' \


### PR DESCRIPTION
## Summary
- Add `md5sum * > checksums-data.md5` step so `make verify` works from the archive
- Drop `.env` stub — `pipeline_loaders.py` computes paths from `__file__`, `CLIMATE_FINANCE_DATA` is unused

## Test plan
- [ ] `make archive-datapaper` produces checksums-data.md5 inside code/
- [ ] Unpack, `cd code && make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)