### PR TITLE
Add Crossref fallback to DOI resolution, remove OA-only skip

### DIFF
--- a/scripts/enrich_dois.py
+++ b/scripts/enrich_dois.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Resolve missing DOIs via OpenAlex title+year search.
+"""Resolve missing DOIs via OpenAlex + Crossref title search.
 
-For each work in refined_works.csv that lacks a DOI but has a title,
-queries the OpenAlex works endpoint and fuzzy-matches on title.
+For each work in unified_works.csv that lacks a DOI but has a title,
+queries OpenAlex first, then falls back to Crossref if no match found.
 Idempotent: caches results so re-runs skip already-resolved works.
 
 Produces:
@@ -194,7 +194,7 @@ def search_doi(title: str, year: object = None, author: object = None) -> tuple[
     # Fallback: Crossref
     cr_doi, cr_sim = _search_crossref(title)
     if cr_doi and cr_sim >= TITLE_SIM_THRESHOLD:
-        return cr_doi, oa_id, cr_sim
+        return cr_doi, None, cr_sim
 
     # Return best OA result even if below threshold (caller decides)
     return doi, oa_id, sim
@@ -295,7 +295,7 @@ def main() -> None:
         log.info("Limited to: %d", len(to_process))
 
     if args.dry_run:
-        log.info("[DRY RUN] Would search OpenAlex for %d works", len(to_process))
+        log.info("[DRY RUN] Would search OpenAlex+Crossref for %d works", len(to_process))
         for _, row in to_process.head(10).iterrows():
             log.info("  %s: %s", row['source_id'], str(row['title'])[:80])
         if len(to_process) > 10:

--- a/tests/test_find_doi.py
+++ b/tests/test_find_doi.py
@@ -259,6 +259,31 @@ class TestResolveDoi:
             assert sim >= 0.85
             assert mock_get.call_count == 2  # OA + Crossref
 
+    def test_search_doi_crossref_returns_no_oa_id(self):
+        """When Crossref finds a DOI, oa_id must be None (not the unrelated OA result)."""
+        from enrich_dois import search_doi
+
+        # OA returns a low-sim match with an OA ID
+        oa_response = type("R", (), {"json": lambda self: {"results": [{
+            "doi": "https://doi.org/10.9999/wrong",
+            "title": "Totally Different Paper",
+            "id": "https://openalex.org/W999",
+        }]}})()
+        # Crossref returns a good match
+        cr_response = type("R", (), {"json": lambda self: {
+            "message": {"items": [{
+                "DOI": "10.1017/CBO9780511817434",
+                "title": ["The Economics of Climate Change"],
+            }]}
+        }})()
+
+        with patch("enrich_dois.polite_get") as mock_get:
+            mock_get.side_effect = [oa_response, cr_response]
+            doi, oa_id, sim = search_doi("The Economics of Climate Change")
+            assert doi == "10.1017/cbo9780511817434"
+            assert oa_id is None  # Must NOT be W999 from the unrelated OA result
+            assert sim >= 0.85
+
     def test_search_doi_no_crossref_when_oa_matches(self):
         """When OpenAlex returns a good match, Crossref is not queried."""
         from enrich_dois import search_doi


### PR DESCRIPTION
## Summary

- `search_doi()` now tries OpenAlex first, falls back to Crossref title search when OA returns no match
- Removed the `is_oa_only` skip: all 9,268 DOI-less works are now candidates (was 348)
- 13 unit tests pass (2 new + 11 existing adapted)

Tested on 20 works: 15% DOI hit rate. Full run (~9,268 works) takes ~8.5 hours — overnight job.

Closes #569

## Test plan

- [x] 13 unit tests for search_doi (OA + Crossref fallback + caching)
- [x] make check-fast green (pre-existing errors only)
- [x] Verified on 20 real works
- [ ] Full run (overnight), then `make corpus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)