### PR TITLE
feat: equal-n growth-bias correction for S1-S4, L1

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -37,7 +37,8 @@ divergence:
     S2_energy: {}                                # no hyperparams
     S3_sliced_wasserstein:
       n_projections: [100, 500, 1000]
-    S4_frechet: {}                               # Gaussian assumption
+    S4_frechet:
+      max_dim: 256                               # PCA reduce before Fréchet (covariance stability + speed)
 
   lexical:
     tfidf_max_features: 5000

--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -26,6 +26,7 @@ divergence:
   min_papers: 30          # per window minimum (override with 5 for smoke)
   min_papers_smoke: 5     # auto-detected when n_works < 200
   max_subsample: 2000     # cap per side for O(n²) methods
+  equal_n: true            # subsample both windows to min(n_before, n_after)
   pelt_penalties: [1, 3, 5]
   pelt_model: rbf
   pelt_min_size: 2

--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -30,6 +30,7 @@ def infer_channel(method_name):
 
 # ── Method name extraction ──────────────────────────────────────────────
 
+
 def extract_method_from_path(path):
     """Extract method name from divergence CSV filename.
 
@@ -38,7 +39,7 @@ def extract_method_from_path(path):
     """
     basename = os.path.splitext(os.path.basename(path))[0]
     if basename.startswith("tab_div_"):
-        return basename[len("tab_div_"):]
+        return basename[len("tab_div_") :]
     m = re.match(r"tab_sens_(?:pca|jl)_(.+)", basename)
     if m:
         return m.group(1)
@@ -46,6 +47,7 @@ def extract_method_from_path(path):
 
 
 # ── Divergence table loading ────────────────────────────────────────────
+
 
 def load_divergence_tables(input_paths):
     """Load and concatenate divergence CSVs, adding method from filename.
@@ -77,8 +79,9 @@ def load_divergence_tables(input_paths):
 
         expected = {"year", "channel", "window", "hyperparams", "value"}
         if not expected.issubset(set(df.columns)):
-            log.warning("Skipping %s: missing columns %s",
-                        path, expected - set(df.columns))
+            log.warning(
+                "Skipping %s: missing columns %s", path, expected - set(df.columns)
+            )
             continue
         div_frames.append(df)
 
@@ -87,13 +90,20 @@ def load_divergence_tables(input_paths):
             breaks_frames.append(pd.read_csv(breaks_path))
 
     div_df = pd.concat(div_frames, ignore_index=True) if div_frames else pd.DataFrame()
-    breaks_df = pd.concat(breaks_frames, ignore_index=True) if breaks_frames else pd.DataFrame()
-    log.info("Loaded %d divergence rows, %d break rows from %d files",
-             len(div_df), len(breaks_df), len(div_frames))
+    breaks_df = (
+        pd.concat(breaks_frames, ignore_index=True) if breaks_frames else pd.DataFrame()
+    )
+    log.info(
+        "Loaded %d divergence rows, %d break rows from %d files",
+        len(div_df),
+        len(breaks_df),
+        len(div_frames),
+    )
     return div_df, breaks_df
 
 
 # ── Smoke-mode parameter selection ──────────────────────────────────────
+
 
 def get_min_papers(n_works, cfg):
     """Return appropriate min_papers based on corpus size.
@@ -107,3 +117,25 @@ def get_min_papers(n_works, cfg):
         log.info("Smoke mode: n_works=%d < 200, min_papers=%d", n_works, mp)
         return mp
     return div_cfg.get("min_papers", 30)
+
+
+def subsample_equal_n(before, after, min_papers, rng):
+    """Subsample the larger collection to match the smaller.
+
+    Works on both numpy arrays and Python lists.
+    Returns (before_sub, after_sub), or None if min(len) < min_papers.
+    """
+    import numpy as np
+
+    n = min(len(before), len(after))
+    if n < min_papers:
+        return None
+    if len(before) > n:
+        idx = rng.choice(len(before), n, replace=False)
+        before = (
+            before[idx] if isinstance(before, np.ndarray) else [before[i] for i in idx]
+        )
+    if len(after) > n:
+        idx = rng.choice(len(after), n, replace=False)
+        after = after[idx] if isinstance(after, np.ndarray) else [after[i] for i in idx]
+    return before, after

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -97,6 +97,10 @@ def compute_l1_js(df, cfg):
     )
     vec.fit(all_texts)
 
+    equal_n = div_cfg.get("equal_n", False)
+    seed = div_cfg.get("random_seed", 42)
+    rng = np.random.RandomState(seed) if equal_n else None
+
     rows = []
     for w in windows:
         log.info("  L1 window=%d", w)
@@ -109,6 +113,17 @@ def compute_l1_js(df, cfg):
 
             if len(texts_before) < min_papers or len(texts_after) < min_papers:
                 continue
+
+            if equal_n and len(texts_before) != len(texts_after):
+                n = min(len(texts_before), len(texts_after))
+                if n < min_papers:
+                    continue
+                if len(texts_before) > n:
+                    idx = rng.choice(len(texts_before), n, replace=False)
+                    texts_before = [texts_before[i] for i in idx]
+                if len(texts_after) > n:
+                    idx = rng.choice(len(texts_after), n, replace=False)
+                    texts_after = [texts_after[i] for i in idx]
 
             X_before = vec.transform(texts_before)
             X_after = vec.transform(texts_after)

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -115,15 +115,12 @@ def compute_l1_js(df, cfg):
                 continue
 
             if equal_n and len(texts_before) != len(texts_after):
-                n = min(len(texts_before), len(texts_after))
-                if n < min_papers:
+                from _divergence_io import subsample_equal_n
+
+                result = subsample_equal_n(texts_before, texts_after, min_papers, rng)
+                if result is None:
                     continue
-                if len(texts_before) > n:
-                    idx = rng.choice(len(texts_before), n, replace=False)
-                    texts_before = [texts_before[i] for i in idx]
-                if len(texts_after) > n:
-                    idx = rng.choice(len(texts_after), n, replace=False)
-                    texts_after = [texts_after[i] for i in idx]
+                texts_before, texts_after = result
 
             X_before = vec.transform(texts_before)
             X_after = vec.transform(texts_after)

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -108,10 +108,14 @@ def _get_window_embeddings(
     return vecs
 
 
-def _iter_window_pairs(df, emb, years, windows, min_papers, max_subsample, rng=None):
+def _iter_window_pairs(
+    df, emb, years, windows, min_papers, max_subsample, rng=None, equal_n=False
+):
     """Yield (year, window, X, Y) for each valid before/after window pair.
 
     Centralises the nested loop and skip logic shared by S1-S4.
+    When equal_n is True, the larger window is subsampled to match
+    the smaller, removing growth-rate bias (ticket 0045).
     """
     for w in windows:
         for y in years:
@@ -123,6 +127,16 @@ def _iter_window_pairs(df, emb, years, windows, min_papers, max_subsample, rng=N
             )
             if X is None or Y is None:
                 continue
+            if equal_n and len(X) != len(Y):
+                n = min(len(X), len(Y))
+                if n < min_papers:
+                    continue
+                if rng is None:
+                    raise ValueError("rng required for equal_n subsampling")
+                if len(X) > n:
+                    X = X[rng.choice(len(X), n, replace=False)]
+                if len(Y) > n:
+                    Y = Y[rng.choice(len(Y), n, replace=False)]
             yield y, w, X, Y
 
 
@@ -211,10 +225,19 @@ def compute_s1_mmd(df, emb, cfg):
     sem_cfg = cfg["divergence"]["semantic"]
     bandwidth_multipliers = sem_cfg["S1_MMD"]["bandwidth_multipliers"]
 
+    equal_n = cfg["divergence"].get("equal_n", False)
+
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
-        df, emb, years, windows, min_papers, max_subsample, rng=rng
+        df,
+        emb,
+        years,
+        windows,
+        min_papers,
+        max_subsample,
+        rng=rng,
+        equal_n=equal_n,
     ):
         if last_w is not None and w != last_w:
             log.info("S1 MMD window=%d done", last_w)
