### PR TITLE
Simplify Doing inner cycle: values over procedure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,17 +49,7 @@ Explore alternatives, design strategies, prototype approaches. Use GitHub Issues
 ### Doing
 Runs in a fresh context — the ticket is the only input. Launch via `/start-ticket`.
 
-Autonomous execution using test-driven development. The inner cycle is:
-
-1. **Red**: write a failing test that defines the expected behavior. Commit.
-2. **Green**: write the minimum code to make it pass. Commit.
-3. **Refactor**: clean up, then confirm tests still pass. Use `make check-fast` during development. Commit.
-4. **PR**: Pass `make check` gate, then push and open a PR.
-5. **Review**: `/review-pr` or `/review-pr-prose`.
-6. **Fix**: Fix all issues. Nits: fix them. Code smells: ultrathink architectural improvements.
-7. **Iterate**: Up to three review/fix cycles.
-
-Use `make check-fast` during development, `make check` before opening a PR.
+Test first. Fix the pattern, not just the instance. Clean up. `make check-fast` between commits, `make check` before PR. Then `/review-pr` — up to three review/fix cycles.
 
 ### Celebrating (autonomous)
 Runs via `/celebrate`. Celebrating is not a formality — it closes the energy cycle. Reflect on what was accomplished and learned, acknowledge contributions, release the context.


### PR DESCRIPTION
TDAD research (arXiv 2603.17973) shows verbose multi-step TDD
instructions hurt agent performance — 107-line prescriptive SKILL.md
quadrupled regressions vs 20-line concise guidance. Surfacing context
outperforms prescribing workflow.

Replace 7-step numbered procedure with one sentence conveying the same
values: test-first, pattern-level fixes, verify. Agent decides when to
sweep for siblings, when to refactor, when to commit.

https://claude.ai/code/session_019BJu2utvU57VhhhzfrQqvx