### PR TITLE
align agentic harness to Claude Code native specs

### DIFF
--- a/.claude/hooks/on-start.sh
+++ b/.claude/hooks/on-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SessionStart hook: set agent identity and activate git hooks.
+# Runs at the beginning of every Claude Code session.
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Load .env if present
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+# Set agent identity (non-blocking: don't fail if vars are missing)
+if [ -n "$AGENT_GIT_NAME" ]; then
+    git config user.name "$AGENT_GIT_NAME"
+fi
+if [ -n "$AGENT_GIT_EMAIL" ]; then
+    git config user.email "$AGENT_GIT_EMAIL"
+fi
+
+# Activate project hooks
+git config core.hooksPath hooks 2>/dev/null
+
+# Export GitHub token for gh CLI
+if [ -n "$AGENT_GH_TOKEN" ]; then
+    # Write to CLAUDE_ENV_FILE so it persists for the session
+    if [ -n "$CLAUDE_ENV_FILE" ]; then
+        echo "GH_TOKEN=$AGENT_GH_TOKEN" >> "$CLAUDE_ENV_FILE"
+    fi
+fi
+
+echo "Agent identity configured. Read STATE.md and ROADMAP.md to orient."

--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -1,0 +1,104 @@
+---
+paths:
+  - "scripts/**/*.py"
+  - "tests/**/*.py"
+  - "Makefile"
+  - "dvc.yaml"
+  - "pyproject.toml"
+  - "config/**/*"
+---
+
+# Coding Rules
+
+## Testing
+
+- Tests live in `tests/`. A new script or changed behavior starts with a test in `tests/test_<module>.py`.
+- `make check-fast`: unit tests + prose lint, < 20 s — run during development.
+- `make check`: full suite including integration + slow tests — run before opening a PR.
+- Acceptance tests (e.g., `make corpus-validate`) are the top-level contract — never weaken them without discussion.
+
+### Test markers
+
+| Marker | Meaning | Excluded from |
+|--------|---------|---------------|
+| *(none)* | Unit test — pure logic, no subprocess, no sleep | — |
+| `@pytest.mark.integration` | Spawns subprocesses or uses sleep-based timing | `check-fast` |
+| `@pytest.mark.slow` | Requires network access or real corpus data | `check-fast` |
+
+**When writing new tests:**
+- CLI flag presence: check via source inspection (`open().read()` + string match), not subprocess `--help`.
+- Tests that run a Python script via `subprocess.run()`: mark `@pytest.mark.integration`.
+- Tests that use `time.sleep()` or threading timeouts: mark `@pytest.mark.integration`.
+- Tests that import heavy modules only for `inspect.getsource()`: read the file directly instead.
+
+## Conventions
+
+- `uv sync` to install (never pip). `uv run python scripts/...` to execute.
+- All scripts support `--no-pdf`.
+- `make` builds all documents. `make manuscript` builds manuscript only. `make papers` builds the 3 companion documents. `make figures` regenerates all figures (byte-reproducible).
+- **Logging, not print.** All scripts MUST use `from utils import get_logger; log = get_logger("script_name")` — never bare `print()`.
+
+## Makefile conventions
+
+- **One output per rule.** Each Make target should produce a known file so timestamps work.
+- **Sentinel stamps for dynamic outputs.** Use a stamp file when a script produces data-dependent filenames. Add `*.stamp` to `.gitignore`.
+- **No `.PHONY` for real work.** Use `.PHONY` only for aliases (`figures`, `stats`, `clean`).
+
+## Script hygiene
+
+- **No `sys.path` hacks.** Use proper packaging (`pyproject.toml`).
+- **Centralize research parameters.** Constants belong in `config/analysis.yaml`, read via `load_analysis_config()`.
+- **Every entry point gets argparse.** If `__name__ == "__main__"` exists, it gets an `ArgumentParser`.
+
+## Python style (3.10+)
+
+- Built-in generics: `list[str]`, `dict[str, int]`, `str | None`. Never `from typing import List, Dict, Tuple, Optional`.
+- `X | Y` union syntax, not `Union[X, Y]`.
+- No `from __future__ import annotations`.
+- No ABC classes. Use Protocol for structural subtyping if needed.
+- Type hints where they clarify intent. Skip where they add noise.
+- Assertions at system boundaries. Trust internal code.
+
+## Dependency management
+
+- **Always use `uv sync`** to install. Never `pip` or `uv pip`.
+- torch extras: `--extra cpu` (doudou) or `--extra cu130` (padme, CUDA 13.0).
+
+## Data location
+
+- Data lives **outside the repo**, at `CLIMATE_FINANCE_DATA` in `.env`.
+- `scripts/utils.py` reads `.env` and exports `DATA_DIR`, `CATALOGS_DIR`, `EMBEDDINGS_PATH`. Never hardcode `data/catalogs/` relative to the repo.
+
+## Project structure
+
+Quarto multi-document project (`_quarto.yml`). Four outputs share reusable fragments in `content/_includes/`:
+
+- `content/manuscript.qmd` — main article (self-contained)
+- `technical-report.qmd` — pipeline documentation (composed of includes)
+- `data-paper.qmd` — corpus data paper
+- `companion-paper.qmd` — methods companion
+
+## Pipeline phases
+
+**Phase 1 — Corpus building** (slow, API-dependent, run rarely).
+- Scripts: `catalog_*`, `enrich_*`, `qa_*`, `qc_*`, `corpus_*`
+- Four steps with intermediate artifacts:
+  1. **corpus-discover**: merge sources → `unified_works.csv`
+  2. **corpus-enrich**: enrich DOIs/abstracts/citations → `enriched_works.csv`
+  3. **corpus-extend**: flag all works (no rows removed) → `extended_works.csv`
+  4. **corpus-filter**: apply policy, audit → `refined_works.csv`
+- Phase 1 → Phase 2 **contract**: `refined_works.csv`, `embeddings.npz`, `citations.csv`
+
+**Phase 2 — Analysis & figures** (fast, deterministic, run often):
+- Scripts: `analyze_*`, `plot_*`, `compute_*`, `export_*`, `summarize_*`, `build_het_core.py`
+- Reads Phase 1 outputs; produces `content/figures/`, `content/tables/`, `content/_includes/`, `content/*-vars.yml`
+
+**Phase 3 — Render** (Quarto → PDF/DOCX):
+- Reads Phase 2 outputs. Build artifacts go to `output/` (gitignored).
+
+## Incremental caches vs DVC outputs
+
+- **`enrich_cache/`** — persistent cache directory (gitignored, not a DVC output). Survives `dvc repro`.
+- **DVC output** — declared in `dvc.yaml` `outs:`. Ephemeral — DVC may delete it.
+
+When adding a new enrichment script: put incremental state in `enrich_cache/<name>.csv`, write the DVC output separately.

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,0 +1,13 @@
+# Git Discipline
+
+- **Always work on a branch.** Branch naming: `t{N}-short-description` (Doing), `explore-{topic}` (Dreaming), or `submission/{journal}-{document}` (submission tracking). Main is read-only except for STATE housekeeping.
+- **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers.
+- **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees.
+- **Git hooks** live in `hooks/`. After cloning: `make setup`. Agents: set automatically at session start.
+- **Agent identity**: machine user `HDMX-coding-agent`. Credentials (`AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`) from `.env`.
+- **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
+- **Merge commits**: strategic-level detail — architecture decisions, cross-file impacts, residual debt. Feature merges go through PRs; chores merge locally via short-lived branch + fast-forward.
+- **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`.
+- **Use worktrees** for feature branches — work in isolated copies via `git worktree`, not `git stash`/`git checkout`.
+- **Create PR** for each ticket to review changes before merging.
+- **Submission branches** are protected: no merges (cherry-pick only), no deletion, no force-push.

--- a/.claude/rules/oeconomia-style.md
+++ b/.claude/rules/oeconomia-style.md
@@ -1,0 +1,56 @@
+---
+paths:
+  - "content/manuscript.qmd"
+  - "content/manuscript-vars.yml"
+---
+
+# Oeconomia House Style
+
+Eyeballed from Oeconomia 15-4 (2025) samples. Platform chrome (paragraph numbers, "Résumés"/"Entrées d'index"/"Texte intégral" headers) is added by OpenEdition — do NOT include in the submitted manuscript.
+
+## 1. Title (English)
+
+Large bold. If composed, separate parts with a dot:
+*Fairness, Game Theory and Public Policy. The Case of Ken Binmore*
+
+## 2. Title (French)
+
+Normal size, regular italics. Exact translation of the English title.
+
+## 3. Author
+
+Small caps. Example: Minh Ha-Duong
+
+## 4. Submission line
+
+"For initial submission to *Œconomia*"
+
+## 5. Abstracts
+
+Résumé (French) then Abstract (English), both required.
+
+## 6. Keywords
+
+Two lines, comma-separated, each prefixed in roman:
+
+> Mots-clés : mot1, mot2, mot3
+>
+> Keywords: word1, word2, word3
+
+## 7. Text
+
+- **Introduction** has no heading — just start with the first paragraph.
+- Sections numbered: `1. Heading` and `1.1 Heading`
+- H1 and H2 are bold. H1 larger than H2, H2 larger than paragraph text.
+- Block quotes: indented, smaller font.
+- **Conclusion** has heading "Conclusion" with no number.
+
+## 8. Bibliography
+
+- Header "Bibliography", no number.
+- Paragraphs justified, one blank line between paragraphs (including between references).
+- DOI on a separate line after the reference.
+
+## 9. Notes
+
+Footnotes as superscript numbers in text, collected after the bibliography.

--- a/.claude/rules/pre-commit-checks.md
+++ b/.claude/rules/pre-commit-checks.md
@@ -1,0 +1,21 @@
+# Pre-commit Checks
+
+Run these checks mentally before every commit.
+
+## DVC lock sanity
+
+If `dvc.lock` is staged, verify the recorded hashes exist in the local cache. If any stage shows "not in cache", the lock file contains phantom hashes — run `dvc repro <stage>` or `dvc commit <stage>` first.
+
+## Stale check
+
+Re-read any project file you modified or relied on. If it contains outdated numbers, stale status, or dead references, fix them in the same commit. The commit is the quality gate — nothing stale gets versioned.
+
+This includes test files: if a refactor moves where a contract is enforced, tests asserting on the old location are dead references — update them in the same commit.
+
+## When to update `content/technical-report.qmd`
+
+- Pipeline phase contract changed (new inputs/outputs)
+- New script added or existing script's interface changed
+- Data schema changed (columns added/removed in CSV files)
+- Methodology changed (embedding model, clustering params, break detection)
+- NOT for manuscript prose edits, figure styling, or build tweaks

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,49 @@
+# Session Start
+
+At the beginning of every conversation:
+
+## 1. Setup
+
+Load `.env`, set agent identity, and activate hooks:
+```bash
+set -a && source .env && set +a
+git config user.name  "$AGENT_GIT_NAME"
+git config user.email "$AGENT_GIT_EMAIL"
+git config core.hooksPath hooks
+export GH_TOKEN="$AGENT_GH_TOKEN"
+```
+
+## 2. Orient
+
+Read `STATE.md` and `ROADMAP.md`.
+
+## 3. Branch and announce phase
+
+**GATE — nothing below this step runs until a branch is checked out.**
+
+Infer the Dragon Dreaming phase from context, create or checkout the working branch, then announce. The pre-commit hook blocks all commits on main.
+
+| Context | Phase | Branch |
+|---------|-------|--------|
+| Fresh conversation, no ticket | `[→ Dreaming]` | Create `explore-{topic}` |
+| Ticket reference but no branch | `[→ Planning]` | Create `explore-{topic}`; the `/start-ticket` skill creates the `t{N}` branch when Doing begins |
+| Active feature branch + open PR | `[→ Doing]` | Checkout existing branch |
+
+If the conversation turns out to be a quick question with no file edits, the branch is harmless — delete it at session end if empty.
+
+# Escalation Protocol
+
+When stuck, escalate progressively:
+1. Fix direct — review feedback is straightforward.
+2. Alternative approach — rethink the solution.
+3. Parallel expert agents — fan-out different directions.
+4. Re-ticket with diagnosis — the problem is mis-specified.
+5. Stop — ask the author.
+
+Save a feedback memory at each escalation (what failed, why). Stop if repeating yourself.
+
+# When to Ask the Author
+
+- You're stuck after three different approaches (including expert fan-out).
+- The task requires a judgment call outside your domain docs.
+- See writing rules for manuscript-specific guidance.

--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -1,0 +1,96 @@
+---
+paths:
+  - "content/**/*.qmd"
+  - "content/**/*.md"
+  - "content/bibliography/**"
+---
+
+# Writing Rules
+
+## Core argument
+
+Climate finance crystallized as an economic object by ~2009. Everything since has been fought within the categories established at that moment. This is intellectual history showing how economists create governable objects through quantification.
+
+## Three-act periodization (data-driven)
+
+- I. Before climate finance (1990–2006) — three disconnected traditions
+- II. Crystallization (2007–2014) — structural breaks at 2007 (cosine) and 2013 (JS)
+- III. The established field (2015–2025) — no further structural break
+
+The periodization is endogenous (embedding-based break detection), not imposed from COP milestones. The core subset (most-cited papers) shows no structural break at all.
+
+## Corpus
+
+~28,400 works from OpenAlex + Semantic Scholar + ISTEX + bibCNRS + SciSpace + grey lit + teaching. Core subset: ~2,300 papers cited ≥ 50 times.
+
+## Self-check questions
+
+Before producing any substantial text:
+1. Does this advance the core argument? (Climate finance as constructed economic object)
+2. Is the economist's role visible? (Not just "institutions" or "policymakers")
+3. Is this historically grounded? (Specific dates, documents, actors)
+4. Does this fit Œconomia's interdisciplinary scope? (HET + STS + policy studies)
+5. Will this interest both historians of economics AND climate policy scholars?
+
+This is not a policy paper or a technical report. It's intellectual history.
+
+## Voice and style
+
+- Academic but accessible
+- Historical narrative combined with analytical argument
+- Avoid jargon; define terms when first introduced
+- Show, don't just tell (use specific examples, names, dates)
+
+## Things to avoid
+
+- **Don't:** Write as if climate finance naturally exists. **Do:** Show how it was constructed.
+- **Don't:** Assume categories are neutral or technical. **Do:** Analyze political implications of measurement choices.
+- **Don't:** Oversimplify North-South divides. **Do:** Show specific actors and their motivations.
+
+## Citation practices
+
+- Cite primary sources with dates
+- Name economists and institutions specifically (not "policymakers" but "OECD DAC")
+- Include both academic and grey literature
+- Track evolution of key terms across time
+- Prioritize works that show economists' role in category-making
+- Balance institutional documents with critical scholarship
+- Include Global South perspectives
+
+## AI tells to eliminate
+
+### Blacklisted words (target: 0 occurrences)
+
+delve, nuanced, multifaceted, pivotal, crucial, robust (unless statistical sense),
+intricate, comprehensive, meticulous, vibrant, arguably, showcasing, underscores,
+foster, tapestry, landscape (unless proper noun, e.g. CPI *Global Landscape*)
+
+### Blacklisted phrases (target: 0 occurrences)
+
+"it is important to note," "in the realm of," "stands as a testament to,"
+"plays a vital role," "the landscape of," "navigating the complexities,"
+"the interplay between," "sheds light on," "a growing body of literature,"
+"offers a lens through which," "it is worth noting," "cannot be overstated"
+
+### Density limits
+
+- **Contrast farming** ("not X, but Y"): ≤3 justified instances per document. Each must be genuinely contrastive.
+- **Em-dash density**: ≤2 per paragraph.
+- **Sentence-initial "Moreover/Furthermore/Additionally"**: ≤2 per section.
+
+### Other patterns to avoid
+
+- Compulsive tricolons: not every list needs exactly three items
+- Uniform sentence length: vary between short and long
+- Excessive hedging: cut "perhaps," "it might be argued that," "to some extent"
+- Over-explanation: trust the reader; cut "In other words," "That is to say,"
+
+## Testing
+
+`make check-fast` before editing. `make clean && make all` as integration test before PR.
+
+## When to ask the author
+
+- Argument direction is genuinely ambiguous
+- Multiple good sources conflict
+- Author's position on controversial topic is unclear

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/on-start.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(make check-fast)",
+      "Bash(make check)",
+      "Bash(make lint-prose)",
+      "Bash(make manuscript)",
+      "Bash(make papers)",
+      "Bash(make figures)",
+      "Bash(uv sync*)",
+      "Bash(uv run python*)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git branch*)",
+      "Bash(git worktree*)",
+      "Read",
+      "Glob",
+      "Grep",
+      "Skill"
+    ]
+  }
+}

--- a/.claude/skills/autonomous/SKILL.md
+++ b/.claude/skills/autonomous/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: autonomous
+description: Launch unsupervised autonomous exploration session. Works in Dragon Dreaming cycles with 60/40 deliverable/tooling balance.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: [territory]
+model: claude-opus-4-6
+effort: max
+---
+
+# Autonomous exploration session
+
+Unsupervised session — work autonomously, review your own PRs, push forward on deliverables. Author reviews results when the session ends.
+
+## Balance rule
+
+**Deliverable work ≥60%, tooling ≤40%.** If two consecutive tickets were tooling, the next must advance a deliverable. Track in session log.
+
+**Deliverables**: items in `ROADMAP.md` under current milestone — papers, slides, reading notes, figures, responses to reviewers. Tooling: tests, hygiene, refactoring, harness improvements.
+
+**Escape hatch**: if `make check-fast` fails and blocks all deliverable work, tooling may exceed 40%. Document why.
+
+## Procedure
+
+Loop of Dragon Dreaming cycles: Dream → Plan → Do → Celebrate. Keep cycling until wrap-up time.
+
+### Picking targets (per cycle)
+
+1. Scientific deliverable is paramount
+2. Resolve gaps with north star (`README.md`)
+3. Fix ripest open issues
+4. Sweep for inline markers (FIXME, TODO, HACK)
+
+### Bootstrap
+
+Run session start setup. Record start time. Read territory files. Run `make check` as baseline.
+
+### Deliverable work
+
+For papers: analyze findings → survey journals → match → outline → draft → review literature → iterate. Up to 3 journal targets in parallel.
+
+### Tooling tickets
+
+TDD in worktrees. Self-review (single agent, correctness focus). Max 4 active worktrees.
+
+### Competing explorations
+
+Up to 3 implementations in parallel for each idea. Branch naming: `t{N}-explore-A-desc`, etc.
+
+### Memos (per cycle)
+
+Write `docs/local-ai/YYYY-MM-DD-memo-topic.md` reflecting learning. Commit on cycle branch.
+
+### Mid-session checkpoint (~50% effort)
+
+- [ ] Opened at least one deliverable-forward PR?
+- [ ] Tooling/deliverable ratio within bounds?
+- [ ] Self-reviewed at least one PR?
+- [ ] Session log started?
+- [ ] `make check` passes on main?
+
+### Session log
+
+Write `docs/local-ai/YYYY-MM-DD-log.md` on `session-log-YYYY-MM-DD` branch. Include balance table, decisions, feedback, open questions, token usage.
+
+### Wrap up
+
+1. `make check` on main — compare against baseline. New failures → ticket.
+2. Clean up worktrees.
+3. All work pushed, PRs open.
+4. Write briefing (session log + PR list + test delta).
+5. Do NOT run `/end-session` (would re-trigger autonomous).
+
+## Invariants
+
+- **Never merge to main.** All changes as PRs.
+- **Archive bit-identical.** Verify: `make archive-analysis && make -C /tmp/climate-finance-analysis verify`
+- **One ticket per worktree.**
+- **Commit messages explain why.**
+
+## Anti-patterns
+
+- Entire session on tooling, zero deliverable progress.
+- Did not self-review PRs.
+- Did not recurse into new dreams after completing existing ones.
+- Moved failing tests out of sight instead of fixing.
+- Session log stashed in feature branch instead of housekeeping branch.

--- a/.claude/skills/celebrate/SKILL.md
+++ b/.claude/skills/celebrate/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: celebrate
+description: Post-task wrap-up. Reflects on completed work, updates project state, cleans up branches.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Celebrate — post-task wrap-up
+
+`[Doing → Celebrating]`
+
+Do not skip steps.
+
+## Reflect and update
+
+1. **Reflect**: what worked, what didn't, what was surprising.
+2. **Update STATE.md**: refresh stats, remove resolved blockers.
+3. **Update ROADMAP.md**: check off completed items, note new ones.
+4. **Update technical-report.qmd** if pipeline, data contract, or methodology changed.
+5. **Save persistent memory**: durable lessons from this task. No sweep here — sweeps happen at `/end-session`.
+6. **Commit** the updates on the current branch (before merging).
+
+## Close and clean up
+
+7. **Merge to main**: feature work through PR. Chores merge locally via short-lived branch + fast-forward.
+8. **Push** and **clean up**: delete local and remote branch.
+9. **Close** the ticket if still open.
+10. **Check for tracking ticket**: if the closed ticket has a parent, check whether all sibling sub-tickets are now closed.
+    - All closed → integration review: re-read all child PR diffs, run `make check`, verify exit criteria.
+    - Any open → do nothing, tracker stays open.
+11. **Verify hygiene**:
+    - `git worktree list` → only main (or active work)
+    - `git branch -a` → no stale remote branches
+    - `gh pr list` → no stale PRs
+12. **Log celebration** (skip if harness not installed):
+    ```bash
+    ~/.agent/log/log-celebration '{"project":"oeconomia","session_type":"task",...}'
+    ```
+13. **Offer** to work on AGENTS.md if the workflow can be improved.

--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: end-session
+description: End-of-day session wrap-up. Pushes branches, runs tests, refreshes STATE, offers autonomous session.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# End session — day wrap-up
+
+Run when the user ends a work session ("done for today", "let's stop", "wrap up").
+
+## Steps
+
+1. **Reflect on the session** — summarize work done. `git log --since="6am" --oneline` as starting point.
+2. **Push all branches** — no local-only work overnight. `git branch` → ensure each non-main branch is pushed.
+3. **Commit WIP if needed** — uncommitted work gets `wip:` prefix and push.
+4. **Handoff notes** — for in-progress tickets with unpushed context, add a GitHub comment: what's done, what's next, blockers.
+5. **Hygiene sweep**:
+   - `git worktree list` + scan for stale worktree directories
+   - `git branch -a` → delete stale remote branches
+   - `gh issue list` → no orphan issues
+   - `gh pr list` → no stale PRs
+6. **Full test suite** — `make check` on main. New failures → open ticket (tag `bug`). Known failures → confirm still open.
+7. **Refresh STATE.md** on a throwaway branch:
+   a. `git checkout -b housekeeping-state-YYYY-MM-DD main`
+   b. Update date, stats, blockers, next actions.
+   c. Commit, merge to main via fast-forward, delete branch.
+8. **Memory sweep** — follow `/memory` skill (includes staleness check + rule cross-reference).
+9. **Log celebration** (skip if harness not installed).
+10. **Autonomous session** — offer to launch `/autonomous` if user wants unsupervised exploration.

--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: memory
+description: Write, update, or sweep persistent memory. Enforces list caps, TTLs, and staleness criteria.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Memory — persistent memory management
+
+Persistent memory lives at `$CLAUDE_MEMORY_DIR/MEMORY.md`.
+
+## When to run
+
+- During `/celebrate` (save only, no sweep)
+- During `/end-session` (full sweep: stale check + rule cross-reference)
+- After a user correction (save feedback immediately)
+- After discovering a project quirk
+
+## Procedure
+
+1. Check the entry against policy:
+   - Is it something to remember? (not derivable from code/git/docs)
+   - Does it fit within list caps?
+   - Does it have a TTL?
+2. For sweeps: scan every entry against staleness criteria.
+3. **Cross-reference against rules and skills**: if covered, delete the memory. If the rule is worth codifying but missing, add it to the appropriate rule file and delete the memory.
+4. For `project_*.md` files: delete if complete or superseded.
+
+## What to remember
+
+- User preferences and workflow corrections
+- Machine-specific configuration (paths, API keys, remote machines)
+- Naming conventions and project quirks not obvious from code
+
+## What NOT to remember
+
+- Anything derivable from code, git history, or other docs
+- Ephemeral task state (use STATE.md or git commits)
+- Content already in README, ROADMAP, STATE, rules, or skills
+
+## List size limits
+
+| Section type | Cap |
+|---|---|
+| Corpus statistics | 3 — replace, don't append |
+| Feedback entries | 5 — older feedback should be distilled into rule changes |
+| Project-state entries | 3 — stale project state belongs in git history |
+| Named scripts or output files | 10 |
+
+## Time limits (TTL)
+
+| Memory type | TTL | Action on expiry |
+|---|---|---|
+| Corpus statistics | 30 days | Re-derive or delete |
+| "X needed" / "X blocked" | 14 days | File ticket or delete |
+| Performance benchmarks | 60 days | Re-run or delete |
+| Remote machine config | 90 days | Confirm or delete |
+
+No TTL (stable until contradicted): workflow preferences, feedback, naming conventions, architectural decisions.
+
+## Staleness criteria
+
+An entry is stale if:
+- It references a file that no longer exists
+- It describes a state marked resolved elsewhere
+- Its TTL has elapsed without confirmation
+- A newer entry in the same section contradicts it

--- a/.claude/skills/new-ticket/SKILL.md
+++ b/.claude/skills/new-ticket/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: new-ticket
+description: Create a GitHub issue as a handoff document with required sections for TDD workflow.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: [title]
+---
+
+# New ticket — create a GitHub issue
+
+`[Dreaming → Planning]`
+
+Issues are handoff documents. A new agent will only have the context provided.
+
+## Required sections
+
+```markdown
+## Context
+What problem or need this addresses. Why now.
+
+## Relevant files
+- `path/to/file.py` — role in this task
+
+## Actions
+1. Concrete step
+2. Concrete step
+
+## Test
+- What test to write first (red step of TDD)
+
+## Verification
+- [ ] How to confirm each action worked
+
+## Invariants
+- What must not break (tests, build, existing behavior)
+
+## Exit criteria
+- Definition of done — when is this ticket complete?
+```
+
+## Command
+
+```bash
+gh issue create --title "$ARGUMENTS" --body "$(cat <<'EOF'
+<paste template above, filled in>
+EOF
+)"
+```
+
+## Tracking issue convention
+
+When investigation spawns sub-issues:
+
+1. Original issue becomes the **tracking issue** — leave it open.
+2. Create each sub-issue as a GitHub child: `gh issue create --title "..." --body "..." --parent <TRACKING_ISSUE_NUMBER>`
+3. Edit tracking issue body to add `## Sub-issues` heading listing each child.
+4. Tracking issue closes only after integration review (see `/celebrate` step 10).

