### PR TITLE
refactor: restructure STATE.md and ROADMAP.md with spec and pruning rules

### DIFF
--- a/.claude/rules/state-roadmap.md
+++ b/.claude/rules/state-roadmap.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "STATE.md"
+  - "ROADMAP.md"
+---
+
+# STATE.md and ROADMAP.md
+
+Both files are loaded at every session start. Keep them short and current — history lives in `git log`.
+
+## STATE.md — snapshot of now (~30 lines max)
+
+| Section | Content |
+|---------|---------|
+| `Last updated:` | Date |
+| `## Status` | One-liner summary |
+| `## Submissions` | Active submissions only (journal, date, key links) |
+| `## Corpus` | Current version + key stats. No changelog. |
+| `## Blockers` | Current blockers or "None" |
+| `## Next actions` | 5–10 items, most urgent first |
+
+**Pruning:** each update *replaces* sections, not appends. Completed next-actions are deleted. Infrastructure improvements are not listed — they're in git history.
+
+## ROADMAP.md — forward-looking milestones (~40 lines max)
+
+| Section | Content |
+|---------|---------|
+| `## North star` | One paragraph — the core argument |
+| `## Current milestone` | What we're working toward, with `- [ ]` checkboxes |
+| `## Next milestone` | What comes after |
+| `## Backlog` | Parked ideas, no checkboxes |
+
+**Pruning:** when an item is checked off, it stays for one session (so the author sees it acknowledged), then is deleted on the next update. No "Completed" section — git has the history.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash(*merge*)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "PR merged — run /celebrate if this completes a ticket."
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash(*git commit*)",

--- a/.claude/skills/celebrate/SKILL.md
+++ b/.claude/skills/celebrate/SKILL.md
@@ -15,8 +15,8 @@ Do not skip steps.
 
 1. **Reflect**: what worked, what didn't, what was surprising.
 2. **Sweep for similar patterns**: review the fix just completed. Grep/audit the codebase for the same anti-pattern in other files. File tickets for all instances found.
-3. **Update STATE.md**: refresh stats, remove resolved blockers.
-4. **Update ROADMAP.md**: check off completed items, note new ones.
+3. **Update STATE.md**: rewrite per spec in `.claude/rules/state-roadmap.md`. Delete completed next-actions. No changelog.
+4. **Update ROADMAP.md**: check off completed items. Delete items checked off before this session. See `.claude/rules/state-roadmap.md`.
 5. **Update technical-report.qmd** if pipeline, data contract, or methodology changed.
 6. **Save persistent memory**: durable lessons from this task. No sweep here — sweeps happen at `/end-session`.
 7. **Commit** the updates on the current branch (before merging).

--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -22,10 +22,11 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
    - `gh pr list` → no stale PRs
    - `.claude/settings.local.json` → review accumulated one-off permissions. Propose promoting recurring patterns to `settings.json` (shared), then reset local `allow` to `[]`
 6. **Full test suite** — `make check` on main. New failures → open ticket (tag `bug`). Known failures → confirm still open.
-7. **Refresh STATE.md** on a throwaway branch:
+7. **Refresh STATE.md and ROADMAP.md** on a throwaway branch per `.claude/rules/state-roadmap.md`:
    a. `git checkout -b housekeeping-state-YYYY-MM-DD main`
-   b. Update date, stats, blockers, next actions.
-   c. Commit, merge to main via fast-forward, delete branch.
+   b. Rewrite STATE: current stats, blockers, next actions. No changelog.
+   c. Prune ROADMAP: delete items checked off before this session.
+   d. Commit, merge to main via fast-forward, delete branch.
 8. **Memory sweep** — follow `/memory` skill (includes staleness check + rule cross-reference).
 9. **Log celebration** (skip if harness not installed).
 10. **Autonomous session** — offer to launch `/autonomous` if user wants unsupervised exploration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@
 | File | Purpose | When to consult |
 |------|---------|-----------------|
 | `README.md` | Project vision, repo structure, build commands | Onboarding, orientation |
