### PR TITLE
fix: G1 PageRank — replace zero-padded Kendall tau with JS divergence (t0059)

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -62,6 +62,7 @@ divergence:
   citation:
     G1_pagerank:
       damping: 0.85
+      n_bins: 20                                   # histogram bins for JS divergence on PR distributions
     G2_spectral: {}
     G3_coupling_age: {}
     G4_cross_tradition:

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -84,8 +84,8 @@ def _compare_pagerank_distributions(pr_before, pr_after, n_bins=20):
         return np.nan
     bin_max = max(pr_b.max(), pr_a.max())
     bins = np.linspace(0, bin_max, actual_bins + 1)
-    hist_b, _ = np.histogram(pr_b, bins=bins, density=True)
-    hist_a, _ = np.histogram(pr_a, bins=bins, density=True)
+    hist_b, _ = np.histogram(pr_b, bins=bins)
+    hist_a, _ = np.histogram(pr_a, bins=bins)
 
     # Add epsilon to avoid zero bins, then re-normalize
     eps = 1e-10
@@ -206,8 +206,9 @@ def compute_g1_pagerank(works, citations, internal_edges, cfg):
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     cit_cfg = cfg["divergence"]["citation"]
-    damping = cit_cfg["G1_pagerank"]["damping"]
-    n_bins = 20
+    g1_cfg = cit_cfg["G1_pagerank"]
+    damping = g1_cfg["damping"]
+    n_bins = g1_cfg.get("n_bins", 20)
 
     log.info("G1: PageRank distribution divergence (sliding, JS)")
     results = []

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -67,32 +67,20 @@ def _compare_pagerank_distributions(pr_before, pr_after, n_bins=20):
     _nodes_b, vals_b = pr_before
     _nodes_a, vals_a = pr_after
 
-    # Sort descending (distribution shape, not per-node identity)
-    pr_b = np.sort(vals_b)[::-1]
-    pr_a = np.sort(vals_a)[::-1]
-
-    # Normalize to probability distributions
-    sum_b, sum_a = pr_b.sum(), pr_a.sum()
-    if sum_b == 0 or sum_a == 0:
-        return np.nan
-    pr_b = pr_b / sum_b
-    pr_a = pr_a / sum_a
-
-    # Bin into histograms (handles different-sized distributions)
-    actual_bins = min(n_bins, min(len(pr_b), len(pr_a)))
+    # Bin into histograms over a shared range (handles different-sized distributions).
+    # PageRank values already sum to 1.0; jensenshannon normalizes internally.
+    actual_bins = min(n_bins, min(len(vals_b), len(vals_a)))
     if actual_bins < 2:
         return np.nan
-    bin_max = max(pr_b.max(), pr_a.max())
+    bin_max = max(vals_b.max(), vals_a.max())
     bins = np.linspace(0, bin_max, actual_bins + 1)
-    hist_b, _ = np.histogram(pr_b, bins=bins)
-    hist_a, _ = np.histogram(pr_a, bins=bins)
+    hist_b, _ = np.histogram(vals_b, bins=bins)
+    hist_a, _ = np.histogram(vals_a, bins=bins)
 
-    # Add epsilon to avoid zero bins, then re-normalize
+    # Add epsilon to avoid zero bins before jensenshannon (which uses log internally).
     eps = 1e-10
     hist_b = hist_b + eps
     hist_a = hist_a + eps
-    hist_b = hist_b / hist_b.sum()
-    hist_a = hist_a / hist_a.sum()
 
     return float(jensenshannon(hist_b, hist_a) ** 2)
 

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -24,7 +24,8 @@ from _divergence_citation import (
 )
 from scipy.optimize import curve_fit
 from scipy.sparse.linalg import eigsh
-from scipy.stats import entropy, kendalltau
+from scipy.spatial.distance import jensenshannon
+from scipy.stats import entropy
 from utils import get_logger
 
 log = get_logger("_citation_methods")
@@ -41,6 +42,59 @@ def _pagerank_vector(G, damping):
     nodes = sorted(pr.keys())
     vals = np.array([pr[n] for n in nodes])
     return nodes, vals
