### PR TITLE
feat: multilingual epistemic structure analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,11 @@ content/tables/tab_lexical_tfidf.csv: scripts/compute_lexical.py scripts/utils.p
 		content/tables/tab_breakpoint_robustness.csv
 	uv run python $< --output $@
 
+# Multilingual epistemic structure (exploratory JSON report)
+content/tables/multilingual_report.json: scripts/analyze_multilingual.py scripts/utils.py \
+		scripts/build_het_core.py $(REFINED) $(REFINED_EMB) $(REFINED_CIT) $(SEMANTIC_CLUSTERS)
+	uv run python $< --output $@
+
 # K-sensitivity table
 content/tables/tab_k_sensitivity.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
 	uv run python $< --output $@ --k-sensitivity

--- a/scripts/analyze_multilingual.py
+++ b/scripts/analyze_multilingual.py
@@ -36,7 +36,7 @@ def classify_quadrant(row):
     if not lang:
         return None
 
-    is_en = lang in ("en", "eng", "en_us", "english")
+    is_en = not is_non_english(row)
     aff = str(row.get("affiliations", "") or "").lower().strip()
     if not aff:
         return None  # Cannot determine geography without affiliations
@@ -68,16 +68,18 @@ def compute_quadrant_stats(df):
     df["quadrant"] = df.apply(classify_quadrant, axis=1)
     classified = df.dropna(subset=["quadrant"])
 
+    total_classified = len(classified)
     result = {}
     for q in ["EN-N", "EN-S", "nonEN-N", "nonEN-S"]:
         subset = classified[classified["quadrant"] == q]
+        n = len(subset)
         result[q] = {
-            "n": int(len(subset)),
-            "pct": round(100 * len(subset) / len(classified), 2),
-            "mean_cited_by": round(float(subset["cited_by_count"].mean()), 1),
-            "median_cited_by": round(float(subset["cited_by_count"].median()), 1),
+            "n": int(n),
+            "pct": round(100 * n / total_classified, 2) if total_classified else 0.0,
+            "mean_cited_by": round(float(subset["cited_by_count"].mean()), 1) if n else 0.0,
+            "median_cited_by": round(float(subset["cited_by_count"].median()), 1) if n else 0.0,
         }
-    result["unclassified"] = int(len(df) - len(classified))
+    result["unclassified"] = int(len(df) - total_classified)
     return result
 
 
@@ -88,10 +90,9 @@ def compute_contingency(df, clusters_df):
         on="doi",
         how="inner",
     )
