### PR TITLE
docs: document Phase 4 (release/archive) in project docs

### DIFF
--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -96,6 +96,11 @@ Quarto multi-document project (`_quarto.yml`). Four outputs share reusable fragm
 **Phase 3 — Render** (Quarto → PDF/DOCX):
 - Reads Phase 2 outputs. Build artifacts go to `output/` (gitignored).
 
+**Phase 4 — Release & archives** (reproducibility packaging):
+- Scripts: `release/scripts/build_*_archive.sh`
+- Templates: `release/templates/` (Makefiles, READMEs, Dockerfiles shipped in archives)
+- Reads Phase 2/3 outputs; produces `*.tar.gz` reproducibility archives
+
 ## Incremental caches vs DVC outputs
 
 - **`enrich_cache/`** — persistent cache directory (gitignored, not a DVC output). Survives `dvc repro`.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Makefile — Counting Climate Finance (Œconomia)
 #
-# Three-phase pipeline:
+# Four-phase pipeline:
 #   Phase 1: make corpus       Corpus building (slow — API calls, run rarely)
 #   Phase 2: make figures      Analysis & figures (fast, deterministic, run often)
 #   Phase 3: make manuscript   Render documents (Quarto → PDF/DOCX)
+#   Phase 4: make archive-*    Release & reproducibility archives
 #
 # Usage:
 #   make              Build all documents (manuscript + 3 companion papers)
@@ -426,7 +427,7 @@ output/content/data-paper.pdf: content/data-paper.qmd $(PROJECT_INCLUDES) $(BIB)
 output/content/companion-paper.pdf: content/companion-paper.qmd $(PROJECT_INCLUDES) $(BIB) content/companion-paper-vars.yml
 	quarto render $< --to pdf
 
-# ── Phase 2 archive (analysis reproducibility) ────────────
+# ── Phase 4a — analysis archive (packages Phase 2 outputs) ─
 # Data + scripts: reviewers verify figures/tables are reproducible.
 #   tar xzf archive.tar.gz && cd ... && uv sync && make
 SHELL            := /bin/bash
@@ -443,7 +444,7 @@ ANALYSIS_OUTPUTS := content/figures/fig_bars_v1.png \
 archive-analysis: check-manuscript-data $(ANALYSIS_OUTPUTS)
 	bash release/scripts/build_analysis_archive.sh
 
-# ── Phase 3 archive (manuscript reproducibility) ──────────
+# ── Phase 4b — manuscript archive (packages Phase 3 outputs) ─
 # Pre-built figures + content: reviewers verify PDF renders.
 # No Python needed — only Quarto + XeLaTeX.
 #   tar xzf archive.tar.gz && cd ... && make
@@ -451,7 +452,7 @@ archive-analysis: check-manuscript-data $(ANALYSIS_OUTPUTS)
 archive-manuscript: $(MANUSCRIPT_FIGS) $(MANUSCRIPT_INCLUDES) content/manuscript-vars.yml output/content/manuscript.pdf
 	bash release/scripts/build_manuscript_archive.sh
 
-# ── Data paper archive (full pipeline) ────────────────────
+# ── Phase 4c — data paper archive (full pipeline) ─────────
 # Complete reproducibility package: all corpus-building scripts, DVC pipeline,
 # pool data, caches.  Reviewers can verify with:
 #   tar xzf archive.tar.gz && cd ... && uv sync && dvc repro

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ The ideal state the project works towards:
 │   └── tables/                       # Generated tables (gitignored)
 ├── output/                           # Quarto rendered output (gitignored)
 ├── config/                           # Pipeline parameters (YAML)
-├── Makefile                          # Build: make manuscript, make figures, make corpus
+├── Makefile                          # Build: make corpus, make figures, make manuscript, make archive-*
 ├── dvc.yaml                          # Phase 1 pipeline DAG (DVC stages)
 ├── data/                             # DVC-managed data (dvc pull to populate)
 │   ├── catalogs/                    #   Corpus CSVs, embeddings, caches
 │   └── pool/                        #   Raw API responses (gzipped JSONL)
 ├── scripts/                          # Python analysis pipeline
 ├── docs/                             # Guidelines, journal info, book project notes
-├── release/                          # Releases outside CIRED. Append-only.
+├── release/                          # Phase 4: reproducibility archives & submissions. Append-only.
 └── attic/                            # Old stuff to delete when paper is accepted
 ```
 
@@ -146,6 +146,8 @@ After pulling data, regenerate them before building documents:
 make corpus-validate  # run acceptance tests on corpus
 make figures          # regenerate all figures and tables (~2 min)
 make manuscript       # build PDF (requires figures)
+make archive-analysis # Phase 4: reproducibility archive (data + scripts)
+make archive-manuscript # Phase 4: manuscript archive (pre-built figures + Quarto)
 ```
 
 ## Project documentation


### PR DESCRIPTION
## Summary
- Added Phase 4 (`make archive-*`) to the Makefile header, changing "Three-phase pipeline" to "Four-phase pipeline"
- Renamed Makefile archive section headers from "Phase 2/3 archive" to "Phase 4a/4b/4c" to reflect they are Phase 4 subsections
- Added Phase 4 references in README.md (repo structure, build commands)
- Added Phase 4 block in `.claude/rules/coding.md` pipeline phases reference

ROADMAP.md deliberately left unchanged -- it tracks milestones, not pipeline architecture.

## Test plan
- [x] Grep confirms all four phases appear consistently in Makefile, README.md, coding.md
- [x] `make check-fast`: 538 passed, 1 pre-existing failure (test_litellm_migration), 4 pre-existing data errors

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)