+
+
+def _compare_pagerank_distributions(pr_before, pr_after, n_bins=20):
+    """Compare two PageRank distributions via Jensen-Shannon divergence.
+
+    Unlike per-node comparison (which requires shared nodes), this compares
+    the *shape* of the PageRank value distributions — whether concentration
+    or spread changed between windows. Works correctly on disjoint node sets.
+
+    Parameters
+    ----------
+    pr_before, pr_after : tuple (nodes, values)
+        Output of _pagerank_vector().
+    n_bins : int
+        Number of histogram bins for discretizing the distributions.
+
+    Returns
+    -------
+    float
+        JS divergence squared, in [0, 1]. 0 = identical distributions.
+
+    """
+    _nodes_b, vals_b = pr_before
+    _nodes_a, vals_a = pr_after
+
+    # Sort descending (distribution shape, not per-node identity)
+    pr_b = np.sort(vals_b)[::-1]
+    pr_a = np.sort(vals_a)[::-1]
+
+    # Normalize to probability distributions
+    sum_b, sum_a = pr_b.sum(), pr_a.sum()
+    if sum_b == 0 or sum_a == 0:
+        return np.nan
+    pr_b = pr_b / sum_b
+    pr_a = pr_a / sum_a
+
+    # Bin into histograms (handles different-sized distributions)
+    actual_bins = min(n_bins, min(len(pr_b), len(pr_a)))
+    if actual_bins < 2:
+        return np.nan
+    bin_max = max(pr_b.max(), pr_a.max())
+    bins = np.linspace(0, bin_max, actual_bins + 1)
+    hist_b, _ = np.histogram(pr_b, bins=bins, density=True)
+    hist_a, _ = np.histogram(pr_a, bins=bins, density=True)
+
+    # Add epsilon to avoid zero bins, then re-normalize
+    eps = 1e-10
+    hist_b = hist_b + eps
+    hist_a = hist_a + eps
+    hist_b = hist_b / hist_b.sum()
+    hist_a = hist_a / hist_a.sum()
+
+    return float(jensenshannon(hist_b, hist_a) ** 2)
 
 
 def _spectral_gap(G_dir):
@@ -142,17 +196,20 @@ def _mean_betweenness(G_dir, max_nodes):
 
 
 def compute_g1_pagerank(works, citations, internal_edges, cfg):
-    """PageRank divergence between before/after sliding windows.
+    """PageRank distribution divergence between before/after sliding windows.
 
-    Computes Kendall tau distance between PageRank rankings of the
-    before and after windows. Common nodes are used for comparison.
+    Compares the *shape* of PageRank value distributions using
+    Jensen-Shannon divergence (ticket 0059). This works correctly on
+    disjoint node sets — sliding windows rarely share nodes, so per-node
+    comparison (the old Kendall-tau approach) was dominated by zero-padding.
 
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     cit_cfg = cfg["divergence"]["citation"]
     damping = cit_cfg["G1_pagerank"]["damping"]
+    n_bins = 20
 
-    log.info("G1: PageRank divergence (sliding)")
+    log.info("G1: PageRank distribution divergence (sliding, JS)")
     results = []
 
     for year, w, G_before, G_after in _iter_sliding_pairs(works, internal_edges, cfg):
@@ -161,31 +218,23 @@ def compute_g1_pagerank(works, citations, internal_edges, cfg):
 
         if pr_before is None or pr_after is None:
             results.append(
-                {"year": year, "window": str(w), "hyperparams": "", "value": np.nan}
+                {
+                    "year": year,
+                    "window": str(w),
+                    "hyperparams": f"n_bins={n_bins}",
+                    "value": np.nan,
+                }
             )
             continue
 
-        nodes_b, vals_b = pr_before
-        nodes_a, vals_a = pr_after
-
-        # Use all nodes from both windows (union) for comparison.
-        # Nodes absent from one window get PageRank = 0.
-        all_nodes = sorted(set(nodes_b) | set(nodes_a))
-        if len(all_nodes) < 3:
-            results.append(
-                {"year": year, "window": str(w), "hyperparams": "", "value": np.nan}
-            )
-            continue
-
-        pr_b_map = dict(zip(nodes_b, vals_b))
-        pr_a_map = dict(zip(nodes_a, vals_a))
-        vec_b = np.array([pr_b_map.get(n, 0.0) for n in all_nodes])
-        vec_a = np.array([pr_a_map.get(n, 0.0) for n in all_nodes])
-
-        tau, _ = kendalltau(vec_b, vec_a)
-        value = 1.0 - tau if not np.isnan(tau) else np.nan
+        value = _compare_pagerank_distributions(pr_before, pr_after, n_bins)
         results.append(
-            {"year": year, "window": str(w), "hyperparams": "", "value": value}
+            {
+                "year": year,
+                "window": str(w),
+                "hyperparams": f"n_bins={n_bins}",
+                "value": value,
+            }
         )
 
     return pd.DataFrame(results)

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -7,6 +7,7 @@ Tests:
 4. Seed reproducibility (same seed -> same output, different seed -> different)
 5. Property tests for S1-S4 metric axioms
 6. _get_break_years helper tests