-    merged["lang_group"] = merged["language"].apply(
-        lambda x: x if x in ("en", "pt", "de", "es", "fr", "zh", "ja") else "other"
+    merged["lang_group"] = merged["language"].fillna("missing").apply(
+        lambda x: x if x in ("en", "pt", "de", "es", "fr", "zh", "ja", "missing") else "other"
     )
-    merged["lang_group"] = merged["lang_group"].fillna("missing")
 
     ct = pd.crosstab(merged["lang_group"], merged["semantic_cluster"])
     chi2, p, dof, expected = stats.chi2_contingency(ct)
@@ -176,8 +177,9 @@ def compute_isolation_scores(df, embeddings, k=10):
     dists = cosine_distances(sample_emb, en_north_emb)
     baseline_scores = []
     for row_dists in dists:
-        sorted_dists = np.sort(row_dists)
-        knn_dists = sorted_dists[1:k + 1]  # skip self
+        # partition k+1 smallest, skip self (index 0 after partition)
+        knn_dists = np.partition(row_dists, k + 1)[:k + 1]
+        knn_dists = np.sort(knn_dists)[1:]  # drop the self-distance (0)
         baseline_scores.append(float(np.mean(knn_dists)))
     baseline = np.array(baseline_scores)
     results["EN-N"] = {

--- a/scripts/analyze_multilingual.py
+++ b/scripts/analyze_multilingual.py
@@ -1,0 +1,306 @@
+"""Multilingual epistemic structure analysis.
+
+Computes language x geography statistics, semantic isolation scores,
+and citation directionality for the multilingual research note.
+
+Outputs a JSON report with all preliminary results.
+"""
+
+import json
+import os
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+from sklearn.metrics.pairwise import cosine_distances
+
+from build_het_core import is_global_south, is_non_english
+from pipeline_loaders import (
+    CATALOGS_DIR,
+    REFINED_WORKS_PATH,
+    load_refined_citations,
+    load_refined_embeddings,
+)
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("analyze_multilingual")
+
+
+def classify_quadrant(row):
+    """Assign work to one of four quadrants: EN-N, EN-S, nonEN-N, nonEN-S.
+
+    Returns None if classification is impossible (missing language or affiliation).
+    """
+    lang = str(row.get("language", "") or "").lower().strip()
+    if not lang:
+        return None
+
+    is_en = lang in ("en", "eng", "en_us", "english")
+    aff = str(row.get("affiliations", "") or "").lower().strip()
+    if not aff:
+        return None  # Cannot determine geography without affiliations
+
+    south = is_global_south(row)
+    if is_en and not south:
+        return "EN-N"
+    elif is_en and south:
+        return "EN-S"
+    elif not is_en and not south:
+        return "nonEN-N"
+    else:
+        return "nonEN-S"
+
+
+def compute_language_stats(df):
+    """Table T1: corpus composition by language."""
+    lang_counts = df["language"].fillna("missing").value_counts()
+    total = len(df)
+    result = {}
+    for lang, count in lang_counts.items():
+        result[lang] = {"n": int(count), "pct": round(100 * count / total, 2)}
+    return result
+
+
+def compute_quadrant_stats(df):
+    """Table T2: four-quadrant classification."""
+    df = df.copy()
+    df["quadrant"] = df.apply(classify_quadrant, axis=1)
+    classified = df.dropna(subset=["quadrant"])
+
+    result = {}
+    for q in ["EN-N", "EN-S", "nonEN-N", "nonEN-S"]:
+        subset = classified[classified["quadrant"] == q]
+        result[q] = {
+            "n": int(len(subset)),
+            "pct": round(100 * len(subset) / len(classified), 2),
+            "mean_cited_by": round(float(subset["cited_by_count"].mean()), 1),
+            "median_cited_by": round(float(subset["cited_by_count"].median()), 1),
+        }
+    result["unclassified"] = int(len(df) - len(classified))
+    return result
+
+
+def compute_contingency(df, clusters_df):
+    """Table T3: language x cluster contingency table + chi-squared test."""
+    merged = df.merge(
+        clusters_df[["doi", "semantic_cluster"]],
+        on="doi",
+        how="inner",
+    )
+    merged["lang_group"] = merged["language"].apply(
+        lambda x: x if x in ("en", "pt", "de", "es", "fr", "zh", "ja") else "other"
+    )
+    merged["lang_group"] = merged["lang_group"].fillna("missing")
+
+    ct = pd.crosstab(merged["lang_group"], merged["semantic_cluster"])
+    chi2, p, dof, expected = stats.chi2_contingency(ct)
+
+    # Standardized residuals
+    residuals = (ct.values - expected) / np.sqrt(expected)
+
+    return {
+        "contingency_table": ct.to_dict(),
+        "chi2": round(float(chi2), 2),
+        "p_value": float(p),
+        "dof": int(dof),
+        "significant_cells": [
+            {
+                "lang": ct.index[i],
+                "cluster": int(ct.columns[j]),
+                "residual": round(float(residuals[i, j]), 2),
+            }
+            for i in range(residuals.shape[0])
+            for j in range(residuals.shape[1])
+            if abs(residuals[i, j]) > 2.0
+        ],
+    }
+
+
+def compute_isolation_scores(df, embeddings, k=10):
+    """Compute semantic isolation score for each work.
+
+    Isolation = mean cosine distance to k nearest EN-North neighbors.
+    """
+    df = df.copy()
+    df["quadrant"] = df.apply(classify_quadrant, axis=1)
+    classified_mask = df["quadrant"].notna()
+
+    # Get EN-North indices
+    en_north_mask = df["quadrant"] == "EN-N"
+    en_north_indices = df.index[en_north_mask & classified_mask].tolist()
+
+    if len(en_north_indices) < k:
+        log.warning("Too few EN-North works (%d) for k=%d", len(en_north_indices), k)
+        return {}
+
+    en_north_emb = embeddings[en_north_indices]
+
+    # Compute isolation for each classified non-EN-North work
+    results = {}
+    for quadrant in ["EN-S", "nonEN-N", "nonEN-S"]:
+        q_mask = df["quadrant"] == quadrant
+        q_indices = df.index[q_mask].tolist()
+        if not q_indices:
+            continue
+
+        q_emb = embeddings[q_indices]
+
+        # Compute cosine distances to all EN-North works in chunks
+        chunk_size = 500
+        isolation_scores = []
+        for start in range(0, len(q_indices), chunk_size):
+            end = min(start + chunk_size, len(q_indices))
+            chunk_emb = q_emb[start:end]
+            dists = cosine_distances(chunk_emb, en_north_emb)
+            # Mean of k nearest neighbors
+            for row_dists in dists:
+                knn_dists = np.partition(row_dists, k)[:k]
+                isolation_scores.append(float(np.mean(knn_dists)))
+
+        scores = np.array(isolation_scores)
+        results[quadrant] = {
+            "n": len(scores),
+            "mean": round(float(np.mean(scores)), 4),
+            "median": round(float(np.median(scores)), 4),
+            "std": round(float(np.std(scores)), 4),
+            "p10": round(float(np.percentile(scores, 10)), 4),
+            "p90": round(float(np.percentile(scores, 90)), 4),
+        }
+
+    # EN-North baseline: distance to own quadrant (sampled)
+    sample_size = min(2000, len(en_north_indices))
+    rng = np.random.RandomState(42)
+    sample_idx = rng.choice(len(en_north_indices), sample_size, replace=False)
+    sample_emb = en_north_emb[sample_idx]
+    dists = cosine_distances(sample_emb, en_north_emb)
+    baseline_scores = []
+    for row_dists in dists:
+        sorted_dists = np.sort(row_dists)
+        knn_dists = sorted_dists[1:k + 1]  # skip self
+        baseline_scores.append(float(np.mean(knn_dists)))
+    baseline = np.array(baseline_scores)
+    results["EN-N"] = {
+        "n": len(baseline),
+        "mean": round(float(np.mean(baseline)), 4),
+        "median": round(float(np.median(baseline)), 4),
+        "std": round(float(np.std(baseline)), 4),
+        "p10": round(float(np.percentile(baseline, 10)), 4),
+        "p90": round(float(np.percentile(baseline, 90)), 4),
+        "note": f"baseline sample of {sample_size}",
+    }
+
+    return results
+
+
+def compute_citation_directionality(df, citations_df):
+    """Table T6: citation flows by geography (N->N, N->S, S->N, S->S)."""
+    df = df.copy()
+    df["quadrant"] = df.apply(classify_quadrant, axis=1)
+    geo_map = {"EN-N": "N", "nonEN-N": "N", "EN-S": "S", "nonEN-S": "S"}
+    df["geo"] = df["quadrant"].map(geo_map)
+
+    doi_geo = df.dropna(subset=["geo"]).set_index("doi")["geo"]
+
+    # Vectorized: map source and ref DOIs to geography
+    src_geo = citations_df["source_doi"].map(doi_geo)
+    ref_geo = citations_df["ref_doi"].map(doi_geo)
+
+    classified_mask = src_geo.notna() & ref_geo.notna()
+    flow_labels = src_geo[classified_mask] + "\u2192" + ref_geo[classified_mask]
+    flow_counts = flow_labels.value_counts().to_dict()
+
+    flows = {
+        "N\u2192N": flow_counts.get("N\u2192N", 0),
+        "N\u2192S": flow_counts.get("N\u2192S", 0),
+        "S\u2192N": flow_counts.get("S\u2192N", 0),
+        "S\u2192S": flow_counts.get("S\u2192S", 0),
+        "unclassified": int((~classified_mask).sum()),
+    }
+
+    total_classified = sum(v for k, v in flows.items() if k != "unclassified")
+    if total_classified > 0:
+        flows["pct"] = {
+            k: round(100 * v / total_classified, 2)
+            for k, v in flows.items()
+            if k != "unclassified"
+        }
+        ns = flows["N\u2192S"]
+        sn = flows["S\u2192N"]
+        flows["asymmetry_ratio"] = round(ns / sn, 3) if sn > 0 else None
+
+    return flows
+
+
+def compute_core_composition(df):
+    """Language and geography composition of the core subset (cited >= 50)."""
+    core = df[df["cited_by_count"] >= 50].copy()
+    core["quadrant"] = core.apply(classify_quadrant, axis=1)
+    core["is_en"] = ~core.apply(is_non_english, axis=1)
+
+    total = len(core)
+    en_count = int(core["is_en"].sum())
+    quadrant_counts = core["quadrant"].value_counts().to_dict()
+
+    return {
+        "total": total,
+        "english": en_count,
+        "english_pct": round(100 * en_count / total, 1) if total > 0 else 0,
+        "quadrants": {k: int(v) for k, v in quadrant_counts.items()},
+    }
+
+
+def main():
+    args, _ = parse_io_args()
+    validate_io(output=args.output)
+
+    log.info("Loading corpus...")
+    df = pd.read_csv(REFINED_WORKS_PATH, low_memory=False)
+    embeddings = load_refined_embeddings()
+    assert len(df) == len(embeddings), (
+        f"Row mismatch: {len(df)} works vs {embeddings.shape[0]} embeddings"
+    )
+    df = df.reset_index(drop=True)
+    log.info("Loaded %d works with %s embeddings", len(df), embeddings.shape)
+
+    log.info("Loading citations...")
+    citations_df = load_refined_citations()
+    log.info("Loaded %d citation edges", len(citations_df))
+
+    clusters_path = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+    clusters_df = pd.read_csv(clusters_path, low_memory=False)
+    log.info("Loaded %d cluster assignments", len(clusters_df))
+
+    report = {}
+
+    log.info("Computing language stats...")
+    report["language_stats"] = compute_language_stats(df)
+
+    log.info("Computing quadrant stats...")
+    report["quadrant_stats"] = compute_quadrant_stats(df)
+
+    log.info("Computing language x cluster contingency...")
+    report["contingency"] = compute_contingency(df, clusters_df)
+
+    log.info("Computing isolation scores (k=10)...")
+    report["isolation_k10"] = compute_isolation_scores(df, embeddings, k=10)
+
+    log.info("Computing isolation scores (k=5)...")
+    report["isolation_k5"] = compute_isolation_scores(df, embeddings, k=5)
+
+    log.info("Computing isolation scores (k=20)...")
+    report["isolation_k20"] = compute_isolation_scores(df, embeddings, k=20)
+
+    log.info("Computing citation directionality...")
+    report["citation_flows"] = compute_citation_directionality(df, citations_df)
+
+    log.info("Computing core composition...")
+    report["core_composition"] = compute_core_composition(df)
+
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2, default=str)
+    log.info("Report saved to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_analyze_multilingual.py
+++ b/tests/test_analyze_multilingual.py
@@ -14,6 +14,7 @@ sys.path.insert(0, SCRIPTS_DIR)
 from analyze_multilingual import (
     classify_quadrant,
     compute_citation_directionality,
+    compute_contingency,
     compute_core_composition,
     compute_isolation_scores,
     compute_language_stats,
@@ -98,6 +99,55 @@ class TestComputeQuadrantStats:
         })
         result = compute_quadrant_stats(df)
         assert result["unclassified"] == 1
+
+
+class TestComputeContingency:
+    """Unit tests for language x cluster contingency table."""
+
+    def test_basic_contingency(self):
+        df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3", "d4"],
+            "language": ["en", "en", "pt", "de"],
+        })
+        clusters_df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3", "d4"],
+            "semantic_cluster": [0, 1, 0, 1],
+        })
+        result = compute_contingency(df, clusters_df)
+        assert "chi2" in result
+        assert "p_value" in result
+        assert "dof" in result
+        assert "contingency_table" in result
+        assert isinstance(result["significant_cells"], list)
+
+    def test_missing_language_grouped(self):
+        """NaN languages should appear as 'missing', not crash."""
+        df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3"],
+            "language": ["en", None, "en"],
+        })
+        clusters_df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3"],
+            "semantic_cluster": [0, 0, 1],
+        })
+        result = compute_contingency(df, clusters_df)
+        # ct.to_dict() keys by column (cluster); lang_group is in the inner dict
+        first_cluster = result["contingency_table"][0]
+        assert "missing" in first_cluster
+
+    def test_rare_language_grouped_as_other(self):
+        """Languages not in the top-7 list should map to 'other'."""
+        df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3", "d4"],
+            "language": ["en", "en", "ko", "tr"],
+        })
+        clusters_df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3", "d4"],
+            "semantic_cluster": [0, 1, 0, 1],
+        })
+        result = compute_contingency(df, clusters_df)
+        first_cluster = result["contingency_table"][0]
+        assert "other" in first_cluster
 
 
 class TestComputeIsolationScores:

