### PR TITLE
fix: circuit breaker for persistent 429 rate limits (#590)

### DIFF
--- a/scripts/enrich_dois.py
+++ b/scripts/enrich_dois.py
@@ -35,6 +35,11 @@ CACHE_DIR = os.path.join(CATALOGS_DIR, "enrich_cache")
 CACHE_FILE = os.path.join(CACHE_DIR, "doi_resolved.csv")
 TITLE_SIM_THRESHOLD = 0.85
 OPENALEX_SEARCH_URL = "https://api.openalex.org/works"
+CONSECUTIVE_FAIL_LIMIT = 5  # abort after this many consecutive API failures
+
+
+class RateLimitExhausted(Exception):
+    """Raised when an API returns 429 after all retries are exhausted."""
 
 
 class _DiskCache:
@@ -137,7 +142,12 @@ def _search_openalex(title: str) -> tuple[str | None, str | None, float]:
 
     try:
         resp = polite_get(OPENALEX_SEARCH_URL, params=params, delay=1.0)
+        if resp.status_code == 429:
+            raise RateLimitExhausted("OpenAlex rate limit after retries")
+        resp.raise_for_status()
         results = resp.json().get("results", [])
+    except RateLimitExhausted:
+        raise
     except Exception as e:
         log.warning("OpenAlex search failed for '%s': %s", title[:60], e)
         return None, None, 0.0
@@ -164,7 +174,12 @@ def _search_crossref(title: str) -> tuple[str | None, float]:
     }
     try:
         resp = polite_get(CROSSREF_SEARCH_URL, params=params, delay=1.0)
+        if resp.status_code == 429:
+            raise RateLimitExhausted("Crossref rate limit after retries")
+        resp.raise_for_status()
         items = resp.json().get("message", {}).get("items", [])
+    except RateLimitExhausted:
+        raise
     except Exception as e:
         log.warning("Crossref search failed for '%s': %s", title[:60], e)
         return None, 0.0
@@ -307,6 +322,7 @@ def main() -> None:
     # Process
     resolved = 0
     not_found = 0
+    consecutive_failures = 0
     has_author_col = "first_author" in to_process.columns
     for i, (idx, row) in enumerate(to_process.iterrows()):
         title = str(row["title"])
@@ -314,7 +330,23 @@ def main() -> None:
         sid = row["source_id"]
         author = str(row["first_author"]) if has_author_col else None
 
-        doi, oa_id, sim = search_doi(title, year, author=author)
+        try:
+            doi, oa_id, sim = search_doi(title, year, author=author)
+            consecutive_failures = 0  # reset on any successful API call
+        except RateLimitExhausted:
+            consecutive_failures += 1
+            log.warning("Rate limit exhausted (%d/%d consecutive)",
+                        consecutive_failures, CONSECUTIVE_FAIL_LIMIT)
+            if consecutive_failures >= CONSECUTIVE_FAIL_LIMIT:
+                log.error("Aborting: %d consecutive rate-limit failures. "
+                          "Cache saved — re-run to resume.",
+                          CONSECUTIVE_FAIL_LIMIT)
+                save_cache(cache)
+                flush_cache()
+                raise SystemExit(1)
+            cache[sid] = ""
+            not_found += 1
+            continue
 
         if doi and sim >= TITLE_SIM_THRESHOLD:
             cache[sid] = doi

--- a/tests/test_find_doi.py
+++ b/tests/test_find_doi.py
@@ -8,11 +8,14 @@ Verifies:
 - Titles below similarity threshold cache empty string
 - author parameter: author-keyed cache takes priority, falls back to title-only
 - search_doi passes author to OpenAlex search string when provided