--- a/.claude/skills/review-pr-prose/SKILL.md
+++ b/.claude/skills/review-pr-prose/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: review-pr-prose
+description: Simulated peer review panel for manuscript prose. Spins discipline-specific agents for multi-perspective review.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: <pr-number>
+context: fork
+---
+
+# Review PR prose $ARGUMENTS — simulated peer review panel
+
+Spin disciplinary agents in parallel, each in a fresh context. Prose review reads **full text**, not just diff.
+
+## Setup
+
+1. Identify the text: which `.qmd`/`.md` files changed? What is the target venue?
+2. Read the diff: `gh pr diff $ARGUMENTS`
+3. Select the panel from templates below.
+
+## Panel templates
+
+### Oeconomia manuscript (HPS journal)
+
+| Agent | Focus | Key question |
+|---|---|---|
+| **Historian of economics** | Historical accuracy, periodization, actors | Claims grounded in specific dates, documents, people? |
+| **STS / constructivism** | Category-making, co-production, performativity | Shows how the object was constructed? |
+| **Climate policy specialist** | Institutional accuracy, missing actors, policy nuance | Would practitioners recognize this account? |
+| **Literature specialist** | Deep research on cited/uncited works | Key references missing? Recent contradictions? |
+| **Adversarial referee** | Logical gaps, unsupported claims, rhetorical overreach | Where exactly does the argument fail? |
+| **Copy editor** | AI tells, blacklist words, house style | Passes writing rules and oeconomia-style rules? |
+
+### Technical report
+
+Scientometrician, Replicator, Literature specialist, Adversarial referee, Copy editor.
+
+### Custom panels
+
+One perspective per audience segment. Always include: Literature specialist + Adversarial referee + Copy editor.
+
+## Each agent runs
+
+1. Read the **full text** (not just the diff).
+2. **Literature specialist** does actual web searches and cites specific papers.
+3. **Adversarial referee** quotes specific sentences and explains why they fail.
+4. Report **confidence** + **severity** (major / minor / suggestion).
+5. Verdict: **accept**, **minor revision**, or **major revision**.
+
+## Synthesis
+
+1. Preserve dissent verbatim.
+2. Group findings: major (blocks acceptance), minor (should fix), suggestion.
+3. Deduplicate convergent findings.
+4. Run `make lint-prose` and `make manuscript`.
+5. Check consistency with `content/*-vars.yml`, figures, tables.
+6. Post single review via `gh pr review`.
+
+## Proportional depth
+
+| Text change | Panel size |
+|---|---|
+| Typo, citation fix | Copy editor only |
+| Section rewrite | 3 agents (domain + adversarial + copy) |
+| Full paper draft | Full panel (5-6 agents) |
+| Submission-ready | Full panel + response-to-reviewers template |

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: review-pr
+description: Multi-perspective code review with parallel agents. Covers correctness, consistency, scope, red team, and doc propagation.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: <pr-number>
+context: fork
+---
+
+# Review PR $ARGUMENTS — multi-perspective agent review
+
+Spin multiple agents in parallel, each with a distinct perspective. Run all agents in fresh contexts.
+
+## Setup
+
+1. **Read the issue** linked to the PR. Note the exit criteria.
+2. **Read the diff**: `gh pr diff $ARGUMENTS`
+3. **Launch review agents** in parallel:
+
+| Agent | Focus | Key question |
+|---|---|---|
+| **Correctness** | Logic, edge cases, test coverage | Does this do what the exit criteria say? |
+| **Consistency** | Style, naming, docs, stale references | Does this fit the rest of the codebase? |
+| **Scope** | Over-engineering, unrelated changes | Does this change *only* what the ticket asks? |
+| **Red team** | Adversarial inputs, broken invariants | How can this break? |
+| **Doc propagation** | Downstream text accuracy | Do docs, papers, and configs still match the code? |
+
+**Doc propagation** is **mandatory** when the PR touches `scripts/`, configuration, methodology, or data contracts.
+
+### Doc propagation checklist
+
+Trace references in: `content/technical-report.qmd`, `content/data-paper.qmd`, `content/manuscript.qmd`, `content/*-vars.yml`, `docs/`, `README.md`, `STATE.md`, `ROADMAP.md`, config files.
+
+### Proportional depth
+
+| PR risk | Agents |
+|---|---|
+| Trivial + user present | **Skip PR** — merge directly |
+| Trivial (typo, config) | Correctness only |
+| Standard | Correctness + Consistency |
+| Standard + `scripts/` | + Doc propagation |
+| Substantial | All five |
+| High-risk (schema, methodology) | All five + domain experts |
+
+## Each agent runs
+
+1. Read the issue exit criteria and the diff.
+2. Evaluate from its assigned perspective.
+3. Report **confidence** (high / medium / low) per finding.
+4. Return verdict: **approve**, **comment**, or **request-changes**.
+
+## Synthesis
+
+1. **Preserve dissent** — surface contradictions verbatim. The human author decides.
+2. **Triage by confidence** — investigate low-confidence findings before posting.
+3. **Deduplicate** findings across agents.
+4. **Run tests**: `make check`
+5. **Run build**: `make manuscript` (if prose changed)
+6. **Post a single review** via `gh pr review`, attributing each finding to its perspective.
+
+## Code-quality escalation
+
+| Severity | Action |
+|---|---|
+| Blocks correctness (bug, data loss) | request-changes |
+| Introduced by this PR | request-changes |
+| Pre-existing but touched | comment + new ticket |
+| Pre-existing and untouched | investigate → ticket if warranted |

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: start-ticket
+description: Begin work on a GitHub issue. Creates worktree, writes first test, transitions to Doing phase.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: <issue-number>
+---
+
+# Start ticket — begin work on issue $ARGUMENTS
+
+`[Planning → Doing]`
+
+## Steps
+
+1. Read the ticket: `gh issue view $ARGUMENTS --json title,body`
+2. Check the **Exit criteria** section. If unclear, ask the author before writing code.
+3. Create a worktree and branch:
+   ```bash
+   git worktree add ../t$ARGUMENTS-short-description -b t$ARGUMENTS-short-description
+   ```
+4. Read the files listed in **Relevant files**.
+5. Write the first test from the **Test** section of the ticket.
+6. Run `make check-fast` — confirm the test fails (Red).
+7. Announce `[Planning → Doing]`, then begin: Red → Green → Refactor.
+8. Create the PR when `make check` passes.
+9. Review according to `/review-pr`.
+10. Fix all comments regardless of severity.
+11. Repeat 9–10 up to 3 times. If still not clean, escalate (see workflow rules).