--- a/tests/test_analyze_multilingual.py
+++ b/tests/test_analyze_multilingual.py
@@ -1,0 +1,195 @@
+"""Tests for analyze_multilingual.py."""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+from analyze_multilingual import (
+    classify_quadrant,
+    compute_citation_directionality,
+    compute_core_composition,
+    compute_isolation_scores,
+    compute_language_stats,
+    compute_quadrant_stats,
+)
+
+
+class TestClassifyQuadrant:
+    """Unit tests for the four-quadrant classification."""
+
+    def test_english_north(self):
+        row = {"language": "en", "affiliations": "MIT, Cambridge, USA"}
+        assert classify_quadrant(row) == "EN-N"
+
+    def test_english_south(self):
+        row = {"language": "en", "affiliations": "University of Nairobi, Kenya"}
+        assert classify_quadrant(row) == "EN-S"
+
+    def test_non_english_north(self):
+        row = {"language": "de", "affiliations": "TU Berlin, Germany"}
+        assert classify_quadrant(row) == "nonEN-N"
+
+    def test_non_english_south(self):
+        row = {"language": "pt", "affiliations": "USP, São Paulo, Brazil"}
+        assert classify_quadrant(row) == "nonEN-S"
+
+    def test_missing_language(self):
+        row = {"language": "", "affiliations": "MIT, USA"}
+        assert classify_quadrant(row) is None
+
+    def test_missing_affiliations(self):
+        row = {"language": "en", "affiliations": ""}
+        assert classify_quadrant(row) is None
+
+    def test_none_language(self):
+        row = {"language": None, "affiliations": "MIT, USA"}
+        assert classify_quadrant(row) is None
+
+    def test_eng_variant(self):
+        row = {"language": "eng", "affiliations": "Oxford, UK"}
+        assert classify_quadrant(row) == "EN-N"
+
+
+class TestComputeLanguageStats:
+    """Unit tests for language distribution computation."""
+
+    def test_basic_counts(self):
+        df = pd.DataFrame({"language": ["en", "en", "pt", None]})
+        result = compute_language_stats(df)
+        assert result["en"]["n"] == 2
+        assert result["pt"]["n"] == 1
+        assert result["missing"]["n"] == 1
+
+    def test_percentages(self):
+        df = pd.DataFrame({"language": ["en"] * 9 + ["fr"]})
+        result = compute_language_stats(df)
+        assert result["en"]["pct"] == 90.0
+        assert result["fr"]["pct"] == 10.0
+
+
+class TestComputeQuadrantStats:
+    """Unit tests for quadrant classification stats."""
+
+    def test_all_quadrants(self):
+        df = pd.DataFrame({
+            "language": ["en", "en", "de", "pt"],
+            "affiliations": ["MIT, USA", "Nairobi, Kenya", "TU Berlin", "USP, Brazil"],
+            "cited_by_count": [100, 50, 30, 10],
+        })
+        result = compute_quadrant_stats(df)
+        assert result["EN-N"]["n"] == 1
+        assert result["EN-S"]["n"] == 1
+        assert result["nonEN-N"]["n"] == 1
+        assert result["nonEN-S"]["n"] == 1
+        assert result["unclassified"] == 0
+
+    def test_unclassified_counted(self):
+        df = pd.DataFrame({
+            "language": ["en", ""],
+            "affiliations": ["MIT, USA", "somewhere"],
+            "cited_by_count": [10, 5],
+        })
+        result = compute_quadrant_stats(df)
+        assert result["unclassified"] == 1
+
+
+class TestComputeIsolationScores:
+    """Unit tests for isolation score computation."""
+
+    def test_basic_isolation(self):
+        """EN-S works farther from EN-N cluster should have higher isolation."""
+        rng = np.random.RandomState(42)
+        # EN-N cluster around origin
+        en_n_emb = rng.randn(20, 8) * 0.1
+        # EN-S cluster offset
+        en_s_emb = rng.randn(5, 8) * 0.1 + 2.0
+
+        embeddings = np.vstack([en_n_emb, en_s_emb])
+        df = pd.DataFrame({
+            "language": ["en"] * 25,
+            "affiliations": ["MIT, USA"] * 20 + ["Nairobi, Kenya"] * 5,
+            "cited_by_count": [10] * 25,
+        })
+
+        result = compute_isolation_scores(df, embeddings, k=5)
+        assert "EN-N" in result
+        assert "EN-S" in result
+        assert result["EN-S"]["mean"] > result["EN-N"]["mean"]
+
+    def test_too_few_en_north(self):
+        embeddings = np.random.randn(3, 8)
+        df = pd.DataFrame({
+            "language": ["en", "pt", "fr"],
+            "affiliations": ["MIT, USA", "USP, Brazil", "Paris, France"],
+            "cited_by_count": [10, 5, 3],
+        })
+        result = compute_isolation_scores(df, embeddings, k=10)
+        assert result == {}
+
+
+class TestComputeCitationDirectionality:
+    """Unit tests for vectorized citation flow computation."""
+
+    def test_basic_flows(self):
+        df = pd.DataFrame({
+            "doi": ["d1", "d2", "d3"],
+            "language": ["en", "en", "en"],
+            "affiliations": ["MIT, USA", "MIT, USA", "Nairobi, Kenya"],
+            "cited_by_count": [10, 5, 3],
+        })
+        citations = pd.DataFrame({
+            "source_doi": ["d1", "d3"],
+            "ref_doi": ["d3", "d1"],
+        })
+        result = compute_citation_directionality(df, citations)
+        assert result["N\u2192S"] == 1
+        assert result["S\u2192N"] == 1
+        assert result["asymmetry_ratio"] == 1.0
+
+    def test_unclassified_edges(self):
+        df = pd.DataFrame({
+            "doi": ["d1"],
+            "language": ["en"],
+            "affiliations": ["MIT, USA"],
+            "cited_by_count": [10],
+        })
+        citations = pd.DataFrame({
+            "source_doi": ["d1", "d1"],
+            "ref_doi": ["d_unknown", "d1"],
+        })
+        result = compute_citation_directionality(df, citations)
+        assert result["unclassified"] == 1
+        assert result["N\u2192N"] == 1
+
+
+class TestComputeCoreComposition:
+    """Unit tests for core subset composition."""
+
+    def test_core_threshold(self):
+        df = pd.DataFrame({
+            "language": ["en", "en", "pt"],
+            "affiliations": ["MIT, USA", "MIT, USA", "USP, Brazil"],
+            "cited_by_count": [100, 30, 60],
+        })
+        result = compute_core_composition(df)
+        assert result["total"] == 2  # only cited >= 50
+
+
+@pytest.mark.integration
+class TestScriptCLI:
+    """Integration test: script enforces --output."""
+
+    def test_requires_output(self):
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "analyze_multilingual.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()


### PR DESCRIPTION
## Summary

- Add `scripts/analyze_multilingual.py` — Phase 2 analysis script for the multilingual research note
- Computes: language stats (T1), quadrant classification (T2), language×cluster contingency + χ² (T3), semantic isolation scores at k=5/10/20 (T4), citation directionality (T6), core subset composition
- Citation directionality uses vectorized pandas map instead of iterrows (~970K edges)
- No sys.path hacks — uses direct sibling imports via `uv run`
- 17 unit tests covering all helper functions
- Makefile rule: `content/tables/multilingual_report.json`

## Test plan

- [x] `make check-fast` passes (1 flaky pre-existing failure in parallel, passes solo)
- [x] 17/17 unit tests pass
- [ ] Run `make content/tables/multilingual_report.json` on real corpus data

🤖 Generated with [Claude Code](https://claude.com/claude-code)