### PR TITLE
Performance baseline: time_target.sh + make benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ output/
 
 /.quarto/
 _variables.yml
+benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ TECHREP_FIGS    := content/figures/fig_alluvial_core.png \
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(COMPANION_FIGS) $(TECHREP_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep stats check check-fast smoke check-corpus check-manuscript-data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures
+.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep stats check check-fast smoke benchmark check-corpus check-manuscript-data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures
 
 .DEFAULT_GOAL := manuscript
 
@@ -488,6 +488,20 @@ check-fast:
 # Exercises: compute_breakpoints, compute_clusters, plot_fig1_bars.
 smoke:
 	uv run pytest tests/test_smoke_pipeline.py -v --tb=short
+
+# ── Benchmarking ─────────────────────────────────────────
+# Record wall time + peak RSS per Phase 2 target.
+# Output: benchmarks/timings.jsonl (one JSON line per target).
+BENCH := scripts/time_target.sh
+BENCH_OUT := benchmarks/timings.jsonl
+
+benchmark: check-corpus
+	@mkdir -p benchmarks
+	$(BENCH) compute_breakpoints $(BENCH_OUT) uv run python scripts/compute_breakpoints.py --no-pdf
+	$(BENCH) compute_clusters $(BENCH_OUT) uv run python scripts/compute_clusters.py --no-pdf
+	$(BENCH) analyze_bimodality $(BENCH_OUT) uv run python scripts/analyze_bimodality.py --no-pdf
+	$(BENCH) plot_fig1_bars $(BENCH_OUT) uv run python scripts/plot_fig1_bars.py --no-pdf
+	@echo "Benchmark results: $(BENCH_OUT)"
 
 # ── Setup (run once after cloning) ───────────────────────
 setup:

--- a/scripts/time_target.sh
+++ b/scripts/time_target.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Usage: scripts/time_target.sh <label> <output_jsonl> <command...>
+#
+# Runs <command> and appends a JSON line to <output_jsonl> with:
+#   label, wall_s, peak_rss_kb, timestamp, git_sha
+#
+# Uses /usr/bin/time -v (GNU time) for peak RSS measurement.
+# On macOS, install `gtime` via Homebrew and symlink or use gtime.
+
+set -euo pipefail
+
+# Force C locale for consistent decimal separator in awk/printf
+export LC_ALL=C
+
+LABEL="$1"
+OUTPUT="$2"
+shift 2
+
+# Create output directory if needed
+mkdir -p "$(dirname "$OUTPUT")"
+
+# GNU time writes to stderr in a specific format
+TIMEFILE=$(mktemp)
+trap 'rm -f "$TIMEFILE"' EXIT
+
+if command -v /usr/bin/time &>/dev/null; then
+    TIME_CMD="/usr/bin/time"
+elif command -v gtime &>/dev/null; then
+    TIME_CMD="gtime"
+else
+    echo "ERROR: GNU time not found (/usr/bin/time or gtime)" >&2
+    exit 1
+fi
+
+# Run the command with GNU time
+"$TIME_CMD" -v "$@" 2>"$TIMEFILE"
+EXIT_CODE=$?
+
+# Parse wall time (format: h:mm:ss or m:ss.ss)
+WALL_RAW=$(grep "Elapsed (wall clock) time" "$TIMEFILE" | sed 's/.*: //')
+# Convert to seconds
+if echo "$WALL_RAW" | grep -q "^[0-9]*:[0-9]*:[0-9]"; then
+    # h:mm:ss format
+    WALL_S=$(echo "$WALL_RAW" | awk -F: '{print $1*3600 + $2*60 + $3}')
+else
+    # m:ss.ss format
+    WALL_S=$(echo "$WALL_RAW" | awk -F: '{print $1*60 + $2}')
+fi
+
+# Parse peak RSS (in KB)
+PEAK_RSS=$(grep "Maximum resident set size" "$TIMEFILE" | awk '{print $NF}')
+
+# Git SHA (short)
+GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Timestamp
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Append JSON line
+printf '{"label":"%s","wall_s":%s,"peak_rss_kb":%s,"exit_code":%d,"timestamp":"%s","git_sha":"%s"}\n' \
+    "$LABEL" "$WALL_S" "${PEAK_RSS:-0}" "$EXIT_CODE" "$TIMESTAMP" "$GIT_SHA" >> "$OUTPUT"

--- a/tests/test_perf_baseline.py
+++ b/tests/test_perf_baseline.py
@@ -1,0 +1,57 @@
+"""Tests for #514: Performance baseline — time_target wrapper."""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
+
+
+class TestTimeTarget:
+    """time_target.sh produces valid JSONL records."""
+
+    @pytest.mark.integration
+    def test_produces_valid_jsonl(self, tmp_path):
+        out = tmp_path / "timings.jsonl"
+        result = subprocess.run(
+            ["bash", os.path.join(SCRIPTS_DIR, "time_target.sh"),
+             "test_label", str(out), "sleep", "0.1"],
+            capture_output=True, text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"time_target.sh failed:\n{result.stderr}"
+        assert out.exists(), "No output file produced"
+        record = json.loads(out.read_text().strip().split("\n")[-1])
+        assert "label" in record
+        assert "wall_s" in record
+        assert record["label"] == "test_label"
+        assert record["wall_s"] > 0
+
+    @pytest.mark.integration
+    def test_appends_to_existing_file(self, tmp_path):
+        out = tmp_path / "timings.jsonl"
+        for label in ["run1", "run2"]:
+            subprocess.run(
+                ["bash", os.path.join(SCRIPTS_DIR, "time_target.sh"),
+                 label, str(out), "true"],
+                capture_output=True, text=True,
+                timeout=10,
+            )
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["label"] == "run1"
+        assert json.loads(lines[1])["label"] == "run2"
+
+
+class TestMakefileBenchmark:
+    def test_benchmark_target_exists(self):
+        import re
+        with open(MAKEFILE) as f:
+            mk = f.read()
+        assert re.search(r"^benchmark\s*:", mk, re.MULTILINE), (
+            "Makefile missing 'benchmark' target"
+        )


### PR DESCRIPTION
## Summary

- Add `scripts/time_target.sh` — records wall time + peak RSS per command as JSONL
- Add `make benchmark` target — runs 4 Phase 2 scripts with timing
- Handle French locale (LC_ALL=C for consistent decimal separators)
- benchmarks/ directory gitignored

## Test plan

- [x] 3 tests pass (JSONL output valid, appends correctly, Makefile target exists)
- [x] `make check-fast` passes (no regressions)

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)