### PR TITLE
fix: .values() → .values on pandas Series (#604)

### DIFF
--- a/scripts/analyze_communities_clusters.py
+++ b/scripts/analyze_communities_clusters.py
@@ -145,7 +145,7 @@ log.info("Building co-citation matrix...")
 source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
 
 cocit_matrix = lil_matrix((TOP_N, TOP_N), dtype=np.float64)
-for ref_list in source_groups.values():
+for ref_list in source_groups.values:
     refs_in_top = [r for r in ref_list if r in top_set]
     if len(refs_in_top) < 2:
         continue

--- a/scripts/archive_traditions/detect_traditions_pre2015.py
+++ b/scripts/archive_traditions/detect_traditions_pre2015.py
@@ -161,7 +161,7 @@ log.info("Building co-citation matrix...")
 source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
 
 cocit_matrix = lil_matrix((TOP_N, TOP_N), dtype=np.float64)
-for ref_list in source_groups.values():
+for ref_list in source_groups.values:
     refs_in_top = [r for r in ref_list if r in top_set]
     if len(refs_in_top) < 2:
         continue

--- a/scripts/archive_traditions/detect_traditions_pre2020.py
+++ b/scripts/archive_traditions/detect_traditions_pre2020.py
@@ -146,7 +146,7 @@ log.info("Building co-citation matrix...")
 source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
 
 cocit_matrix = lil_matrix((actual_n, actual_n), dtype=np.float64)
-for ref_list in source_groups.values():
+for ref_list in source_groups.values:
     refs_in_top = [r for r in ref_list if r in top_set]
     if len(refs_in_top) < 2:
         continue

--- a/scripts/archive_traditions/detect_traditions_v2.py
+++ b/scripts/archive_traditions/detect_traditions_v2.py
@@ -166,7 +166,7 @@ log.info("Building co-citation matrix...")
 source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
 
 cocit_matrix = lil_matrix((TOP_N, TOP_N), dtype=np.float64)
-for ref_list in source_groups.values():
+for ref_list in source_groups.values:
     refs_in_top = [r for r in ref_list if r in top_set]
     if len(refs_in_top) < 2:
         continue

--- a/scripts/compute_temporal_communities.py
+++ b/scripts/compute_temporal_communities.py
@@ -238,7 +238,7 @@ def detect_communities(cutoff_year, top_n, min_cocit, resolution, random_state):
     # Build co-citation matrix
     log.info("  Building co-citation matrix...")
     cocit_matrix = lil_matrix((actual_n, actual_n), dtype=np.float64)
-    for ref_list in source_groups.values():
+    for ref_list in source_groups.values:
         refs_in_top = [r for r in ref_list if r in top_set]
         if len(refs_in_top) < 2:
             continue

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1138,3 +1138,27 @@ class TestOutputFlag:
             f"{script} exited 0 but --output {out_path} was not created. "
             f"The script ignores --output and writes elsewhere."
         )
+
+
+class TestNoValuesCallOnSeries:
+    """Pandas Series .values is a property, not a method (#604).
+
+    source_groups.values() raises TypeError at runtime because
+    .values returns a numpy array, which is not callable.
+    """
+
+    COCITATION_SCRIPTS = [
+        "scripts/analyze_communities_clusters.py",
+        "scripts/compute_temporal_communities.py",
+        "scripts/archive_traditions/detect_traditions_v2.py",
+        "scripts/archive_traditions/detect_traditions_pre2015.py",
+        "scripts/archive_traditions/detect_traditions_pre2020.py",
+    ]
+
+    @pytest.mark.parametrize("script", COCITATION_SCRIPTS)
+    def test_source_groups_uses_property_not_method(self, script):
+        """Verify source_groups.values is used, not source_groups.values()."""
+        src = Path(script).read_text()
+        assert "source_groups.values()" not in src, (
+            f"{script} uses source_groups.values() — should be .values (property)"
+        )


### PR DESCRIPTION
## Summary

- Fix `source_groups.values()` → `source_groups.values` in 5 co-citation scripts (2 active, 3 archived). The `.values` attribute on a pandas Series returns a numpy array; calling `.values()` tries to invoke that array as a function, raising `TypeError` at runtime.
- Add regression test `TestNoValuesCallOnSeries` in `test_script_hygiene.py` to prevent recurrence.

Closes #604

## Test plan

- [x] New parametrized test passes for all 5 affected scripts
- [x] `make check-fast` passes (pre-existing failures unrelated)

https://claude.ai/code/session_012mNGsFRWCfCK2T7iGfxQFG