@@ -279,10 +302,19 @@ def compute_s2_energy(df, emb, cfg):
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
+    equal_n = cfg["divergence"].get("equal_n", False)
+
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
-        df, emb, years, windows, min_papers, max_subsample, rng=rng
+        df,
+        emb,
+        years,
+        windows,
+        min_papers,
+        max_subsample,
+        rng=rng,
+        equal_n=equal_n,
     ):
         if last_w is not None and w != last_w:
             log.info("S2 energy window=%d done", last_w)
@@ -329,11 +361,19 @@ def compute_s3_wasserstein(df, emb, cfg):
 
     sem_cfg = cfg["divergence"]["semantic"]
     n_projections_list = sem_cfg["S3_sliced_wasserstein"]["n_projections"]
+    equal_n = cfg["divergence"].get("equal_n", False)
 
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
-        df, emb, years, windows, min_papers, max_subsample, rng=rng
+        df,
+        emb,
+        years,
+        windows,
+        min_papers,
+        max_subsample,
+        rng=rng,
+        equal_n=equal_n,
     ):
         if last_w is not None and w != last_w:
             log.info("S3 sliced Wasserstein window=%d done", last_w)
@@ -454,10 +494,19 @@ def compute_s4_frechet(df, emb, cfg):
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
+    equal_n = cfg["divergence"].get("equal_n", False)
+
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
-        df, emb, years, windows, min_papers, max_subsample, rng=rng
+        df,
+        emb,
+        years,
+        windows,
+        min_papers,
+        max_subsample,
+        rng=rng,
+        equal_n=equal_n,
     ):
         if last_w is not None and w != last_w:
             log.info("S4 Frechet window=%d done", last_w)

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -130,15 +130,14 @@ def _iter_window_pairs(
             if X is None or Y is None:
                 continue
             if equal_n and len(X) != len(Y):
-                n = min(len(X), len(Y))
-                if n < min_papers:
-                    continue
                 if rng is None:
                     raise ValueError("rng required for equal_n subsampling")
-                if len(X) > n:
-                    X = X[rng.choice(len(X), n, replace=False)]
-                if len(Y) > n:
-                    Y = Y[rng.choice(len(Y), n, replace=False)]
+                from _divergence_io import subsample_equal_n
+
+                result = subsample_equal_n(X, Y, min_papers, rng)
+                if result is None:
+                    continue
+                X, Y = result
             yield y, w, X, Y
 
 

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -512,21 +512,21 @@ def compute_s4_frechet(df, emb, cfg):
             log.info("S4 Frechet window=%d done", last_w)
         last_w = w
 
-        # Frechet needs n > d for full-rank covariance.
-        # With smoke data, n << 1024, so we PCA-reduce first.
-        d = X.shape[1]
-        n_eff = min(len(X), len(Y))
-        if n_eff < d:
-            from sklearn.decomposition import PCA
+        # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
+        # (2) sqrtm is O(d³), and (3) sensitivity analysis shows breaks
+        # are stable from d=32 to d=1024.
+        from sklearn.decomposition import PCA
 
-            n_components = max(2, n_eff - 1)
-            pca = PCA(n_components=n_components, random_state=seed)
-            combined = np.vstack([X, Y])
-            combined_r = pca.fit_transform(combined)
-            X_r = combined_r[: len(X)]
-            Y_r = combined_r[len(X) :]
-        else:
-            X_r, Y_r = X, Y
+        frechet_max_dim = cfg["divergence"]["semantic"]["S4_frechet"].get(
+            "max_dim", 256
+        )
+        max_d = min(frechet_max_dim, min(len(X), len(Y)) - 1, X.shape[1])
+        n_components = max(2, max_d)
+        pca = PCA(n_components=n_components, random_state=seed)
+        combined = np.vstack([X, Y])
+        combined_r = pca.fit_transform(combined)
+        X_r = combined_r[: len(X)]
+        Y_r = combined_r[len(X) :]
 
         val = frechet_fn(X_r, Y_r)
         results.append(

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 import pandas as pd
 from pipeline_loaders import load_analysis_corpus
+from sklearn.decomposition import PCA
 from utils import get_logger
 
 log = get_logger("_divergence_semantic")
@@ -60,11 +61,12 @@ def load_semantic_data(input_paths):
 def _get_years_and_params(df, emb, cfg):
     """Derive year range and smoke-safe parameters from config.
 
-    Returns (years, min_papers, max_subsample, windows).
+    Returns (years, min_papers, max_subsample, windows, equal_n).
     """
     div_cfg = cfg["divergence"]
     windows = div_cfg["windows"]
     max_subsample = div_cfg["max_subsample"]
+    equal_n = div_cfg.get("equal_n", False)
 
     from _divergence_io import get_min_papers
 
@@ -77,7 +79,7 @@ def _get_years_and_params(df, emb, cfg):
         end_year = int(df["year"].max()) - min(windows) - 1
 
     years = list(range(start_year, end_year + 1))
-    return years, min_papers, max_subsample, windows
+    return years, min_papers, max_subsample, windows, equal_n
 
 
 def _get_window_embeddings(
@@ -218,14 +220,14 @@ def compute_s1_mmd(df, emb, cfg):
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
+        df, emb, cfg
+    )
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     sem_cfg = cfg["divergence"]["semantic"]
     bandwidth_multipliers = sem_cfg["S1_MMD"]["bandwidth_multipliers"]
-
-    equal_n = cfg["divergence"].get("equal_n", False)
 
     results = []
     last_w = None
@@ -298,11 +300,11 @@ def compute_s2_energy(df, emb, cfg):
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
+        df, emb, cfg
+    )
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
-
-    equal_n = cfg["divergence"].get("equal_n", False)
 
     results = []
     last_w = None
@@ -355,13 +357,14 @@ def compute_s3_wasserstein(df, emb, cfg):
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
+        df, emb, cfg
+    )
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     sem_cfg = cfg["divergence"]["semantic"]
     n_projections_list = sem_cfg["S3_sliced_wasserstein"]["n_projections"]
-    equal_n = cfg["divergence"].get("equal_n", False)
 
     results = []
     last_w = None
