### PR TITLE
fix: per-window deterministic seeds in null model (t0061)

### DIFF
--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -213,7 +213,6 @@ def _run_semantic_permutations(method_name, div_df, cfg):
     perm_cfg = div_cfg["permutation"]
     n_perm = perm_cfg["n_perm"]
     seed = div_cfg.get("random_seed", 42)
-    rng = np.random.RandomState(seed)
 
     _, min_papers, max_subsample, _, equal_n = _get_years_and_params(df, emb, cfg)
 
@@ -227,25 +226,32 @@ def _run_semantic_permutations(method_name, div_df, cfg):
         y = int(row["year"])
         w = int(row["window"])
 
+        # Per-window deterministic seeds — isolate rng streams so each
+        # (year, window) produces identical results regardless of which
+        # other pairs are processed (ticket 0061).
+        window_seed = seed + y * 100 + w
+        subsample_rng = np.random.RandomState(window_seed)
+        perm_rng = np.random.RandomState(window_seed + 50000)
+
         X = _get_window_embeddings(
-            df, emb, y, w, "before", min_papers, max_subsample, rng=rng
+            df, emb, y, w, "before", min_papers, max_subsample, rng=subsample_rng
         )
         Y = _get_window_embeddings(
-            df, emb, y, w, "after", min_papers, max_subsample, rng=rng
+            df, emb, y, w, "after", min_papers, max_subsample, rng=subsample_rng
         )
         if X is None or Y is None:
             rows.append(_nan_row(y, w))
             continue
 
         if equal_n and len(X) != len(Y):
-            eq_result = subsample_equal_n(X, Y, min_papers, rng)
+            eq_result = subsample_equal_n(X, Y, min_papers, subsample_rng)
             if eq_result is None:
                 rows.append(_nan_row(y, w))
                 continue
             X, Y = eq_result
 
         observed, null_mean, null_std, z, p = permutation_test(
-            X, Y, statistic_fn, n_perm, rng
+            X, Y, statistic_fn, n_perm, perm_rng
         )
         rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
         log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
@@ -265,7 +271,6 @@ def _run_lexical_permutations(method_name, div_df, cfg):
     perm_cfg = div_cfg["permutation"]
     n_perm = perm_cfg["n_perm"]
     seed = div_cfg.get("random_seed", 42)
-    rng = np.random.RandomState(seed)
 
     min_papers = get_min_papers(len(df), cfg)
     equal_n = div_cfg.get("equal_n", False)
@@ -291,6 +296,11 @@ def _run_lexical_permutations(method_name, div_df, cfg):
         y = int(row["year"])
         w = int(row["window"])
 
+        # Per-window deterministic seeds (ticket 0061)
+        window_seed = seed + y * 100 + w
+        subsample_rng = np.random.RandomState(window_seed)
+        perm_rng = np.random.RandomState(window_seed + 50000)
+
         mask_before = (df["year"] >= y - w) & (df["year"] <= y)
         mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)
 
@@ -302,14 +312,16 @@ def _run_lexical_permutations(method_name, div_df, cfg):
             continue
 
         if equal_n and len(texts_before) != len(texts_after):
-            eq_result = subsample_equal_n(texts_before, texts_after, min_papers, rng)
+            eq_result = subsample_equal_n(
+                texts_before, texts_after, min_papers, subsample_rng
+            )
             if eq_result is None:
                 rows.append(_nan_row(y, w))
                 continue
             texts_before, texts_after = eq_result
 
         observed, null_mean, null_std, z, p = permutation_test(
-            texts_before, texts_after, statistic_fn, n_perm, rng
+            texts_before, texts_after, statistic_fn, n_perm, perm_rng
         )
         rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
         log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -231,6 +231,8 @@ def _run_semantic_permutations(method_name, div_df, cfg):
         # other pairs are processed (ticket 0061).
         window_seed = seed + y * 100 + w
         subsample_rng = np.random.RandomState(window_seed)