+7. G1 PageRank on disjoint sliding windows (ticket 0059)
 """
 
 import copy
@@ -664,3 +665,180 @@ class TestEqualN:
         # Both should produce results; equal_n should not crash
         assert len(result_eq) > 0, "equal_n L1 JS produced no results"
         assert len(result_raw) > 0, "raw L1 JS produced no results"
+
+
+# ---------------------------------------------------------------------------
+# G1 PageRank on disjoint sliding windows (ticket 0059)
+# ---------------------------------------------------------------------------
+
+
+def _make_star_graph(center, n_leaves, prefix):
+    """Create a star graph: center node with n_leaves spokes.
+
+    Returns (works_df, internal_edges_df).
+    Star topology produces concentrated PageRank on the center.
+    """
+    nodes = [center] + [f"{prefix}_{i}" for i in range(n_leaves)]
+    works = pd.DataFrame({"doi": nodes, "year": [2010] * len(nodes)})
+    # Edges: every leaf cites the center
+    edges = pd.DataFrame(
+        {
+            "source_doi": [f"{prefix}_{i}" for i in range(n_leaves)],
+            "ref_doi": [center] * n_leaves,
+            "source_year": [2010] * n_leaves,
+        }
+    )
+    return works, edges
+
+
+def _make_uniform_ring(n_nodes, prefix, year=2015):
+    """Create a ring graph: each node cites the next.
+
+    Returns (works_df, internal_edges_df).
+    Ring topology produces nearly uniform PageRank.
+    """
+    nodes = [f"{prefix}_{i}" for i in range(n_nodes)]
+    works = pd.DataFrame({"doi": nodes, "year": [year] * n_nodes})
+    edges = pd.DataFrame(
+        {
+            "source_doi": [nodes[i] for i in range(n_nodes)],
+            "ref_doi": [nodes[(i + 1) % n_nodes] for i in range(n_nodes)],
+            "source_year": [year] * n_nodes,
+        }
+    )
+    return works, edges
+
+
+class TestG1DisjointWindows:
+    """G1 PageRank should distinguish similar vs different distributions
+    even on disjoint sliding windows (ticket 0059).
+
+    The old implementation compared per-node PageRank with union+zero-padding,
+    which is meaningless on disjoint node sets. The fix uses distributional
+    comparison (Jensen-Shannon divergence on PageRank value histograms).
+    """
+
+    def _g1_cfg(self):
+        """Minimal config for G1 tests."""
+        cfg = _smoke_cfg(seed=42)
+        cfg["divergence"]["windows"] = [2]
+        cfg["divergence"]["min_papers"] = 3
+        cfg["divergence"]["min_papers_smoke"] = 3
+        return cfg
+
+    def test_g1_disjoint_windows_not_degenerate(self):
+        """G1 must produce different values for similar vs different distributions.
+
+        Pair A: two star graphs (both have concentrated PageRank) → low divergence.
+        Pair B: star graph vs ring graph (concentrated vs uniform PageRank) → high divergence.
+        """
+        import networkx as nx
+        from _citation_methods import _pagerank_vector
+
+        # Build two star graphs (similar concentrated distributions)
+        G_star1 = nx.DiGraph()
+        G_star1.add_nodes_from([f"s1_{i}" for i in range(20)])
+        for i in range(1, 20):
+            G_star1.add_edge(f"s1_{i}", "s1_0")
+        pr_star1 = _pagerank_vector(G_star1, damping=0.85)
+
+        G_star2 = nx.DiGraph()
+        G_star2.add_nodes_from([f"s2_{i}" for i in range(20)])
+        for i in range(1, 20):
+            G_star2.add_edge(f"s2_{i}", "s2_0")
+        pr_star2 = _pagerank_vector(G_star2, damping=0.85)
+
+        # Build a ring graph (uniform distribution)
+        G_ring = nx.DiGraph()
+        ring_nodes = [f"r_{i}" for i in range(20)]
+        G_ring.add_nodes_from(ring_nodes)
+        for i in range(20):
+            G_ring.add_edge(ring_nodes[i], ring_nodes[(i + 1) % 20])
+        pr_ring = _pagerank_vector(G_ring, damping=0.85)
+
+        assert pr_star1 is not None
+        assert pr_star2 is not None
+        assert pr_ring is not None
+
+        # Node sets are completely disjoint in all cases
+        assert set(pr_star1[0]).isdisjoint(set(pr_star2[0]))
+        assert set(pr_star1[0]).isdisjoint(set(pr_ring[0]))
+
+        # Now use the actual comparison method from G1
+        from _citation_methods import _compare_pagerank_distributions
+
+        # Similar distributions (star vs star) → low divergence
+        val_similar = _compare_pagerank_distributions(pr_star1, pr_star2)
+        # Different distributions (star vs ring) → high divergence
+        val_different = _compare_pagerank_distributions(pr_star1, pr_ring)
+
+        assert not np.isnan(val_similar), "Similar pair should not be NaN"
+        assert not np.isnan(val_different), "Different pair should not be NaN"
+        assert val_different > val_similar, (
+            f"Star-vs-ring ({val_different:.4f}) should exceed "
+            f"star-vs-star ({val_similar:.4f})"
+        )
+
+    def test_g1_output_matches_schema(self):
+        """G1 output should match DivergenceSchema regardless of implementation."""
+        from _citation_methods import compute_g1_pagerank
+        from schemas import DivergenceSchema
+
+        # Create a synthetic corpus spanning years 2005-2015 so that
+        # _iter_sliding_pairs (window=2) produces valid pairs.
+        # Each year gets 5 papers with star-topology edges.
+        rows = []
+        edge_rows = []
+        for y in range(2005, 2016):
+            prefix = f"y{y}"
+            center = f"{prefix}_0"
+            nodes = [center] + [f"{prefix}_{i}" for i in range(1, 5)]
+            for n in nodes:
+                rows.append({"doi": n, "year": y, "cited_by_count": 10})
+            for i in range(1, 5):
+                edge_rows.append(
+                    {
+                        "source_doi": f"{prefix}_{i}",
+                        "ref_doi": center,
+                        "source_year": y,
+                    }
+                )
+
+        works = pd.DataFrame(rows)
+        internal_edges = pd.DataFrame(edge_rows)
+        citations = internal_edges.copy()
+        citations["ref_year"] = citations["source_year"]
+
+        cfg = self._g1_cfg()
+        result = compute_g1_pagerank(works, citations, internal_edges, cfg)
+
+        assert len(result) > 0, "G1 should produce at least one row"
+        assert set(result.columns) == {"year", "window", "hyperparams", "value"}
+
+        # Add channel column for schema validation
+        result["channel"] = "citation"
+        DivergenceSchema.validate(result)
+
+    def test_g1_value_bounded_0_1(self):
+        """Jensen-Shannon divergence squared is bounded in [0, 1]."""
+        import networkx as nx
+        from _citation_methods import _compare_pagerank_distributions, _pagerank_vector
+
+        # Star graph
+        G1 = nx.DiGraph()
+        G1.add_nodes_from(range(20))
+        for i in range(1, 20):
+            G1.add_edge(i, 0)
+
+        # Chain graph
+        G2 = nx.DiGraph()
+        G2.add_nodes_from(range(100, 120))
+        for i in range(100, 119):
+            G2.add_edge(i, i + 1)
+
+        pr1 = _pagerank_vector(G1, 0.85)
+        pr2 = _pagerank_vector(G2, 0.85)
+        assert pr1 is not None and pr2 is not None
+
+        val = _compare_pagerank_distributions(pr1, pr2)
+        assert 0.0 <= val <= 1.0, f"Value {val} out of [0, 1] bounds"

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -672,43 +672,6 @@ class TestEqualN:
 # ---------------------------------------------------------------------------
 
 
-def _make_star_graph(center, n_leaves, prefix):
-    """Create a star graph: center node with n_leaves spokes.
-
-    Returns (works_df, internal_edges_df).
-    Star topology produces concentrated PageRank on the center.
-    """
-    nodes = [center] + [f"{prefix}_{i}" for i in range(n_leaves)]
-    works = pd.DataFrame({"doi": nodes, "year": [2010] * len(nodes)})
-    # Edges: every leaf cites the center
-    edges = pd.DataFrame(
-        {
-            "source_doi": [f"{prefix}_{i}" for i in range(n_leaves)],
-            "ref_doi": [center] * n_leaves,
-            "source_year": [2010] * n_leaves,
-        }
-    )
-    return works, edges
-
-
-def _make_uniform_ring(n_nodes, prefix, year=2015):
-    """Create a ring graph: each node cites the next.
-
-    Returns (works_df, internal_edges_df).
-    Ring topology produces nearly uniform PageRank.
-    """
-    nodes = [f"{prefix}_{i}" for i in range(n_nodes)]
-    works = pd.DataFrame({"doi": nodes, "year": [year] * n_nodes})
-    edges = pd.DataFrame(
-        {
-            "source_doi": [nodes[i] for i in range(n_nodes)],
-            "ref_doi": [nodes[(i + 1) % n_nodes] for i in range(n_nodes)],
-            "source_year": [year] * n_nodes,
-        }
-    )
-    return works, edges
-
-
 class TestG1DisjointWindows:
     """G1 PageRank should distinguish similar vs different distributions
     even on disjoint sliding windows (ticket 0059).


### PR DESCRIPTION
## Summary
- Replace union+zero-padding+Kendall-tau with JS divergence on PageRank distributions
- New `_compare_pagerank_distributions()` helper bins PageRank values and computes JSD²
- Works correctly on disjoint node sets from sliding windows

## Test plan
- [x] `test_g1_disjoint_windows_not_degenerate` — similar vs dissimilar graphs produce different values
- [x] `test_g1_output_matches_schema` — DivergenceSchema validation
- [x] `test_g1_value_bounded_0_1` — output range check
- [x] `make check-fast` passes (788 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)