@@ -490,11 +493,17 @@ def compute_s4_frechet(df, emb, cfg):
     seed = cfg["divergence"].get("random_seed", 42)
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
+        df, emb, cfg
+    )
     if not years:
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
-    equal_n = cfg["divergence"].get("equal_n", False)
+    # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
+    # (2) sqrtm is O(d³), and (3) sensitivity analysis shows breaks
+    # are stable from d=32 to d=1024.
+
+    frechet_max_dim = cfg["divergence"]["semantic"]["S4_frechet"].get("max_dim", 256)
 
     results = []
     last_w = None
@@ -511,15 +520,6 @@ def compute_s4_frechet(df, emb, cfg):
         if last_w is not None and w != last_w:
             log.info("S4 Frechet window=%d done", last_w)
         last_w = w
-
-        # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
-        # (2) sqrtm is O(d³), and (3) sensitivity analysis shows breaks
-        # are stable from d=32 to d=1024.
-        from sklearn.decomposition import PCA
-
-        frechet_max_dim = cfg["divergence"]["semantic"]["S4_frechet"].get(
-            "max_dim", 256
-        )
         max_d = min(frechet_max_dim, min(len(X), len(Y)) - 1, X.shape[1])
         n_components = max(2, max_d)
         pca = PCA(n_components=n_components, random_state=seed)

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -503,18 +503,25 @@ class TestGetBreakYears:
 # ---------------------------------------------------------------------------
 
 
+def _growth_counts(n_years=20, base=5, growth_factor=10):
+    """Return per-year paper counts with linear growth for equal-n tests."""
+    return [
+        max(base, int(base + (growth_factor - 1) * base * i / (n_years - 1)))
+        for i in range(n_years)
+    ]
+
+
 def _make_growth_data(n_years=20, start_year=2000, growth_factor=10, dim=16):
-    """Synthetic corpus with exponential growth for equal-n tests.
+    """Synthetic corpus with growth for equal-n tests (semantic).
 
     Returns (df, emb) with ~few papers in early years and many later.
     """
     rng = np.random.RandomState(42)
+    counts = _growth_counts(n_years, base=5, growth_factor=growth_factor)
     years = []
     vecs = []
-    for i in range(n_years):
+    for i, n in enumerate(counts):
         y = start_year + i
-        # Linear growth: early years get few, later years get many
-        n = max(5, int(5 + (growth_factor - 1) * 5 * i / (n_years - 1)))
         years.extend([y] * n)
         vecs.append(rng.randn(n, dim))
     df = pd.DataFrame({"year": years, "cited_by_count": 0})
@@ -522,12 +529,26 @@ def _make_growth_data(n_years=20, start_year=2000, growth_factor=10, dim=16):
     return df, emb
 
 
-def _equal_n_cfg(equal_n=True):
-    """Minimal config for equal-n tests."""
-    from pipeline_loaders import load_analysis_config
+def _make_growth_text_data(n_years=15, start_year=2000, growth_factor=10):
+    """Synthetic corpus with growth for equal-n tests (lexical).
 