+        # +50000 offset guarantees no overlap: subsample seeds span
+        # [seed+199044, seed+202547], perm seeds [seed+249044, seed+252547]
         perm_rng = np.random.RandomState(window_seed + 50000)
 
         X = _get_window_embeddings(
@@ -299,6 +301,8 @@ def _run_lexical_permutations(method_name, div_df, cfg):
         # Per-window deterministic seeds (ticket 0061)
         window_seed = seed + y * 100 + w
         subsample_rng = np.random.RandomState(window_seed)
+        # +50000 offset guarantees no overlap: subsample seeds span
+        # [seed+199044, seed+202547], perm seeds [seed+249044, seed+252547]
         perm_rng = np.random.RandomState(window_seed + 50000)
 
         mask_before = (df["year"] >= y - w) & (df["year"] <= y)

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -199,6 +199,20 @@ def _result_row(year, window, observed, null_mean, null_std, z, p):
 # ---------------------------------------------------------------------------
 
 
+def _make_window_rngs(seed, y, w):
+    """Return independent (subsample_rng, perm_rng) for a (year, window) pair.
+
+    Each pair gets deterministic seeds derived from (seed, y, w) so results
+    are identical regardless of which other pairs are processed (ticket 0061).
+    The +50000 offset ensures no overlap: subsample seeds span roughly
+    [seed+199044, seed+202547], perm seeds [seed+249044, seed+252547].
+    """
+    window_seed = seed + y * 100 + w
+    return np.random.RandomState(window_seed), np.random.RandomState(
+        window_seed + 50000
+    )
+
+
 def _run_semantic_permutations(method_name, div_df, cfg):
     """Permutation test for semantic methods (S1-S4)."""
     from _divergence_io import subsample_equal_n
@@ -226,14 +240,7 @@ def _run_semantic_permutations(method_name, div_df, cfg):
         y = int(row["year"])
         w = int(row["window"])
 
-        # Per-window deterministic seeds — isolate rng streams so each
-        # (year, window) produces identical results regardless of which
-        # other pairs are processed (ticket 0061).
-        window_seed = seed + y * 100 + w
-        subsample_rng = np.random.RandomState(window_seed)
-        # +50000 offset guarantees no overlap: subsample seeds span
-        # [seed+199044, seed+202547], perm seeds [seed+249044, seed+252547]
-        perm_rng = np.random.RandomState(window_seed + 50000)
+        subsample_rng, perm_rng = _make_window_rngs(seed, y, w)
 
         X = _get_window_embeddings(
             df, emb, y, w, "before", min_papers, max_subsample, rng=subsample_rng
@@ -298,12 +305,7 @@ def _run_lexical_permutations(method_name, div_df, cfg):
         y = int(row["year"])
         w = int(row["window"])
 
-        # Per-window deterministic seeds (ticket 0061)
-        window_seed = seed + y * 100 + w
-        subsample_rng = np.random.RandomState(window_seed)
-        # +50000 offset guarantees no overlap: subsample seeds span
-        # [seed+199044, seed+202547], perm seeds [seed+249044, seed+252547]
-        perm_rng = np.random.RandomState(window_seed + 50000)
+        subsample_rng, perm_rng = _make_window_rngs(seed, y, w)
 
         mask_before = (df["year"] >= y - w) & (df["year"] <= y)
         mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -1,10 +1,11 @@
-"""Tests for the permutation Z-score null model (ticket 0055).
+"""Tests for the permutation Z-score null model (tickets 0055, 0061).
 
 Tests:
 1. permutation_test core function — null distribution and planted breaks
 2. NullModelSchema validation
 3. Smoke test: run compute_null_model.py on fixture data
 4. Output reuses year/window combos from existing tab_div_{method}.csv
+5. Shared-rng contamination regression (ticket 0061)
 """
 
 import os
@@ -306,4 +307,148 @@ class TestNullModelReusesYearWindow:
         # And the null model should cover most pairs
         assert len(null_pairs) >= len(div_pairs) * 0.5, (
             f"Null model covers too few pairs: {len(null_pairs)} / {len(div_pairs)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared-rng contamination regression tests (ticket 0061)
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_data(n_years=20, papers_per_year=60, emb_dim=10, seed=99):
+    """Build a synthetic (df, emb) for testing null-model rng isolation.
+
+    Returns a DataFrame with 'year' and 'cited_by_count' columns, plus an
+    embedding matrix aligned to df.index.  Years span [2000, 2000+n_years).
+    """
+    rng = np.random.RandomState(seed)
+    years = np.repeat(np.arange(2000, 2000 + n_years), papers_per_year)
+    df = pd.DataFrame({"year": years, "cited_by_count": 10})
+    emb = rng.randn(len(df), emb_dim).astype(np.float32)
+    return df, emb
+
+
+class TestSharedRngContamination:
+    """Ticket 0061 — per-window rng isolation.
+
+    The bug: _run_semantic_permutations and _run_lexical_permutations used a
+    single rng for both subsampling and permutation across all (year, window)
+    iterations.  Adding or removing earlier windows changed the rng state
+    entering later windows, making results non-reproducible.
+
+    The fix: derive per-window seeds so each (year, window) gets independent
+    rng instances for subsampling and permutation.
+    """
+
+    def test_single_window_reproducible_regardless_of_prior_windows_semantic(self):
+        """Semantic: z-score for (year=2005, w=3) must be identical whether
+        we process it alone or after (year=2003, w=3).
+        """
+        from unittest.mock import patch
+
+        from compute_null_model import _run_semantic_permutations
+
+        df, emb = _make_synthetic_data(n_years=20, papers_per_year=60)
+
+        # Minimal config matching what _run_semantic_permutations reads
+        cfg = {
+            "divergence": {
+                "windows": [3],
+                "max_subsample": 40,  # Force subsampling (60 > 40)
+                "equal_n": False,
+                "random_seed": 42,
+                "permutation": {"n_perm": 50},
+                "min_papers_fraction": 0.001,
+                "min_papers_floor": 5,
+            }
+        }
+
+        # Run 1: only year=2005
+        div_df_single = pd.DataFrame({"year": [2005], "window": [3]})
+
+        with patch("_divergence_semantic.load_semantic_data", return_value=(df, emb)):
+            result_single = _run_semantic_permutations("S4_frechet", div_df_single, cfg)
+
+        z_single = result_single.loc[result_single["year"] == 2005, "z_score"].iloc[0]
+
+        # Run 2: year=2003 first, then year=2005
+        div_df_double = pd.DataFrame({"year": [2003, 2005], "window": [3, 3]})
+
+        with patch("_divergence_semantic.load_semantic_data", return_value=(df, emb)):
+            result_double = _run_semantic_permutations("S4_frechet", div_df_double, cfg)
+
+        z_double = result_double.loc[result_double["year"] == 2005, "z_score"].iloc[0]
+
+        assert z_single == z_double, (
+            f"Shared-rng contamination: z(2005) alone={z_single:.6f} "
+            f"vs after 2003={z_double:.6f}"
+        )
+
+    def test_single_window_reproducible_regardless_of_prior_windows_lexical(self):
+        """Lexical: z-score for (year=2005, w=3) must be identical whether
+        we process it alone or after (year=2003, w=3).
+        """
+        from unittest.mock import patch
+
+        from compute_null_model import _run_lexical_permutations
+
+        # Build synthetic text data
+        rng = np.random.RandomState(77)
+        n_years = 20
+        papers_per_year = 60
+        vocab = [
+            "climate",
+            "finance",
+            "carbon",
+            "energy",
+            "policy",
+            "market",
+            "green",
+            "bond",
+            "risk",
+            "fund",
+            "investment",
+            "emissions",
+            "trading",
+            "bank",
+            "tax",
+        ]
+        years = np.repeat(np.arange(2000, 2000 + n_years), papers_per_year)
+        abstracts = []
+        for _ in range(len(years)):
+            n_words = rng.randint(10, 30)
+            words = rng.choice(vocab, n_words, replace=True)
+            abstracts.append(" ".join(words))
+        df = pd.DataFrame({"year": years, "abstract": abstracts})
+
+        cfg = {
+            "divergence": {
+                "windows": [3],
+                "equal_n": True,  # Force subsample_equal_n
+                "random_seed": 42,
+                "permutation": {"n_perm": 50},
+                "min_papers_fraction": 0.001,
+                "min_papers_floor": 5,
+                "lexical": {
+                    "tfidf_max_features": 100,
+                    "tfidf_min_df": 2,
+                },
+            }
+        }
+
+        div_df_single = pd.DataFrame({"year": [2005], "window": [3]})
+        div_df_double = pd.DataFrame({"year": [2003, 2005], "window": [3, 3]})
+
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result_single = _run_lexical_permutations("L1", div_df_single, cfg)
+
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result_double = _run_lexical_permutations("L1", div_df_double, cfg)
+
+        z_single = result_single.loc[result_single["year"] == 2005, "z_score"].iloc[0]
+        z_double = result_double.loc[result_double["year"] == 2005, "z_score"].iloc[0]
+
+        assert z_single == z_double, (
+            f"Shared-rng contamination (lexical): z(2005) alone={z_single:.6f} "
+            f"vs after 2003={z_double:.6f}"
         )


### PR DESCRIPTION
## Summary
- Replace shared rng with per-window deterministic seeds: `seed + year*100 + window`
- Separate rng instances for subsampling vs permutation
- Each (year, window) pair now produces identical results regardless of other pairs

## Test plan
- [x] `test_single_window_reproducible_regardless_of_prior_windows_semantic`
- [x] `test_single_window_reproducible_regardless_of_prior_windows_lexical`
- [x] `make check-fast` passes (787 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)