### PR TITLE
feat: GPU acceleration for semantic divergence S1-S4

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -21,6 +21,7 @@ clustering:
 
 divergence:
   random_seed: 42
+  backend: auto        # auto (GPU if available), cpu, cuda
   windows: [2, 3, 4, 5]
   min_papers: 30          # per window minimum (override with 5 for smoke)
   min_papers_smoke: 5     # auto-detected when n_works < 200

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -1,0 +1,89 @@
+"""Backend dispatch for divergence computations (CPU / CUDA).
+
+Private module — called by _divergence_semantic.py.
+
+Resolves the ``backend`` key from config/analysis.yaml:
+  auto  → CUDA if torch+CUDA available, else NumPy
+  cpu   → NumPy only
+  cuda  → torch CUDA (raises if unavailable)
+"""
+
+import numpy as np
+from utils import get_logger
+
+log = get_logger("_divergence_backend")
+
+_TORCH_AVAILABLE: bool | None = None
+_DEVICE: str | None = None
+
+
+def _probe_torch() -> bool:
+    """Lazy-check whether torch with CUDA is importable."""
+    global _TORCH_AVAILABLE
+    if _TORCH_AVAILABLE is None:
+        try:
+            import torch
+
+            _TORCH_AVAILABLE = torch.cuda.is_available()
+            if _TORCH_AVAILABLE:
+                log.info(
+                    "torch %s, CUDA device: %s",
+                    torch.__version__,
+                    torch.cuda.get_device_name(0),
+                )
+            else:
+                log.info("torch available but no CUDA — using NumPy")
+        except ImportError:
+            _TORCH_AVAILABLE = False
+            log.info("torch not installed — using NumPy")
+    return _TORCH_AVAILABLE
+
+
+def get_backend(cfg: dict) -> str:
+    """Return 'torch' or 'numpy' based on config and hardware.
+
+    Parameters
+    ----------
+    cfg : dict
+        Full analysis config (reads ``cfg["divergence"]["backend"]``).
+
+    Returns
+    -------
+    str
+        ``"torch"`` or ``"numpy"``.
+
+    Raises
+    ------
+    RuntimeError
+        If ``backend: cuda`` but no CUDA-capable torch is found.
+
+    """
+    setting = cfg["divergence"].get("backend", "auto")
+
+    if setting == "cpu":
+        log.info("Backend forced to NumPy (config: cpu)")
+        return "numpy"
+
+    has_cuda = _probe_torch()
+
+    if setting == "cuda":
+        if not has_cuda:
+            raise RuntimeError(
+                "Config requires backend: cuda but torch CUDA is not available"
+            )
+        return "torch"
+
+    # auto
+    return "torch" if has_cuda else "numpy"
+
+
+def to_tensor(arr: np.ndarray) -> "torch.Tensor":
+    """Convert NumPy array to float32 torch tensor on CUDA."""
+    import torch
+
+    return torch.as_tensor(arr, dtype=torch.float32, device="cuda")
+
+
+def to_numpy(t: "torch.Tensor") -> np.ndarray:
+    """Move torch tensor back to NumPy on CPU."""
+    return t.detach().cpu().numpy()

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -14,7 +14,7 @@ from utils import get_logger
 log = get_logger("_divergence_backend")
 
 _TORCH_AVAILABLE: bool | None = None
-_DEVICE: str | None = None
+_VALID_BACKENDS = {"auto", "cpu", "cuda"}
 
 
 def _probe_torch() -> bool:
@@ -59,6 +59,10 @@ def get_backend(cfg: dict) -> str:
 
     """
     setting = cfg["divergence"].get("backend", "auto")
+    if setting not in _VALID_BACKENDS:
+        raise ValueError(
+            f"Invalid backend {setting!r}, must be one of {_VALID_BACKENDS}"
+        )
 
     if setting == "cpu":
         log.info("Backend forced to NumPy (config: cpu)")

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -244,6 +244,8 @@ def _energy_distance_torch(X, Y):
     """Energy distance via torch on CUDA.
 
     E(X,Y) = 2*E[||X-Y||] - E[||X-X'||] - E[||Y-Y'||]