--- a/.claude/skills/submission-branch/SKILL.md
+++ b/.claude/skills/submission-branch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: submission-branch
+description: Manage submission branch lifecycle — sprout, freeze, errata, revision, resubmission, acceptance.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: <journal> <document>
+---
+
+# Submission branch lifecycle
+
+Manages a long-running branch tracking a manuscript through submission, review, revision, and acceptance.
+
+## When to use
+
+Create when a paper is ready to submit. The branch freezes the submitted state and accumulates revision history. Main continues to evolve; the submission branch cherry-picks only what's relevant.
+
+## Branch naming
+
+`submission/{journal}-{document}` — e.g., `submission/oeconomia-manuscript`.
+
+## 1. Sprout
+
+**Gate**: run `/submission-readiness` checklist first.
+
+```bash
+git checkout -b submission/$0-$1 main
+# Verify build: make output/content/$1.pdf
+git tag v{N}.0-$0-submitted
+```
+
+Add to `release/`: cover letter, AI disclosure, journal-specific files. Commit and push. Enable branch protection.
+
+## 2. Freeze
+
+Branch is frozen. Guards: pre-commit rejects merges (cherry-pick only), pre-push blocks deletion, GitHub prevents force-push.
+
+Frozen: git tag, pinned vars in `content/{document}-vars.yml`, reference data in `config/`, Zenodo archives.
+
+No changes except errata, reviewer responses, and revision commits.
+
+## 3. Errata
+
+Fix errors post-submission. Add to `release/YYYY-MM-DD {journal} errata/`. Contact editor if needed.
+
+## 4. Revision
+
+When reviewer reports arrive:
+1. Add reports to `release/YYYY-MM-DD {journal} revision/`
+2. Create response document
+3. One commit per reviewer point
+4. Tag: `v{N}.1-{journal}-revised`
+5. Cherry-pick relevant improvements from main (never merge)
+
+## 5. Resubmission
+
+Rebuild, prepare diff/track-changes, add to `release/`, commit, push.
+
+## 6. Acceptance
+
+Tag `v{N}.{final}-{journal}-accepted`. Add acceptance letter. Merge submission branch back to main. Update Zenodo.
+
+## 7. Rejection
+
+Record decision. Decide: resubmit elsewhere (new submission branch) or abandon (leave as record). Cherry-pick improvements back to main.