-| `ROADMAP.md` | Milestones, deliverables, what's done | Starting work, picking tasks |
-| `STATE.md` | Current decisions, blockers, stats | Before any task (snapshot of now) |
+| `ROADMAP.md` | Forward-looking milestones with checkboxes | Starting work, picking tasks |
+| `STATE.md` | Snapshot of now: status, stats, blockers, next actions | Before any task |
 | `.env` | Project secrets + machine paths (gitignored) | Script execution, agent identity |
 | `content/technical-report.qmd` | Full data pipeline documentation | Understanding methodology |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,67 +6,19 @@ Climate finance crystallized as an economic object by ~2009. Everything since �
 
 ## Current milestone: Under review
 
-Submitted to Oeconomia (Varia) on 2026-03-18. Waiting for referee reports (~3 months).
+Manuscript submitted to Oeconomia (Varia) 2026-03-18. Data paper submitted to RDJ4HSS 2026-03-26. Waiting for referee reports (~3 months).
 
 - [ ] Prepare ESHET-HES conference slides (Nice, May 26–29, 2026)
 - [ ] Continue Tier 1 reading plan (defence against reviewer questions)
-- [ ] Companion methods paper (Scientometrics/QSS): parked for post-acceptance
 
-## Next milestone: Data paper
-
-Submit data paper to RDJ4HSS (diamond OA). Immediate priority.
-
-- [ ] Finalize and submit data paper (PDF ready at `output/content/data-paper.pdf`)
-
-## Then: Transfer to AEDIST
+## Next milestone: Transfer to AEDIST
 
 Before this repo can serve the AEDIST project, the reusable harness must be split out.
 
 - [ ] Extract harness into standalone repo (#391)
-- [ ] Offline ticket system — good to have (PR #385)
 
-## Post-submission improvements
+## Backlog
 
-- [x] Split embeddings encoding (Phase 1) from UMAP+clustering (Phase 2) (#189)
-- [x] Split remaining enrich stages into independent DVC stages (#428)
-- [x] Re-enable Semantic Scholar with API key (#263)
-- [x] Add `in_v1` provenance column for v1.0 backward compatibility (#283)
-- [ ] JETP query: add concept filter to exclude physics journal noise
-
-## Completed
-
-- **Submission packaging (2026-03-18)**: Zenodo (DOI 10.5281/zenodo.19097045), HAL (hal-05558422v1), git tag v1.0-submission, cover letter + AI disclosure, figures ≥1500px
-- **Revision**: proofread, word count trim (9,600→8,860), final build + visual check, release/
-- Foundations: figures, bibliography audit, empirical findings
-- Drafting: all sections (intro, §1–§4, conclusion)
-- Œconomia house style, AI-tell sweep, code audit, PDF+ODT build clean
-- Doc restructuring: separated concerns (AGENTS → workflow only, domain guidance → docs/), added Dragon Dreaming + TDD + git hooks
-- Agent-agnostic skills: `.claude/skills/`, make check, AGENTS.md works with any AI assistant
-- Harness consolidation (#457): `docs/` guidelines + `runbooks/` → `.agent/` → `.claude/rules/` + `.claude/skills/`
-- Agent identity (#109): machine user `HDMX-coding-agent`, classic PAT in `.env`, convention documented in AGENTS.md
-- DVC integration (#101–#104, #109): data versioning, pipeline DAG, repro archives, external cache, bidirectional sync
-- Source normalized to 1NF (#113): pipe-separated source → boolean from_* columns
-- Teaching canon refactored (#114): single merge, build_teaching_canon simplified 363→100 lines
-- Test infra (#117–#123, #129–#130): pytest-timeout, make check-fast
-- Flags column normalized (#126): removed derived list from extended_works.csv; boolean columns are source of truth
-- catalog_bibcnrs as DVC stage (#134): data/exports/ DVC-tracked
-- Teaching source pipeline (#135): scraped syllabi → YAML → teaching_works.csv
-- Teaching scraper improvement (#258): PDF table extraction + chunk overlap, manual catalog removed — scraper covers all 24 reference works alone
-- Split discover into per-source DVC stages (#152): parallel, granular, skippable
-- OpenAlex --from-date incremental filtering (#153): budget-aware, sidecar auto-detect
-- Venue table replaces fig-seed (#150, #151): @tbl-venues in §3.4 body
-- Companion paper complete draft (#149): all sections filled
-- Retry robustness + budget guard (#171): unified retry_get, API key fix, budget-aware fetch
-- Split embeddings (#189): enrich_embeddings.py (Phase 1 encoding) + analyze_embeddings.py (Phase 2 UMAP+clustering)
-- Phase separation + manuscript cleanup (#189b): surgical Makefile deps, no API calls in Phase 3, structural break purge, layout fixes
-- Enrichment pipeline independence (#428): 4 DVC stages + join_enrichments.py, post-checkout hook symlinks .dvc/config.local (#505)
-- Code smell cleanup (#507): 26 dead imports removed, 11 complex functions refactored, global cache → class, normalize_doi_safe helper, exception narrowing
-- God module split (#542): `analyze_genealogy.py` 808→322L, M/V architecture with table-as-contract, robustness to `analyze_cocitation.py`
-- PDF opt-in flip (#544): `save_figure()` default from PDF-on to PDF-off across 33 files, `TestPdfDiscipline` guard (#545)
-- Fuzzy ref matching (#539): GROBID-parsed citation refs matched to corpus works via rapidfuzz, new `ref_match` DVC stage, integrated into `corpus_merge_citations`
-- Worktree isolation (#568): every conversation runs in throwaway worktree via `EnterWorktree`, `.worktreeinclude` replaces post-checkout symlinks
-- Text normalization (#533): ftfy + html.unescape at merge funnel point, fixes ~3,000 rows with encoding artifacts from upstream aggregators
-- GROBID citation parsing (#538): 352K unstructured Crossref refs → structured title/author/year via local GROBID (podman), 200 cit/sec, JSONL cache
-- Crossref DOI fallback (#569): `enrich_dois` queries Crossref when OpenAlex has no DOI, 9,268 OA-only candidates unlocked
-- 1-output-per-invocation (#594): `compute_breakpoints.py` refactored to 3 mutually exclusive modes, Makefile targets split from grouped `&:` to separate `--output $@` rules
-- I/O discipline complete (#549): all Phase 2 scripts accept `--output`/`--input` via `parse_io_args()`, 10 blackbox smoke tests, Makefile passes `$@`
+- Companion methods paper (Scientometrics/QSS): parked for post-acceptance
+- JETP query: add concept filter to exclude physics journal noise
+- Offline ticket system (PR #385)

--- a/STATE.md
+++ b/STATE.md
@@ -2,51 +2,23 @@
 
 Last updated: 2026-03-31
 
-## Status: TWO PAPERS SUBMITTED
+## Status
 
-### Oeconomia (Varia) — submitted 2026-03-18
-Under double-blind review.
-- Zenodo: https://doi.org/10.5281/zenodo.19097045
-- HAL: hal-05558422v1
-- Git tag: v1.0-submission
-- Branch: `submission/oeconomia-varia`
-- Errata 1 ready in `release/2026-03-23 Oeconomia errata/` (Figure 2 label fix)
+Two papers under review. Waiting for referee reports.
 
-### RDJ4HSS (data paper) — submitted 2026-03-26
-Under review (peer reviewers + data specialists).
-- Zenodo: https://doi.org/10.5281/zenodo.19236130
-- Git tag: v1.1-rdj-submitted
-- Branch: `submission/rdj-data-paper`
-- 2,495 words, 1 figure, 3 tables, 10 bib entries
+## Submissions
 
-## Manuscript (Oeconomia)
+| Paper | Journal | Submitted | Links |
+|-------|---------|-----------|-------|
+| Manuscript | Oeconomia (Varia) | 2026-03-18 | [Zenodo](https://doi.org/10.5281/zenodo.19097045), HAL hal-05558422v1, tag `v1.0-submission` |
+| Data paper | RDJ4HSS | 2026-03-26 | [Zenodo](https://doi.org/10.5281/zenodo.19236130), tag `v1.1-rdj-submitted` |
 
-- ~8,860 words, 61 bib entries — submitted as anonymized PDF
-- 2 figures (bars_v1, composition) + 2 tables (traditions, venues), no supplement
-- Manuscript decoupled from live corpus: frozen archive data in `config/v1_*`, pinned vars in `manuscript-vars.yml`
-- Figure 2 labels corrected (Errata 1): 5/6 cluster titles were mapped to wrong panels
+Errata 1 ready in `release/2026-03-23 Oeconomia errata/` (Figure 2 label fix).
 
 ## Corpus (v1.1.1)
 
-- 6 sources: OpenAlex, ISTEX, bibCNRS (news/discourse), SciSpace, grey literature, teaching canon
-- 42,916 raw → 31,712 refined works, 38,479 embeddings, 967,204 citations
-- Teaching expanded: 622 works from 52 institutions (scraper + LLM extraction)
-- Text normalization: ftfy + html.unescape at merge time fixes mojibake, HTML entities, zero-width chars (#533)
-- Citation pipeline: cache-is-data architecture (#441), hardened with atomic writes + crash tolerance + no-DOI dedup (#529)
-- GROBID citation parsing: 352K unstructured Crossref refs parsed into structured fields, 200 cit/sec via podman (#538)
-- Fuzzy ref matching: GROBID-parsed refs matched to corpus works, 3,414 new graph edges (#539)
-- Crossref DOI fallback: enrich_dois now queries Crossref when OpenAlex has no DOI, 9,268 candidates unlocked (#569)
-- DVC clean, 18 files pushed
-- Enrichment pipeline split into independent DVC stages (#428, #505)
-- Test suite: check-fast < 10s (4 xdist workers), 664 tests, mypy enabled, 0 skips, 0 warnings
-- 1-output-per-invocation: `compute_breakpoints.py` refactored to 3 mutually exclusive modes (#594)
-- Code smells cleared: all ruff C901/PLR0912/PLR0915 smell thresholds pass (#507)
-- PDF output now opt-in (`--pdf`): `save_figure()` default flipped (#544), phantom flag removed from non-plotting scripts (#545)
-- God module split: `analyze_genealogy.py` (808L) → 3 scripts M/V architecture (#542), robustness block to `analyze_cocitation.py`
-- Infrastructure sprint (#508–#514): smoke pipeline, I/O discipline, Makefile namespaces, parameterized K, revision runbook, performance baseline
-- Feather handoff (#527, #528): Phase 2 reads Feather instead of CSV (~48s → ~1.5s cumulative parse time), `analyze_embeddings` removed from DVC pipeline, pyarrow added
-- Circuit breaker for API loops (#590, #598): all OpenAlex scripts abort after 5 consecutive 429s instead of retrying indefinitely; shared `check_rate_limit()` helper in `pipeline_io.py`
-- I/O discipline complete (#549): all Phase 2 scripts accept `--output` (required) and `--input` (optional), Makefile passes `$@`, 10 blackbox smoke tests
+6 sources, 42,916 raw → 31,712 refined works, 38,479 embeddings, 967,204 citations.
+Test suite: 664 tests, check-fast < 10s, mypy enabled.
 
 ## Blockers
 
@@ -55,8 +27,8 @@ None.
 ## Next actions
 
 - ESHET-HES conference slides (Nice, May 26–29)
-- Remaining infrastructure: #515 (DAG viz), #428 (enrichment normalization)
-- 1-fig-1-script sweep: #546 (alluvial), #550 (bimodality), #551 (embeddings), #552 (cocitation), #559 (filter_flags LLM extraction)
-- #567: Redesign ref_match_corpus (caching, progress logging, smarter algorithm)
-- #569: Run overnight Crossref DOI resolution (8.5h, ~1,400 new DOIs expected)
-- #602: Add circuit breaker to non-OpenAlex API loops (ISTEX, S2, World Bank, Crossref, syllabi)
+- #569: Run overnight Crossref DOI resolution (~1,400 new DOIs expected)
+- #602: Circuit breaker for non-OpenAlex API loops
+- #567: Redesign ref_match_corpus (caching, progress, smarter algorithm)
+- 1-fig-1-script sweep: #546, #550, #551, #552, #559
+- #515: DAG visualization


### PR DESCRIPTION
## Summary

- STATE.md: 62 → 34 lines. Snapshot of now, no changelog.
- ROADMAP.md: 73 → 24 lines. Forward-looking only, no "Completed" section.
- New `.claude/rules/state-roadmap.md`: structural spec scoped to both files
- celebrate + end-session skills reference the spec
- PostToolUse hook nudges `/celebrate` after PR merges

## Test plan

- [ ] Verify STATE.md and ROADMAP.md match the spec
- [ ] Verify celebrate/end-session reference `.claude/rules/state-roadmap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)