### PR TITLE
fix: move rapidfuzz from corpus group to core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pandera>=0.30.1",
     "ftfy>=6.3.1",
     "pyarrow>=23.0.1",
+    "rapidfuzz",
 ]
 
 [project.optional-dependencies]
@@ -48,7 +49,6 @@ corpus = [
     "pdfplumber",
     "ddgs",
     "bibtexparser",
-    "rapidfuzz",
 ]
 dev = [
     "fpdf2>=2.8.7",

--- a/uv.lock
+++ b/uv.lock
@@ -765,6 +765,7 @@ dependencies = [
     { name = "pytest-timeout" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "rapidfuzz" },
     { name = "requests" },
     { name = "requests-mock" },
     { name = "rich" },
@@ -792,7 +793,6 @@ corpus = [
     { name = "hdbscan" },
     { name = "pdfplumber" },
     { name = "python-louvain" },
-    { name = "rapidfuzz" },
     { name = "sentence-transformers" },
     { name = "umap-learn" },
 ]
@@ -818,6 +818,7 @@ requires-dist = [
     { name = "pytest-timeout" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml" },
+    { name = "rapidfuzz" },
     { name = "requests" },
     { name = "requests-mock" },
     { name = "rich", specifier = ">=13.0" },
@@ -838,7 +839,6 @@ corpus = [
     { name = "hdbscan" },
     { name = "pdfplumber" },
     { name = "python-louvain" },
-    { name = "rapidfuzz" },
     { name = "sentence-transformers" },
     { name = "umap-learn" },
 ]


### PR DESCRIPTION
## Summary\n\n- Move `rapidfuzz` from `[dependency-groups] corpus` to `[project] dependencies` in `pyproject.toml`\n- Update `uv.lock` to reflect the change (3 sections updated)\n- Fixes 16 test failures in `make check-fast` caused by missing import when only core deps are installed\n\n## Rationale\n\nTests that import `rapidfuzz` (fuzzy string matching for `ref_match_corpus`) run during `make check-fast` without skip guards. The corpus dependency group is meant for heavy Phase 1 ML/NLP work (sentence-transformers, DVC, torch). `rapidfuzz` is lightweight (~3 MB wheel, pure Python + C extension, no GPU deps) and needed unconditionally by the test suite.\n\n## Test plan\n\n- [x] `uv sync` installs rapidfuzz without `--group corpus`\n- [x] `make check-fast` passes (no rapidfuzz-related failures)\n- [ ] `uv sync --group corpus` still works (rapidfuzz available via core deps)\n\nCloses #611\n\nhttps://claude.ai/code/session_01GumEvcpz6cRMyCrMaogEUB"