--- a/.claude/skills/submission-readiness/SKILL.md
+++ b/.claude/skills/submission-readiness/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: submission-readiness
+description: Pre-submission checklist gate. Every item must pass before sprouting a submission branch.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: <document>
+---
+
+# Submission readiness — pre-sprout gate
+
+Run before creating a submission branch (`/submission-branch`). Every item must pass.
+
+## Build
+
+- [ ] Paper builds cleanly: e.g., `make output/content/$ARGUMENTS.pdf`
+- [ ] Full test suite passes: `make check`
+- [ ] No warnings or missing references in the build log
+
+## Data freeze
+
+- [ ] Computed variables pinned in `content/{document}-vars.yml`
+- [ ] Reference data snapshots saved in `config/` (e.g., `config/v1_*` files)
+- [ ] Manuscript decoupled from live corpus — re-running `dvc repro` does not change the paper
+- [ ] Provenance column links current corpus rows to the frozen version
+
+## Reproducibility
+
+- [ ] Reproducibility archive(s) built (code tarball + data tarball)
+- [ ] Archive tested on a second machine — builds from scratch, produces identical output
+- [ ] Zenodo deposit created (or deposit plan documented)
+- [ ] HAL deposit created (or planned)
+
+## Submission artifacts
+
+- [ ] Cover letter in `release/`
+- [ ] AI disclosure statement in `release/`
+- [ ] Journal-specific files prepared (anonymized PDF, figures at required resolution, metadata)
+- [ ] `release/release-journal.md` entry drafted
+
+## Prior art
+
+The v1.0 Oeconomia submission established this pattern:
+- Frozen `config/v1_cluster_labels.json`, `config/v1_tab_alluvial.csv`, `config/v1_identifiers.txt.gz`
+- Pinned `content/manuscript-vars.yml`
+- Zenodo tarballs (analysis 56 MB + manuscript 683 KB), tested on two machines
+- `release/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,13 @@ output/
 *~
 *.swp
 
-# Claude Code config
-.claude/
+# Claude Code config — track shared config, ignore local/user files
+.claude/*
+!.claude/rules/
+!.claude/skills/
+!.claude/hooks/
+!.claude/settings.json
+.claude/settings.local.json
 
 /.quarto/
 _variables.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,18 @@
 | `README.md` | Project vision, repo structure, build commands | Onboarding, orientation |
 | `ROADMAP.md` | Milestones, deliverables, what's done | Starting work, picking tasks |
 | `STATE.md` | Current decisions, blockers, stats | Before any task (snapshot of now) |
-| `.agent/guidelines/writing-guidelines.md` | Prose style, language polish, citations | Editing manuscript text |
-| `.agent/guidelines/coding-guidelines.md` | Pipeline, scripts, conventions | Writing or running code |
-| `.agent/guidelines/oeconomia-style.md` | Journal house style | Final formatting |
 | `.env` | Project secrets + machine paths (gitignored) | Script execution, agent identity |
 | `content/technical-report.qmd` | Full data pipeline documentation | Understanding methodology |
-| `.agent/runbooks/` | Procedures fired by workflow triggers (see Triggers below) | Automated steps |
+
+## Configuration
+
+| Location | Purpose |
+|----------|---------|
+| `.claude/rules/` | Coding, writing, git, style, workflow rules (auto-loaded, path-scoped) |
+| `.claude/skills/` | Slash commands for workflow triggers (invoke with `/skill-name`) |
+| `.claude/settings.json` | SessionStart hook, permissions |
+| `.claude/hooks/` | Hook scripts (on-start setup) |
+| `hooks/` | Git hooks (pre-commit, pre-push, post-checkout) |
 
 ## Dragon Dreaming workflow
 
@@ -25,77 +31,55 @@ Interactive discussion with the user on an `explore-{topic}` branch. Imagine spe
 Generate portfolio of options with their probabilities. Go beyond conventional habits to explore new approaches. Take the high road.
 Act as my high-level advisor. Challenge my thinking, question my assumptions, and expose blind spots. Stop defaulting to agreement. If my reasoning is weak, break it down and show me why.
 
-Commits are workspace artifacts (notes, analysis, braindumps) unless the conversation produces a small fix (see below). Deliverable: a shared vision, plus one of:
+Commits are workspace artifacts unless the conversation produces a small fix. Deliverable: a shared vision, plus one of:
 
-- **Tickets** — non-trivial work gets one ticket per action item, for future Doing conversations.
-- **Small fix** — if the fix fits in one red/green/refactor cycle and doesn't need a fresh context, do it on the explore branch. TDD still applies. Rationale goes in the commit message (why this change) and the PR description (the Dreaming context that led to it). If during the fix you realize it's bigger than expected, stop — open a ticket, start fresh.
+- **Tickets** — non-trivial work gets one ticket per action item (`/new-ticket`).
+- **Small fix** — if it fits in one red/green/refactor cycle, do it on the explore branch. TDD still applies.
 - **Nothing actionable** — delete the branch at session end.
 
 ### Planning
-Explore alternatives, design strategies, prototype approaches. Read code, research, draft plans. Use GitHub Issues as the planning artifact — write tickets with full context (see below). **Specify the first test in the ticket** — the Doing phase enforces TDD. No production commits yet. Deliverable: a ticket with test spec.
+Explore alternatives, design strategies, prototype approaches. Use GitHub Issues as the planning artifact — write tickets with full context (`/new-ticket`). **Specify the first test in the ticket** — the Doing phase enforces TDD. No production commits yet. Deliverable: a ticket with test spec.
 
 ### Doing
-Runs in a fresh context — the ticket is the only input. This prevents context window pollution from Dreaming/Planning conversations. Launch via `start-ticket` trigger.
+Runs in a fresh context — the ticket is the only input. Launch via `/start-ticket`.
 
-Autonomous execution using test-driven development. See `.agent/guidelines/coding-guidelines.md` and `.agent/guidelines/writing-guidelines.md` for domain-specific test conventions. The inner cycle is:
+Autonomous execution using test-driven development. The inner cycle is:
 
 1. **Red**: write a failing test that defines the expected behavior. Commit.
 2. **Green**: write the minimum code to make it pass. Commit.
 3. **Refactor**: clean up, then confirm tests still pass. Use `make check-fast` during development. Commit.
-4. **PR**: Pass `make check` gate, then submit the work by pushing the branch and opening a PR with detailed context.
-5. **Review**: See `.agent/runbooks/review-pr.md`.
-6. **Fix**: Fix all issues and comments. Nits: fix them. Leave no debt. Seemingly unrelated issues: Spin an agent to explore and decide between fixing now or opening a ticket. Code smells: ultrathink architectural improvements, not code shaving.
-6. **Iterate**: As necessary for top quality, up to three review/fix cycle.
+4. **PR**: Pass `make check` gate, then push and open a PR.
+5. **Review**: `/review-pr` or `/review-pr-prose`.
+6. **Fix**: Fix all issues. Nits: fix them. Code smells: ultrathink architectural improvements.
+7. **Iterate**: Up to three review/fix cycles.
 
- Use `make check-fast` during development, `make check` before opening a PR.
-
-When stuck, escalate progressively:
-1. Fix direct — review feedback is straightforward.
-2. Alternative approach — rethink the solution.
-3. Parallel expert agents — fan-out different directions.
-4. Re-ticket with diagnosis — the problem is mis-specified.
-5. Stop — ask the author.
-
-Save a feedback memory at each escalation (what failed, why). Stop if repeating yourself. Deliverable: a merged PR.
+Use `make check-fast` during development, `make check` before opening a PR.
 
 ### Celebrating (autonomous)
-The `post-task` trigger runs automatically. Celebrating is not a formality — it closes the energy cycle. The agent reflects on what was accomplished and learned, acknowledges contributions, and releases the context before the next dream begins.
+Runs via `/celebrate`. Celebrating is not a formality — it closes the energy cycle. Reflect on what was accomplished and learned, acknowledge contributions, release the context.
 
 ### Phase state
 
 The agent must always know and declare its current DD phase.
 
-- **At conversation start**: `on-start.md` infers the initial phase from context and announces it (e.g., `[→ Dreaming]`).
-- **At each transition**: announce explicitly with `[Phase → Phase] reason` before proceeding. Runbooks include these markers at the appropriate steps.
-- **No implicit transitions**: if no announcement was made, the phase hasn't changed. When in doubt, state the current phase.
+- **At conversation start**: workflow rule infers the initial phase and announces it (e.g., `[→ Dreaming]`).
+- **At each transition**: announce explicitly with `[Phase → Phase] reason`.
+- **No implicit transitions**: if no announcement was made, the phase hasn't changed.
 
-## Triggers
+## Skills (slash commands)
 
-| Event | When | Runbook |
+| Skill | When | Purpose |
 |-------|------|---------|
-| on-start | Beginning of every conversation | `.agent/runbooks/on-start.md` |
-| start-ticket | Starting work on a GitHub issue | `.agent/runbooks/start-ticket.md` |
-| pre-commit | Before every commit | `.agent/runbooks/pre-commit.md` |
-| post-task | After completing a ticket | `.agent/runbooks/celebrate.md` |
-| end-session | User ends a work session | `.agent/runbooks/celebrate-day.md` |
-| new-ticket | Creating a GitHub issue (issues are handoff documents) | `.agent/runbooks/new-ticket.md` |
-| review-pr | Reviewing a pull request (code) | `.agent/runbooks/review-pr.md` |
-| review-pr-prose | Reviewing a pull request (prose/manuscript) | `.agent/runbooks/review-pr-prose.md` |
-| memory-write | Writing or sweeping persistent memory | `.agent/runbooks/memory.md` |
-| autonomous | Unsupervised autonomous session (via end-session) | `.agent/runbooks/autonomous-session.md` |
-
-## Git discipline
-
-- **Always work on a branch.** Branch naming: `t{N}-short-description` (Doing), `explore-{topic}` (Dreaming), or `submission/{journal}-{document}` (long-lived submission tracking, see `.agent/runbooks/submission-branch.md`). Main is read-only except for STATE housekeeping (see `.agent/runbooks/celebrate-day.md` step 7). Submission branches are protected: no merges (cherry-pick only), no deletion, no force-push.
-- **Enforced by pre-commit hook**: no commits on `main`, `CLAUDE.md` locked, no secrets, no large files (>500KB), no conflict markers.
-- **Post-checkout hook**: symlinks `.env` from main worktree into new worktrees (scripts need it for data paths).
-- **Git hooks** live in `hooks/`. After cloning: `make setup`. Agents: set automatically by `on-start` trigger.
-- **Agent identity**: set at conversation start by the `on-start` trigger. The machine user is `HDMX-coding-agent` (GitHub account). Credentials (`AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`) are project-specific secrets, deployed per-machine in `.env` (gitignored).
-- **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
-- **Merge commits**: strategic-level detail — architecture decisions, cross-file impacts, residual debt. Readable via `git log --merges`. Feature merges go through PRs; chores (dvc.lock, housekeeping) merge locally via short-lived branch + fast-forward.
-- **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`. In doubt, check older versions.
-- **Use worktrees** for feature branches — work in isolated copies via `git worktree`, not `git stash`/`git checkout`.
-- **Create PR** for each ticket to review changes before merging.
+| `/start-ticket N` | Starting work on a GitHub issue | Create worktree, write first test, transition to Doing |
+| `/celebrate` | After completing a ticket | Reflect, update STATE/ROADMAP, clean up |
+| `/end-session` | User ends a work session | Push branches, run tests, refresh STATE |
+| `/new-ticket` | Creating a GitHub issue | Write handoff document with test spec |
+| `/review-pr N` | Reviewing a pull request (code) | Multi-perspective agent review |
+| `/review-pr-prose N` | Reviewing a pull request (prose) | Simulated peer review panel |
+| `/memory` | Writing or sweeping persistent memory | Enforce caps, TTLs, staleness |
+| `/autonomous` | Unsupervised autonomous session | Dragon Dreaming cycles with 60/40 balance |
+| `/submission-branch` | Creating a submission branch | Sprout, freeze, revision lifecycle |
+| `/submission-readiness` | Pre-submission gate | Checklist before sprouting |
 
 ## Autonomous workflow
 