-    cfg = copy.deepcopy(load_analysis_config())
-    cfg["divergence"]["random_seed"] = 42
+    Returns DataFrame with year + abstract columns.
+    """
+    rng = np.random.RandomState(42)
+    words = ["climate", "finance", "carbon", "green", "bond", "risk", "policy"]
+    counts = _growth_counts(n_years, base=6, growth_factor=growth_factor)
+    rows = []
+    for i, n in enumerate(counts):
+        y = start_year + i
+        for _ in range(n):
+            text = " ".join(rng.choice(words, size=10))
+            rows.append({"year": y, "abstract": text})
+    return pd.DataFrame(rows)
+
+
+def _equal_n_cfg(equal_n=True):
+    """Minimal config for equal-n tests, built on _smoke_cfg."""
+    cfg = _smoke_cfg(seed=42)
     cfg["divergence"]["windows"] = [2]
     cfg["divergence"]["max_subsample"] = 5000
     cfg["divergence"]["equal_n"] = equal_n
@@ -633,18 +654,7 @@ class TestEqualN:
         """L1 JS subsampling path should equalise before/after text counts."""
         from _divergence_lexical import compute_l1_js
 
-        rng = np.random.RandomState(42)
-        words = ["climate", "finance", "carbon", "green", "bond", "risk", "policy"]
-        n_years = 15
-        rows = []
-        for i in range(n_years):
-            y = 2000 + i
-            n = max(6, int(6 + 4 * i))  # growth
-            for _ in range(n):
-                text = " ".join(rng.choice(words, size=10))
-                rows.append({"year": y, "abstract": text})
-        df = pd.DataFrame(rows)
-
+        df = _make_growth_text_data()
         cfg_eq = _equal_n_cfg(equal_n=True)
         cfg_raw = _equal_n_cfg(equal_n=False)
 

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -496,3 +496,131 @@ class TestGetBreakYears:
         )
         years = _get_break_years(breaks_df, "S1_MMD", penalty=3)
         assert years == set()
+
+
+# ---------------------------------------------------------------------------
+# Equal-N growth-bias correction (ticket 0045)
+# ---------------------------------------------------------------------------
+
+
+def _make_growth_data(n_years=20, start_year=2000, growth_factor=10, dim=16):
+    """Synthetic corpus with exponential growth for equal-n tests.
+
+    Returns (df, emb) with ~few papers in early years and many later.
+    """
+    rng = np.random.RandomState(42)
+    years = []
+    vecs = []
+    for i in range(n_years):
+        y = start_year + i
+        # Linear growth: early years get few, later years get many
+        n = max(5, int(5 + (growth_factor - 1) * 5 * i / (n_years - 1)))
+        years.extend([y] * n)
+        vecs.append(rng.randn(n, dim))
+    df = pd.DataFrame({"year": years, "cited_by_count": 0})
+    emb = np.vstack(vecs).astype(np.float32)
+    return df, emb
+
+
+def _equal_n_cfg(equal_n=True):
+    """Minimal config for equal-n tests."""
+    from pipeline_loaders import load_analysis_config
+
+    cfg = copy.deepcopy(load_analysis_config())
+    cfg["divergence"]["random_seed"] = 42
+    cfg["divergence"]["windows"] = [2]
+    cfg["divergence"]["max_subsample"] = 5000
+    cfg["divergence"]["equal_n"] = equal_n
+    return cfg
+
+
+class TestEqualN:
+    """Verify equal-n growth-bias correction for _iter_window_pairs."""
+
+    def test_equal_n_produces_equal_sized_windows(self):
+        """With equal_n, both windows should have the same number of samples."""
+        from _divergence_semantic import _get_years_and_params, _iter_window_pairs
+
+        df, emb = _make_growth_data()
+        cfg = _equal_n_cfg(equal_n=True)
+        years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+        rng = np.random.RandomState(42)
+
+        for y, w, X, Y in _iter_window_pairs(
+            df,
+            emb,
+            years,
+            windows,
+            min_papers,
+            max_subsample,
+            rng=rng,
+            equal_n=True,
+        ):
+            assert len(X) == len(Y), (
+                f"year={y}, w={w}: len(X)={len(X)} != len(Y)={len(Y)}"
+            )
+
+    def test_equal_n_false_allows_unequal(self):
+        """Without equal_n, windows may have different sizes."""
+        from _divergence_semantic import _get_years_and_params, _iter_window_pairs
+
+        df, emb = _make_growth_data()
+        cfg = _equal_n_cfg(equal_n=False)
+        years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+        rng = np.random.RandomState(42)
+
+        sizes = []
+        for y, w, X, Y in _iter_window_pairs(
+            df,
+            emb,
+            years,
+            windows,
+            min_papers,
+            max_subsample,
+            rng=rng,
+            equal_n=False,
+        ):
+            sizes.append((len(X), len(Y)))
+
+        # At least some pairs should be unequal in the growth data
+        unequal = [pair for pair in sizes if pair[0] != pair[1]]
+        assert len(unequal) > 0, "Expected some unequal window sizes in growth data"
+
+    def test_equal_n_s2_not_correlated_with_size(self):
+        """Corrected S2 energy should not strongly correlate with window size."""
+        from _divergence_semantic import compute_s2_energy
+
+        df, emb = _make_growth_data(n_years=20, growth_factor=10, dim=16)
+
+        # With equal_n
+        cfg_eq = _equal_n_cfg(equal_n=True)
+        result_eq = compute_s2_energy(df, emb, cfg_eq)
+
+        # Without equal_n
+        cfg_raw = _equal_n_cfg(equal_n=False)
+        result_raw = compute_s2_energy(df, emb, cfg_raw)
+
+        if len(result_eq) < 3 or len(result_raw) < 3:
+            pytest.skip("Not enough data points for correlation test")
+
+        # Compute min(n_before, n_after) for each year
+        years_sorted = sorted(df["year"].unique())
+        year_counts = df["year"].value_counts().to_dict()
+        w = 2  # single window
+
+        def min_n_for_year(y):
+            n_before = sum(year_counts.get(yy, 0) for yy in range(y - w, y + 1))
+            n_after = sum(year_counts.get(yy, 0) for yy in range(y + 1, y + w + 2))
+            return min(n_before, n_after)
+
+        # Merge min_n into results
+        for result in [result_eq, result_raw]:
+            result["min_n"] = result["year"].apply(min_n_for_year)
+
+        corr_eq = abs(result_eq["value"].corr(result_eq["min_n"]))
+        corr_raw = abs(result_raw["value"].corr(result_raw["min_n"]))
+
+        # The corrected version should have lower correlation with size
+        assert corr_eq < corr_raw or corr_eq < 0.5, (
+            f"equal_n correlation ({corr_eq:.3f}) not lower than raw ({corr_raw:.3f})"
+        )

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -543,7 +543,9 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=True)
-        years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+        years, min_papers, max_subsample, windows, _equal_n = _get_years_and_params(
+            df, emb, cfg
+        )
         rng = np.random.RandomState(42)
 
         for y, w, X, Y in _iter_window_pairs(
@@ -566,7 +568,9 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=False)
-        years, min_papers, max_subsample, windows = _get_years_and_params(df, emb, cfg)
+        years, min_papers, max_subsample, windows, _equal_n = _get_years_and_params(
+            df, emb, cfg
+        )
         rng = np.random.RandomState(42)
 
         sizes = []
@@ -624,3 +628,29 @@ class TestEqualN:
         assert corr_eq < corr_raw or corr_eq < 0.5, (
             f"equal_n correlation ({corr_eq:.3f}) not lower than raw ({corr_raw:.3f})"
         )
+
+    def test_l1_js_equal_n_produces_equal_sized_inputs(self):
+        """L1 JS subsampling path should equalise before/after text counts."""
+        from _divergence_lexical import compute_l1_js
+
+        rng = np.random.RandomState(42)
+        words = ["climate", "finance", "carbon", "green", "bond", "risk", "policy"]
+        n_years = 15
+        rows = []
+        for i in range(n_years):
+            y = 2000 + i
+            n = max(6, int(6 + 4 * i))  # growth
+            for _ in range(n):
+                text = " ".join(rng.choice(words, size=10))
+                rows.append({"year": y, "abstract": text})
+        df = pd.DataFrame(rows)
+
+        cfg_eq = _equal_n_cfg(equal_n=True)
+        cfg_raw = _equal_n_cfg(equal_n=False)
+
+        result_eq = compute_l1_js(df, cfg_eq)
+        result_raw = compute_l1_js(df, cfg_raw)
+
+        # Both should produce results; equal_n should not crash
+        assert len(result_eq) > 0, "equal_n L1 JS produced no results"
+        assert len(result_raw) > 0, "raw L1 JS produced no results"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130'",
@@ -263,6 +263,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
+name = "array-api-compat"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/e5/9a12dd1c2b0ad61f3c3ad0fc14b888c65fd735dd9d26805f77317303cbe5/array_api_compat-1.14.0.tar.gz", hash = "sha256:c819ba707f5c507800cb545f7e6348ff1ecc46538381d9ad9b371ffc9cd6d784", size = 106369, upload-time = "2026-02-26T12:02:42.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/d3/54cd560804a8c2b898824778e86c13c2a14600bc83532a9c4f69f2f469c3/array_api_compat-1.14.0-py3-none-any.whl", hash = "sha256:ed5af1f9b6595a199c942505f281ec994892556b6efc24679a0501e87a7d6279", size = 60124, upload-time = "2026-02-26T12:02:41.127Z" },
 ]
 
 [[package]]
@@ -749,6 +758,7 @@ name = "climate-finance-het"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "dcor" },
     { name = "ftfy" },
     { name = "langdetect" },
     { name = "litellm" },
@@ -760,7 +770,9 @@ dependencies = [
     { name = "pandera" },
     { name = "pdfplumber" },
     { name = "plotly" },
+    { name = "pot" },
     { name = "pyarrow" },
+    { name = "pybursts" },
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "python-dotenv" },
@@ -769,6 +781,7 @@ dependencies = [
     { name = "requests" },
     { name = "requests-mock" },
     { name = "rich" },
+    { name = "ruptures" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
     { name = "seaborn" },
@@ -803,6 +816,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dcor", specifier = ">=0.6.1" },
     { name = "ftfy", specifier = ">=6.3.1" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "litellm", specifier = ">=1.30.0,<=1.82.6" },
@@ -812,7 +826,9 @@ requires-dist = [
     { name = "pandera", specifier = ">=0.30.1" },
     { name = "pdfplumber" },
     { name = "plotly" },
+    { name = "pot", specifier = ">=0.9.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
+    { name = "pybursts", specifier = ">=0.1.1" },
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -821,6 +837,7 @@ requires-dist = [
     { name = "requests" },
     { name = "requests-mock" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "ruptures", specifier = ">=1.1.9" },
     { name = "scikit-learn" },
     { name = "seaborn" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "climate-finance-het", extra = "cpu" } },
@@ -1167,6 +1184,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "dcor"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "array-api-compat" },
+    { name = "joblib" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/87/2a3141de80310e503d11d5f23d951c41a7f86aeae2045bbec54a480c748a/dcor-0.7.tar.gz", hash = "sha256:386d408596d7ec39af28b52c89e9fc438c4f13d8ed3d673e2c3b21029f57cbce", size = 69061, upload-time = "2026-01-17T18:01:58.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/70/d82c194d53d684b6e75a228170a36f414cc86f5824693f6b0e443032461d/dcor-0.7-py3-none-any.whl", hash = "sha256:2a5875467d2b554a9d7673e574a26f9ba06fc53f3229d49cd9a18c90d7d25042", size = 44580, upload-time = "2026-01-17T18:01:56.926Z" },
 ]
 
 [[package]]
@@ -3893,6 +3928,48 @@ wheels = [
 ]
 
 [[package]]
+name = "pot"
+version = "0.9.6.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/8b/5f939eaf1fbeb7ff914fe540d659486951a056e5537b8f454362045b6c72/pot-0.9.6.post1.tar.gz", hash = "sha256:9b6cc14a8daecfe1268268168cf46548f9130976b22b24a9e8ec62a734be6c43", size = 604243, upload-time = "2025-09-22T12:51:14.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/65/3ed0362444818585d62521f9bf5e6166b8626a714354bc2c8ea5fbdbcbe6/pot-0.9.6.post1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2127b310a13f03951be450812e7dfdf62c5484bc6219bd0e0639f0347b3b60dd", size = 595401, upload-time = "2025-09-22T12:50:23.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9b/5145c4264953f03f054d4dc4ce1d8f337eb5827896f9e6a51267432ab86d/pot-0.9.6.post1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef7d50dbc851d8b69a6c5305fcad197f149047093e5f4555aed1ea77d1d7823b", size = 464517, upload-time = "2025-09-22T12:50:25.003Z" },
+    { url = "https://files.pythonhosted.org/packages/83/23/9724a5a1ebfd4769377d5293208465ef8e803fbcf85350d5d38af349cbea/pot-0.9.6.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1de9cf2af8920c5902f1ee779cf2bf388d5677618735ce91f65d7f8e0ead629e", size = 450810, upload-time = "2025-09-22T12:50:26.28Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e9/f8f343588d2a18cd0c77fcf6b6f275642dea3cdf4f0e28e16c6e78198aec/pot-0.9.6.post1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b17c1373366f8ebd745d159793f415660ec45e69048305bb8597267d900145ab", size = 1459588, upload-time = "2025-09-22T12:50:27.739Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7d/1529014aebb9d5fd54538115886d005d371a624b1ecaf5c2525b45ad0f77/pot-0.9.6.post1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48924f34d61b909e68651f3fe9fc1a892c69ae38d3c52bc832f95a28569c0e0e", size = 1478099, upload-time = "2025-09-22T12:50:29.201Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/87/84cfc49d4d0eb3e7b6cfc8352f0e73f62d456f6ce875da612b919a6bff6f/pot-0.9.6.post1-cp310-cp310-win32.whl", hash = "sha256:06e21b4dcebc2e8e318a96889243580ea64364830d05d53c4d038afedbe072cc", size = 443775, upload-time = "2025-09-22T12:50:30.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/21/9731ac0b125f755bb513a4ee081dca0ca5335e9059fb3332dd7c50d28415/pot-0.9.6.post1-cp310-cp310-win_amd64.whl", hash = "sha256:d35bb0169ef242fc2ce4f610572a5d11ac11d646698cbdf8cbb45d828f3c514b", size = 458481, upload-time = "2025-09-22T12:50:32.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fc/3f4014bd6713c5b4c8a329b12c52842443b2284f52213a80e697b76b9f20/pot-0.9.6.post1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7fd8482a0262e5c875c05cf52e9c087e7c8bc473ef05d175887ad16e3c0443b7", size = 599499, upload-time = "2025-09-22T12:50:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/b22b789ee3a81c11c6f39ff08ed6a2e797a2a75a831fae996f4057db4771/pot-0.9.6.post1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c0bfac9daec0095061279a709f52be740e09363a62fe4c7edc843a4a0f6144c6", size = 466484, upload-time = "2025-09-22T12:50:34.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ae/2b35b96562bd72baf6de9583458878738f4508eef70d6fa9dd5867760d6a/pot-0.9.6.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:703853f7ba0ae2afed8203ea3478e87ef5f39d55cd75b1a39bb622867d1d5628", size = 453014, upload-time = "2025-09-22T12:50:36.157Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7e/f49d0593338a3b7f2c88c4cd6f1285c084e8ce05d52d42ac6f89f4f7ec0c/pot-0.9.6.post1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68268b4dd926976cf0604d466a57dff2ca44372e8ae9c879ba1f3d2a51e3be3d", size = 1494875, upload-time = "2025-09-22T12:50:37.903Z" },
+    { url = "https://files.pythonhosted.org/packages/15/91/844c8437caaca6d6a71b38623df75c43642a116d399316adb1d0a9280c85/pot-0.9.6.post1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7568ddc957d3a16739bd24f9e07ce655166d27ebbc8786aad692cc5ba5d4c59", size = 1514551, upload-time = "2025-09-22T12:50:39.616Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/de/34a50565c37c0b71725a8075ff1ad2de62213d2e119276b546ef20356ac2/pot-0.9.6.post1-cp311-cp311-win32.whl", hash = "sha256:9649b736ea5dddad3a89d55a4a3bb0078610307ba64cac2efebe6bfcf8cfe785", size = 443490, upload-time = "2025-09-22T12:50:41.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fa/453730c1b10094ab4d2ecd0b5fbfcdfe0305419cf01e32a2d31efd333559/pot-0.9.6.post1-cp311-cp311-win_amd64.whl", hash = "sha256:e161e49a22d5a925993baace4679f4e32fc2ade8f45ad73cf8417e13df5bd337", size = 458509, upload-time = "2025-09-22T12:50:43.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/28/13622807461f9f6082a8cd6768f9b4a810bc3a8fda474b81572da94b4d23/pot-0.9.6.post1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f7c542fc20662e35c24dd82eeff8a737220757434d7f0038664a7322221452f7", size = 599240, upload-time = "2025-09-22T12:50:44.848Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5c/b4e017560531f53d06798c681b0d0a9488bb8116bc98da9d399a3d096391/pot-0.9.6.post1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c1755516a7354cbd6110ad2e5f341b98b9968240c2f0f67b0ff5e3ebcb3105bd", size = 464695, upload-time = "2025-09-22T12:50:46.341Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/57e49b3f7173359741053c5e2766a45dcf649d767c2e967ef93526c9045f/pot-0.9.6.post1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3207362d3e3b5aaa783f452aa85f66e83edbefb5764f34662860af54ac72ee6", size = 454726, upload-time = "2025-09-22T12:50:47.953Z" },
+    { url = "https://files.pythonhosted.org/packages/30/60/fa72dd6094f7dbe6b38e2c6907af8cd0f18c6bd107e0cf4874deddaba883/pot-0.9.6.post1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f6659c5657e6d7e9f98f4a82e0ed64f88e9fce69b2e557416d156343919ba3", size = 1503391, upload-time = "2025-09-22T12:50:49.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3f/cc519c1176116271b6282268a705162fa042c16cc922bc56039445c9d697/pot-0.9.6.post1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f1b0148ae17bec0ed12264c6da3a05e13913b716e2a8c9043242b5d8349d8df", size = 1528170, upload-time = "2025-09-22T12:50:50.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/01/0132c94404cd0b1b2f21c4a49698db9dcd6107c47c02b22df1ed38206b2a/pot-0.9.6.post1-cp312-cp312-win32.whl", hash = "sha256:571e543cc2b0a462365002203595baf2b89c3d064cce4fce70fd1231e832c21f", size = 440577, upload-time = "2025-09-22T12:50:51.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6d/23229c0e198a4f7fb27750b3ef8497e6ebed23fe531ed64b5194da8b2b02/pot-0.9.6.post1-cp312-cp312-win_amd64.whl", hash = "sha256:b1d8bd9a334c72baa37f9a2b268de5366c23c0f9c9e3d6dc25d150137ec2823c", size = 455404, upload-time = "2025-09-22T12:50:52.956Z" },
+    { url = "https://files.pythonhosted.org/packages/53/17/e4aebb8deef58b0d40ac339d952d12c63559801b50ae43c622d49bebda7e/pot-0.9.6.post1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:659fff750a162f58b52b33a64c4ac358f4ff44e9dff0841052c088e1b6a54430", size = 596485, upload-time = "2025-09-22T12:50:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b9/3646c153b13f999ac30112dcf85c5f233af79b0d98c37b52dda9a624c91b/pot-0.9.6.post1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4f54830e9f9cb78b1ff7abd5c5bf162625ed6aea903241267c64ea9f0fb73ddb", size = 463244, upload-time = "2025-09-22T12:50:56.004Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e9/c7092f7aec8cb32739ad66ba1f1259626546e4893b61b905ce2da3987235/pot-0.9.6.post1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e9fd4b1fafacd37debdb984687ddb26f5c43d1429401847d388a6f1bd1f10e98", size = 453215, upload-time = "2025-09-22T12:50:57.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/f0187ab15aa1538ece07b28f3a7938b8592ef01fbe37b1a8f9c2f8f47f4d/pot-0.9.6.post1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec097ec0ef8bb93fee8cdb187b6a0a9653613cba7b06bb603247930e2c629cdc", size = 1496245, upload-time = "2025-09-22T12:50:58.848Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fa/85af71553b7e990fc37da8d5f2e7294ec66297e62cba419efeec11518e5a/pot-0.9.6.post1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:299f11f172908d799793ef18b2bc82452305350d2528d243e255a17876e98a57", size = 1521691, upload-time = "2025-09-22T12:51:00.203Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/96b2bce173b3d2d3d0faf8b7362fe79e60e1a6a939c9459b2f7b64e625d8/pot-0.9.6.post1-cp313-cp313-win32.whl", hash = "sha256:8a1d95310faae9c75355d9e2fac8dfac41316a2450061eefc982ee498a687a34", size = 439760, upload-time = "2025-09-22T12:51:01.601Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b1/8ca34418e7c4a2ec666e2204539577287223c4e78ab80b1c746cedb559c3/pot-0.9.6.post1-cp313-cp313-win_amd64.whl", hash = "sha256:a43e2b61389bd32f5b488da2488999ed55867e95fedb25dd64f9f390e40b4fab", size = 454228, upload-time = "2025-09-22T12:51:03.215Z" },
+]
+
+[[package]]
 name = "primp"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4140,6 +4217,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
 ]
+
+[[package]]
+name = "pybursts"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/71/804e7bb39b104a100b318ca18275385c3d65e54d69ced258aed21914aeaf/pybursts-0.1.1.tar.gz", hash = "sha256:8b6f48013802d7905cca6ca19f1b2162fee4734885bb72eeb79cb7d4dc60e50d", size = 1776, upload-time = "2014-12-08T15:30:08.342Z" }
 
 [[package]]
 name = "pycparser"
@@ -5112,6 +5195,40 @@ wheels = [
 ]
 
 [[package]]
+name = "ruptures"
+version = "1.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/32/3bcf5a62479b4d83187f872fc68b918b59285f560bee4f37c5d49b1d957a/ruptures-1.1.10.tar.gz", hash = "sha256:76b998f10709045e91a5f44173dc574bf98a106fd3bf22ec3c63b298a02df031", size = 320689, upload-time = "2025-09-10T09:48:02.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6b/fbd0f47c95c2e55bfe21447fb5f3878692f1a3686e2f65e70bc7dbbea15b/ruptures-1.1.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d2dae4173db1ffab6cf1eead44825b360e354b3c37f7316b7a827dea6a34b577", size = 497431, upload-time = "2025-09-10T09:47:30.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6e/3fbe3d105bc9100535682dcae147a6f93bde7ebc29af7795236204b7952e/ruptures-1.1.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:20ea4ce1e7503bef60aa879196343acea660905f85692c9612d1a1f787e21da6", size = 495403, upload-time = "2025-09-10T09:47:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/61/e0015e0a95a310edfcf1dc3413ccb4afad1905e33511b78768b32647e14f/ruptures-1.1.10-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8810f3c9f71262fa5d4866ea0a8f2d0ea4e15a9d28d868c97043d260c8c87bc8", size = 1282302, upload-time = "2025-09-10T09:47:33.817Z" },
+    { url = "https://files.pythonhosted.org/packages/48/8f/36bf50751f11a2b2e81b24b502fbc386c7ae2033a3faf3f7b4502dbdd7fd/ruptures-1.1.10-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1a62f024d3714facca48e8859ba2602367af0c7ca1680cffded1cbff7cf264f", size = 1289697, upload-time = "2025-09-10T09:47:35.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d3/eb3fb911c23019ac6fdce873a959c63c344780a391ca55355c6fdb088912/ruptures-1.1.10-cp310-cp310-win_amd64.whl", hash = "sha256:171fe4f61044a0520e1cd4e429f69242570939700aa4990b3401bf9a8d61aebe", size = 476077, upload-time = "2025-09-10T09:47:36.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ea/b561e98a69e412c29a808cdb25acff73005b26d0313632b7ec29a5846f8c/ruptures-1.1.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4038c09d8148bde4c3689adc3570dd3728163326a0b7baa82474641b8276f53e", size = 496985, upload-time = "2025-09-10T09:47:37.754Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7a/0026c5a85c11d6eb0202e828b5fa8dc829615f6bb61155463827ba1d2e5d/ruptures-1.1.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef2f26424b267a3da46b05b6d78322249ab1325754c61cafd9580d4eef0011ea", size = 494748, upload-time = "2025-09-10T09:47:38.798Z" },
+    { url = "https://files.pythonhosted.org/packages/85/81/06be598b7dedbcd63683296ebae683dbdab62bb0134fc8a6fd05a4b74e03/ruptures-1.1.10-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:728ec63779ebb94341caaca70c57d01eb6a22cb98d7e3079935a73a43febcb30", size = 1335652, upload-time = "2025-09-10T09:47:40.118Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c0/0d211972132f2161c594a67552fd0eb30697750c13e7351ab9dc0bb1f2a5/ruptures-1.1.10-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14860e1b1bbb439837320147dcd71ad31fc76a35988de94b5aa90bb0d22b1022", size = 1341581, upload-time = "2025-09-10T09:47:41.208Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a9/14aa9d2413ad7c29ab9c983cf5f6ce65202c1a63af56a56d1ab075bcf91d/ruptures-1.1.10-cp311-cp311-win_amd64.whl", hash = "sha256:733adb020910dbcfc6fdbca7295db28295177a927a70002c7080f2a4bfbf1840", size = 475907, upload-time = "2025-09-10T09:47:42.727Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/18/2b93d310a3a96393d48ee06363db860c576dcff3f925c8873a0ca7be219f/ruptures-1.1.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a7f614c63f2cecd76d7b5f9f79ff34712234d274a41867428ace4a3a45757c8", size = 499197, upload-time = "2025-09-10T09:47:43.707Z" },
+    { url = "https://files.pythonhosted.org/packages/67/28/a25c5eecf1b9df53d27482c953c573515ab0056e64b0e9173312344fc169/ruptures-1.1.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:14e3aa451220a05c6a7782a3b31fdd4fc578d39b77404dc94649bcae5eebd1db", size = 496449, upload-time = "2025-09-10T09:47:45.206Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/e54eba1861ab1be8d63fe019ce57632422ae8d0e8979b897d3f2fb4ca33d/ruptures-1.1.10-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01fb8847a58cbb158103c1810022ea29e3fa3291d6531631bc6134f636ea2fc1", size = 1327050, upload-time = "2025-09-10T09:47:46.228Z" },
+    { url = "https://files.pythonhosted.org/packages/78/57/5d00e8500b4d906809b86a23390c035e40460f2ff90acd134a6198320428/ruptures-1.1.10-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0930cecc7ec1c9af0b1a7da6fb769d298691e077c6cba8daad6ebaef49ed8e80", size = 1346678, upload-time = "2025-09-10T09:47:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0a/df3f6843d4715e571b1bf4c075802c1cd002d1e462a1fc54faeda79a3b21/ruptures-1.1.10-cp312-cp312-win_amd64.whl", hash = "sha256:4be700aa3fee9057667062343a2fa728e25765f457ea54dac116fd2f4b7f49c9", size = 477643, upload-time = "2025-09-10T09:47:48.799Z" },
+    { url = "https://files.pythonhosted.org/packages/29/40/087c4deede27066eb9f075c3768749366030bb24fd2c490fb1affe0b8a3f/ruptures-1.1.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:29038a863f52c026d950066a62d23719304273e2cef41159259422a055f04fc0", size = 497249, upload-time = "2025-09-10T09:47:50.204Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/84/f5fe5ded842d1c57ecd53db71f1e9c099ce14d7d2c2cc997f0351ef6f0cb/ruptures-1.1.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bfaf4dbf51ae74a4f8893ba36be98912cd4bd7f2a94a79a5ff0d2edca65c21f5", size = 494490, upload-time = "2025-09-10T09:47:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/26/29499f16b62220ce3b0bb75a8f8de921814e55c223e3263df7f2733eb5a7/ruptures-1.1.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fea4d0049051530e73babc2f44e75e6ba520bb90fe5bfa60d59c4d054180893e", size = 1311189, upload-time = "2025-09-10T09:47:52.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dc/f0a268190b233c4d4b9fa50cd7078bbc536bf319d724218087b2cb4a1138/ruptures-1.1.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fada68f6617e26138151a1ce6f73932e84ae01119e48be005773a40363454e51", size = 1330363, upload-time = "2025-09-10T09:47:53.999Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/29/1fe6a1b1811f64bdd35b61300e9d57f68d630d271c92423553a30072d5c5/ruptures-1.1.10-cp313-cp313-win_amd64.whl", hash = "sha256:39f3ece91327440fbebca84155b39435970ccc0f52bd3e33878aaff157d04e01", size = 477215, upload-time = "2025-09-10T09:47:55.027Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5845,21 +5962,21 @@ dependencies = [
     { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-19-climate-finance-het-cpu') or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:4db72a4d257c45c3502f11764ee41460a87312fdc3dff47a8957812efe961725" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0826ac8e409551e12b2360ac18b4161a838cbd111933e694752f351191331d09" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7417ef370d7c3969dd509dae8d5c7daeb945af335ab76dd38358ba30a91251c1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:90821a3194b8806d9fa9fdaa9308c1bc73df0c26808274b14129a97c99f35794" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2d16abfce6c92584ceeb00c3b2665d5798424dd9ed235ea69b72e045cd53ae97" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:4584ab167995c0479f6821e3dceaf199c8166c811d3adbba5d8eedbbfa6764fd" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:4db72a4d257c45c3502f11764ee41460a87312fdc3dff47a8957812efe961725" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0826ac8e409551e12b2360ac18b4161a838cbd111933e694752f351191331d09" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7417ef370d7c3969dd509dae8d5c7daeb945af335ab76dd38358ba30a91251c1" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:90821a3194b8806d9fa9fdaa9308c1bc73df0c26808274b14129a97c99f35794" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2d16abfce6c92584ceeb00c3b2665d5798424dd9ed235ea69b72e045cd53ae97" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:4584ab167995c0479f6821e3dceaf199c8166c811d3adbba5d8eedbbfa6764fd" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c" },
 ]
 
 [[package]]
@@ -5963,44 +6080,44 @@ dependencies = [
     { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-19-climate-finance-het-cpu') or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_aarch64.whl", hash = "sha256:31ae44836c8b9bbd1a3943d29c7c7457709ddf7c6173aa34aefe9d2203e4c405" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:beadc2a6a1785b09a46daad378de91ef274b8d3eea7af0bc2d017d97f115afdf" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d63ee6a80982fd73fe44bb70d97d2976e010312ff6db81d7bfb9167b06dd45b9" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a280ffaea7b9c828e0c1b9b3bd502d9b6a649dc9416997b69b84544bd469f215" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:6c6f0df770144907092a0d067048d96ed4f278a6c840376d2ff0e27e7579b925" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_aarch64.whl", hash = "sha256:ce5c113d1f55f8c1f5af05047a24e50d11d293e0cbbb5bf7a75c6c761edd6eaa" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:0e286fcf6ce0cc7b204396c9b4ea0d375f1f0c3e752f68ce3d3aeb265511db8c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1cfcb9b1558c6e52dffd0d4effce83b13c5ae5d97338164c372048c21f9cfccb" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7cb1ec66cefb90fd7b676eac72cfda3b8d4e4d0cacd7a531963bc2e0a9710ab" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:17a09465bab2aab8f0f273410297133d8d8fb6dd84dccbd252ca4a4f3a111847" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:c35c0de592941d4944698dbfa87271ab85d3370eca3b694943a2ab307ac34b3f" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_aarch64.whl", hash = "sha256:31ae44836c8b9bbd1a3943d29c7c7457709ddf7c6173aa34aefe9d2203e4c405" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:beadc2a6a1785b09a46daad378de91ef274b8d3eea7af0bc2d017d97f115afdf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d63ee6a80982fd73fe44bb70d97d2976e010312ff6db81d7bfb9167b06dd45b9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a280ffaea7b9c828e0c1b9b3bd502d9b6a649dc9416997b69b84544bd469f215" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:6c6f0df770144907092a0d067048d96ed4f278a6c840376d2ff0e27e7579b925" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_aarch64.whl", hash = "sha256:ce5c113d1f55f8c1f5af05047a24e50d11d293e0cbbb5bf7a75c6c761edd6eaa" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:0e286fcf6ce0cc7b204396c9b4ea0d375f1f0c3e752f68ce3d3aeb265511db8c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1cfcb9b1558c6e52dffd0d4effce83b13c5ae5d97338164c372048c21f9cfccb" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7cb1ec66cefb90fd7b676eac72cfda3b8d4e4d0cacd7a531963bc2e0a9710ab" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:17a09465bab2aab8f0f273410297133d8d8fb6dd84dccbd252ca4a4f3a111847" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:c35c0de592941d4944698dbfa87271ab85d3370eca3b694943a2ab307ac34b3f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae" },
 ]
 
 [[package]]
@@ -6050,27 +6167,27 @@ dependencies = [
     { name = "typing-extensions", marker = "extra == 'extra-19-climate-finance-het-cu130'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:adfb2bca94f12a5baca6ccf9aa40d6c5b1259748ebb38938be670b07a24d4e15" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0f8566d1b3d8353b7f18d5a15375a00dae89d886bb7d01143bb394f475832286" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:0de43ec229a78a2e80ae8578252f9eb14f898457d1cf2be81c8c91a4108c6c79" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ea3239d544b2e569a8f47db5c7fa4fd42a2fe96aefb84bb1eda45ce213020fd2" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:22cfa45e73f1e8c64f4012737987a727d01d152121b93d196b0ca22f39a3f8e3" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:218ae0f323d5ebe8f2770e46cbfb7bbff9af2c8d192d5187878d0964d43c8b71" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4fc8f67637f4c92b989a07d80ffe755e79a3510ca02ebf23ce66396fb277c88d" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:858f0cbcc78d726fea9499eb3464faa98392fa093845a3262209bd226b7844d6" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:224649fa0ab181ec483cc368e3303dda1760e4ba31bea806b88979f855436aaa" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:75780283308df9fede371eeda01e9607c8862a1803a2f2f31a08a2c0deaed342" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7e0d9922e9e91f780b2761a0c5ebac3c15c9740bab042e1b59149afa6d6474eb" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:48af94af745a9dd9b42be81ea15b56aba981666bcfe10394dceca6d9476a50fa" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:46699da91f0367d8dfa1b606cb0352aaf190b5853f463010e75ff08f15a94e7d" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:775d1fff07e302fb669d555a5005f781aa460aa80dff7a512e8e6e723f9def83" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:b38e5b505b015903a51c2b3f12e50a9f152f92fe7e3992e79f504138cf90601d" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:18f87ae628c02f095f2e97756e4fa249ceef6ed6e87d5a3c79b5338abf842511" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db5a61791b7da3c1aa5a496e64cd72dbd4ef3ef2cbb69680fd45dc255b0da2f3" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:dda35d473dd34cafa0668be176b9ad2cb69b1ff570d0336715a6541e89e27640" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7781235583ea06b214075c10fa95f83b9805f06af44efc6e9946808413cff94f" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:526b737db11d632281795484ec729baae5f193a5a0d76a1f7d822f7897c8b4f5" },
-    { url = "https://download.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:d5ea18790a18b660d655f6e75a8ca6e8d6298b55fc338f8c921764b94c886743" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:adfb2bca94f12a5baca6ccf9aa40d6c5b1259748ebb38938be670b07a24d4e15" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0f8566d1b3d8353b7f18d5a15375a00dae89d886bb7d01143bb394f475832286" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:0de43ec229a78a2e80ae8578252f9eb14f898457d1cf2be81c8c91a4108c6c79" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ea3239d544b2e569a8f47db5c7fa4fd42a2fe96aefb84bb1eda45ce213020fd2" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:22cfa45e73f1e8c64f4012737987a727d01d152121b93d196b0ca22f39a3f8e3" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:218ae0f323d5ebe8f2770e46cbfb7bbff9af2c8d192d5187878d0964d43c8b71" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4fc8f67637f4c92b989a07d80ffe755e79a3510ca02ebf23ce66396fb277c88d" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:858f0cbcc78d726fea9499eb3464faa98392fa093845a3262209bd226b7844d6" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:224649fa0ab181ec483cc368e3303dda1760e4ba31bea806b88979f855436aaa" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:75780283308df9fede371eeda01e9607c8862a1803a2f2f31a08a2c0deaed342" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7e0d9922e9e91f780b2761a0c5ebac3c15c9740bab042e1b59149afa6d6474eb" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:48af94af745a9dd9b42be81ea15b56aba981666bcfe10394dceca6d9476a50fa" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:46699da91f0367d8dfa1b606cb0352aaf190b5853f463010e75ff08f15a94e7d" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:775d1fff07e302fb669d555a5005f781aa460aa80dff7a512e8e6e723f9def83" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:b38e5b505b015903a51c2b3f12e50a9f152f92fe7e3992e79f504138cf90601d" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:18f87ae628c02f095f2e97756e4fa249ceef6ed6e87d5a3c79b5338abf842511" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db5a61791b7da3c1aa5a496e64cd72dbd4ef3ef2cbb69680fd45dc255b0da2f3" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:dda35d473dd34cafa0668be176b9ad2cb69b1ff570d0336715a6541e89e27640" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7781235583ea06b214075c10fa95f83b9805f06af44efc6e9946808413cff94f" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:526b737db11d632281795484ec729baae5f193a5a0d76a1f7d822f7897c8b4f5" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:d5ea18790a18b660d655f6e75a8ca6e8d6298b55fc338f8c921764b94c886743" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `equal_n: true` config option — subsamples both windows to min(n_before, n_after), removing finite-sample bias
- S1-S4: equal-n in `_iter_window_pairs` (single chokepoint)
- L1: equal-n subsampling of texts_before/texts_after
- L2 (novelty/transience): not corrected — per-document KL against aggregated distributions already normalizes for window size
- S4 Fréchet: always PCA-reduce to `max_dim: 256` (config-driven) — scipy sqrtm on 1024² was hours, now seconds
- 4 new tests: equal window sizes, unequal allowed when off, no size-correlation, L1 JS path

## Results on real data
Equal-n reduces but does not eliminate the declining trend — the decline is mostly real (field homogenization), not a sample-size artifact:

| Method | Raw r(year,val) | Corrected | 
|--------|-----------------|-----------| 
| S1 MMD | -0.724 | -0.715 |
| S2 energy | -0.777 | -0.706 |
| S4 Fréchet | -0.917 | -0.872 |
| L1 JS | -0.897 | -0.886 |

## Test plan
- [x] 4/4 TestEqualN tests pass
- [x] `make check-fast` — no new failures (4 pre-existing doc-related)
- [x] Full S+L pipeline on real corpus (7 methods, ~1 min with GPU)

Closes #0045

🤖 Generated with [Claude Code](https://claude.com/claude-code)