+
+    Uses V-statistic (includes diagonal) to match dcor.energy_distance.
     """
     import torch
     from _divergence_backend import to_tensor

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -167,11 +167,40 @@ def compute_mmd_rbf(X, Y, bandwidth):
     return max(float(mmd2), 0.0)
 
 
+def _mmd_rbf_torch(X, Y, bandwidth):
+    """MMD^2 via torch on CUDA — same algorithm as compute_mmd_rbf."""
+    import torch
+    from _divergence_backend import to_tensor
+
+    gamma = 1.0 / (2.0 * bandwidth) if bandwidth > 0 else 1.0
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    K_XX = torch.exp(-gamma * torch.cdist(Xt, Xt).pow(2))
+    K_YY = torch.exp(-gamma * torch.cdist(Yt, Yt).pow(2))
+    K_XY = torch.exp(-gamma * torch.cdist(Xt, Yt).pow(2))
+
+    n = Xt.shape[0]
+    m = Yt.shape[0]
+
+    mmd2 = (
+        (K_XX.sum() - K_XX.trace()) / (n * (n - 1))
+        + (K_YY.sum() - K_YY.trace()) / (m * (m - 1))
+        - 2.0 * K_XY.mean()
+    )
+    return max(float(mmd2.item()), 0.0)
+
+
 def compute_s1_mmd(df, emb, cfg):
     """S1: MMD with RBF kernel at 0.5x, 1x, 2x median bandwidth.
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+    mmd_fn = _mmd_rbf_torch if backend == "torch" else compute_mmd_rbf
+
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
@@ -194,7 +223,7 @@ def compute_s1_mmd(df, emb, cfg):
         med = _median_heuristic(X, Y, rng=rng)
         for mult in bandwidth_multipliers:
             bw = med * mult