@@ -105,22 +89,15 @@ When issue exploration leads to multiple action items, open one ticket for each 
 
 1. **Select** — pick ripe tickets (dependencies met, blockers cleared).
 2. **Launch** — each ticket in its own worktree, independent tickets in parallel.
-3. **Verify** — review each PR in a fresh-context worktree (`.agent/runbooks/review-pr.md`).
+3. **Verify** — review each PR in a fresh-context worktree (`/review-pr`).
 4. **Learn** — for each result:
-   - **Success**: celebrate (`.agent/runbooks/celebrate.md`), save what worked as feedback memory.
-   - **Failure**: diagnose root cause, save lesson as feedback memory, re-ticket with the diagnosis.
-5. **Adapt** — read feedback memories before planning the next wave. Adjust approach based on what failed and what worked.
+   - **Success**: `/celebrate`, save what worked as feedback memory.
+   - **Failure**: diagnose root cause, save lesson, re-ticket with diagnosis.
+5. **Adapt** — read feedback memories before planning the next wave.
 6. **Clean up** — worktrees, branches, stale PRs. Then start the next wave.
-
-The wave ends with a global verification pass across all changes merged in this wave. If integration breaks, that's a new ticket for the next wave — not a reason to revert silently.
-
-## When to ask the author
-- You're stuck after three different approaches (including expert fan-out).
-- The task requires a judgment call outside your domain docs.
-- See `.agent/guidelines/writing-guidelines.md` for manuscript-specific guidance.
 
 ## Conversation scope
 
 **Dreaming conversations**: may produce zero or many tickets, or inline small fixes. The explore branch is the workspace; the tickets (or PR) are the deliverables.
 
