### PR TITLE
Fix null-DOI cartesian explosion in multilingual analysis

### DIFF
--- a/scripts/analyze_multilingual.py
+++ b/scripts/analyze_multilingual.py
@@ -85,8 +85,11 @@ def compute_quadrant_stats(df):
 
 def compute_contingency(df, clusters_df):
     """Table T3: language x cluster contingency table + chi-squared test."""
-    merged = df.merge(
-        clusters_df[["doi", "semantic_cluster"]],
+    # Drop null DOIs before merge to avoid cartesian product (~8K × 8K = 60M rows)
+    df_with_doi = df.dropna(subset=["doi"])
+    clusters_with_doi = clusters_df.dropna(subset=["doi"])
+    merged = df_with_doi.merge(
+        clusters_with_doi[["doi", "semantic_cluster"]],
         on="doi",
         how="inner",
     )
@@ -187,7 +190,7 @@ def compute_citation_directionality(df, citations_df):
     geo_map = {"EN-N": "N", "nonEN-N": "N", "EN-S": "S", "nonEN-S": "S"}
     df["geo"] = df["quadrant"].map(geo_map)
 
-    doi_geo = df.dropna(subset=["geo"]).set_index("doi")["geo"]
+    doi_geo = df.dropna(subset=["geo", "doi"]).set_index("doi")["geo"]
 
     # Vectorized: map source and ref DOIs to geography
     src_geo = citations_df["source_doi"].map(doi_geo)


### PR DESCRIPTION
## Summary
- Drop null DOIs before merge(on=doi) in compute_contingency — 7678 x 7921 null matches produced a 60M-row cartesian product (69GB PyArrow allocation), OOM-killing padme twice.
- Drop null DOIs before set_index(doi) in compute_citation_directionality — duplicate null index entries crashed Series.map().

## Root cause
refined_works.csv has 7678 rows without DOIs; semantic_clusters.csv has 7921. Pandas merge(on=doi, how=inner) matches null == null, creating NxM rows.

## Test plan
- [x] Script completes on padme in 13s, peak 1.9GB RSS (was OOM at 105GB)
- [x] Report generated with all expected keys
- [ ] make check-fast passes