### PR TITLE
fix: include API hostname in 429 log messages

### DIFF
--- a/scripts/pipeline_io.py
+++ b/scripts/pipeline_io.py
@@ -121,6 +121,9 @@ def retry_get(url: str, params: dict[str, Any] | None = None,
     if counters is None:
         counters = {}
 
+    from urllib.parse import urlparse
+    host = urlparse(url).hostname or url
+
     last_exc = None
     for attempt in range(max_retries):
         try:
@@ -147,15 +150,15 @@ def retry_get(url: str, params: dict[str, Any] | None = None,
             if attempt == max_retries - 1:
                 # Return the 429 response instead of raising — lets callers
                 # inspect budget headers and degrade gracefully.
-                _log.warning("Rate limited (429) after %d attempts, returning response.",
-                             max_retries)
+                _log.warning("Rate limited (429) by %s after %d attempts, returning response.",
+                             host, max_retries)
                 return resp
             retry_after = min(
                 int(resp.headers.get("Retry-After", backoff_base ** (attempt + 1))), 120
             )
             jitter = random.uniform(0, min(jitter_max * 2, 2))
             wait = retry_after + jitter
-            _log.warning("Rate limited (429), waiting %.1fs...", wait)
+            _log.warning("Rate limited (429) by %s, waiting %.1fs...", host, wait)
             time.sleep(wait)
             continue
         if resp.status_code >= 500:


### PR DESCRIPTION
## Summary

- 429 log messages now include the API hostname: `Rate limited (429) by api.openalex.org, waiting 120.8s...`
- Previously just said `Rate limited (429), waiting 120.8s...` with no indication which API

🤖 Generated with [Claude Code](https://claude.com/claude-code)