### PR TITLE
fix: simplify backend, fix divergence.mk and G3 dtype

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -21,6 +21,7 @@ clustering:
 
 divergence:
   random_seed: 42
+  backend: auto        # auto (GPU if available), cpu, cuda
   windows: [2, 3, 4, 5]
   min_papers: 30          # per window minimum (override with 5 for smoke)
   min_papers_smoke: 5     # auto-detected when n_works < 200

--- a/divergence.mk
+++ b/divergence.mk
@@ -40,19 +40,19 @@ DIV_CSV_ALL := $(DIV_CSV_SEM) $(DIV_CSV_LEX) $(DIV_CSV_CIT)
 
 $(foreach m,$(DIV_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Lexical methods (depend on REFINED only) ─────────────────────────────
 
 $(foreach m,$(DIV_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Citation methods (depend on REFINED + REFINED_CIT) ───────────────────
 
 $(foreach m,$(DIV_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_citation.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Convenience targets ──────────────────────────────────────────────────
 
@@ -76,7 +76,7 @@ divergence-tables: $(DIV_CSV_ALL)
 DIV_FIG_STAMP := $(DIV_FIGS)/.divergence_figs.stamp
 
 $(DIV_FIG_STAMP): scripts/plot_divergence.py $(DIV_CSV_ALL)
-	python3 scripts/plot_divergence.py \
+	uv run python scripts/plot_divergence.py \
 		--output $(DIV_FIGS)/fig_divergence.png \
 		--input $(DIV_CSV_ALL)
 	touch $@
@@ -100,11 +100,11 @@ SENS_CSV_ALL := $(SENS_CSV_PCA) $(SENS_CSV_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_pca_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
+	uv run python $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_jl_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
+	uv run python $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
 
 # Figures: one PNG per (method, projection) pair — 1 invocation = 1 figure
 SENS_FIG_PCA := $(foreach m,$(SENS_METHODS),$(DIV_FIGS)/fig_sensitivity_pca_$(m).png)
@@ -113,11 +113,11 @@ SENS_FIG_ALL := $(SENS_FIG_PCA) $(SENS_FIG_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_pca_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_pca_$(m).csv ; \
-	python3 $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
+	uv run python $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_jl_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_jl_$(m).csv ; \
-	python3 $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
+	uv run python $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
 
 .PHONY: sensitivity-tables
 sensitivity-tables: $(SENS_CSV_ALL)
@@ -143,13 +143,13 @@ CV_TABLE   := $(DIV_TABLES)/tab_convergence.csv
 CP_FIG     := $(DIV_FIGS)/fig_convergence.png
 
 $(CP_TABLE): $(CP_SCRIPT) $(DIV_CSV_ALL) $(DIV_CFG)
-	python3 $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
+	uv run python $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
 
 $(CV_TABLE): $(CV_SCRIPT) $(CP_TABLE)
-	python3 $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
+	uv run python $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
 
 $(CP_FIG): $(CP_PLOT) $(CP_TABLE) $(CV_TABLE)
-	python3 $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
+	uv run python $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
 
 .PHONY: changepoints-tables
 changepoints-tables: $(CP_TABLE) $(CV_TABLE)

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -11,6 +11,7 @@ import warnings
 
 import networkx as nx
 import numpy as np
+import pandas as pd
 from _divergence_citation import (
     _cumulative_graph,
     _dict_to_df,
@@ -144,10 +145,13 @@ def compute_g3_age_shift(works, citations, internal_edges, cfg):
             results[y] = np.nan
             continue
 
-        refs = citations.loc[
-            citations["source_doi"].isin(year_dois) & citations["ref_year"].notna(),
-            "ref_year",
-        ]
+        refs = pd.to_numeric(
+            citations.loc[
+                citations["source_doi"].isin(year_dois) & citations["ref_year"].notna(),
+                "ref_year",
+            ],
+            errors="coerce",
+        ).dropna()
         if len(refs) < 3:
             results[y] = np.nan
             continue

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -1,0 +1,89 @@
+"""Backend dispatch for divergence computations (CPU / CUDA).
+
+Private module — called by _divergence_semantic.py.
+
+Resolves the ``backend`` key from config/analysis.yaml:
+  auto  → CUDA if torch+CUDA available, else NumPy
+  cpu   → NumPy only
+  cuda  → torch CUDA (raises if unavailable)
+"""
+
+import numpy as np
+from utils import get_logger
+
+log = get_logger("_divergence_backend")
+
+_TORCH_AVAILABLE: bool | None = None
+_DEVICE: str | None = None
+
+
+def _probe_torch() -> bool:
+    """Lazy-check whether torch with CUDA is importable."""
+    global _TORCH_AVAILABLE
+    if _TORCH_AVAILABLE is None:
+        try:
+            import torch
+
+            _TORCH_AVAILABLE = torch.cuda.is_available()
+            if _TORCH_AVAILABLE:
+                log.info(
+                    "torch %s, CUDA device: %s",
+                    torch.__version__,
+                    torch.cuda.get_device_name(0),
+                )
+            else:
+                log.info("torch available but no CUDA — using NumPy")
+        except ImportError:
+            _TORCH_AVAILABLE = False
+            log.info("torch not installed — using NumPy")
+    return _TORCH_AVAILABLE
+
+
+def get_backend(cfg: dict) -> str:
+    """Return 'torch' or 'numpy' based on config and hardware.
+
+    Parameters
+    ----------
+    cfg : dict
+        Full analysis config (reads ``cfg["divergence"]["backend"]``).
+
+    Returns
+    -------
+    str
+        ``"torch"`` or ``"numpy"``.
+
+    Raises
+    ------
+    RuntimeError
+        If ``backend: cuda`` but no CUDA-capable torch is found.
+
+    """
+    setting = cfg["divergence"].get("backend", "auto")
+
+    if setting == "cpu":
+        log.info("Backend forced to NumPy (config: cpu)")
+        return "numpy"
+
+    has_cuda = _probe_torch()
+
+    if setting == "cuda":
+        if not has_cuda:
+            raise RuntimeError(
+                "Config requires backend: cuda but torch CUDA is not available"
+            )
+        return "torch"
+
+    # auto
+    return "torch" if has_cuda else "numpy"
+
+
+def to_tensor(arr: np.ndarray) -> "torch.Tensor":
+    """Convert NumPy array to float32 torch tensor on CUDA."""
+    import torch
+
+    return torch.as_tensor(arr, dtype=torch.float32, device="cuda")
+
+
+def to_numpy(t: "torch.Tensor") -> np.ndarray:
+    """Move torch tensor back to NumPy on CPU."""
+    return t.detach().cpu().numpy()

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -14,7 +14,7 @@ from utils import get_logger
 log = get_logger("_divergence_backend")
 
 _TORCH_AVAILABLE: bool | None = None
-_DEVICE: str | None = None
+_VALID_BACKENDS = {"auto", "cpu", "cuda"}
 
 
 def _probe_torch() -> bool:
@@ -59,6 +59,10 @@ def get_backend(cfg: dict) -> str:
 
     """
     setting = cfg["divergence"].get("backend", "auto")
+    if setting not in _VALID_BACKENDS:
+        raise ValueError(
+            f"Invalid backend {setting!r}, must be one of {_VALID_BACKENDS}"
+        )
 
     if setting == "cpu":
         log.info("Backend forced to NumPy (config: cpu)")

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -8,12 +8,12 @@ Resolves the ``backend`` key from config/analysis.yaml:
   cuda  → torch CUDA (raises if unavailable)
 """
 
-import numpy as np
 from utils import get_logger
 
 log = get_logger("_divergence_backend")
 
 _TORCH_AVAILABLE: bool | None = None
+_RESOLVED_BACKEND: str | None = None
 _VALID_BACKENDS = {"auto", "cpu", "cuda"}
 
 
@@ -58,6 +58,10 @@ def get_backend(cfg: dict) -> str:
         If ``backend: cuda`` but no CUDA-capable torch is found.
 
     """
+    global _RESOLVED_BACKEND
+    if _RESOLVED_BACKEND is not None:
+        return _RESOLVED_BACKEND
+
     setting = cfg["divergence"].get("backend", "auto")
     if setting not in _VALID_BACKENDS:
         raise ValueError(
@@ -65,29 +69,24 @@ def get_backend(cfg: dict) -> str:
         )
 
     if setting == "cpu":
-        log.info("Backend forced to NumPy (config: cpu)")
-        return "numpy"
-
-    has_cuda = _probe_torch()
-
-    if setting == "cuda":
-        if not has_cuda:
+        result = "numpy"
+    elif setting == "cuda":
+        if not _probe_torch():
             raise RuntimeError(
                 "Config requires backend: cuda but torch CUDA is not available"
             )
-        return "torch"
+        result = "torch"
+    else:
+        # auto
+        result = "torch" if _probe_torch() else "numpy"
 
-    # auto
-    return "torch" if has_cuda else "numpy"
+    log.info("Divergence backend: %s (config: %s)", result, setting)
+    _RESOLVED_BACKEND = result
+    return result
 
 
-def to_tensor(arr: np.ndarray) -> "torch.Tensor":
+def to_tensor(arr: "np.ndarray") -> "torch.Tensor":
     """Convert NumPy array to float32 torch tensor on CUDA."""
     import torch
 
     return torch.as_tensor(arr, dtype=torch.float32, device="cuda")
-
-
-def to_numpy(t: "torch.Tensor") -> np.ndarray:
-    """Move torch tensor back to NumPy on CPU."""
-    return t.detach().cpu().numpy()

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -244,6 +244,8 @@ def _energy_distance_torch(X, Y):
     """Energy distance via torch on CUDA.
 
     E(X,Y) = 2*E[||X-Y||] - E[||X-X'||] - E[||Y-Y'||]
+
+    Uses V-statistic (includes diagonal) to match dcor.energy_distance.
     """
     import torch
     from _divergence_backend import to_tensor

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -167,11 +167,40 @@ def compute_mmd_rbf(X, Y, bandwidth):
     return max(float(mmd2), 0.0)
 
 
+def _mmd_rbf_torch(X, Y, bandwidth):
+    """MMD^2 via torch on CUDA — same algorithm as compute_mmd_rbf."""
+    import torch
+    from _divergence_backend import to_tensor
+
+    gamma = 1.0 / (2.0 * bandwidth) if bandwidth > 0 else 1.0
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    K_XX = torch.exp(-gamma * torch.cdist(Xt, Xt).pow(2))
+    K_YY = torch.exp(-gamma * torch.cdist(Yt, Yt).pow(2))
+    K_XY = torch.exp(-gamma * torch.cdist(Xt, Yt).pow(2))
+
+    n = Xt.shape[0]
+    m = Yt.shape[0]
+
+    mmd2 = (
+        (K_XX.sum() - K_XX.trace()) / (n * (n - 1))
+        + (K_YY.sum() - K_YY.trace()) / (m * (m - 1))
+        - 2.0 * K_XY.mean()
+    )
+    return max(float(mmd2.item()), 0.0)
+
+
 def compute_s1_mmd(df, emb, cfg):
     """S1: MMD with RBF kernel at 0.5x, 1x, 2x median bandwidth.
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+    mmd_fn = _mmd_rbf_torch if backend == "torch" else compute_mmd_rbf
+
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
@@ -194,7 +223,7 @@ def compute_s1_mmd(df, emb, cfg):
         med = _median_heuristic(X, Y, rng=rng)
         for mult in bandwidth_multipliers:
             bw = med * mult
-            val = compute_mmd_rbf(X, Y, bw)
+            val = mmd_fn(X, Y, bw)
             results.append(
                 {
                     "year": int(y),
@@ -211,20 +240,38 @@ def compute_s1_mmd(df, emb, cfg):
 # ── S2: Energy distance ──────────────────────────────────────────────────
 
 
+def _energy_distance_torch(X, Y):
+    """Energy distance via torch on CUDA.
+
+    E(X,Y) = 2*E[||X-Y||] - E[||X-X'||] - E[||Y-Y'||]
+    """
+    import torch
+    from _divergence_backend import to_tensor
+
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    dXY = torch.cdist(Xt, Yt).mean()
+    dXX = torch.cdist(Xt, Xt).mean()
+    dYY = torch.cdist(Yt, Yt).mean()
+
+    return float((2.0 * dXY - dXX - dYY).item())
+
+
 def compute_s2_energy(df, emb, cfg):
-    """S2: Energy distance (multivariate via dcor).
+    """S2: Energy distance (multivariate via dcor or torch).
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
-    import dcor
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+
+    if backend == "numpy":
+        import dcor
 
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
-
-    # dcor.energy_distance is O(n**2) in the number of samples.
-    # Benchmark: 2000x1024 arrays -> ~X seconds on CPU.
-    # TODO: measure actual runtime on padme with real data.
-    # Subsampling via max_subsample in config caps n at 2000.
 
     years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
     if not years:
@@ -239,7 +286,10 @@ def compute_s2_energy(df, emb, cfg):
             log.info("S2 energy window=%d done", last_w)
         last_w = w
 
-        val = float(dcor.energy_distance(X, Y))
+        if backend == "torch":
+            val = _energy_distance_torch(X, Y)
+        else:
+            val = float(dcor.energy_distance(X, Y))
         results.append(
             {
                 "year": int(y),
@@ -259,9 +309,14 @@ def compute_s2_energy(df, emb, cfg):
 def compute_s3_wasserstein(df, emb, cfg):
     """S3: Sliced Wasserstein distance with varying projection counts.
 
+    POT natively supports torch tensors, so GPU dispatch is transparent.
+
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     import ot
+    from _divergence_backend import get_backend, to_tensor
+
+    backend = get_backend(cfg)
 
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
@@ -282,11 +337,16 @@ def compute_s3_wasserstein(df, emb, cfg):
             log.info("S3 sliced Wasserstein window=%d done", last_w)
         last_w = w
 
+        if backend == "torch":
+            Xt, Yt = to_tensor(X), to_tensor(Y)
+        else:
+            Xt, Yt = X, Y
+
         for n_proj in n_projections_list:
             val = float(
                 ot.sliced_wasserstein_distance(
-                    X,
-                    Y,
+                    Xt,
+                    Yt,
                     n_projections=n_proj,
                     seed=seed,
                 )
@@ -340,11 +400,51 @@ def compute_frechet_distance(X, Y):
     return float(max(mean_term + trace_term, 0.0))
 
 
+def _frechet_torch(X, Y):
+    """Frechet distance via torch on CUDA.
+
+    Uses eigendecomposition for matrix square root (more stable than sqrtm).
+    """
+    import torch
+    from _divergence_backend import to_tensor
+
+    Xt = to_tensor(X)
+    Yt = to_tensor(Y)
+
+    mu1 = Xt.mean(dim=0)
+    mu2 = Yt.mean(dim=0)
+
+    eps = 1e-6
+    C1 = torch.cov(Xt.T) + eps * torch.eye(Xt.shape[1], device=Xt.device)
+    C2 = torch.cov(Yt.T) + eps * torch.eye(Yt.shape[1], device=Yt.device)
+
+    diff = mu1 - mu2
+    mean_term = diff.dot(diff)
+
+    # Matrix square root via eigendecomposition: S = V diag(sqrt(λ)) V^T
+    def _sqrtm_eigh(M):
+        eigvals, eigvecs = torch.linalg.eigh(M)
+        eigvals = eigvals.clamp(min=0.0)
+        return eigvecs @ torch.diag(eigvals.sqrt()) @ eigvecs.T
+
+    sqrt_C1 = _sqrtm_eigh(C1)
+    product = sqrt_C1 @ C2 @ sqrt_C1
+    sqrt_product = _sqrtm_eigh(product)
+
+    trace_term = torch.trace(C1 + C2 - 2.0 * sqrt_product)
+    return float(max((mean_term + trace_term).item(), 0.0))
+
+
 def compute_s4_frechet(df, emb, cfg):
     """S4: Frechet distance (Gaussian fit).
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
+    from _divergence_backend import get_backend
+
+    backend = get_backend(cfg)
+    frechet_fn = _frechet_torch if backend == "torch" else compute_frechet_distance
+
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
@@ -377,7 +477,7 @@ def compute_s4_frechet(df, emb, cfg):
         else:
             X_r, Y_r = X, Y
 
-        val = compute_frechet_distance(X_r, Y_r)
+        val = frechet_fn(X_r, Y_r)
         results.append(
             {
                 "year": int(y),

--- a/scripts/plot_divergence.py
+++ b/scripts/plot_divergence.py
@@ -57,6 +57,9 @@ matplotlib.rcParams.update(
 
 # ── Visual encoding ──────────────────────────────────────────────────────
 
+YEAR_MIN, YEAR_MAX = 1995, 2025
+YEAR_TICKS = list(range(YEAR_MIN, YEAR_MAX + 1, 5))
+
 WINDOW_STYLES = {2: "-", 3: "--", 4: "-.", 5: ":", "cumulative": "-"}
 COLORS = [
     "#1f77b4",
@@ -266,6 +269,10 @@ def _draw_curves(ax, mdf, breaks_df, method, aggregate="none", palette="auto"):
         for by in sorted(break_years):
             ax.axvline(by, color="red", linewidth=0.7, linestyle="--", alpha=0.7)
 
+    # Consistent axis range: 1995–2025 with 5-year ticks
+    ax.set_xlim(YEAR_MIN, YEAR_MAX)
+    ax.set_xticks(YEAR_TICKS)
+
     handles, labels = ax.get_legend_handles_labels()
     if handles:
         ncol = 2 if len(handles) <= 12 else 3
@@ -274,6 +281,8 @@ def _draw_curves(ax, mdf, breaks_df, method, aggregate="none", palette="auto"):
 
 def _draw_lines(ax, mdf):
     """One curve per (window, hyperparams) group, discrete colors."""
+    mdf = mdf.copy()
+    mdf["hyperparams"] = mdf["hyperparams"].fillna("default")
     groups = mdf.groupby(["window", "hyperparams"])
     color_idx = 0
     for (window, hp), grp in sorted(groups):

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -60,6 +60,13 @@ def cfg_cpu():
 class TestBackendDispatch:
     """get_backend returns correct value for each config setting."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_backend_cache(self, monkeypatch):
+        """Clear cached backend before each test so config takes effect."""
+        import _divergence_backend
+
+        monkeypatch.setattr(_divergence_backend, "_RESOLVED_BACKEND", None)
+
     def test_cpu_setting(self, cfg_cpu):
         from _divergence_backend import get_backend
 
@@ -77,14 +84,12 @@ class TestBackendDispatch:
         assert get_backend(cfg) == "torch"
 
     def test_invalid_cuda_raises(self, monkeypatch):
-        # Temporarily pretend CUDA is unavailable
         import _divergence_backend
         from _divergence_backend import get_backend
 
         monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", False)
         with pytest.raises(RuntimeError, match="cuda"):
             get_backend({"divergence": {"backend": "cuda"}})
-        # Reset cached state
         monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", None)
 
 

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -1,0 +1,174 @@
+"""Tests for GPU backend dispatch and torch/numpy equivalence.
+
+Tests:
+1. Backend dispatch logic (auto, cpu, cuda)
+2. Torch implementations match numpy within tolerance (S1-S4)
+3. Config toggle works end-to-end
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+# Skip entire module if torch+CUDA unavailable
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available",
+)
+
+
+@pytest.fixture()
+def random_arrays():
+    """Two random 200x64 arrays (small but enough for all methods)."""
+    rng = np.random.RandomState(123)
+    X = rng.randn(200, 64).astype(np.float32)
+    Y = rng.randn(200, 64).astype(np.float32) + 0.3  # shift for nonzero distance
+    return X, Y
+
+
+@pytest.fixture()
+def cfg_gpu():
+    """Config with backend: cuda."""
+    from pipeline_loaders import load_analysis_config
+
+    cfg = load_analysis_config()
+    cfg["divergence"]["backend"] = "cuda"
+    return cfg
+
+
+@pytest.fixture()
+def cfg_cpu():
+    """Config with backend: cpu."""
+    from pipeline_loaders import load_analysis_config
+
+    cfg = load_analysis_config()
+    cfg["divergence"]["backend"] = "cpu"
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDispatch:
+    """get_backend returns correct value for each config setting."""
+
+    def test_cpu_setting(self, cfg_cpu):
+        from _divergence_backend import get_backend
+
+        assert get_backend(cfg_cpu) == "numpy"
+
+    def test_cuda_setting(self, cfg_gpu):
+        from _divergence_backend import get_backend
+
+        assert get_backend(cfg_gpu) == "torch"
+
+    def test_auto_selects_torch_when_cuda(self):
+        from _divergence_backend import get_backend
+
+        cfg = {"divergence": {"backend": "auto"}}
+        assert get_backend(cfg) == "torch"
+
+    def test_invalid_cuda_raises(self, monkeypatch):
+        # Temporarily pretend CUDA is unavailable
+        import _divergence_backend
+        from _divergence_backend import get_backend
+
+        monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", False)
+        with pytest.raises(RuntimeError, match="cuda"):
+            get_backend({"divergence": {"backend": "cuda"}})
+        # Reset cached state
+        monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", None)
+
+
+# ---------------------------------------------------------------------------
+# Torch/numpy equivalence for S1-S4
+# ---------------------------------------------------------------------------
+
+RTOL = 1e-3  # float32 accumulation tolerance for O(n²) sums
+
+
+class TestMMDEquivalence:
+    """S1: _mmd_rbf_torch matches compute_mmd_rbf."""
+
+    def test_values_match(self, random_arrays):
+        from _divergence_semantic import _mmd_rbf_torch, compute_mmd_rbf
+
+        X, Y = random_arrays
+        bandwidth = float(np.median(np.sum((X[:100] - Y[:100]) ** 2, axis=1)))
+
+        val_np = compute_mmd_rbf(X, Y, bandwidth)
+        val_torch = _mmd_rbf_torch(X, Y, bandwidth)
+
+        assert val_np > 0, "numpy MMD should be positive for shifted distributions"
+        assert val_torch > 0, "torch MMD should be positive for shifted distributions"
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestEnergyEquivalence:
+    """S2: _energy_distance_torch matches dcor.energy_distance."""
+
+    def test_values_match(self, random_arrays):
+        import dcor
+        from _divergence_semantic import _energy_distance_torch
+
+        X, Y = random_arrays
+
+        val_np = float(dcor.energy_distance(X, Y))
+        val_torch = _energy_distance_torch(X, Y)
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestFrechetEquivalence:
+    """S4: _frechet_torch matches compute_frechet_distance."""
+
+    def test_values_match(self, random_arrays):
+        from _divergence_semantic import _frechet_torch, compute_frechet_distance
+
+        X, Y = random_arrays
+
+        val_np = compute_frechet_distance(X, Y)
+        val_torch = _frechet_torch(X, Y)
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=RTOL)
+
+
+class TestWassersteinGPU:
+    """S3: POT with torch tensors produces same result as numpy.
+
+    POT generates random projections independently per backend, so
+    exact match is not expected — we check both are positive and
+    within 1% of each other.
+    """
+
+    def test_values_match(self, random_arrays):
+        import ot
+        from _divergence_backend import to_tensor
+
+        X, Y = random_arrays
+        n_proj = 500
+
+        val_np = float(
+            ot.sliced_wasserstein_distance(X, Y, n_projections=n_proj, seed=42)
+        )
+        val_torch = float(
+            ot.sliced_wasserstein_distance(
+                to_tensor(X), to_tensor(Y), n_projections=n_proj, seed=42
+            )
+        )
+
+        assert val_np > 0
+        assert val_torch > 0
+        np.testing.assert_allclose(val_torch, val_np, rtol=5e-3)

--- a/tickets/0037-gpu-acceleration.erg
+++ b/tickets/0037-gpu-acceleration.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: GPU acceleration for semantic divergence methods S1-S4
-Status: open
+Status: in-progress
 Created: 2026-04-15
 Author: user
 
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note from simplify review; padme A4000 16GB
+2026-04-15T22:00Z claude status implemented — branch t0037-gpu-acceleration pushed, 8/8 tests pass
 
 --- body ---
 ## Context

--- a/tickets/0042-run-real-corpus.erg
+++ b/tickets/0042-run-real-corpus.erg
@@ -3,12 +3,10 @@ Title: Run divergence pipeline on real corpus (padme)
 Status: open
 Created: 2026-04-15
 Author: user
-Blocked-by: 0037
-Blocked-by: 0039
-
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note the actual scientific computation; blocked by robustness + GPU
+2026-04-15T21:00Z claude unblocked from 0037 and 0039 per workplan review — CPU run is fine, robustness is polish
 
 --- body ---
 ## Context

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -69,7 +69,8 @@ not on figures.
 ### Correction implementation
 1. Add `equal_n=True` option to `_iter_window_pairs` in
    `_divergence_semantic.py`. Subsample both sides to min(n_before,
-   n_after). Return K=200 bootstrap replicates.
+   n_after). Single pass — no bootstrap replicates by default.
+   Bootstrap K=200 for CIs is a separate step (ticket 0047).
 2. Refactor citation methods (G1, G2, G5, G6, G8) from cumulative
    to sliding windows. Keep cumulative as legacy option.
 3. Verify L1-L2 use union vocabulary. Verify G3, G4, G7 are
@@ -122,6 +123,6 @@ same-pool null, and survives first-difference diagnostic. The paper
 states significance after controlling for corpus growth.
 
 ## Compute estimate
-Layer 1 (correction + bootstrap K=200): ~3h GPU overnight.
-Layer 2 (null N=500 per year): ~8h GPU (can run in parallel).
-Total: two overnight runs, or one weekend run.
+Layer 1 (correction, single pass): same as current run (~3.5 min GPU).
+Layer 2 (null N=500 per year): ~8h GPU (one overnight run).
+Bootstrap CIs (ticket 0047, K=200): ~3h GPU (separate overnight run).

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -1,75 +1,114 @@
 %erg v1
-Title: Size-matched bootstrap null model for divergence significance
+Title: Growth-bias correction + significance testing for divergence
 Status: open
 Created: 2026-04-15
 Author: user
 
 --- log ---
 2026-04-15T23:00Z claude created from workplan review — growth-rate confound identified on first real data run
+2026-04-16T00:00Z claude reimagined — method-specific corrections + same-pool null on corrected series
 
 --- body ---
 ## Context
 First real-data run (ticket 0042) revealed that 6+ of 15 divergence
 methods show monotone declining trends that track corpus growth, not
-structural change. The dominant "break" at 2003 may be an inflection
-point in the publication growth curve, not a genuine structural break.
+structural change. Each method has a specific bias mechanism.
 
-Methods affected: S1-S4 (finite-sample bias), G1/G5/G8 (cumulative
-graph dilution), L1/L2 (vocabulary averaging), G6 (entropy growth).
+## Design: two layers
 
-Methods less affected: G3 (reference age), G4 (cross-community ratio),
-G7 (disruption index) — these measure structural properties not
-mechanically tied to corpus size.
+### Layer 1 — Method-specific growth-bias correction
+
+**S1-S4 (semantic): equal-n subsampling**
+Finite-sample bias inflates distances when windows have unequal sizes.
+Fix: subsample both windows to n = min(n_before, n_after, max_subsample).
+Repeat K=200 times for bootstrap CIs on the corrected divergence.
+
+**L1-L2 (lexical): equal-n + shared vocabulary**
+Same subsampling as S1-S4. Additionally, ensure TF-IDF is computed on
+the union vocabulary of both windows (verify current code does this).
+
+**G1, G2, G5, G6, G8 (citation, cumulative): sliding windows**
+Replace cumulative graph with sliding windows (w=2,3,4,5 years),
+matching the semantic methods. Compare graph(t-w, t) vs graph(t+1, t+w+1).
+Both windows now have locally comparable graph sizes.
+
+**G3, G4, G7 (structural properties): verify size-robustness**
+These measure per-paper or normalized properties. Verify empirically
+that they don't correlate with corpus size. If they do, apply
+per-year normalization.
+
+### Layer 2 — Same-pool null for significance
+
+After correction removes the growth trend, test whether the corrected
+before/after divergence exceeds random noise.
+
+For each (method, year, window):
+1. Pool all papers in [t-w, t+w+1].
+2. Split randomly into two equal halves (ignoring the before/after boundary).
+3. Compute the divergence between the random halves.
+4. Repeat N=500 times → null distribution at year t.
+5. p-value = fraction of null draws ≥ observed corrected divergence.
+
+This works because the correction has removed the trend — before and
+after are no longer systematically different under the null.
+
+### Pipeline
+```
+Raw data
+  → Layer 1: method-specific correction
+    → Corrected divergence + bootstrap CIs  [estimation]
+    → Layer 2: same-pool null on corrected data  [significance]
+      → p-value per (method, year)
+        → Convergence: which years significant across methods?
+```
 
 ## Actions
 
-### Size-matched bootstrap (primary)
-1. Add `--bootstrap K` flag to compute_divergence.py dispatcher.
-2. For each (year, window) pair: subsample both sides to
-   n = min(n_before, n_after, max_subsample). Repeat K times.
-3. Output: mean, median, q025, q975 per (method, year, window).
-4. Schema: extend DivergenceSchema with bootstrap columns, or use
-   a separate BootstrapSchema.
-5. Run PELT on the mean bootstrap series — compare detected breaks
-   with the raw (unmatched) results.
+### Correction implementation
+1. Add `equal_n=True` option to `_iter_window_pairs` in
+   `_divergence_semantic.py`. Subsample both sides to min(n_before,
+   n_after). Return K=200 bootstrap replicates.
+2. Refactor citation methods (G1, G2, G5, G6, G8) from cumulative
+   to sliding windows. Keep cumulative as legacy option.
+3. Verify L1-L2 use union vocabulary. Verify G3, G4, G7 are
+   size-robust.
 
-### Rate-of-change diagnostic (complementary, free)
-6. Post-process existing tables: compute first-difference series.
-7. Run PELT on first-differences.
-8. If 2003 appears in both raw and first-difference breaks, it
-   survives the simplest detrending.
+### Null model implementation
+4. New script: `compute_null_divergence.py`. For each (method, year,
+   window): pool papers, random-split N=500 times, compute divergence.
+   Output: null distribution quantiles per (method, year).
+5. New script: `compute_significance.py`. Compare corrected divergence
+   against null distribution → p-values.
 
-### Visualization A: Null envelope on per-method plots
-9. Extend plot_divergence.py: accept optional bootstrap CSV.
-10. Draw grey ribbon (95% CI of null) behind the observed curve.
-11. Mark years where observed exits the ribbon (significant).
-12. One figure per method, same layout as current plots.
+### Visualization A: null envelope on per-method plots
+6. Grey ribbon = null 95% CI. Observed corrected curve on top.
+   Where curve exits ribbon = significant. Bootstrap CI as thinner
+   ribbon around the observed curve.
 
-### Visualization C: Detrended convergence heatmap
-13. Extend plot_convergence.py: z-score each method's series
-    against its bootstrap null (z = (observed - null_mean) / null_sd)
-    instead of against its own mean.
-14. Color scale becomes "SDs above null expectation" — every hot
-    cell has been tested against the growth confound.
-15. Run PELT on the null-z-scored series for break detection.
-16. This replaces the raw heatmap in the paper.
+### Visualization C: significance heatmap
+7. Replace raw z-score heatmap with significance heatmap.
+   Color = -log10(p-value). Grey = not significant. Hot = significant.
+   PELT on -log10(p) series for break detection.
 
-### Reporting
-17. Convergence table: report which breaks survive size-matching,
-    with p-values from the bootstrap distribution.
+### Rate-of-change diagnostic (free, complementary)
+8. First-difference of corrected series. If 2003 spike survives
+   both correction and differentiation, it's robust.
 
 ## Test
 ```python
-def test_bootstrap_reduces_early_year_variance():
-    """Size-matched bootstrap should produce tighter CIs than raw."""
+def test_equal_n_removes_size_correlation():
+    """Corrected divergence should not correlate with min(n_before, n_after)."""
+
+def test_null_divergence_below_observed_at_known_break():
+    """On synthetic data with planted break, p < 0.05 at break year."""
 ```
 
 ## Exit criteria
-Each reported break year has a p-value or CI. The paper can state:
-"The break at year X is significant at the 0.05 level after
-controlling for corpus growth" — or not.
+Each reported break has: corrected divergence ± CI, p-value from
+same-pool null, and survives first-difference diagnostic. The paper
+states significance after controlling for corpus growth.
 
 ## Compute estimate
-K=200, 4 semantic methods on GPU: ~3h overnight.
-Lexical methods (CPU): ~2h. Citation: negligible.
-Total: one overnight run.
+Layer 1 (correction + bootstrap K=200): ~3h GPU overnight.
+Layer 2 (null N=500 per year): ~8h GPU (can run in parallel).
+Total: two overnight runs, or one weekend run.

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -39,9 +39,24 @@ mechanically tied to corpus size.
 8. If 2003 appears in both raw and first-difference breaks, it
    survives the simplest detrending.
 
+### Visualization A: Null envelope on per-method plots
+9. Extend plot_divergence.py: accept optional bootstrap CSV.
+10. Draw grey ribbon (95% CI of null) behind the observed curve.
+11. Mark years where observed exits the ribbon (significant).
+12. One figure per method, same layout as current plots.
+
+### Visualization C: Detrended convergence heatmap
+13. Extend plot_convergence.py: z-score each method's series
+    against its bootstrap null (z = (observed - null_mean) / null_sd)
+    instead of against its own mean.
+14. Color scale becomes "SDs above null expectation" — every hot
+    cell has been tested against the growth confound.
+15. Run PELT on the null-z-scored series for break detection.
+16. This replaces the raw heatmap in the paper.
+
 ### Reporting
-9. Add bootstrap CIs to divergence figures (ribbon around mean).
-10. Convergence table: report which breaks survive size-matching.
+17. Convergence table: report which breaks survive size-matching,
+    with p-values from the bootstrap distribution.
 
 ## Test
 ```python

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -56,10 +56,12 @@ after are no longer systematically different under the null.
 ```
 Raw data
   → Layer 1: method-specific correction
-    → Corrected divergence + bootstrap CIs  [estimation]
+    → Corrected divergence (point estimate = bootstrap median)
     → Layer 2: same-pool null on corrected data  [significance]
       → p-value per (method, year)
         → Convergence: which years significant across methods?
+Bootstrap CIs on data curves go in supplementary table (ticket 0047),
+not on figures.
 ```
 
 ## Actions
@@ -82,8 +84,19 @@ Raw data
 
 ### Visualization A: null envelope on per-method plots
 6. Grey ribbon = null 95% CI. Observed corrected curve on top.
-   Where curve exits ribbon = significant. Bootstrap CI as thinner
-   ribbon around the observed curve.
+   Where curve exits ribbon = significant. No bootstrap CI ribbon
+   on figures (goes in supplementary table, ticket 0047).
+
+### Variant reduction: max 4 curves per figure
+   - S1 MMD: w=2,3,4 × bw=1x_median only (drop w=5, drop 0.5x/2x)
+   - S2 energy: w=2,3,4 (no hyperparams → 3 curves)
+   - S3 Wasserstein: w=2,3,4 × n_proj=500 only (drop w=5, drop 100/1000)
+   - S4 Fréchet: w=2,3,4 (no hyperparams → 3 curves)
+   - L1-L3: w=2,3,4 (drop w=5)
+   - G methods: single curve (sliding window, one window size)
+   - Sensitivity: original + 256d + 32d only (drop 64/128/512)
+   Configure in config/analysis.yaml under a `plot` section, or
+   hardcode in plot_divergence.py as default display variants.
 
 ### Visualization C: significance heatmap
 7. Replace raw z-score heatmap with significance heatmap.

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -1,0 +1,60 @@
+%erg v1
+Title: Size-matched bootstrap null model for divergence significance
+Status: open
+Created: 2026-04-15
+Author: user
+
+--- log ---
+2026-04-15T23:00Z claude created from workplan review — growth-rate confound identified on first real data run
+
+--- body ---
+## Context
+First real-data run (ticket 0042) revealed that 6+ of 15 divergence
+methods show monotone declining trends that track corpus growth, not
+structural change. The dominant "break" at 2003 may be an inflection
+point in the publication growth curve, not a genuine structural break.
+
+Methods affected: S1-S4 (finite-sample bias), G1/G5/G8 (cumulative
+graph dilution), L1/L2 (vocabulary averaging), G6 (entropy growth).
+
+Methods less affected: G3 (reference age), G4 (cross-community ratio),
+G7 (disruption index) — these measure structural properties not
+mechanically tied to corpus size.
+
+## Actions
+
+### Size-matched bootstrap (primary)
+1. Add `--bootstrap K` flag to compute_divergence.py dispatcher.
+2. For each (year, window) pair: subsample both sides to
+   n = min(n_before, n_after, max_subsample). Repeat K times.
+3. Output: mean, median, q025, q975 per (method, year, window).
+4. Schema: extend DivergenceSchema with bootstrap columns, or use
+   a separate BootstrapSchema.
+5. Run PELT on the mean bootstrap series — compare detected breaks
+   with the raw (unmatched) results.
+
+### Rate-of-change diagnostic (complementary, free)
+6. Post-process existing tables: compute first-difference series.
+7. Run PELT on first-differences.
+8. If 2003 appears in both raw and first-difference breaks, it
+   survives the simplest detrending.
+
+### Reporting
+9. Add bootstrap CIs to divergence figures (ribbon around mean).
+10. Convergence table: report which breaks survive size-matching.
+
+## Test
+```python
+def test_bootstrap_reduces_early_year_variance():
+    """Size-matched bootstrap should produce tighter CIs than raw."""
+```
+
+## Exit criteria
+Each reported break year has a p-value or CI. The paper can state:
+"The break at year X is significant at the 0.05 level after
+controlling for corpus growth" — or not.
+
+## Compute estimate
+K=200, 4 semantic methods on GPU: ~3h overnight.
+Lexical methods (CPU): ~2h. Citation: negligible.
+Total: one overnight run.

--- a/tickets/0046-robustness-suite.erg
+++ b/tickets/0046-robustness-suite.erg
@@ -1,0 +1,86 @@
+%erg v1
+Title: Robustness suite: five bias checks for divergence pipeline
+Status: open
+Created: 2026-04-15
+Author: user
+Blocked-by: 0045
+
+--- log ---
+2026-04-15T23:30Z claude created — bias inventory from first real-data run
+
+--- body ---
+## Context
+The divergence pipeline has a growth-rate confound (ticket 0045) plus
+at least four other systematic biases that could produce spurious
+structural breaks. Each needs an explicit robustness check.
+
+The pattern for each check: restrict or transform the input, rerun
+the pipeline, compare break dates with the baseline. A break that
+survives all five checks is robust. One that vanishes under any
+check needs qualification in the paper.
+
+## R1: Citation truncation
+Recent papers have fewer citations (accumulation lag). The citation
+graph is systematically sparser near the present.
+
+**Check**: Censor the citation graph at T-5 (drop all citations
+involving papers published in the last 5 years of each window).
+Rerun G1-G8. If breaks shift toward the present, truncation is
+driving them.
+
+## R2: Embedding model bias
+BGE-M3 was trained on modern text. It may encode 1990s papers
+less faithfully, inflating early-year distributional distances.
+
+**Check**: Re-embed a sample (e.g. 5000 papers, stratified by
+decade) with a second model (SPECTER2 or all-MiniLM-L6-v2).
+Rerun S1-S4 on both embedding sets. If break dates are
+model-dependent, they reflect encoding quality, not content.
+
+## R3: Retrospective curation bias
+Early corpus = curated canonical works. Late corpus = comprehensive.
+This creates artificial homogeneity early, heterogeneity late.
+
+**Check**: Restrict to a consistently-sourced subset. Options:
+  (a) OpenAlex-only (broadest uniform source)
+  (b) DOI-only (excludes grey lit, which skews early)
+  (c) Journal articles only (excludes reports, working papers)
+Rerun full pipeline on each subset.
+
+## R4: Source coverage drift
+Different sources (OpenAlex, ISTEX, bibCNRS, grey lit) have
+different temporal profiles. Breaks could reflect source boundaries.
+
+**Check**: Stratify by source. Run divergence on each source
+independently. If a break appears in OpenAlex but not ISTEX,
+it's a coverage artifact.
+
+## R5: Abstract quality variation
+Short/missing abstracts produce poor embeddings and sparse TF-IDF.
+Their prevalence varies by period and source type.
+
+**Check**: Filter to abstracts > 100 words (or > 50 tokens).
+Compare corpus composition before/after filtering. Rerun S1-S4
+and L1-L2. If the declining trend attenuates, abstract quality
+was driving it.
+
+## Reporting
+For each check, produce a comparison table:
+
+  | Break year | Baseline | R1 | R2 | R3a | R3b | R4-OA | R5 |
+  |------------|----------|----|----|-----|-----|-------|----|
+  | 2003       | 60%      | ?  | ?  |  ?  |  ?  |   ?   |  ? |
+
+Breaks that survive all columns go in the paper without
+qualification. Breaks that fail any check get a caveat.
+
+## Test
+```python
+def test_robustness_table_has_all_checks():
+    """Verify the comparison table has columns for all 5 checks."""
+```
+
+## Exit criteria
+Each reported break is annotated: robust (survives all checks),
+qualified (survives most), or artifact (fails multiple checks).
+The paper's periodization rests only on robust breaks.

--- a/tickets/0047-supplementary-table.erg
+++ b/tickets/0047-supplementary-table.erg
@@ -1,0 +1,37 @@
+%erg v1
+Title: Supplementary table: corrected divergence with bootstrap CIs and p-values
+Status: open
+Created: 2026-04-15
+Author: user
+Blocked-by: 0045
+
+--- log ---
+2026-04-15T23:45Z claude created — keep figures clean, put estimation detail in table
+
+--- body ---
+## Context
+The per-method figures show one curve + one null ribbon (ticket 0045
+viz A). Bootstrap CIs on the observed curve are not shown — they
+would clutter the figure with a second ribbon per variant. But
+reviewers may ask about estimation uncertainty. Put it in a table.
+
+## Actions
+1. New script: `export_divergence_summary.py`. For each (method,
+   year, window), output one row with:
+   - corrected divergence: median, q025, q975 (bootstrap K=200)
+   - null: median, q975 (same-pool N=500)
+   - p-value
+   - significant (boolean, p < 0.05)
+2. Output: `content/tables/tab_divergence_summary.csv`
+3. Pandera schema in schemas.py.
+4. Makefile target in divergence.mk.
+
+## Test
+```python
+def test_summary_table_has_all_methods_and_years():
+    """Every (method, year) pair from the divergence run appears."""
+```
+
+## Exit criteria
+Table is machine-readable, referenced from technical report as
+supplementary material. Figures stay clean — one curve, one ribbon.

--- a/tickets/0047-supplementary-table.erg
+++ b/tickets/0047-supplementary-table.erg
@@ -1,5 +1,5 @@
 %erg v1
-Title: Supplementary table: corrected divergence with bootstrap CIs and p-values
+Title: Supplementary table: bootstrap CIs on corrected divergence
 Status: open
 Created: 2026-04-15
 Author: user
@@ -7,24 +7,36 @@ Blocked-by: 0045
 
 --- log ---
 2026-04-15T23:45Z claude created — keep figures clean, put estimation detail in table
+2026-04-16T00:15Z claude updated — owns the bootstrap K=200 computation, not computed by default
 
 --- body ---
 ## Context
-The per-method figures show one curve + one null ribbon (ticket 0045
-viz A). Bootstrap CIs on the observed curve are not shown — they
-would clutter the figure with a second ribbon per variant. But
-reviewers may ask about estimation uncertainty. Put it in a table.
+Ticket 0045 produces corrected divergence (single pass, equal-n) and
+null p-values. This ticket adds bootstrap CIs for estimation
+uncertainty — not needed during development, only for the final paper.
+
+Separated from 0045 so the bootstrap K=200 run (~3h GPU) is not
+triggered during iterative dev cycles.
 
 ## Actions
-1. New script: `export_divergence_summary.py`. For each (method,
-   year, window), output one row with:
-   - corrected divergence: median, q025, q975 (bootstrap K=200)
-   - null: median, q975 (same-pool N=500)
-   - p-value
+
+### Bootstrap computation
+1. New script: `compute_divergence_bootstrap.py`.
+   - Reads corrected divergence config from 0045.
+   - For each (method, year, window): equal-n subsample K=200 times.
+   - Output: `content/tables/tab_divergence_bootstrap.csv` with
+     columns: method, year, window, hyperparams, replicate, value.
+2. Makefile target `bootstrap-tables` in divergence.mk.
+   Not a dependency of `divergence` — run explicitly.
+
+### Summary table
+3. New script: `export_divergence_summary.py`. Joins:
+   - corrected divergence (0045, single pass) → point estimate
+   - bootstrap replicates (this ticket) → median, q025, q975
+   - null distribution (0045) → null_median, null_q975, p-value
    - significant (boolean, p < 0.05)
-2. Output: `content/tables/tab_divergence_summary.csv`
-3. Pandera schema in schemas.py.
-4. Makefile target in divergence.mk.
+4. Output: `content/tables/tab_divergence_summary.csv`
+5. Pandera schema in schemas.py.
 
 ## Test
 ```python
@@ -34,4 +46,8 @@ def test_summary_table_has_all_methods_and_years():
 
 ## Exit criteria
 Table is machine-readable, referenced from technical report as
-supplementary material. Figures stay clean — one curve, one ribbon.
+supplementary material. Not computed during `make divergence` —
+only via explicit `make bootstrap-tables divergence-summary`.
+
+## Compute estimate
+K=200 bootstrap on GPU: ~3h. One overnight run, after 0045 is done.


### PR DESCRIPTION
## Summary
- Cache resolved backend in `_RESOLVED_BACKEND` — log once, not per method
- Remove dead `to_numpy()` and unused `numpy` import from backend module
- Fix `divergence.mk` to use `uv run python` (was bare `python3`, broke in worktrees)
- Fix G3 coupling_age: `pd.to_numeric()` on `ref_year` before `.median()` (real data has string dtype)

## Context
Follow-up to #654 (squash-merged). These are the simplify review fixes + bugs found during the first real data run.

## Test plan
- [x] 8/8 GPU tests pass
- [x] `make -j15 divergence-tables` completes all 15 methods on real corpus
- [x] G3 coupling_age produces valid output

🤖 Generated with [Claude Code](https://claude.com/claude-code)