-            val = compute_mmd_rbf(X, Y, bw)
+            val = mmd_fn(X, Y, bw)
             results.append(
                 {
                     "year": int(y),
@@ -211,20 +240,38 @@ def compute_s1_mmd(df, emb, cfg):
 # ── S2: Energy distance ──────────────────────────────────────────────────
 
 
+def _energy_distance_torch(X, Y):
+    """Energy distance via torch on CUDA.
+
+    E(X,Y) = 2*E[||X-Y||] - E[||X-X'||] - E[||Y-Y'||]
+    """
+    import torch
+    from _divergence_backend import to_tensor
+
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    dXY = torch.cdist(Xt, Yt).mean()
+    dXX = torch.cdist(Xt, Xt).mean()
+    dYY = torch.cdist(Yt, Yt).mean()
+
+    return float((2.0 * dXY - dXX - dYY).item())
+
+
 def compute_s2_energy(df, emb, cfg):
-    """S2: Energy distance (multivariate via dcor).
+    """S2: Energy distance (multivariate via dcor or torch).
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
-    import dcor
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+
+    if backend == "numpy":
+        import dcor
 
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
-
-    # dcor.energy_distance is O(n**2) in the number of samples.
-    # Benchmark: 2000x1024 arrays -> ~X seconds on CPU.
-    # TODO: measure actual runtime on padme with real data.
-    # Subsampling via max_subsample in config caps n at 2000.
 
     years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
     if not years:
@@ -239,7 +286,10 @@ def compute_s2_energy(df, emb, cfg):
             log.info("S2 energy window=%d done", last_w)
         last_w = w
 
-        val = float(dcor.energy_distance(X, Y))
+        if backend == "torch":
+            val = _energy_distance_torch(X, Y)
+        else:
+            val = float(dcor.energy_distance(X, Y))
         results.append(
             {
                 "year": int(y),
@@ -259,9 +309,14 @@ def compute_s2_energy(df, emb, cfg):
 def compute_s3_wasserstein(df, emb, cfg):
     """S3: Sliced Wasserstein distance with varying projection counts.
 
+    POT natively supports torch tensors, so GPU dispatch is transparent.
+
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     import ot
+    from _divergence_backend import get_backend, to_tensor
+
+    backend = get_backend(cfg)
 
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
@@ -282,11 +337,16 @@ def compute_s3_wasserstein(df, emb, cfg):
             log.info("S3 sliced Wasserstein window=%d done", last_w)
         last_w = w
 
+        if backend == "torch":
+            Xt, Yt = to_tensor(X), to_tensor(Y)
+        else:
+            Xt, Yt = X, Y
+
         for n_proj in n_projections_list:
             val = float(
                 ot.sliced_wasserstein_distance(
-                    X,
-                    Y,
+                    Xt,
+                    Yt,
                     n_projections=n_proj,
                     seed=seed,
                 )
@@ -340,11 +400,51 @@ def compute_frechet_distance(X, Y):
     return float(max(mean_term + trace_term, 0.0))
 
 
+def _frechet_torch(X, Y):
+    """Frechet distance via torch on CUDA.
+
+    Uses eigendecomposition for matrix square root (more stable than sqrtm).
+    """
+    import torch
+    from _divergence_backend import to_tensor
+
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    mu1 = Xt.mean(dim=0)
+    mu2 = Yt.mean(dim=0)
+
+    eps = 1e-6
+    C1 = torch.cov(Xt.T) + eps * torch.eye(Xt.shape[1], device=Xt.device)
+    C2 = torch.cov(Yt.T) + eps * torch.eye(Yt.shape[1], device=Yt.device)
+
+    diff = mu1 - mu2
+    mean_term = diff.dot(diff)
+
+    # Matrix square root via eigendecomposition: S = V diag(sqrt(λ)) V^T
+    def _sqrtm_eigh(M):
+        eigvals, eigvecs = torch.linalg.eigh(M)
+        eigvals = eigvals.clamp(min=0.0)
+        return eigvecs @ torch.diag(eigvals.sqrt()) @ eigvecs.T
+
+    sqrt_C1 = _sqrtm_eigh(C1)
+    product = sqrt_C1 @ C2 @ sqrt_C1
+    sqrt_product = _sqrtm_eigh(product)
+
+    trace_term = torch.trace(C1 + C2 - 2.0 * sqrt_product)
+    return float(max((mean_term + trace_term).item(), 0.0))
+
+
 def compute_s4_frechet(df, emb, cfg):
     """S4: Frechet distance (Gaussian fit).
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+    frechet_fn = _frechet_torch if backend == "torch" else compute_frechet_distance
+
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
@@ -377,7 +477,7 @@ def compute_s4_frechet(df, emb, cfg):
         else:
             X_r, Y_r = X, Y
 
-        val = compute_frechet_distance(X_r, Y_r)
+        val = frechet_fn(X_r, Y_r)
         results.append(
             {
                 "year": int(y),

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -1,0 +1,174 @@
+"""Tests for GPU backend dispatch and torch/numpy equivalence.
+
+Tests:
+1. Backend dispatch logic (auto, cpu, cuda)
+2. Torch implementations match numpy within tolerance (S1-S4)
+3. Config toggle works end-to-end
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+# Skip entire module if torch+CUDA unavailable
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
+
+@pytest.fixture()
+def random_arrays():
+    """Two random 200x64 arrays (small but enough for all methods)."""
+    rng = np.random.RandomState(123)
+    X = rng.randn(200, 64).astype(np.float32)
+    Y = rng.randn(200, 64).astype(np.float32) + 0.3  # shift for nonzero distance
+    return X, Y
+
+
+@pytest.fixture()
+def cfg_gpu():
+    """Config with backend: cuda."""
+    from pipeline_loaders import load_analysis_config
+
+    cfg = load_analysis_config()
+    cfg["divergence"]["backend"] = "cuda"
+    return cfg
+
+
+@pytest.fixture()
+def cfg_cpu():
+    """Config with backend: cpu."""
+    from pipeline_loaders import load_analysis_config
+
+    cfg = load_analysis_config()
+    cfg["divergence"]["backend"] = "cpu"
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDispatch:
+    """get_backend returns correct value for each config setting."""
+
+    def test_cpu_setting(self, cfg_cpu):
+        from _divergence_backend import get_backend
+
+        assert get_backend(cfg_cpu) == "numpy"
+
+    def test_cuda_setting(self, cfg_gpu):
+        from _divergence_backend import get_backend
+
+        assert get_backend(cfg_gpu) == "torch"
+
+    def test_auto_selects_torch_when_cuda(self):
+        from _divergence_backend import get_backend
+
+        cfg = {"divergence": {"backend": "auto"}}
+        assert get_backend(cfg) == "torch"
+
+    def test_invalid_cuda_raises(self, monkeypatch):
+        # Temporarily pretend CUDA is unavailable
+        import _divergence_backend
+        from _divergence_backend import get_backend
+
+        monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", False)
+        with pytest.raises(RuntimeError, match="cuda"):
+            get_backend({"divergence": {"backend": "cuda"}})
+        # Reset cached state
+        monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", None)
+
+
+# ---------------------------------------------------------------------------
+# Torch/numpy equivalence for S1-S4
+# ---------------------------------------------------------------------------
+
+RTOL = 1e-3  # float32 accumulation tolerance for O(n²) sums
+
+
+class TestMMDEquivalence:
+    """S1: _mmd_rbf_torch matches compute_mmd_rbf."""
+
+    def test_values_match(self, random_arrays):
+        from _divergence_semantic import _mmd_rbf_torch, compute_mmd_rbf
+
+        X, Y = random_arrays
+        bandwidth = float(np.median(np.sum((X[:100] - Y[:100]) ** 2, axis=1)))
+
+        val_np = compute_mmd_rbf(X, Y, bandwidth)
+        val_torch = _mmd_rbf_torch(X, Y, bandwidth)
+
+        assert val_np > 0, "numpy MMD should be positive for shifted distributions"
+        assert val_torch > 0, "torch MMD should be positive for shifted distributions"
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestEnergyEquivalence:
+    """S2: _energy_distance_torch matches dcor.energy_distance."""
+
+    def test_values_match(self, random_arrays):
+        import dcor
+        from _divergence_semantic import _energy_distance_torch
+
+        X, Y = random_arrays
+
+        val_np = float(dcor.energy_distance(X, Y))
+        val_torch = _energy_distance_torch(X, Y)
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestFrechetEquivalence:
+    """S4: _frechet_torch matches compute_frechet_distance."""
+
+    def test_values_match(self, random_arrays):
+        from _divergence_semantic import _frechet_torch, compute_frechet_distance
+
+        X, Y = random_arrays
+
+        val_np = compute_frechet_distance(X, Y)
+        val_torch = _frechet_torch(X, Y)
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestWassersteinGPU:
+    """S3: POT with torch tensors produces same result as numpy.
+
+    POT generates random projections independently per backend, so
+    exact match is not expected — we check both are positive and
+    within 1% of each other.
+    """
+
+    def test_values_match(self, random_arrays):
+        import ot
+        from _divergence_backend import to_tensor
+
+        X, Y = random_arrays
+        n_proj = 500
+
+        val_np = float(
+            ot.sliced_wasserstein_distance(X, Y, n_projections=n_proj, seed=42)
+        )
+        val_torch = float(
+            ot.sliced_wasserstein_distance(
+                to_tensor(X), to_tensor(Y), n_projections=n_proj, seed=42
+            )
+        )
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=5e-3)

--- a/tickets/0037-gpu-acceleration.erg
+++ b/tickets/0037-gpu-acceleration.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: GPU acceleration for semantic divergence methods S1-S4
-Status: open
+Status: in-progress
 Created: 2026-04-15
 Author: user
 
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note from simplify review; padme A4000 16GB
+2026-04-15T22:00Z claude status implemented — branch t0037-gpu-acceleration pushed, 8/8 tests pass
 
 --- body ---
 ## Context

--- a/tickets/0042-run-real-corpus.erg
+++ b/tickets/0042-run-real-corpus.erg
@@ -3,12 +3,10 @@ Title: Run divergence pipeline on real corpus (padme)
 Status: open
 Created: 2026-04-15
 Author: user
-Blocked-by: 0037
-Blocked-by: 0039
-
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note the actual scientific computation; blocked by robustness + GPU
+2026-04-15T21:00Z claude unblocked from 0037 and 0039 per workplan review — CPU run is fine, robustness is polish
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- Add torch CUDA backend for O(n²) semantic divergence methods (S1 MMD, S2 energy, S3 Wasserstein, S4 Fréchet)
- Config-driven dispatch (`backend: auto|cpu|cuda` in `config/analysis.yaml`) — auto-detects CUDA, falls back to NumPy
- New `scripts/_divergence_backend.py` module for device management
- Also unblocks ticket 0042 from 0037/0039 — CPU run is fine for first real data pass

## Files changed
- `config/analysis.yaml` — added `backend: auto` setting
- `scripts/_divergence_backend.py` — new backend dispatch module
- `scripts/_divergence_semantic.py` — torch implementations + dispatch in S1-S4
- `tests/test_gpu_backend.py` — 8 tests: dispatch logic + torch/numpy equivalence
- `tickets/0042-run-real-corpus.erg` — removed stale blockers

## Test plan
- [x] 8/8 GPU backend tests pass (dispatch + equivalence for all 4 methods)
- [x] `make check-fast` — no new failures (14 pre-existing on main)
- [ ] Benchmark on real data (ticket 0042) to confirm speedup

Closes #0037

🤖 Generated with [Claude Code](https://claude.com/claude-code)