### PR TITLE
fix: repair 3 test failures from stale fixtures and API changes

### DIFF
--- a/scripts/compute_regression_hashes.py
+++ b/scripts/compute_regression_hashes.py
@@ -98,7 +98,7 @@ REGISTRY: list[dict] = [
         "args": [],
         "deps": [],
         "outputs": [
-            "tests/fixtures/smoke/het_mostcited_50.csv",
+            "tests/fixtures/smoke/catalogs/het_mostcited_50.csv",
         ],
     },
     # --- Wave 2: depend on compute_* outputs ---

--- a/tests/fixtures/smoke/golden_hashes.json
+++ b/tests/fixtures/smoke/golden_hashes.json
@@ -1,6 +1,6 @@
 {
   "build_het_core": {
-    "tests/fixtures/smoke/het_mostcited_50.csv": "3c962705efc33469e6d5f8a24a5698ac3f249a0110760ea53b0ca2597c928522"
+    "tests/fixtures/smoke/catalogs/het_mostcited_50.csv": "3c962705efc33469e6d5f8a24a5698ac3f249a0110760ea53b0ca2597c928522"
   },
   "compute_breakpoints": {
     "content/tables/tab_breakpoint_robustness.csv": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -305,14 +305,18 @@ class TestEnrichDois:
     def test_load_cache_handles_empty_file(self, tmp_path):
         """load_cache() returns {} when cache file is empty (DVC stub)."""
         import enrich_dois
-        orig_cache = enrich_dois.CACHE_FILE
+        cache = enrich_dois._cache
+        orig_path = cache._path
+        orig_data = cache._data
         try:
             empty_file = tmp_path / "doi_resolved.csv"
             empty_file.write_text("")
-            enrich_dois.CACHE_FILE = str(empty_file)
+            cache._path = str(empty_file)
+            cache._data = None  # reset memoized state
             assert enrich_dois.load_cache() == {}
         finally:
-            enrich_dois.CACHE_FILE = orig_cache
+            cache._path = orig_path
+            cache._data = orig_data
 
 
 # ============================================================

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -176,13 +176,15 @@ class TestSmokeCriticalPath:
         )
 
     def test_plot_fig1_bars(self, smoke_output_dir):
-        result = _run_script("plot_fig1_bars.py")
+        output = os.path.join(smoke_output_dir, "fig1_bars.png")
+        result = _run_script("plot_fig1_bars.py", "--output", output)
         assert result.returncode == 0, (
             f"plot_fig1_bars.py failed:\n{result.stderr}"
         )
 
     def test_plot_fig1_bars_v1(self, smoke_output_dir):
-        result = _run_script("plot_fig1_bars.py", "--v1-only")
+        output = os.path.join(smoke_output_dir, "fig1_bars_v1.png")
+        result = _run_script("plot_fig1_bars.py", "--v1-only", "--output", output)
         assert result.returncode == 0, (
             f"plot_fig1_bars.py --v1-only failed:\n{result.stderr}"
         )


### PR DESCRIPTION
## Summary
- Fix `test_load_cache_handles_empty_file`: reset `_DiskCache` singleton, not stale module var
- Fix `test_plot_fig1_bars`: pass `--output` now required after script-io migration
- Fix `test_regression_build_het_core`: correct output path in REGISTRY (`catalogs/` subdir)

Remaining 2 failures (`test_qa_report_has_verification`, `test_language_null_rate`) are corpus-data staleness — fixed by `make corpus`.

## Test plan
- [x] All 4 fixed tests pass
- [x] `make check-fast` still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)