### PR TITLE
fix: C2ST — use shuffled StratifiedKFold (t0060)

### DIFF
--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -16,7 +16,7 @@ import pandas as pd
 import scipy.sparse as sp
 from sklearn.decomposition import PCA
 from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import StratifiedKFold, cross_val_score
 from utils import get_logger
 
 log = get_logger("_divergence_c2st")
@@ -65,7 +65,8 @@ def _c2st_auc(X, Y, *, cv_folds=5, class_weight="balanced", seed):
         max_iter=1000,
         random_state=seed,
     )
-    scores = cross_val_score(clf, features, labels, cv=cv_folds, scoring="roc_auc")
+    cv = StratifiedKFold(n_splits=cv_folds, shuffle=True, random_state=seed)
+    scores = cross_val_score(clf, features, labels, cv=cv, scoring="roc_auc")
     return float(np.mean(scores))
 
 

--- a/tests/test_c2st.py
+++ b/tests/test_c2st.py
@@ -55,6 +55,67 @@ class TestC2STCore:
         auc = _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=42)
         assert 0.0 <= auc <= 1.0, f"AUC out of bounds: {auc}"
 
+    def test_shuffled_cv_reproducible(self):
+        """Same seed must produce identical AUC (shuffled CV is deterministic)."""
+        from _divergence_c2st import _c2st_auc
+
+        rng = np.random.RandomState(7)
+        X = rng.randn(150, 20)
+        Y = rng.randn(150, 20) + 0.3
+        auc1 = _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=123)
+        auc2 = _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=123)
+        assert auc1 == auc2, f"Same seed gave different AUC: {auc1} vs {auc2}"
+
+    def test_contiguous_labels_not_degenerate(self):
+        """With contiguous labels (all 0s then all 1s), AUC must not be degenerate.
+
+        This is the bug scenario: unshuffled StratifiedKFold on contiguous labels
+        can produce extreme fold compositions. A properly shuffled CV should yield
+        AUC in a reasonable range for a mild shift.
+        """
+        from _divergence_c2st import _c2st_auc
+
+        # Contiguous labels: all X first, then all Y — exactly what _c2st_auc builds
+        rng = np.random.RandomState(42)
+        X = rng.randn(100, 10)
+        Y = rng.randn(100, 10) + 0.5  # mild shift
+        auc = _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=42)
+        # A reasonable classifier should find a mild shift; AUC should be clearly
+        # between 0.5 and 1.0 (not degenerate 0.0 or 1.0)
+        assert 0.5 < auc < 0.95, (
+            f"AUC on contiguous-label mild shift should be moderate, got {auc}"
+        )
+
+    def test_uses_shuffled_stratified_kfold(self):
+        """Verify that _c2st_auc uses StratifiedKFold with shuffle=True.
+
+        Patches StratifiedKFold to record whether shuffle=True was passed.
+        This is the direct regression test for the contiguous-labels bug.
+        """
+        from unittest.mock import patch
+
+        from _divergence_c2st import _c2st_auc
+        from sklearn.model_selection import StratifiedKFold
+
+        rng = np.random.RandomState(42)
+        X = rng.randn(100, 10)
+        Y = rng.randn(100, 10)
+
+        calls = []
+        original_init = StratifiedKFold.__init__
+
+        def recording_init(self, *args, **kwargs):
+            calls.append(kwargs)
+            return original_init(self, *args, **kwargs)
+
+        with patch.object(StratifiedKFold, "__init__", recording_init):
+            _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=42)
+
+        assert len(calls) > 0, "_c2st_auc did not instantiate StratifiedKFold"
+        assert calls[0].get("shuffle") is True, (
+            f"StratifiedKFold not called with shuffle=True: {calls[0]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Schema validation

--- a/tests/test_c2st.py
+++ b/tests/test_c2st.py
@@ -89,7 +89,6 @@ class TestC2STCore:
     def test_uses_shuffled_stratified_kfold(self):
         """Verify that _c2st_auc uses StratifiedKFold with shuffle=True.
 
-        Patches StratifiedKFold to record whether shuffle=True was passed.
         This is the direct regression test for the contiguous-labels bug.
         """
         from unittest.mock import patch
@@ -101,19 +100,14 @@ class TestC2STCore:
         X = rng.randn(100, 10)
         Y = rng.randn(100, 10)
 
-        calls = []
-        original_init = StratifiedKFold.__init__
-
-        def recording_init(self, *args, **kwargs):
-            calls.append(kwargs)
-            return original_init(self, *args, **kwargs)
-
-        with patch.object(StratifiedKFold, "__init__", recording_init):
+        with patch(
+            "_divergence_c2st.StratifiedKFold", wraps=StratifiedKFold
+        ) as mock_skf:
             _c2st_auc(X, Y, cv_folds=5, class_weight="balanced", seed=42)
 
-        assert len(calls) > 0, "_c2st_auc did not instantiate StratifiedKFold"
-        assert calls[0].get("shuffle") is True, (
-            f"StratifiedKFold not called with shuffle=True: {calls[0]}"
+        mock_skf.assert_called_once()
+        assert mock_skf.call_args.kwargs.get("shuffle") is True, (
+            f"StratifiedKFold not called with shuffle=True: {mock_skf.call_args.kwargs}"
         )
 
 


### PR DESCRIPTION
## Summary
- Replace default `cv=int` with explicit `StratifiedKFold(shuffle=True, random_state=seed)`
- Contiguous labels [0,0,...,1,1,...] with no shuffle caused biased fold boundaries

## Test plan
- [x] `test_shuffled_cv_reproducible` — same seed → same AUC
- [x] `test_contiguous_labels_not_degenerate` — AUC in reasonable range
- [x] `test_uses_shuffled_stratified_kfold` — implementation check
- [x] `make check-fast` passes (788 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)