### PR TITLE
fix: repair 13 failing tests

### DIFF
--- a/content/_includes/corpus-construction.md
+++ b/content/_includes/corpus-construction.md
@@ -1,3 +1,14 @@
+## Pipeline overview
+
+Corpus construction follows four stages, each producing an intermediate artifact:
+
+1. **Discover** — merge sources into a deduplicated pool → `unified_works.csv`
+2. **Enrich** — fetch metadata, abstracts, and citations → `enriched_works.csv`
+3. **Extend** — compute derived flags (language, relevance, duplicates) without removing rows → `extended_works.csv`
+4. **Filter** — apply inclusion policy, audit removals → `refined_works.csv`
+
+The discover stage is described below; enrichment and filtering are documented in their own sections.
+
 ## Discovery Sources
 
 ### Sources

--- a/scripts/compute_vars.py
+++ b/scripts/compute_vars.py
@@ -58,14 +58,6 @@ DOC_VARS = {
         "bim_n_post2015",
         "bim_n_pre2007",
         "bim_var_pct",
-        "cite_coverage_pct",
-        "cite_crossref_rows",
-        "cite_doi_ref_pct",
-        "cite_doi_ref_rows",
-        "cite_fetched_dois",
-        "cite_never_fetched",
-        "cite_total_dois",
-        "cite_total_rows",
         "cite_refined_rows",
         "cite_refined_sources",
         "corpus_core",
@@ -74,7 +66,7 @@ DOC_VARS = {
         "corpus_total",
         "corpus_with_embeddings",
         "analysis_corpus_n",
-        "lang_english_pct",
+        "emb_dimensions",
         "pca_emb_pc2_cosine",
         "pca_emb_pc2_dbic",
         "pca_emb_pc2_var_pct",
@@ -157,6 +149,7 @@ MISSING = "[MISSING]"
 
 # ── Helpers ──────────────────────────────────────────────────
 
+
 def _int(value):
     """Format integer with comma thousands separator."""
     return f"{int(round(value)):,}"
@@ -195,6 +188,7 @@ def _read_json(filename, directory=TABLES_DIR):
 
 
 # ── Collectors ───────────────────────────────────────────────
+
 
 def corpus_stats(v):
     """Corpus size, language, multi-source from refined_works.csv."""
@@ -277,6 +271,7 @@ def filter_stats(v):
 def embedding_stats(v):
     """Embedding count and dimensions from embeddings.npz."""
     from utils import EMBEDDINGS_PATH, REFINED_EMBEDDINGS_PATH
+
     if not os.path.isfile(EMBEDDINGS_PATH):
         warnings.warn(f"Missing: {EMBEDDINGS_PATH}")
         return
@@ -422,6 +417,7 @@ def citation_stats(v):
 
     # Refined (corpus-internal) citations from refined_citations.csv
     from utils import REFINED_CITATIONS_PATH, REFINED_WORKS_PATH, normalize_doi
+
     if os.path.isfile(REFINED_CITATIONS_PATH):
         ref_cite_df = pd.read_csv(REFINED_CITATIONS_PATH)[["source_doi"]]
         v["cite_refined_rows"] = _int(len(ref_cite_df))
@@ -429,21 +425,30 @@ def citation_stats(v):
 
         # Coverage: % of refined DOIs that appear as citation sources
         if os.path.isfile(REFINED_WORKS_PATH):
-            refined_df = pd.read_csv(REFINED_WORKS_PATH, usecols=["doi", "cited_by_count"])
+            refined_df = pd.read_csv(
+                REFINED_WORKS_PATH, usecols=["doi", "cited_by_count"]
+            )
             refined_dois = {normalize_doi(d) for d in refined_df["doi"].dropna()} - {""}
             source_dois = {normalize_doi(d) for d in ref_cite_df["source_doi"].dropna()}
             covered = len(source_dois & refined_dois)
             if refined_dois:
-                v["cite_refined_coverage_pct"] = str(round(100 * covered / len(refined_dois)))
+                v["cite_refined_coverage_pct"] = str(
+                    round(100 * covered / len(refined_dois))
+                )
             # Core coverage (cited >= 50)
             core_mask = refined_df["cited_by_count"].fillna(0).astype(int) >= 50
-            core_dois = {normalize_doi(d) for d in refined_df.loc[core_mask, "doi"].dropna()} - {""}
+            core_dois = {
+                normalize_doi(d) for d in refined_df.loc[core_mask, "doi"].dropna()
+            } - {""}
             if core_dois:
                 core_covered = len(source_dois & core_dois)
-                v["cite_coverage_core_pct"] = str(round(100 * core_covered / len(core_dois)))
+                v["cite_coverage_core_pct"] = str(
+                    round(100 * core_covered / len(core_dois))
+                )
 
 
 # ── Write YAML ───────────────────────────────────────────────
+
 
 def write_yaml(v, path):
     """Write variables dict as a YAML file with all values quoted."""
@@ -459,6 +464,7 @@ def write_yaml(v, path):
 
 
 # ── Main ─────────────────────────────────────────────────────
+
 
 def main(output_dir):
     v = {}
@@ -481,8 +487,11 @@ def main(output_dir):
         write_yaml(doc_v, path)
 
     if all_missing:
-        log.error("Aborting: %d variables could not be computed. "
-                  "Rendering would produce ?meta:X placeholders.", len(all_missing))
+        log.error(
+            "Aborting: %d variables could not be computed. "
+            "Rendering would produce ?meta:X placeholders.",
+            len(all_missing),
+        )
         sys.exit(1)
 
 

--- a/tests/test_alluvial_unit.py
+++ b/tests/test_alluvial_unit.py
@@ -26,19 +26,22 @@ sys.path.insert(0, SCRIPTS_DIR)
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_works(n=20):
     """Create a small synthetic refined_works DataFrame."""
     rng = np.random.RandomState(42)
     years = rng.choice(range(1985, 2030), size=n)
     cited = rng.choice([0, 10, 30, 60, 100], size=n)
     titles = [f"Paper {i}" if i % 10 != 0 else "" for i in range(n)]
-    return pd.DataFrame({
-        "title": titles,
-        "year": years,
-        "cited_by_count": cited,
-        "doi": [f"10.1000/test.{i}" for i in range(n)],
-        "abstract": [f"Abstract {i}" for i in range(n)],
-    })
+    return pd.DataFrame(
+        {
+            "title": titles,
+            "year": years,
+            "cited_by_count": cited,
+            "doi": [f"10.1000/test.{i}" for i in range(n)],
+            "abstract": [f"Abstract {i}" for i in range(n)],
+        }
+    )
 
 
 def _make_embeddings(n=20, dim=1024):
@@ -50,6 +53,7 @@ def _make_embeddings(n=20, dim=1024):
 # load_analysis_corpus()
 # ---------------------------------------------------------------------------
 
+
 class TestLoadAnalysisCorpus:
     """Test filtering logic in load_analysis_corpus()."""
 
@@ -59,10 +63,15 @@ class TestLoadAnalysisCorpus:
 
         with_emb = kwargs.pop("with_embeddings", embeddings is not None)
 
-        with patch("pipeline_loaders.pd.read_csv", return_value=works_df), \
-             patch("pipeline_loaders.REFINED_WORKS_FEATHER", "/nonexistent"), \
-             patch("pipeline_loaders.load_refined_embeddings",
-                   return_value=embeddings):
+        with (
+            patch("pipeline_loaders.pd.read_csv", return_value=works_df),
+            patch("pipeline_loaders.REFINED_WORKS_FEATHER", "/nonexistent"),
+            patch(
+                "pipeline_loaders.os.path.exists",
+                side_effect=lambda p: p != "/nonexistent",
+            ),
+            patch("pipeline_loaders.load_refined_embeddings", return_value=embeddings),
+        ):
             return load_analysis_corpus(with_embeddings=with_emb, **kwargs)
 
     def test_filters_missing_titles(self):
@@ -93,8 +102,9 @@ class TestLoadAnalysisCorpus:
     def test_core_only_filters_by_threshold(self):
         works = _make_works()
         df_all, _ = self._call(works, with_embeddings=False)
-        df_core, _ = self._call(works, with_embeddings=False,
-                                core_only=True, cite_threshold=50)
+        df_core, _ = self._call(
+            works, with_embeddings=False, core_only=True, cite_threshold=50
+        )
         assert len(df_core) < len(df_all)
         assert (df_core["cited_by_count"] >= 50).all()
 
@@ -107,8 +117,9 @@ class TestLoadAnalysisCorpus:
     def test_embeddings_aligned_after_core_filtering(self):
         works = _make_works(20)
         emb = _make_embeddings(20)
-        df, result_emb = self._call(works, embeddings=emb,
-                                    core_only=True, cite_threshold=50)
+        df, result_emb = self._call(
+            works, embeddings=emb, core_only=True, cite_threshold=50
+        )
         assert len(df) == len(result_emb)
 
     def test_embedding_mismatch_raises(self):
@@ -133,12 +144,14 @@ class TestLoadAnalysisCorpus:
 # is_clean_term()
 # ---------------------------------------------------------------------------
 
+
 class TestIsCleanTerm:
     """Test lexical denoising in is_clean_term()."""
 
     @pytest.fixture(autouse=True)
     def _import(self):
         from compute_lexical import is_clean_term
+
         self.is_clean_term = is_clean_term
 
     def test_rejects_short_single_token(self):
@@ -179,6 +192,7 @@ class TestIsCleanTerm:
 # load_analysis_config()
 # ---------------------------------------------------------------------------
 
+
 class TestLoadAnalysisConfig:
     """Test YAML config loading."""
 
@@ -195,6 +209,7 @@ class TestLoadAnalysisConfig:
 
         with patch("pipeline_loaders.CONFIG_DIR", str(tmp_path)):
             from utils import load_analysis_config
+
             cfg = load_analysis_config()
 
         assert cfg["periodization"]["breaks"] == [2007, 2015]
@@ -204,6 +219,7 @@ class TestLoadAnalysisConfig:
     def test_missing_file_raises(self, tmp_path):
         with patch("pipeline_loaders.CONFIG_DIR", str(tmp_path)):
             from utils import load_analysis_config
+
             with pytest.raises(FileNotFoundError, match="analysis.yaml"):
                 load_analysis_config()
 
@@ -211,6 +227,7 @@ class TestLoadAnalysisConfig:
 # ---------------------------------------------------------------------------
 # _build_argv() selective flag forwarding
 # ---------------------------------------------------------------------------
+
 
 class TestBuildArgv:
     """Test the shim's selective flag-forwarding logic."""
@@ -220,10 +237,14 @@ class TestBuildArgv:
 
     SCRIPT_FLAGS = {
         "scripts/compute_breakpoints.py": {
-            "--core-only", "--censor-gap", "--robustness", "--k-sensitivity",
+            "--core-only",
+            "--censor-gap",
+            "--robustness",
+            "--k-sensitivity",
         },
         "scripts/compute_clusters.py": {
-            "--core-only", "--breaks",
+            "--core-only",
+            "--breaks",
         },
         "scripts/compute_lexical.py": set(),
     }
@@ -244,77 +265,77 @@ class TestBuildArgv:
         return argv
 
     def test_core_only_forwarded_to_breakpoints(self):
-        args = Namespace(core_only=True, censor_gap=0, robustness=False,
-                         breaks=None)
-        argv = self._build_argv("scripts/compute_breakpoints.py",
-                                args, self.SCRIPT_FLAGS)
+        args = Namespace(core_only=True, censor_gap=0, robustness=False, breaks=None)
+        argv = self._build_argv(
+            "scripts/compute_breakpoints.py", args, self.SCRIPT_FLAGS
+        )
         assert "--core-only" in argv
 
     def test_core_only_forwarded_to_clusters(self):
-        args = Namespace(core_only=True, censor_gap=0, robustness=False,
-                         breaks=None)
-        argv = self._build_argv("scripts/compute_clusters.py",
-                                args, self.SCRIPT_FLAGS)
+        args = Namespace(core_only=True, censor_gap=0, robustness=False, breaks=None)
+        argv = self._build_argv("scripts/compute_clusters.py", args, self.SCRIPT_FLAGS)
         assert "--core-only" in argv
 
     def test_core_only_not_forwarded_to_lexical(self):
-        args = Namespace(core_only=True, censor_gap=0, robustness=False,
-                         breaks=None)
-        argv = self._build_argv("scripts/compute_lexical.py",
-                                args, self.SCRIPT_FLAGS)
+        args = Namespace(core_only=True, censor_gap=0, robustness=False, breaks=None)
+        argv = self._build_argv("scripts/compute_lexical.py", args, self.SCRIPT_FLAGS)
         assert "--core-only" not in argv
 
     def test_censor_gap_only_to_breakpoints(self):
-        args = Namespace(core_only=False, censor_gap=2, robustness=False,
-                         breaks=None)
-        bp_argv = self._build_argv("scripts/compute_breakpoints.py",
-                                   args, self.SCRIPT_FLAGS)
-        cl_argv = self._build_argv("scripts/compute_clusters.py",
-                                   args, self.SCRIPT_FLAGS)
+        args = Namespace(core_only=False, censor_gap=2, robustness=False, breaks=None)
+        bp_argv = self._build_argv(
+            "scripts/compute_breakpoints.py", args, self.SCRIPT_FLAGS
+        )
+        cl_argv = self._build_argv(
+            "scripts/compute_clusters.py", args, self.SCRIPT_FLAGS
+        )
         assert ["--censor-gap", "2"] == bp_argv
         assert cl_argv == []
 
     def test_robustness_only_to_breakpoints(self):
-        args = Namespace(core_only=False, censor_gap=0, robustness=True,
-                         breaks=None)
-        bp_argv = self._build_argv("scripts/compute_breakpoints.py",
-                                   args, self.SCRIPT_FLAGS)
-        cl_argv = self._build_argv("scripts/compute_clusters.py",
-                                   args, self.SCRIPT_FLAGS)
-        lx_argv = self._build_argv("scripts/compute_lexical.py",
-                                   args, self.SCRIPT_FLAGS)
+        args = Namespace(core_only=False, censor_gap=0, robustness=True, breaks=None)
+        bp_argv = self._build_argv(
+            "scripts/compute_breakpoints.py", args, self.SCRIPT_FLAGS
+        )
+        cl_argv = self._build_argv(
+            "scripts/compute_clusters.py", args, self.SCRIPT_FLAGS
+        )
+        lx_argv = self._build_argv(
+            "scripts/compute_lexical.py", args, self.SCRIPT_FLAGS
+        )
         assert "--robustness" in bp_argv
         assert "--robustness" not in cl_argv
         assert "--robustness" not in lx_argv
 
     def test_breaks_forwarded_to_clusters_only(self):
-        args = Namespace(core_only=False, censor_gap=0, robustness=False,
-                         breaks="2007,2013")
-        bp_argv = self._build_argv("scripts/compute_breakpoints.py",
-                                   args, self.SCRIPT_FLAGS)
-        cl_argv = self._build_argv("scripts/compute_clusters.py",
-                                   args, self.SCRIPT_FLAGS)
-        lx_argv = self._build_argv("scripts/compute_lexical.py",
-                                   args, self.SCRIPT_FLAGS)
+        args = Namespace(
+            core_only=False, censor_gap=0, robustness=False, breaks="2007,2013"
+        )
+        bp_argv = self._build_argv(
+            "scripts/compute_breakpoints.py", args, self.SCRIPT_FLAGS
+        )
+        cl_argv = self._build_argv(
+            "scripts/compute_clusters.py", args, self.SCRIPT_FLAGS
+        )
+        lx_argv = self._build_argv(
+            "scripts/compute_lexical.py", args, self.SCRIPT_FLAGS
+        )
         assert "--breaks" not in bp_argv
         assert ["--breaks", "2007,2013"] == cl_argv[-2:]
         assert "--breaks" not in lx_argv
 
     def test_no_flags_gives_empty(self):
-        args = Namespace(core_only=False, censor_gap=0, robustness=False,
-                         breaks=None)
+        args = Namespace(core_only=False, censor_gap=0, robustness=False, breaks=None)
         for script in self.SCRIPT_FLAGS:
             assert self._build_argv(script, args, self.SCRIPT_FLAGS) == []
 
     def test_all_flags_combined(self):
-        args = Namespace(core_only=True, censor_gap=3, robustness=True,
-                         breaks="2007,2015")
-        bp = self._build_argv("scripts/compute_breakpoints.py",
-                              args, self.SCRIPT_FLAGS)
-        cl = self._build_argv("scripts/compute_clusters.py",
-                              args, self.SCRIPT_FLAGS)
-        lx = self._build_argv("scripts/compute_lexical.py",
-                              args, self.SCRIPT_FLAGS)
+        args = Namespace(
+            core_only=True, censor_gap=3, robustness=True, breaks="2007,2015"
+        )
+        bp = self._build_argv("scripts/compute_breakpoints.py", args, self.SCRIPT_FLAGS)
+        cl = self._build_argv("scripts/compute_clusters.py", args, self.SCRIPT_FLAGS)
+        lx = self._build_argv("scripts/compute_lexical.py", args, self.SCRIPT_FLAGS)
         # breakpoints gets: --core-only, --censor-gap 3, --robustness
         assert "--core-only" in bp
         assert "--censor-gap" in bp


### PR DESCRIPTION
## Summary

- **9 `test_alluvial_unit.py` failures**: `TestLoadAnalysisCorpus._call()` mocked `pd.read_csv` but `load_refined_works()` calls `os.path.exists()` before reaching `read_csv`, hitting `FileNotFoundError`. Fixed by also mocking `os.path.exists` to return `True` for all paths except the `/nonexistent` feather sentinel.
- **2 `test_doc_contract_consistency.py` failures**: `corpus-construction.md` was refactored into separate includes but lost its pipeline overview. Added a 4-stage overview (discover → enrich → extend → filter) with all four artifact names.
- **2 `test_doc_vars_completeness.py` failures**: After the technical-report/corpus-report split, `emb_dimensions` was used in prose but missing from `DOC_VARS`, and 9 citation/language variables moved to the corpus-report but stayed in `DOC_VARS["technical-report"]`. Added `emb_dimensions`, removed the 9 dead entries.

## Test plan

- [x] `pytest tests/test_alluvial_unit.py::TestLoadAnalysisCorpus` — 9/9 pass
- [x] `pytest tests/test_doc_contract_consistency.py::TestCorpusConstructionMd` — 3/3 pass
- [x] `pytest tests/test_doc_vars_completeness.py` — 6/6 pass
- [x] `make check-fast` — 764 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)