-**Doing conversations**: one ticket per conversation. The agent transition to Celebration when the PR is merged with the ticket closed, exit criteria met. If investigation reveals sub-issues, open them as new tickets for future conversations — don't scope-creep the current one.
+**Doing conversations**: one ticket per conversation. Transition to Celebration when the PR is merged and ticket closed. If investigation reveals sub-issues, open them as new tickets — don't scope-creep.

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ make manuscript       # build PDF (requires figures)
 | `AGENTS.md` | AI workflow orchestration, Dragon Dreaming phases, git discipline |
 | `ROADMAP.md` | Milestones: what's done, what's next |
 | `STATE.md` | Current snapshot: stats, blockers, active PRs |
-| `.agent/guidelines/writing-guidelines.md` | Manuscript prose style, language polish rules |
-| `.agent/guidelines/coding-guidelines.md` | Pipeline phases, script reference, conventions |
-| `.agent/guidelines/oeconomia-style.md` | Journal house style |
+| `.claude/rules/writing.md` | Manuscript prose style, language polish rules |
+| `.claude/rules/coding.md` | Pipeline phases, script reference, conventions |
+| `.claude/rules/oeconomia-style.md` | Journal house style |
+| `.claude/skills/` | Workflow skills (slash commands): `/start-ticket`, `/celebrate`, `/review-pr`, etc. |
 
 ## Release
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,8 +41,8 @@ Before this repo can serve the AEDIST project, the reusable harness must be spli
 - Drafting: all sections (intro, §1–§4, conclusion)
 - Œconomia house style, AI-tell sweep, code audit, PDF+ODT build clean
 - Doc restructuring: separated concerns (AGENTS → workflow only, domain guidance → docs/), added Dragon Dreaming + TDD + git hooks
