### PR TITLE
feat: permutation Z-score null model (ticket 0055)

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -33,7 +33,7 @@ divergence:
 
   permutation:
     n_perm: 500
-    z_threshold: 2.0
+    z_threshold: 2.0    # consumed by compute_transition_zones.py (ticket 0055b)
 
   semantic:
     S1_MMD:

--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -31,6 +31,10 @@ divergence:
   pelt_model: rbf
   pelt_min_size: 2
 
+  permutation:
+    n_perm: 500
+    z_threshold: 2.0
+
   semantic:
     S1_MMD:
       bandwidth_multipliers: [0.5, 1.0, 2.0]   # × median heuristic

--- a/divergence.mk
+++ b/divergence.mk
@@ -160,6 +160,30 @@ changepoints-figure: $(CP_FIG)
 .PHONY: changepoints
 changepoints: changepoints-tables changepoints-figure
 
+# ── Null model (permutation Z-scores, ticket 0055) ─────────────────────
+#
+# For each method, permute before/after labels and recompute the statistic
+# to build a null distribution.  Output: tab_null_{method}.csv
+
+NULL_DISPATCH := scripts/compute_null_model.py
+NULL_METHODS_SEM := S2_energy
+NULL_METHODS_LEX := L1
+NULL_METHODS := $(NULL_METHODS_SEM) $(NULL_METHODS_LEX)
+NULL_CSV := $(foreach m,$(NULL_METHODS),$(DIV_TABLES)/tab_null_$(m).csv)
+
+# Semantic null models (depend on embeddings + divergence CSV)
+$(foreach m,$(NULL_METHODS_SEM),$(eval \
+$(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
+	uv run python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+# Lexical null models (depend on REFINED + divergence CSV)
+$(foreach m,$(NULL_METHODS_LEX),$(eval \
+$(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
+	uv run python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+.PHONY: null-model
+null-model: $(NULL_CSV)
+
 # ── Top-level ────────────────────────────────────────────────────────────
 
 .PHONY: divergence

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -165,6 +165,37 @@ def _make_lexical_statistic(vectorizer):
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _nan_row(year, window):
+    """Return a row dict with NaN values for skipped (year, window) pairs."""
+    return {
+        "year": year,
+        "window": str(window),
+        "observed": np.nan,
+        "null_mean": np.nan,
+        "null_std": np.nan,
+        "z_score": np.nan,
+        "p_value": np.nan,
+    }
+
+
+def _result_row(year, window, observed, null_mean, null_std, z, p):
+    """Return a row dict with computed permutation test results."""
+    return {
+        "year": year,
+        "window": str(window),
+        "observed": observed,
+        "null_mean": null_mean,
+        "null_std": null_std,
+        "z_score": z,
+        "p_value": p,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Per-channel permutation drivers
 # ---------------------------------------------------------------------------
 
@@ -203,52 +234,22 @@ def _run_semantic_permutations(method_name, div_df, cfg):
             df, emb, y, w, "after", min_papers, max_subsample, rng=rng
         )
         if X is None or Y is None:
-            rows.append(
-                {
-                    "year": y,
-                    "window": str(w),
-                    "observed": np.nan,
-                    "null_mean": np.nan,
-                    "null_std": np.nan,
-                    "z_score": np.nan,
-                    "p_value": np.nan,
-                }
-            )
+            rows.append(_nan_row(y, w))
             continue
 
         if equal_n and len(X) != len(Y):
             from _divergence_io import subsample_equal_n
 
-            result = subsample_equal_n(X, Y, min_papers, rng)
-            if result is None:
-                rows.append(
-                    {
-                        "year": y,
-                        "window": str(w),
-                        "observed": np.nan,
-                        "null_mean": np.nan,
-                        "null_std": np.nan,
-                        "z_score": np.nan,
-                        "p_value": np.nan,
-                    }
-                )
+            eq_result = subsample_equal_n(X, Y, min_papers, rng)
+            if eq_result is None:
+                rows.append(_nan_row(y, w))
                 continue
-            X, Y = result
+            X, Y = eq_result
 
         observed, null_mean, null_std, z, p = permutation_test(
             X, Y, statistic_fn, n_perm, rng
         )
-        rows.append(
-            {
-                "year": y,
-                "window": str(w),
-                "observed": observed,
-                "null_mean": null_mean,
-                "null_std": null_std,
-                "z_score": z,
-                "p_value": p,
-            }
-        )
+        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
         log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
 
     return pd.DataFrame(rows)
@@ -299,52 +300,22 @@ def _run_lexical_permutations(method_name, div_df, cfg):
         texts_after = df.loc[mask_after, "abstract"].tolist()
 
         if len(texts_before) < min_papers or len(texts_after) < min_papers:
-            rows.append(
-                {
-                    "year": y,
-                    "window": str(w),
-                    "observed": np.nan,
-                    "null_mean": np.nan,
-                    "null_std": np.nan,
-                    "z_score": np.nan,
-                    "p_value": np.nan,
-                }
-            )
+            rows.append(_nan_row(y, w))
             continue
 
         if equal_n and len(texts_before) != len(texts_after):
             from _divergence_io import subsample_equal_n
 
-            result = subsample_equal_n(texts_before, texts_after, min_papers, rng)
-            if result is None:
-                rows.append(
-                    {
-                        "year": y,
-                        "window": str(w),
-                        "observed": np.nan,
-                        "null_mean": np.nan,
-                        "null_std": np.nan,
-                        "z_score": np.nan,
-                        "p_value": np.nan,
-                    }
-                )
+            eq_result = subsample_equal_n(texts_before, texts_after, min_papers, rng)
+            if eq_result is None:
+                rows.append(_nan_row(y, w))
                 continue
-            texts_before, texts_after = result
+            texts_before, texts_after = eq_result
 
         observed, null_mean, null_std, z, p = permutation_test(
             texts_before, texts_after, statistic_fn, n_perm, rng
         )
-        rows.append(
-            {
-                "year": y,
-                "window": str(w),
-                "observed": observed,
-                "null_mean": null_mean,
-                "null_std": null_std,
-                "z_score": z,
-                "p_value": p,
-            }
-        )
+        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
         log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
 
     return pd.DataFrame(rows)

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -1,0 +1,405 @@
+"""Compute permutation Z-score null model for one divergence method.
+
+For each (year, window) in the existing divergence CSV, permute labels
+B times and recompute the statistic to build a null distribution.
+Z(t) = (observed - mean_perm) / std_perm.
+
+Usage:
+    uv run python scripts/compute_null_model.py --method S2_energy \
+        --output content/tables/tab_null_S2_energy.csv \
+        --div-csv content/tables/tab_div_S2_energy.csv
+
+    # Smoke fixture:
+    CLIMATE_FINANCE_DATA=tests/fixtures/smoke \
+        uv run python scripts/compute_null_model.py --method S2_energy \
+        --output /tmp/tab_null_S2_energy.csv \
+        --div-csv /tmp/tab_div_S2_energy.csv
+"""
+
+import argparse
+import os
+
+import numpy as np
+import pandas as pd
+from compute_divergence import METHODS
+from pipeline_loaders import load_analysis_config
+from schemas import NullModelSchema
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("compute_null_model")
+
+# Methods supported for permutation testing (semantic + lexical only)
+SUPPORTED_CHANNELS = {"semantic", "lexical"}
+
+
+# ---------------------------------------------------------------------------
+# Core permutation test
+# ---------------------------------------------------------------------------
+
+
+def permutation_test(X_before, Y_after, statistic_fn, n_perm, rng):
+    """Run a permutation test on two samples.
+
+    Parameters
+    ----------
+    X_before, Y_after : array-like
+        The two samples (numpy arrays or lists).
+    statistic_fn : callable
+        Function(a, b) -> float that computes the test statistic.
+    n_perm : int
+        Number of permutations.
+    rng : np.random.RandomState
+        Random state for reproducibility.
+
+    Returns
+    -------
+    (observed, null_mean, null_std, z_score, p_value)
+
+    """
+    observed = statistic_fn(X_before, Y_after)
+
+    is_array = isinstance(X_before, np.ndarray)
+    if is_array:
+        pooled = np.vstack([X_before, Y_after])
+    else:
+        pooled = list(X_before) + list(Y_after)
+
+    n_before = len(X_before)
+    null_stats = []
+
+    for _ in range(n_perm):
+        if is_array:
+            rng.shuffle(pooled)
+            perm_before = pooled[:n_before]
+            perm_after = pooled[n_before:]
+        else:
+            indices = rng.permutation(len(pooled))
+            perm_before = [pooled[i] for i in indices[:n_before]]
+            perm_after = [pooled[i] for i in indices[n_before:]]
+
+        null_stats.append(statistic_fn(perm_before, perm_after))
+
+    null_stats = np.array(null_stats)
+    null_mean = float(np.mean(null_stats))
+    null_std = float(np.std(null_stats))
+
+    if null_std > 0:
+        z = (observed - null_mean) / null_std
+    else:
+        z = 0.0
+
+    p = float(np.mean(null_stats >= observed))
+
+    return observed, null_mean, null_std, z, p
+
+
+# ---------------------------------------------------------------------------
+# Statistic wrappers (call the same method functions used by divergence)
+# ---------------------------------------------------------------------------
+
+
+def _make_semantic_statistic(method_name, cfg):
+    """Return a statistic_fn(X, Y) -> float for a semantic method."""
+    if method_name == "S2_energy":
+        from _divergence_backend import get_backend
+
+        backend = get_backend(cfg)
+        if backend == "torch":
+            from _divergence_semantic import _energy_distance_torch
+
+            return _energy_distance_torch
+        else:
+            import dcor
+
+            def energy_fn(X, Y):
+                return float(dcor.energy_distance(X, Y))
+
+            return energy_fn
+
+    elif method_name == "S1_MMD":
+        from _divergence_semantic import _median_heuristic, compute_mmd_rbf
+
+        def mmd_fn(X, Y):
+            med = _median_heuristic(X, Y)
+            return compute_mmd_rbf(X, Y, med)
+
+        return mmd_fn
+
+    elif method_name == "S3_sliced_wasserstein":
+        import ot
+
+        seed = cfg["divergence"].get("random_seed", 42)
+
+        def sw_fn(X, Y):
+            return float(
+                ot.sliced_wasserstein_distance(X, Y, n_projections=500, seed=seed)
+            )
+
+        return sw_fn
+
+    elif method_name == "S4_frechet":
+        from _divergence_semantic import compute_frechet_distance
+
+        return compute_frechet_distance
+
+    else:
+        raise ValueError(f"Unsupported semantic method: {method_name}")
+
+
+def _make_lexical_statistic(vectorizer):
+    """Return a statistic_fn(texts_before, texts_after) -> float for L1 JS."""
+    from _divergence_lexical import _smooth_distribution
+    from scipy.spatial.distance import jensenshannon
+
+    def js_fn(texts_before, texts_after):
+        X_before = vectorizer.transform(texts_before)
+        X_after = vectorizer.transform(texts_after)
+        agg_before = np.asarray(X_before.mean(axis=0)).flatten()
+        agg_after = np.asarray(X_after.mean(axis=0)).flatten()
+        p = _smooth_distribution(agg_before)
+        q = _smooth_distribution(agg_after)
+        return float(jensenshannon(p, q))
+
+    return js_fn
+
+
+# ---------------------------------------------------------------------------
+# Per-channel permutation drivers
+# ---------------------------------------------------------------------------
+
+
+def _run_semantic_permutations(method_name, div_df, cfg):
+    """Permutation test for semantic methods (S1-S4)."""
+    from _divergence_semantic import (
+        _get_window_embeddings,
+        _get_years_and_params,
+        load_semantic_data,
+    )
+
+    df, emb = load_semantic_data(None)
+    div_cfg = cfg["divergence"]
+    perm_cfg = div_cfg["permutation"]
+    n_perm = perm_cfg["n_perm"]
+    seed = div_cfg.get("random_seed", 42)
+    rng = np.random.RandomState(seed)
+
+    _, min_papers, max_subsample, _, equal_n = _get_years_and_params(df, emb, cfg)
+
+    statistic_fn = _make_semantic_statistic(method_name, cfg)
+
+    # Get unique (year, window) from divergence CSV
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+
+    rows = []
+    for _, row in year_windows.iterrows():
+        y = int(row["year"])
+        w = int(row["window"])
+
+        X = _get_window_embeddings(
+            df, emb, y, w, "before", min_papers, max_subsample, rng=rng
+        )
+        Y = _get_window_embeddings(
+            df, emb, y, w, "after", min_papers, max_subsample, rng=rng
+        )
+        if X is None or Y is None:
+            rows.append(
+                {
+                    "year": y,
+                    "window": str(w),
+                    "observed": np.nan,
+                    "null_mean": np.nan,
+                    "null_std": np.nan,
+                    "z_score": np.nan,
+                    "p_value": np.nan,
+                }
+            )
+            continue
+
+        if equal_n and len(X) != len(Y):
+            from _divergence_io import subsample_equal_n
+
+            result = subsample_equal_n(X, Y, min_papers, rng)
+            if result is None:
+                rows.append(
+                    {
+                        "year": y,
+                        "window": str(w),
+                        "observed": np.nan,
+                        "null_mean": np.nan,
+                        "null_std": np.nan,
+                        "z_score": np.nan,
+                        "p_value": np.nan,
+                    }
+                )
+                continue
+            X, Y = result
+
+        observed, null_mean, null_std, z, p = permutation_test(
+            X, Y, statistic_fn, n_perm, rng
+        )
+        rows.append(
+            {
+                "year": y,
+                "window": str(w),
+                "observed": observed,
+                "null_mean": null_mean,
+                "null_std": null_std,
+                "z_score": z,
+                "p_value": p,
+            }
+        )
+        log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
+
+    return pd.DataFrame(rows)
+
+
+def _run_lexical_permutations(method_name, div_df, cfg):
+    """Permutation test for lexical methods (L1)."""
+    from _divergence_io import get_min_papers
+    from _divergence_lexical import load_lexical_data
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
+    df = load_lexical_data(None)
+    div_cfg = cfg["divergence"]
+    lex_cfg = div_cfg["lexical"]
+    perm_cfg = div_cfg["permutation"]
+    n_perm = perm_cfg["n_perm"]
+    seed = div_cfg.get("random_seed", 42)
+    rng = np.random.RandomState(seed)
+
+    min_papers = get_min_papers(len(df), cfg)
+    equal_n = div_cfg.get("equal_n", False)
+
+    tfidf_max_features = lex_cfg["tfidf_max_features"]
+    tfidf_min_df = lex_cfg["tfidf_min_df"]
+
+    all_texts = df["abstract"].tolist()
+    vec = TfidfVectorizer(
+        stop_words="english",
+        max_features=tfidf_max_features,
+        min_df=min(tfidf_min_df, max(1, len(all_texts) - 1)),
+        sublinear_tf=True,
+    )
+    vec.fit(all_texts)
+
+    statistic_fn = _make_lexical_statistic(vec)
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+
+    rows = []
+    for _, row in year_windows.iterrows():
+        y = int(row["year"])
+        w = int(row["window"])
+
+        mask_before = (df["year"] >= y - w) & (df["year"] <= y)
+        mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)
+
+        texts_before = df.loc[mask_before, "abstract"].tolist()
+        texts_after = df.loc[mask_after, "abstract"].tolist()
+
+        if len(texts_before) < min_papers or len(texts_after) < min_papers:
+            rows.append(
+                {
+                    "year": y,
+                    "window": str(w),
+                    "observed": np.nan,
+                    "null_mean": np.nan,
+                    "null_std": np.nan,
+                    "z_score": np.nan,
+                    "p_value": np.nan,
+                }
+            )
+            continue
+
+        if equal_n and len(texts_before) != len(texts_after):
+            from _divergence_io import subsample_equal_n
+
+            result = subsample_equal_n(texts_before, texts_after, min_papers, rng)
+            if result is None:
+                rows.append(
+                    {
+                        "year": y,
+                        "window": str(w),
+                        "observed": np.nan,
+                        "null_mean": np.nan,
+                        "null_std": np.nan,
+                        "z_score": np.nan,
+                        "p_value": np.nan,
+                    }
+                )
+                continue
+            texts_before, texts_after = result
+
+        observed, null_mean, null_std, z, p = permutation_test(
+            texts_before, texts_after, statistic_fn, n_perm, rng
+        )
+        rows.append(
+            {
+                "year": y,
+                "window": str(w),
+                "observed": observed,
+                "null_mean": null_mean,
+                "null_std": null_std,
+                "z_score": z,
+                "p_value": p,
+            }
+        )
+        log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--method", required=True, choices=METHODS.keys())
+    parser.add_argument(
+        "--div-csv",
+        required=True,
+        help="Path to the existing tab_div_{method}.csv",
+    )
+    args = parser.parse_args(extra)
+
+    method_name = args.method
+    _, _, channel, _, _ = METHODS[method_name]
+
+    if channel not in SUPPORTED_CHANNELS:
+        raise ValueError(
+            f"Permutation test not yet supported for channel '{channel}'. "
+            f"Supported: {SUPPORTED_CHANNELS}"
+        )
+
+    cfg = load_analysis_config()
+    log.info("=== Null model: %s (channel=%s) ===", method_name, channel)
+
+    # Load existing divergence CSV for year/window pairs
+    div_df = pd.read_csv(args.div_csv)
+    log.info("Loaded %d rows from %s", len(div_df), args.div_csv)
+
+    if channel == "semantic":
+        result = _run_semantic_permutations(method_name, div_df, cfg)
+    elif channel == "lexical":
+        result = _run_lexical_permutations(method_name, div_df, cfg)
+
+    # Validate contract
+    NullModelSchema.validate(result)
+
+    # Ensure output directory exists
+    out_dir = os.path.dirname(io_args.output)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    result.to_csv(io_args.output, index=False)
+    log.info("Saved %s (%d rows) -> %s", method_name, len(result), io_args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -17,7 +17,6 @@ Usage:
 """
 
 import argparse
-import os
 
 import numpy as np
 import pandas as pd
@@ -332,6 +331,9 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--method", required=True, choices=METHODS.keys())
+    # --div-csv is separate from --input because --input refers to the corpus
+    # contract files (via CATALOGS_DIR), while --div-csv is a specific observed
+    # divergence table this script compares against.
     parser.add_argument(
         "--div-csv",
         required=True,
@@ -362,11 +364,6 @@ def main():
 
     # Validate contract
     NullModelSchema.validate(result)
-
-    # Ensure output directory exists
-    out_dir = os.path.dirname(io_args.output)
-    if out_dir:
-        os.makedirs(out_dir, exist_ok=True)
 
     result.to_csv(io_args.output, index=False)
     log.info("Saved %s (%d rows) -> %s", method_name, len(result), io_args.output)

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -80,18 +80,39 @@ RefinedCitationsSchema = DataFrameSchema(
 DivergenceSchema = DataFrameSchema(
     columns={
         "year": Column(int),
-        "channel": Column(str, checks=pa.Check.isin(["semantic", "lexical", "citation"])),
-        "window": Column(str),          # "2", "3", "cumulative", etc.
+        "channel": Column(
+            str, checks=pa.Check.isin(["semantic", "lexical", "citation"])
+        ),
+        "window": Column(str),  # "2", "3", "cumulative", etc.
         "hyperparams": Column(str, nullable=True),
         "value": Column(float, nullable=True),
     },
-    strict=True,   # no extra columns allowed
-    coerce=True,   # coerce types on validation
+    strict=True,  # no extra columns allowed
+    coerce=True,  # coerce types on validation
+)
+
+# ---------------------------------------------------------------------------
+# Null model CSV (permutation Z-scores, ticket 0055)
+# ---------------------------------------------------------------------------
+
+NullModelSchema = DataFrameSchema(
+    columns={
+        "year": Column(int),
+        "window": Column(str),
+        "observed": Column(float, nullable=True),
+        "null_mean": Column(float, nullable=True),
+        "null_std": Column(float, nullable=True),
+        "z_score": Column(float, nullable=True),
+        "p_value": Column(float, nullable=True),
+    },
+    strict=True,
+    coerce=True,
 )
 
 # ---------------------------------------------------------------------------
 # refined_embeddings.npz
 # ---------------------------------------------------------------------------
+
 
 def validate_refined_embeddings(vectors, n_works):
     """Validate embedding vectors are aligned with refined_works.csv.
@@ -110,11 +131,8 @@ def validate_refined_embeddings(vectors, n_works):
 
     """
     if vectors.ndim != 2:
-        raise ValueError(
-            f"Embeddings must be 2D, got {vectors.ndim}D"
-        )
+        raise ValueError(f"Embeddings must be 2D, got {vectors.ndim}D")
     if vectors.shape[0] != n_works:
         raise ValueError(
-            f"Embedding row mismatch: {vectors.shape[0]} vectors "
-            f"vs {n_works} works"
+            f"Embedding row mismatch: {vectors.shape[0]} vectors vs {n_works} works"
         )

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -210,7 +210,6 @@ class TestNullModelSchema:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow
 @pytest.mark.integration
 class TestSmokeNullModel:
     """Smoke tests for compute_null_model.py on fixture data."""
@@ -272,7 +271,6 @@ class TestSmokeNullModel:
         NullModelSchema.validate(df)
 
 
-@pytest.mark.slow
 @pytest.mark.integration
 class TestNullModelReusesYearWindow:
     """Null model should reuse year/window combos from tab_div_{method}.csv."""

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -1,0 +1,311 @@
+"""Tests for the permutation Z-score null model (ticket 0055).
+
+Tests:
+1. permutation_test core function — null distribution and planted breaks
+2. NullModelSchema validation
+3. Smoke test: run compute_null_model.py on fixture data
+4. Output reuses year/window combos from existing tab_div_{method}.csv
+"""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "smoke")
+
+sys.path.insert(0, SCRIPTS_DIR)
+
+from conftest import smoke_env
+
+# ---------------------------------------------------------------------------
+# Helper: run compute_null_model.py
+# ---------------------------------------------------------------------------
+
+
+def _run_null_model(method, output_path, extra_args=None, timeout=300):
+    """Run compute_null_model.py --method M --output P."""
+    cmd = [
+        sys.executable,
+        os.path.join(SCRIPTS_DIR, "compute_null_model.py"),
+        "--method",
+        method,
+        "--output",
+        str(output_path),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(
+        cmd,
+        env=smoke_env(),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: permutation_test core function
+# ---------------------------------------------------------------------------
+
+
+class TestPermutationTest:
+    """Test the permutation_test function directly."""
+
+    def test_z_scores_null_distribution(self):
+        """Under H0 (same distribution), Z-scores should be ~N(0,1).
+
+        We generate many (year, window) pairs from the same distribution
+        and check the resulting Z-scores are not systematically extreme.
+        """
+        from compute_null_model import permutation_test
+
+        rng = np.random.RandomState(42)
+        z_scores = []
+        for _ in range(30):
+            X = rng.randn(50, 10)
+            Y = rng.randn(50, 10)  # same distribution
+
+            def statistic_fn(a, b):
+                return float(np.mean(np.linalg.norm(a - b.mean(axis=0), axis=1)))
+
+            _, _, _, z, _ = permutation_test(X, Y, statistic_fn, n_perm=200, rng=rng)
+            z_scores.append(z)
+
+        z_scores = np.array(z_scores)
+        # Under H0, Z-scores should not be systematically extreme
+        # Mean should be near 0, and most |z| < 3
+        assert abs(np.mean(z_scores)) < 2.0, (
+            f"Mean Z-score under null = {np.mean(z_scores):.2f}, expected ~0"
+        )
+        fraction_extreme = np.mean(np.abs(z_scores) > 3.0)
+        assert fraction_extreme < 0.3, (
+            f"Too many extreme Z-scores under null: {fraction_extreme:.1%}"
+        )
+
+    def test_z_scores_detect_planted_break(self):
+        """Z > 2 at a planted distribution shift."""
+        from compute_null_model import permutation_test
+
+        rng = np.random.RandomState(42)
+        # Before: N(0, I), After: N(3, I)  -- large shift
+        X_before = rng.randn(80, 10)
+        Y_after = rng.randn(80, 10) + 3.0
+
+        def energy_like(a, b):
+            from scipy.spatial.distance import cdist
+
+            dXY = cdist(a, b).mean()
+            dXX = cdist(a, a).mean()
+            dYY = cdist(b, b).mean()
+            return 2.0 * dXY - dXX - dYY
+
+        _, _, _, z, p = permutation_test(
+            X_before, Y_after, energy_like, n_perm=200, rng=rng
+        )
+        assert z > 2.0, f"Expected Z > 2 for planted break, got Z={z:.2f}"
+        assert p < 0.05, f"Expected p < 0.05, got p={p:.3f}"
+
+    def test_permutation_test_reproducible(self):
+        """Same seed gives same Z-score."""
+        from compute_null_model import permutation_test
+
+        X = np.random.RandomState(10).randn(30, 5)
+        Y = np.random.RandomState(20).randn(30, 5) + 1.0
+
+        def stat(a, b):
+            return float(np.linalg.norm(a.mean(axis=0) - b.mean(axis=0)))
+
+        rng1 = np.random.RandomState(42)
+        _, _, _, z1, _ = permutation_test(X, Y, stat, n_perm=100, rng=rng1)
+
+        rng2 = np.random.RandomState(42)
+        _, _, _, z2, _ = permutation_test(X, Y, stat, n_perm=100, rng=rng2)
+
+        assert z1 == z2, f"Not reproducible: {z1} != {z2}"
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestNullModelSchema:
+    """NullModelSchema validation."""
+
+    def test_valid_dataframe_passes(self):
+        from schemas import NullModelSchema
+
+        df = pd.DataFrame(
+            {
+                "year": [2010, 2011],
+                "window": ["3", "3"],
+                "observed": [0.5, 0.6],
+                "null_mean": [0.3, 0.35],
+                "null_std": [0.1, 0.12],
+                "z_score": [2.0, 2.08],
+                "p_value": [0.01, 0.02],
+            }
+        )
+        NullModelSchema.validate(df)
+
+    def test_extra_column_rejected(self):
+        from schemas import NullModelSchema
+
+        df = pd.DataFrame(
+            {
+                "year": [2010],
+                "window": ["3"],
+                "observed": [0.5],
+                "null_mean": [0.3],
+                "null_std": [0.1],
+                "z_score": [2.0],
+                "p_value": [0.01],
+                "extra": ["oops"],
+            }
+        )
+        with pytest.raises(Exception):
+            NullModelSchema.validate(df)
+
+    def test_nullable_fields(self):
+        from schemas import NullModelSchema
+
+        df = pd.DataFrame(
+            {
+                "year": [2010],
+                "window": ["3"],
+                "observed": [np.nan],
+                "null_mean": [np.nan],
+                "null_std": [np.nan],
+                "z_score": [np.nan],
+                "p_value": [np.nan],
+            }
+        )
+        NullModelSchema.validate(df)
+
+    def test_coercion_works(self):
+        from schemas import NullModelSchema
+
+        df = pd.DataFrame(
+            {
+                "year": ["2010"],
+                "window": ["3"],
+                "observed": ["0.5"],
+                "null_mean": ["0.3"],
+                "null_std": ["0.1"],
+                "z_score": ["2.0"],
+                "p_value": ["0.01"],
+            }
+        )
+        validated = NullModelSchema.validate(df)
+        assert validated["year"].dtype in (int, "int64")
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests: run dispatcher on fixture data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestSmokeNullModel:
+    """Smoke tests for compute_null_model.py on fixture data."""
+
+    @pytest.mark.parametrize("method", ["S2_energy", "L1"])
+    def test_compute_produces_output(self, method, tmp_path):
+        """Script runs and produces a valid CSV."""
+        # First, generate the divergence CSV that the null model reads
+        from conftest import run_compute
+
+        div_out = tmp_path / f"tab_div_{method}.csv"
+        result = run_compute(method, div_out)
+        assert result.returncode == 0, f"Divergence {method} failed: {result.stderr}"
+
+        # Now run the null model
+        null_out = tmp_path / f"tab_null_{method}.csv"
+        result = _run_null_model(
+            method,
+            null_out,
+            extra_args=["--div-csv", str(div_out)],
+        )
+        assert result.returncode == 0, (
+            f"Null model {method} failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert null_out.exists(), f"Output CSV not created for {method}"
+
+        df = pd.read_csv(null_out)
+        expected_cols = {
+            "year",
+            "window",
+            "observed",
+            "null_mean",
+            "null_std",
+            "z_score",
+            "p_value",
+        }
+        assert expected_cols == set(df.columns), f"Columns mismatch: {set(df.columns)}"
+        assert len(df) > 0
+
+    @pytest.mark.parametrize("method", ["S2_energy", "L1"])
+    def test_output_passes_schema(self, method, tmp_path):
+        """Output validates against NullModelSchema."""
+        from conftest import run_compute
+
+        div_out = tmp_path / f"tab_div_{method}.csv"
+        run_compute(method, div_out)
+
+        null_out = tmp_path / f"tab_null_{method}.csv"
+        result = _run_null_model(
+            method,
+            null_out,
+            extra_args=["--div-csv", str(div_out)],
+        )
+        assert result.returncode == 0, result.stderr
+
+        from schemas import NullModelSchema
+
+        df = pd.read_csv(null_out)
+        NullModelSchema.validate(df)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestNullModelReusesYearWindow:
+    """Null model should reuse year/window combos from tab_div_{method}.csv."""
+
+    def test_year_window_match(self, tmp_path):
+        """Year/window combos in null output match those in divergence CSV."""
+        from conftest import run_compute
+
+        method = "S2_energy"
+        div_out = tmp_path / f"tab_div_{method}.csv"
+        run_compute(method, div_out)
+
+        null_out = tmp_path / f"tab_null_{method}.csv"
+        result = _run_null_model(
+            method,
+            null_out,
+            extra_args=["--div-csv", str(div_out)],
+        )
+        assert result.returncode == 0, result.stderr
+
+        div_df = pd.read_csv(div_out)
+        null_df = pd.read_csv(null_out)
+
+        # The null model may only cover the "default" hyperparam rows for S2
+        # but year/window pairs should be a subset
+        div_pairs = set(zip(div_df["year"], div_df["window"].astype(str)))
+        null_pairs = set(zip(null_df["year"], null_df["window"].astype(str)))
+
+        assert null_pairs.issubset(div_pairs), (
+            f"Null model has year/window pairs not in divergence CSV: "
+            f"{null_pairs - div_pairs}"
+        )
+        # And the null model should cover most pairs
+        assert len(null_pairs) >= len(div_pairs) * 0.5, (
+            f"Null model covers too few pairs: {len(null_pairs)} / {len(div_pairs)}"
+        )


### PR DESCRIPTION
## Summary

- Add `scripts/compute_null_model.py` — dispatcher that runs permutation tests for semantic (S1-S4) and lexical (L1) divergence methods. For each (year, window) pair from the existing divergence CSV, pools before/after data, shuffles labels B times, and computes Z-scores and p-values.
- Add `NullModelSchema` to `scripts/schemas.py` (strict=True, coerce=True) with columns: year, window, observed, null_mean, null_std, z_score, p_value.
- Add `permutation` config block to `config/analysis.yaml` (n_perm=500, z_threshold=2.0).
- Add Make targets in `divergence.mk`: `null-model` builds `tab_null_S2_energy.csv` and `tab_null_L1.csv`.
- Add 12 tests in `tests/test_null_model.py`: unit tests for the core permutation function (null distribution, planted break detection, reproducibility), schema validation, and subprocess-based smoke tests for S2_energy and L1.

## Test plan

- [x] Unit tests pass: `uv run pytest tests/test_null_model.py -k "not integration"` (7 passed)
- [x] Integration tests pass: `uv run pytest tests/test_null_model.py -k "integration"` (5 passed)
- [x] `make check-fast` shows 13 pre-existing failures, no new ones (750 passed)
- [ ] Run `make null-model` on full corpus to verify production outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)