### PR TITLE
fix: switch HDBSCAN import to scikit-learn (#608)

### DIFF
--- a/content/_includes/reproducibility.md
+++ b/content/_includes/reproducibility.md
@@ -6,7 +6,7 @@
 uv sync    # installs all dependencies from pyproject.toml
 ```
 
-Key packages: pandas, numpy, scikit-learn, scipy, matplotlib, seaborn, sentence-transformers, torch (CPU or CUDA, selected via `--extra cpu` or `--extra cu130`), networkx, python-louvain, hdbscan, umap-learn, adjustText, diptest (optional). Python >= 3.10.
+Key packages: pandas, numpy, scikit-learn, scipy, matplotlib, seaborn, sentence-transformers, torch (CPU or CUDA, selected via `--extra cpu` or `--extra cu130`), networkx, python-louvain, umap-learn, adjustText, diptest (optional). Python >= 3.10.
 
 ### Execution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ corpus = [
     "dvc-ssh>=4.2.2",
     "sentence-transformers",
     "umap-learn",
-
     "python-louvain",
     "beautifulsoup4",
     "pdfplumber",

--- a/scripts/clustering_methods.py
+++ b/scripts/clustering_methods.py
@@ -9,7 +9,7 @@ guard), importable from compute_clustering_comparison.py and tests.
 
 Methods:
 - KMeans (sklearn): fast, deterministic, sensitive to k
-- HDBSCAN (hdbscan): density-based, auto-detects noise, k-free
+- HDBSCAN (sklearn): density-based, auto-detects noise, k-free
 - Spectral (sklearn): affinity-based, subsampled for large corpora
 
 Space builders:


### PR DESCRIPTION
## Summary\n\n- Switch `hdbscan.HDBSCAN` import to `sklearn.cluster.HDBSCAN` (absorbed into scikit-learn since v1.3)\n- Rename `core_dist_n_jobs` → `n_jobs` to match sklearn API\n- Remove standalone `hdbscan` dependency from `pyproject.toml`\n\nCloses #608\n\n## Test plan\n\n- [x] `pytest tests/test_compare_clustering.py -v` — all 17 tests pass (was 4 failures before)\n\nhttps://claude.ai/code/session_01CFcFCynu1YjK9nyKJwu2Ee