### PR TITLE
Mark corpus_table_export tests as slow

### DIFF
--- a/tests/test_corpus_table_export.py
+++ b/tests/test_corpus_table_export.py
@@ -26,12 +26,14 @@ def corpus_table():
     return pd.read_csv(CSV_PATH)
 
 
+@pytest.mark.slow
 def test_required_columns(corpus_table):
     """Table must have Raw, Refined, and Unique columns."""
     for col in ("Raw", "Refined", "Unique"):
         assert col in corpus_table.columns, f"Missing column: {col}"
 
 
+@pytest.mark.slow
 def test_raw_counts_use_from_columns(corpus_table):
     """Raw counts must reflect from_* totals, not primary-source fallback.
 
@@ -51,6 +53,7 @@ def test_raw_counts_use_from_columns(corpus_table):
     )
 
 
+@pytest.mark.slow
 def test_unique_column_plausible(corpus_table):
     """Unique must be <= Refined for every source."""
     data_rows = corpus_table[corpus_table["Source"] != "TOTAL"]
@@ -61,6 +64,7 @@ def test_unique_column_plausible(corpus_table):
             )
 
 
+@pytest.mark.slow
 def test_total_row_present(corpus_table):
     """A TOTAL row must exist."""
     total = corpus_table[corpus_table["Source"] == "TOTAL"]


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.slow` to 4 tests in `test_corpus_table_export.py` that depend on the exported CSV (real corpus data)
- `test_source_meta_matches_source_names` is left unmarked — it only imports module constants and passes without the fixture

Closes #615

## Test plan

- [x] `uv run pytest tests/test_corpus_table_export.py -m "not slow" -v` collects only `test_source_meta_matches_source_names` and passes
- [ ] `make check-fast` passes (blocked by network in sandbox, but change is marker-only)

https://claude.ai/code/session_01GumEvcpz6cRMyCrMaogEUB