### PR TITLE
refactor: archive-datapaper → script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,42 +561,8 @@ archive-manuscript: $(MANUSCRIPT_FIGS) $(MANUSCRIPT_INCLUDES) content/manuscript
 # Complete reproducibility package: all corpus-building scripts, DVC pipeline,
 # pool data, caches.  Reviewers can verify with:
 #   tar xzf archive.tar.gz && cd ... && uv sync && dvc repro
-DPAPER_ARCHIVE   := climate-finance-datapaper
-DPAPER_TMP       := /tmp/$(DPAPER_ARCHIVE)
-
 archive-datapaper: check-corpus corpus-tables figures-datapaper
-	@echo "=== Building data paper archive ==="
-	rm -rf $(DPAPER_TMP)
-	mkdir -p $(DPAPER_TMP)/code $(DPAPER_TMP)/data
-	@# Part 1: Code (pipeline source via git archive)
-	git archive HEAD | tar -x -C $(DPAPER_TMP)/code
-	rm -rf $(DPAPER_TMP)/code/.dvc $(DPAPER_TMP)/code/attic $(DPAPER_TMP)/code/.claude
-	@# Part 2: v1.1 corpus data files
-	@echo "  Preparing deposit CSV (dropping abstracts)..."
-	uv run python scripts/prepare_deposit.py --out-dir $(DPAPER_TMP)/data
-	@echo "  Copying embeddings, citations, and source catalogs..."
-	cp -L $(DATA_DIR)/embeddings.npz $(DPAPER_TMP)/data/
-	cp -L $(DATA_DIR)/citations.csv $(DPAPER_TMP)/data/
-	for src in openalex istex bibcnrs scispace grey teaching; do \
-		cp -L $(DATA_DIR)/$${src}_works.csv $(DPAPER_TMP)/data/ 2>/dev/null || true; \
-	done
-	@# Copy figures, tables, and vars for rendering (hard fail if missing)
-	mkdir -p $(DPAPER_TMP)/code/content/figures $(DPAPER_TMP)/code/content/tables
-	cp content/figures/fig_bars.png $(DPAPER_TMP)/code/content/figures/
-	cp content/tables/tab_corpus_sources.md content/tables/tab_languages.md \
-	   $(DPAPER_TMP)/code/content/tables/
-	cp content/data-paper-vars.yml $(DPAPER_TMP)/code/content/
-	@echo "  Computing data checksums..."
-	cd $(DPAPER_TMP)/data && md5sum * > $(DPAPER_TMP)/code/checksums-data.md5
-	@echo "=== Creating tarball ==="
-	tar czf $(DPAPER_ARCHIVE).tar.gz -C /tmp \
-		--exclude='__pycache__' --exclude='.venv' \
-		$(DPAPER_ARCHIVE)
-	@echo "=== Data paper archive ==="
-	@du -h $(DPAPER_ARCHIVE).tar.gz
-	@echo "Files: $$(tar tzf $(DPAPER_ARCHIVE).tar.gz | wc -l)"
-	rm -rf $(DPAPER_TMP)
-	@echo "Done: $(DPAPER_ARCHIVE).tar.gz"
+	bash scripts/build_datapaper_archive.sh
 
 # ── All checks (tests + lint) ────────────────────────────
 check: lint-prose

--- a/scripts/build_datapaper_archive.sh
+++ b/scripts/build_datapaper_archive.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build the data paper reproducibility archive for Zenodo.
+#
+# Produces climate-finance-datapaper.tar.gz containing:
+#   code/  — full pipeline source (git archive) + pre-built figures/tables
+#   data/  — deposit files (corpus CSV without abstracts, embeddings, citations, catalogs)
+#
+# Prerequisites: make check-corpus corpus-tables figures-datapaper
+# Usage: bash scripts/build_datapaper_archive.sh
+
+set -euo pipefail
+
+PROJ_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARCHIVE=climate-finance-datapaper
+TMP="/tmp/$ARCHIVE"
+DATA_DIR="$PROJ_ROOT/data/catalogs"
+
+echo "=== Building data paper archive ==="
+
+rm -rf "$TMP"
+mkdir -p "$TMP/code" "$TMP/data"
+
+# ── Code: pipeline source via git archive ────────────────
+echo "  Extracting code from git..."
+git -C "$PROJ_ROOT" archive HEAD | tar -x -C "$TMP/code"
+rm -rf "$TMP/code/.dvc" "$TMP/code/attic" "$TMP/code/.claude"
+
+# ── Data: deposit files ──────────────────────────────────
+echo "  Preparing deposit CSV (dropping abstracts)..."
+cd "$PROJ_ROOT"
+uv run python scripts/prepare_deposit.py --out-dir "$TMP/data"
+
+echo "  Copying embeddings, citations, and source catalogs..."
+cp -L "$DATA_DIR/embeddings.npz" "$TMP/data/"
+cp -L "$DATA_DIR/citations.csv" "$TMP/data/"
+for src in openalex istex bibcnrs scispace grey teaching; do
+    cp -L "$DATA_DIR/${src}_works.csv" "$TMP/data/" 2>/dev/null || true
+done
+
+# ── Figures, tables, vars for rendering (hard fail) ──────
+echo "  Copying figures and tables..."
+mkdir -p "$TMP/code/content/figures" "$TMP/code/content/tables"
+cp content/figures/fig_bars.png "$TMP/code/content/figures/"
+cp content/tables/tab_corpus_sources.md content/tables/tab_languages.md \
+   "$TMP/code/content/tables/"
+cp content/data-paper-vars.yml "$TMP/code/content/"
+
+# ── Checksums for make verify ────────────────────────────
+echo "  Computing data checksums..."
+cd "$TMP/data" && md5sum * > "$TMP/code/checksums-data.md5"
+
+# ── Tarball ──────────────────────────────────────────────
+echo "=== Creating tarball ==="
+tar czf "$PROJ_ROOT/$ARCHIVE.tar.gz" -C /tmp \
+    --exclude='__pycache__' --exclude='.venv' \
+    "$ARCHIVE"
+
+echo "=== Data paper archive ==="
+du -h "$PROJ_ROOT/$ARCHIVE.tar.gz"
+echo "Files: $(tar tzf "$PROJ_ROOT/$ARCHIVE.tar.gz" | wc -l)"
+rm -rf "$TMP"
+echo "Done: $ARCHIVE.tar.gz"


### PR DESCRIPTION
## Summary
- Extract archive build logic from Makefile into `scripts/build_datapaper_archive.sh`
- Makefile target keeps dependency gate, delegates to script
- No behavior change

## Test plan
- [ ] `make archive-datapaper` still produces climate-finance-datapaper.tar.gz

🤖 Generated with [Claude Code](https://claude.com/claude-code)