### PR TITLE
fix: pipeline fixes + new tickets (0045-0047)

### DIFF
--- a/divergence.mk
+++ b/divergence.mk
@@ -40,19 +40,19 @@ DIV_CSV_ALL := $(DIV_CSV_SEM) $(DIV_CSV_LEX) $(DIV_CSV_CIT)
 
 $(foreach m,$(DIV_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Lexical methods (depend on REFINED only) ─────────────────────────────
 
 $(foreach m,$(DIV_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Citation methods (depend on REFINED + REFINED_CIT) ───────────────────
 
 $(foreach m,$(DIV_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_citation.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	python3 $(DIV_DISPATCH) --method $(m) --output $$@))
+	uv run python $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Convenience targets ──────────────────────────────────────────────────
 
@@ -76,7 +76,7 @@ divergence-tables: $(DIV_CSV_ALL)
 DIV_FIG_STAMP := $(DIV_FIGS)/.divergence_figs.stamp
 
 $(DIV_FIG_STAMP): scripts/plot_divergence.py $(DIV_CSV_ALL)
-	python3 scripts/plot_divergence.py \
+	uv run python scripts/plot_divergence.py \
 		--output $(DIV_FIGS)/fig_divergence.png \
 		--input $(DIV_CSV_ALL)
 	touch $@
@@ -100,11 +100,11 @@ SENS_CSV_ALL := $(SENS_CSV_PCA) $(SENS_CSV_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_pca_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
+	uv run python $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_jl_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	python3 $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
+	uv run python $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
 
 # Figures: one PNG per (method, projection) pair — 1 invocation = 1 figure
 SENS_FIG_PCA := $(foreach m,$(SENS_METHODS),$(DIV_FIGS)/fig_sensitivity_pca_$(m).png)
@@ -113,11 +113,11 @@ SENS_FIG_ALL := $(SENS_FIG_PCA) $(SENS_FIG_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_pca_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_pca_$(m).csv ; \
-	python3 $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
+	uv run python $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_jl_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_jl_$(m).csv ; \
-	python3 $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
+	uv run python $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
 
 .PHONY: sensitivity-tables
 sensitivity-tables: $(SENS_CSV_ALL)
@@ -143,13 +143,13 @@ CV_TABLE   := $(DIV_TABLES)/tab_convergence.csv
 CP_FIG     := $(DIV_FIGS)/fig_convergence.png
 
 $(CP_TABLE): $(CP_SCRIPT) $(DIV_CSV_ALL) $(DIV_CFG)
-	python3 $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
+	uv run python $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
 
 $(CV_TABLE): $(CV_SCRIPT) $(CP_TABLE)
-	python3 $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
+	uv run python $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
 
 $(CP_FIG): $(CP_PLOT) $(CP_TABLE) $(CV_TABLE)
-	python3 $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
+	uv run python $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
 
 .PHONY: changepoints-tables
 changepoints-tables: $(CP_TABLE) $(CV_TABLE)

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -11,6 +11,7 @@ import warnings
 
 import networkx as nx
 import numpy as np
+import pandas as pd
 from _divergence_citation import (
     _cumulative_graph,
     _dict_to_df,
@@ -144,10 +145,13 @@ def compute_g3_age_shift(works, citations, internal_edges, cfg):
             results[y] = np.nan
             continue
 
-        refs = citations.loc[
-            citations["source_doi"].isin(year_dois) & citations["ref_year"].notna(),
-            "ref_year",
-        ]
+        refs = pd.to_numeric(
+            citations.loc[
+                citations["source_doi"].isin(year_dois) & citations["ref_year"].notna(),
+                "ref_year",
+            ],
+            errors="coerce",
+        ).dropna()
         if len(refs) < 3:
             results[y] = np.nan
             continue

--- a/scripts/_divergence_backend.py
+++ b/scripts/_divergence_backend.py
@@ -8,12 +8,12 @@ Resolves the ``backend`` key from config/analysis.yaml:
   cuda  → torch CUDA (raises if unavailable)
 """
 
-import numpy as np
 from utils import get_logger
 
 log = get_logger("_divergence_backend")
 
 _TORCH_AVAILABLE: bool | None = None
+_RESOLVED_BACKEND: str | None = None
 _VALID_BACKENDS = {"auto", "cpu", "cuda"}
 
 
@@ -58,6 +58,10 @@ def get_backend(cfg: dict) -> str:
         If ``backend: cuda`` but no CUDA-capable torch is found.
 
     """
+    global _RESOLVED_BACKEND
+    if _RESOLVED_BACKEND is not None:
+        return _RESOLVED_BACKEND
+
     setting = cfg["divergence"].get("backend", "auto")
     if setting not in _VALID_BACKENDS:
         raise ValueError(
@@ -65,29 +69,24 @@ def get_backend(cfg: dict) -> str:
         )
 
     if setting == "cpu":
-        log.info("Backend forced to NumPy (config: cpu)")
-        return "numpy"
-
-    has_cuda = _probe_torch()
-
-    if setting == "cuda":
-        if not has_cuda:
+        result = "numpy"
+    elif setting == "cuda":
+        if not _probe_torch():
             raise RuntimeError(
                 "Config requires backend: cuda but torch CUDA is not available"
             )
-        return "torch"
+        result = "torch"
+    else:
+        # auto
+        result = "torch" if _probe_torch() else "numpy"
 
-    # auto
-    return "torch" if has_cuda else "numpy"
+    log.info("Divergence backend: %s (config: %s)", result, setting)
+    _RESOLVED_BACKEND = result
+    return result
 
 
-def to_tensor(arr: np.ndarray) -> "torch.Tensor":
+def to_tensor(arr: "np.ndarray") -> "torch.Tensor":
     """Convert NumPy array to float32 torch tensor on CUDA."""
     import torch
 
     return torch.as_tensor(arr, dtype=torch.float32, device="cuda")
-
-
-def to_numpy(t: "torch.Tensor") -> np.ndarray:
-    """Move torch tensor back to NumPy on CPU."""
-    return t.detach().cpu().numpy()

--- a/scripts/plot_divergence.py
+++ b/scripts/plot_divergence.py
@@ -57,6 +57,9 @@ matplotlib.rcParams.update(
 
 # ── Visual encoding ──────────────────────────────────────────────────────
 
+YEAR_MIN, YEAR_MAX = 1995, 2025
+YEAR_TICKS = list(range(YEAR_MIN, YEAR_MAX + 1, 5))
+
 WINDOW_STYLES = {2: "-", 3: "--", 4: "-.", 5: ":", "cumulative": "-"}
 COLORS = [
     "#1f77b4",
@@ -266,6 +269,10 @@ def _draw_curves(ax, mdf, breaks_df, method, aggregate="none", palette="auto"):
         for by in sorted(break_years):
             ax.axvline(by, color="red", linewidth=0.7, linestyle="--", alpha=0.7)
 
+    # Consistent axis range: 1995–2025 with 5-year ticks
+    ax.set_xlim(YEAR_MIN, YEAR_MAX)
+    ax.set_xticks(YEAR_TICKS)
+
     handles, labels = ax.get_legend_handles_labels()
     if handles:
         ncol = 2 if len(handles) <= 12 else 3
@@ -274,6 +281,8 @@ def _draw_curves(ax, mdf, breaks_df, method, aggregate="none", palette="auto"):
 
 def _draw_lines(ax, mdf):
     """One curve per (window, hyperparams) group, discrete colors."""
+    mdf = mdf.copy()
+    mdf["hyperparams"] = mdf["hyperparams"].fillna("default")
     groups = mdf.groupby(["window", "hyperparams"])
     color_idx = 0
     for (window, hp), grp in sorted(groups):

--- a/tests/test_gpu_backend.py
+++ b/tests/test_gpu_backend.py
@@ -60,6 +60,13 @@ def cfg_cpu():
 class TestBackendDispatch:
     """get_backend returns correct value for each config setting."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_backend_cache(self, monkeypatch):
+        """Clear cached backend before each test so config takes effect."""
+        import _divergence_backend
+
+        monkeypatch.setattr(_divergence_backend, "_RESOLVED_BACKEND", None)
+
     def test_cpu_setting(self, cfg_cpu):
         from _divergence_backend import get_backend
 
@@ -77,14 +84,12 @@ class TestBackendDispatch:
         assert get_backend(cfg) == "torch"
 
     def test_invalid_cuda_raises(self, monkeypatch):
-        # Temporarily pretend CUDA is unavailable
         import _divergence_backend
         from _divergence_backend import get_backend
 
         monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", False)
         with pytest.raises(RuntimeError, match="cuda"):
             get_backend({"divergence": {"backend": "cuda"}})
-        # Reset cached state
         monkeypatch.setattr(_divergence_backend, "_TORCH_AVAILABLE", None)
 
 

--- a/tickets/0045-bootstrap-null-model.erg
+++ b/tickets/0045-bootstrap-null-model.erg
@@ -1,0 +1,128 @@
+%erg v1
+Title: Growth-bias correction + significance testing for divergence
+Status: open
+Created: 2026-04-15
+Author: user
+
+--- log ---
+2026-04-15T23:00Z claude created from workplan review — growth-rate confound identified on first real data run
+2026-04-16T00:00Z claude reimagined — method-specific corrections + same-pool null on corrected series
+
+--- body ---
+## Context
+First real-data run (ticket 0042) revealed that 6+ of 15 divergence
+methods show monotone declining trends that track corpus growth, not
+structural change. Each method has a specific bias mechanism.
+
+## Design: two layers
+
+### Layer 1 — Method-specific growth-bias correction
+
+**S1-S4 (semantic): equal-n subsampling**
+Finite-sample bias inflates distances when windows have unequal sizes.
+Fix: subsample both windows to n = min(n_before, n_after, max_subsample).
+Repeat K=200 times for bootstrap CIs on the corrected divergence.
+
+**L1-L2 (lexical): equal-n + shared vocabulary**
+Same subsampling as S1-S4. Additionally, ensure TF-IDF is computed on
+the union vocabulary of both windows (verify current code does this).
+
+**G1, G2, G5, G6, G8 (citation, cumulative): sliding windows**
+Replace cumulative graph with sliding windows (w=2,3,4,5 years),
+matching the semantic methods. Compare graph(t-w, t) vs graph(t+1, t+w+1).
+Both windows now have locally comparable graph sizes.
+
+**G3, G4, G7 (structural properties): verify size-robustness**
+These measure per-paper or normalized properties. Verify empirically
+that they don't correlate with corpus size. If they do, apply
+per-year normalization.
+
+### Layer 2 — Same-pool null for significance
+
+After correction removes the growth trend, test whether the corrected
+before/after divergence exceeds random noise.
+
+For each (method, year, window):
+1. Pool all papers in [t-w, t+w+1].
+2. Split randomly into two equal halves (ignoring the before/after boundary).
+3. Compute the divergence between the random halves.
+4. Repeat N=500 times → null distribution at year t.
+5. p-value = fraction of null draws ≥ observed corrected divergence.
+
+This works because the correction has removed the trend — before and
+after are no longer systematically different under the null.
+
+### Pipeline
+```
+Raw data
+  → Layer 1: method-specific correction
+    → Corrected divergence (point estimate = bootstrap median)
+    → Layer 2: same-pool null on corrected data  [significance]
+      → p-value per (method, year)
+        → Convergence: which years significant across methods?
+Bootstrap CIs on data curves go in supplementary table (ticket 0047),
+not on figures.
+```
+
+## Actions
+
+### Correction implementation
+1. Add `equal_n=True` option to `_iter_window_pairs` in
+   `_divergence_semantic.py`. Subsample both sides to min(n_before,
+   n_after). Single pass — no bootstrap replicates by default.
+   Bootstrap K=200 for CIs is a separate step (ticket 0047).
+2. Refactor citation methods (G1, G2, G5, G6, G8) from cumulative
+   to sliding windows. Keep cumulative as legacy option.
+3. Verify L1-L2 use union vocabulary. Verify G3, G4, G7 are
+   size-robust.
+
+### Null model implementation
+4. New script: `compute_null_divergence.py`. For each (method, year,
+   window): pool papers, random-split N=500 times, compute divergence.
+   Output: null distribution quantiles per (method, year).
+5. New script: `compute_significance.py`. Compare corrected divergence
+   against null distribution → p-values.
+
+### Visualization A: null envelope on per-method plots
+6. Grey ribbon = null 95% CI. Observed corrected curve on top.
+   Where curve exits ribbon = significant. No bootstrap CI ribbon
+   on figures (goes in supplementary table, ticket 0047).
+
+### Variant reduction: max 4 curves per figure
+   - S1 MMD: w=2,3,4 × bw=1x_median only (drop w=5, drop 0.5x/2x)
+   - S2 energy: w=2,3,4 (no hyperparams → 3 curves)
+   - S3 Wasserstein: w=2,3,4 × n_proj=500 only (drop w=5, drop 100/1000)
+   - S4 Fréchet: w=2,3,4 (no hyperparams → 3 curves)
+   - L1-L3: w=2,3,4 (drop w=5)
+   - G methods: single curve (sliding window, one window size)
+   - Sensitivity: original + 256d + 32d only (drop 64/128/512)
+   Configure in config/analysis.yaml under a `plot` section, or
+   hardcode in plot_divergence.py as default display variants.
+
+### Visualization C: significance heatmap
+7. Replace raw z-score heatmap with significance heatmap.
+   Color = -log10(p-value). Grey = not significant. Hot = significant.
+   PELT on -log10(p) series for break detection.
+
+### Rate-of-change diagnostic (free, complementary)
+8. First-difference of corrected series. If 2003 spike survives
+   both correction and differentiation, it's robust.
+
+## Test
+```python
+def test_equal_n_removes_size_correlation():
+    """Corrected divergence should not correlate with min(n_before, n_after)."""
+
+def test_null_divergence_below_observed_at_known_break():
+    """On synthetic data with planted break, p < 0.05 at break year."""
+```
+
+## Exit criteria
+Each reported break has: corrected divergence ± CI, p-value from
+same-pool null, and survives first-difference diagnostic. The paper
+states significance after controlling for corpus growth.
+
+## Compute estimate
+Layer 1 (correction, single pass): same as current run (~3.5 min GPU).
+Layer 2 (null N=500 per year): ~8h GPU (one overnight run).
+Bootstrap CIs (ticket 0047, K=200): ~3h GPU (separate overnight run).

--- a/tickets/0046-robustness-suite.erg
+++ b/tickets/0046-robustness-suite.erg
@@ -1,0 +1,86 @@
+%erg v1
+Title: Robustness suite: five bias checks for divergence pipeline
+Status: open
+Created: 2026-04-15
+Author: user
+Blocked-by: 0045
+
+--- log ---
+2026-04-15T23:30Z claude created — bias inventory from first real-data run
+
+--- body ---
+## Context
+The divergence pipeline has a growth-rate confound (ticket 0045) plus
+at least four other systematic biases that could produce spurious
+structural breaks. Each needs an explicit robustness check.
+
+The pattern for each check: restrict or transform the input, rerun
+the pipeline, compare break dates with the baseline. A break that
+survives all five checks is robust. One that vanishes under any
+check needs qualification in the paper.
+
+## R1: Citation truncation
+Recent papers have fewer citations (accumulation lag). The citation
+graph is systematically sparser near the present.
+
+**Check**: Censor the citation graph at T-5 (drop all citations
+involving papers published in the last 5 years of each window).
+Rerun G1-G8. If breaks shift toward the present, truncation is
+driving them.
+
+## R2: Embedding model bias
+BGE-M3 was trained on modern text. It may encode 1990s papers
+less faithfully, inflating early-year distributional distances.
+
+**Check**: Re-embed a sample (e.g. 5000 papers, stratified by
+decade) with a second model (SPECTER2 or all-MiniLM-L6-v2).
+Rerun S1-S4 on both embedding sets. If break dates are
+model-dependent, they reflect encoding quality, not content.
+
+## R3: Retrospective curation bias
+Early corpus = curated canonical works. Late corpus = comprehensive.
+This creates artificial homogeneity early, heterogeneity late.
+
+**Check**: Restrict to a consistently-sourced subset. Options:
+  (a) OpenAlex-only (broadest uniform source)
+  (b) DOI-only (excludes grey lit, which skews early)
+  (c) Journal articles only (excludes reports, working papers)
+Rerun full pipeline on each subset.
+
+## R4: Source coverage drift
+Different sources (OpenAlex, ISTEX, bibCNRS, grey lit) have
+different temporal profiles. Breaks could reflect source boundaries.
+
+**Check**: Stratify by source. Run divergence on each source
+independently. If a break appears in OpenAlex but not ISTEX,
+it's a coverage artifact.
+
+## R5: Abstract quality variation
+Short/missing abstracts produce poor embeddings and sparse TF-IDF.
+Their prevalence varies by period and source type.
+
+**Check**: Filter to abstracts > 100 words (or > 50 tokens).
+Compare corpus composition before/after filtering. Rerun S1-S4
+and L1-L2. If the declining trend attenuates, abstract quality
+was driving it.
+
+## Reporting
+For each check, produce a comparison table:
+
+  | Break year | Baseline | R1 | R2 | R3a | R3b | R4-OA | R5 |
+  |------------|----------|----|----|-----|-----|-------|----|
+  | 2003       | 60%      | ?  | ?  |  ?  |  ?  |   ?   |  ? |
+
+Breaks that survive all columns go in the paper without
+qualification. Breaks that fail any check get a caveat.
+
+## Test
+```python
+def test_robustness_table_has_all_checks():
+    """Verify the comparison table has columns for all 5 checks."""
+```
+
+## Exit criteria
+Each reported break is annotated: robust (survives all checks),
+qualified (survives most), or artifact (fails multiple checks).
+The paper's periodization rests only on robust breaks.

--- a/tickets/0047-supplementary-table.erg
+++ b/tickets/0047-supplementary-table.erg
@@ -1,0 +1,53 @@
+%erg v1
+Title: Supplementary table: bootstrap CIs on corrected divergence
+Status: open
+Created: 2026-04-15
+Author: user
+Blocked-by: 0045
+
+--- log ---
+2026-04-15T23:45Z claude created — keep figures clean, put estimation detail in table
+2026-04-16T00:15Z claude updated — owns the bootstrap K=200 computation, not computed by default
+
+--- body ---
+## Context
+Ticket 0045 produces corrected divergence (single pass, equal-n) and
+null p-values. This ticket adds bootstrap CIs for estimation
+uncertainty — not needed during development, only for the final paper.
+
+Separated from 0045 so the bootstrap K=200 run (~3h GPU) is not
+triggered during iterative dev cycles.
+
+## Actions
+
+### Bootstrap computation
+1. New script: `compute_divergence_bootstrap.py`.
+   - Reads corrected divergence config from 0045.
+   - For each (method, year, window): equal-n subsample K=200 times.
+   - Output: `content/tables/tab_divergence_bootstrap.csv` with
+     columns: method, year, window, hyperparams, replicate, value.
+2. Makefile target `bootstrap-tables` in divergence.mk.
+   Not a dependency of `divergence` — run explicitly.
+
+### Summary table
+3. New script: `export_divergence_summary.py`. Joins:
+   - corrected divergence (0045, single pass) → point estimate
+   - bootstrap replicates (this ticket) → median, q025, q975
+   - null distribution (0045) → null_median, null_q975, p-value
+   - significant (boolean, p < 0.05)
+4. Output: `content/tables/tab_divergence_summary.csv`
+5. Pandera schema in schemas.py.
+
+## Test
+```python
+def test_summary_table_has_all_methods_and_years():
+    """Every (method, year) pair from the divergence run appears."""
+```
+
+## Exit criteria
+Table is machine-readable, referenced from technical report as
+supplementary material. Not computed during `make divergence` —
+only via explicit `make bootstrap-tables divergence-summary`.
+
+## Compute estimate
+K=200 bootstrap on GPU: ~3h. One overnight run, after 0045 is done.


### PR DESCRIPTION
## Summary
- Simplify backend module (cache result, remove dead code, validate config)
- Fix `divergence.mk` to use `uv run python` (was bare `python3`)
- Fix G3 coupling_age: `pd.to_numeric` on `ref_year` before `.median()`
- Fix plot_divergence: fill NaN hyperparams (blank G figures), consistent 1995–2025 axes
- New tickets: 0045 (growth-bias correction + null model), 0046 (robustness suite), 0047 (supplementary table)

## Test plan
- [x] 8/8 GPU tests pass
- [x] All 15 divergence methods produce output on real corpus
- [x] All figures render with correct axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)