+- RateLimitExhausted raised on 429 responses (circuit breaker)
 """
 
 import os
 import sys
 from unittest.mock import patch
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
@@ -241,14 +244,20 @@ class TestResolveDoi:
         from enrich_dois import search_doi
 
         # Mock OpenAlex: no results
-        oa_response = type("R", (), {"json": lambda self: {"results": []}})()
+        oa_response = type("R", (), {
+            "status_code": 200, "raise_for_status": lambda self: None,
+            "json": lambda self: {"results": []},
+        })()
         # Mock Crossref: returns a match
-        cr_response = type("R", (), {"json": lambda self: {
-            "message": {"items": [{
-                "DOI": "10.1017/CBO9780511817434",
-                "title": ["The Economics of Climate Change"],
-            }]}
-        }})()
+        cr_response = type("R", (), {
+            "status_code": 200, "raise_for_status": lambda self: None,
+            "json": lambda self: {
+                "message": {"items": [{
+                    "DOI": "10.1017/CBO9780511817434",
+                    "title": ["The Economics of Climate Change"],
+                }]}
+            },
+        })()
 
         with patch("enrich_dois.polite_get") as mock_get:
             # First call = OpenAlex (no results), second = Crossref (match)
@@ -264,18 +273,24 @@ class TestResolveDoi:
         from enrich_dois import search_doi
 
         # OA returns a low-sim match with an OA ID
-        oa_response = type("R", (), {"json": lambda self: {"results": [{
-            "doi": "https://doi.org/10.9999/wrong",
-            "title": "Totally Different Paper",
-            "id": "https://openalex.org/W999",
-        }]}})()
+        oa_response = type("R", (), {
+            "status_code": 200, "raise_for_status": lambda self: None,
+            "json": lambda self: {"results": [{
+                "doi": "https://doi.org/10.9999/wrong",
+                "title": "Totally Different Paper",
+                "id": "https://openalex.org/W999",
+            }]},
+        })()
         # Crossref returns a good match
-        cr_response = type("R", (), {"json": lambda self: {
-            "message": {"items": [{
-                "DOI": "10.1017/CBO9780511817434",
-                "title": ["The Economics of Climate Change"],
-            }]}
-        }})()
+        cr_response = type("R", (), {
+            "status_code": 200, "raise_for_status": lambda self: None,
+            "json": lambda self: {
+                "message": {"items": [{
+                    "DOI": "10.1017/CBO9780511817434",
+                    "title": ["The Economics of Climate Change"],
+                }]}
+            },
+        })()
 
         with patch("enrich_dois.polite_get") as mock_get:
             mock_get.side_effect = [oa_response, cr_response]
@@ -288,11 +303,14 @@ class TestResolveDoi:
         """When OpenAlex returns a good match, Crossref is not queried."""
         from enrich_dois import search_doi
 
-        oa_response = type("R", (), {"json": lambda self: {"results": [{
-            "doi": "https://doi.org/10.1234/oa-match",
-            "title": "Climate Finance Overview",
-            "id": "https://openalex.org/W123",
-        }]}})()
+        oa_response = type("R", (), {
+            "status_code": 200, "raise_for_status": lambda self: None,
+            "json": lambda self: {"results": [{
+                "doi": "https://doi.org/10.1234/oa-match",
+                "title": "Climate Finance Overview",
+                "id": "https://openalex.org/W123",
+            }]},
+        })()
 
         with patch("enrich_dois.polite_get") as mock_get:
             mock_get.return_value = oa_response
@@ -323,3 +341,30 @@ class TestResolveDoi:
             assert saved[title_keys[0]] == "10.1234/saved"
 
         _title_cache.clear()
+
+    def test_search_openalex_raises_on_429(self):
+        """_search_openalex raises RateLimitExhausted when API returns 429."""
+        from enrich_dois import RateLimitExhausted, _search_openalex
+
+        mock_resp = type("R", (), {"status_code": 429})()
+        with patch("enrich_dois.polite_get", return_value=mock_resp):
+            with pytest.raises(RateLimitExhausted):
+                _search_openalex("Some Title")
+
+    def test_search_crossref_raises_on_429(self):
+        """_search_crossref raises RateLimitExhausted when API returns 429."""
+        from enrich_dois import RateLimitExhausted, _search_crossref
+
+        mock_resp = type("R", (), {"status_code": 429})()
+        with patch("enrich_dois.polite_get", return_value=mock_resp):
+            with pytest.raises(RateLimitExhausted):
+                _search_crossref("Some Title")
+
+    def test_search_doi_propagates_rate_limit(self):
+        """search_doi lets RateLimitExhausted propagate (not swallowed)."""
+        from enrich_dois import RateLimitExhausted, search_doi
+
+        mock_resp = type("R", (), {"status_code": 429})()
+        with patch("enrich_dois.polite_get", return_value=mock_resp):
+            with pytest.raises(RateLimitExhausted):
+                search_doi("Some Title")


### PR DESCRIPTION
## Summary

- `_search_openalex` and `_search_crossref` now check `resp.status_code == 429` and raise `RateLimitExhausted` instead of silently treating 429 as empty results
- Main loop counts consecutive rate-limit failures, aborts after 5 with cache flush (re-runs resume)
- Also added `resp.raise_for_status()` so other HTTP errors (500, etc.) aren't silently swallowed

Closes #590

## Test plan

- [ ] 3 new tests: `test_search_openalex_raises_on_429`, `test_search_crossref_raises_on_429`, `test_search_doi_propagates_rate_limit`
- [ ] All 17 `test_find_doi.py` tests pass
- [ ] `make check-fast` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)