### PR TITLE
fix: normalize @slow → @integration for subprocess tests (#562)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ determinism-check:
 #   make regression          — check against golden baseline
 #   make regression-save     — regenerate golden baseline (after intentional change)
 regression:
-	uv run pytest tests/test_regression.py -v --tb=short -m slow -k "test_regression_"
+	uv run pytest tests/test_regression.py -v --tb=short -m integration -k "test_regression_"
 
 regression-save:
 	uv run python scripts/regression_hashes.py --save

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -51,7 +51,7 @@ def _run_twice(script, args, out_name, tmp_path):
     )
 
 
-@pytest.mark.slow
+@pytest.mark.integration
 class TestDeterminism:
     """Phase 2 figure scripts produce identical output on two runs."""
 

--- a/tests/test_parameterize_works_paths.py
+++ b/tests/test_parameterize_works_paths.py
@@ -51,7 +51,7 @@ class TestEnrichDoisCLI:
         assert "unified_works.csv" in self._source, \
             "enrich_dois.py --works-input default should be unified_works.csv"
 
-    @pytest.mark.slow
+    @pytest.mark.integration
     @pytest.mark.timeout(30)
     def test_dry_run_uses_custom_input(self, tmp_path):
         """With --dry-run --works-input, the script reads from the specified path."""

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -123,7 +123,7 @@ def _make_test(entry):
     """Factory: create a test function for one registry entry."""
     name = entry["name"]
 
-    @pytest.mark.slow
+    @pytest.mark.integration
     def test_func(regression_outputs):
         results, errors = regression_outputs
         if name in errors:

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -327,7 +327,7 @@ class TestResumePreview:
         assert "Resume preview" in output or "Missing abstracts" in output
         assert "Total works" in output or "Loaded" in output
 
-    @pytest.mark.slow
+    @pytest.mark.integration
     @pytest.mark.timeout(30)
     def test_enrich_citations_batch_preview_on_empty_corpus(self, tmp_path):
         works_path = make_mini_works(tmp_path)

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -677,3 +677,48 @@ class TestNoPdfDiscipline:
         assert "--no-pdf" not in src, (
             f"{script} accepts --no-pdf but produces no figures"
         )
+
+
+# ---------------------------------------------------------------------------
+# 10. Test marker discipline: @slow vs @integration
+# ---------------------------------------------------------------------------
+
+TESTS_DIR = os.path.join(REPO, "tests")
+
+
+class TestMarkerDiscipline:
+    """Enforce correct use of @pytest.mark.slow vs @pytest.mark.integration.
+
+    - @integration: tests that spawn subprocesses (subprocess.run/Popen)
+      or use sleep-based timing
+    - @slow: tests that require network access or real corpus data
+      (no subprocess spawning)
+
+    A file that imports subprocess and marks tests @slow is almost certainly
+    mislabeled — subprocess tests should be @integration.
+    """
+
+    # Files that legitimately use both @slow and subprocess (none expected).
+    # Add entries here only with a comment explaining why.
+    EXCEPTIONS = set()
+
+    def test_no_slow_in_subprocess_files(self):
+        """Files that import subprocess must not use @slow (use @integration)."""
+        violations = []
+        for fname in sorted(os.listdir(TESTS_DIR)):
+            if not fname.startswith("test_") or not fname.endswith(".py"):
+                continue
+            if fname in self.EXCEPTIONS:
+                continue
+            path = os.path.join(TESTS_DIR, fname)
+            with open(path) as f:
+                source = f.read()
+            uses_subprocess = "import subprocess" in source
+            # Match actual decorator lines (any indent), not string mentions
+            uses_slow = bool(re.search(r"^\s*@pytest\.mark\.slow", source, re.MULTILINE))
+            if uses_subprocess and uses_slow:
+                violations.append(fname)
+        assert not violations, (
+            f"Files using subprocess must mark tests @integration, not @slow: "
+            f"{violations}"
+        )

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -152,7 +152,7 @@ def smoke_output_dir(tmp_path):
         shutil.copy2(backup_path, orig_path)
 
 
-@pytest.mark.slow
+@pytest.mark.integration
 class TestSmokeCriticalPath:
     """Core Phase 2 scripts run without error on fixture data.
 


### PR DESCRIPTION
## Summary
- Re-tagged 5 test files from `@pytest.mark.slow` to `@pytest.mark.integration` where tests spawn subprocesses (per coding rules, `@slow` = network/corpus, `@integration` = subprocess/timing)
- Added `TestMarkerDiscipline` enforcement test in `test_script_hygiene.py` to prevent regression
- Updated Makefile `regression` target from `-m slow` to `-m integration`

## Test plan
- [x] New enforcement test Red before fix, Green after
- [x] `make check-fast` passes (pre-existing #544 Red tests excluded)
- [x] `test_venue_table.py` correctly keeps `@slow` (no subprocess)

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)