-- Agent-agnostic skills: .agent/runbooks/, make check, AGENTS.md works with any AI assistant
-- Harness consolidation (#457): `docs/` guidelines + `runbooks/` → `.agent/guidelines/` + `.agent/runbooks/`
+- Agent-agnostic skills: `.claude/skills/`, make check, AGENTS.md works with any AI assistant
+- Harness consolidation (#457): `docs/` guidelines + `runbooks/` → `.agent/` → `.claude/rules/` + `.claude/skills/`
 - Agent identity (#109): machine user `HDMX-coding-agent`, classic PAT in `.env`, convention documented in AGENTS.md
 - DVC integration (#101–#104, #109): data versioning, pipeline DAG, repro archives, external cache, bidirectional sync
 - Source normalized to 1NF (#113): pipe-separated source → boolean from_* columns

--- a/scripts/qa_word_count.py
+++ b/scripts/qa_word_count.py
@@ -1,7 +1,7 @@
 """QA checks on the manuscript PDF: word count + Oeconomia editorial compliance.
 
 Extracts text from the PDF, counts words (total and per-section), and checks
-editorial requirements from .agent/guidelines/oeconomia-style.md and docs/Informations aux
+editorial requirements from .claude/rules/oeconomia-style.md and docs/Informations aux
 auteurs.md:
   - Abstracts in both French and English
   - Keywords in both languages

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -25,7 +25,7 @@ def test_under_smell_threshold():
     lines = _line_count()
     assert lines <= SMELL_THRESHOLD, (
         f"AGENTS.md is {lines} lines (smell threshold: {SMELL_THRESHOLD}). "
-        f"Consider extracting sections to .agent/guidelines/ or .agent/runbooks/."
+        f"Consider extracting sections to .claude/rules/ or .claude/skills/."
     )
 
 

--- a/tests/test_doc_contract_consistency.py
+++ b/tests/test_doc_contract_consistency.py
@@ -21,7 +21,7 @@ import pytest
 ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 AGENTS_MD = os.path.join(ROOT, "AGENTS.md")
-CODING_GUIDELINES_MD = os.path.join(ROOT, ".agent", "guidelines", "coding-guidelines.md")
+CODING_GUIDELINES_MD = os.path.join(ROOT, ".claude", "rules", "coding.md")
 README_MD = os.path.join(ROOT, "README.md")
 CORPUS_CONSTRUCTION_MD = os.path.join(ROOT, "content", "_includes", "corpus-construction.md")
 REPRODUCIBILITY_MD = os.path.join(ROOT, "content", "_includes", "reproducibility.md")
@@ -37,7 +37,7 @@ def read(path):
 # ---------------------------------------------------------------------------
 
 class TestCodingGuidelinesMd:
-    """Pipeline contract docs moved from AGENTS.md to .agent/guidelines/coding-guidelines.md."""
+    """Pipeline contract docs live in .claude/rules/coding.md."""
 
     def test_all_four_artifacts_mentioned(self):
         """coding-guidelines.md must mention all four Phase 1 intermediate artifacts."""
@@ -45,7 +45,7 @@ class TestCodingGuidelinesMd:
         for artifact in ["unified_works.csv", "enriched_works.csv",
                          "extended_works.csv", "refined_works.csv"]:
             assert artifact in text, \
-                f"coding-guidelines.md missing artifact: {artifact}"
+                f"coding.md missing artifact: {artifact}"
 
     def test_all_four_make_targets_mentioned(self):
         """coding-guidelines.md must mention all four corpus Makefile targets."""
@@ -142,10 +142,10 @@ class TestReproducibilityMd:
 # ---------------------------------------------------------------------------
 
 class TestReadmeMd:
-    """README.md is vision-only; pipeline details live in .agent/guidelines/coding-guidelines.md."""
+    """README.md is vision-only; pipeline details live in .claude/rules/coding.md."""
 
-    def test_points_to_coding_guidelines(self):
-        """README.md should reference coding-guidelines.md for pipeline details."""
+    def test_points_to_coding_rules(self):
+        """README.md should reference coding rules for pipeline details."""
         text = read(README_MD)
-        assert "coding-guidelines" in text, \
-            "README.md should reference .agent/guidelines/coding-guidelines.md"
+        assert "coding" in text, \
+            "README.md should reference .claude/rules/coding.md"


### PR DESCRIPTION
Migrate from custom .agent/ structure to Claude Code's native
configuration system (.claude/). Guidelines become path-scoped rules
(auto-loaded when editing matching files), runbooks become skills
(invokable as /slash-commands), and session setup moves to a
SessionStart hook.

Structure:
- .claude/rules/ (6 files): coding, writing, oeconomia-style, git,
  pre-commit-checks, workflow — replace .agent/guidelines/
- .claude/skills/ (10 skills): start-ticket, celebrate, end-session,
  review-pr, review-pr-prose, new-ticket, memory, autonomous,
  submission-branch, submission-readiness — replace .agent/runbooks/
- .claude/settings.json: SessionStart hook + tool permissions
- .claude/hooks/on-start.sh: agent identity setup at session start

AGENTS.md trimmed from 127 to 103 lines (well under 150 smell
threshold). Now references skills (/start-ticket, /celebrate, etc.)
instead of runbook paths. Old .agent/ files kept for backward
compatibility — removal is a separate ticket.

The old .agent/ runbooks were "triggers" that the agent had to
remember to follow. The new skills are discoverable slash commands
that Claude Code loads on demand. Path-scoped rules (e.g., writing
rules only load when editing .qmd files) reduce context noise.

https://claude.ai/code/session_01K5MVnYn2tYN3mg4w2mXxTa