### PR TITLE
fix: archive _quarto.yml lists data paper only

### DIFF
--- a/scripts/build_datapaper_archive.sh
+++ b/scripts/build_datapaper_archive.sh
@@ -37,6 +37,24 @@ for src in openalex istex bibcnrs scispace grey teaching; do
     cp -L "$DATA_DIR/${src}_works.csv" "$TMP/data/" 2>/dev/null || true
 done
 
+# ── Quarto project config: data paper only ───────────────
+# The repo _quarto.yml lists all papers; Quarto scans them all even when
+# rendering one file. Replace with a minimal config for the data paper.
+cat > "$TMP/code/_quarto.yml" << 'YAML'
+project:
+  type: default
+  output-dir: output
+  render:
+    - content/data-paper.qmd
+
+bibliography: content/bibliography/main.bib
+
+format:
+  pdf:
+    pdf-engine: xelatex
+    cite-method: citeproc
+YAML
+
 # ── Figures, tables, vars for rendering (hard fail) ──────
 echo "  Copying figures and tables..."
 mkdir -p "$TMP/code/content/figures" "$TMP/code/content/tables"


### PR DESCRIPTION
## Summary
- Quarto processes all project files even when targeting one — manuscript.qmd includes tab_venues.md which isn't in the archive
- Override _quarto.yml to only list data-paper.qmd

## Test plan
- [x] `make verify` passes from unpacked archive
- [x] `make papers` renders data-paper.pdf from unpacked archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)