### PR TITLE
feat: G9 community divergence via Louvain + JS (t0054)

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -72,3 +72,5 @@ divergence:
     G7_disruption: {}
     G8_betweenness:
       max_nodes: 500                             # subsample for tractability
+    G9_community:
+      resolution: 1.0

--- a/divergence.mk
+++ b/divergence.mk
@@ -29,7 +29,8 @@ DIV_METHODS_LEX := L1 L2 L3
 DIV_METHODS_C2ST_SEM := C2ST_embedding
 DIV_METHODS_C2ST_LEX := C2ST_lexical
 DIV_METHODS_CIT := G1_pagerank G2_spectral G3_coupling_age G4_cross_tradition \
-                   G5_pref_attachment G6_entropy G7_disruption G8_betweenness
+                   G5_pref_attachment G6_entropy G7_disruption G8_betweenness \
+                   G9_community
 
 # ── Derived file lists ───────────────────────────────────────────────────
 

--- a/scripts/_divergence_community.py
+++ b/scripts/_divergence_community.py
@@ -1,0 +1,105 @@
+"""Community divergence (G9): Louvain partition + Jensen-Shannon divergence.
+
+For each sliding-window pair (before, after):
+  1. Build a union undirected graph: nodes from both windows, plus all
+     internal edges where both endpoints are in the union node set
+  2. Run Louvain community detection on the union graph
+  3. Count the fraction of before-window docs in each community (p_before)
+  4. Count the fraction of after-window docs in each community (p_after)
+  5. Compute JS divergence between p_before and p_after
+
+Private module — no main, no argparse. Called via compute_divergence.py
+dispatcher.
+"""
+
+import community as community_louvain
+import networkx as nx
+import numpy as np
+import pandas as pd
+from _divergence_citation import _iter_sliding_pairs
+from scipy.spatial.distance import jensenshannon
+from utils import get_logger
+
+log = get_logger("_divergence_community")
+
+
+def compute_community_divergence(works, citations, internal_edges, cfg):
+    """Compute community divergence across sliding windows."""
+    div_cfg = cfg["divergence"]
+    cit_cfg = div_cfg.get("citation", {})
+    comm_cfg = cit_cfg.get("G9_community", {})
+    resolution = comm_cfg.get("resolution", 1.0)
+    seed = div_cfg["random_seed"]
+
+    log.info("G9: Community divergence (Louvain + JS, resolution=%.2f)", resolution)
+    results = []
+
+    for year, w, G_before, G_after in _iter_sliding_pairs(works, internal_edges, cfg):
+        value = _community_js_for_pair(
+            G_before, G_after, internal_edges, resolution, seed
+        )
+        results.append(
+            {
+                "year": year,
+                "window": str(w),
+                "hyperparams": f"res={resolution}",
+                "value": value,
+            }
+        )
+
+    return pd.DataFrame(results)
+
+
+def _build_union_graph(G_before, G_after, internal_edges):
+    """Build undirected union graph with cross-window edges."""
+    union_nodes = set(G_before.nodes()) | set(G_after.nodes())
+    G_union = nx.Graph()
+    G_union.add_nodes_from(union_nodes)
+
+    for _, row in internal_edges.iterrows():
+        src, ref = row["source_doi"], row["ref_doi"]
+        if src in union_nodes and ref in union_nodes:
+            G_union.add_edge(src, ref)
+
+    return G_union
+
+
+def _community_js_for_pair(G_before, G_after, internal_edges, resolution, seed):
+    """Compute JS divergence of community share vectors for one window pair."""
+    G_union = _build_union_graph(G_before, G_after, internal_edges)
+
+    if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
+        return np.nan
+
+    partition = community_louvain.best_partition(
+        G_union, resolution=resolution, random_state=seed
+    )
+
+    before_nodes = set(G_before.nodes())
+    after_nodes = set(G_after.nodes())
+
+    all_communities = sorted(set(partition.values()))
+    n_communities = len(all_communities)
+    if n_communities < 2:
+        return 0.0
+
+    comm_to_idx = {c: i for i, c in enumerate(all_communities)}
+
+    p_before = np.zeros(n_communities)
+    for node in before_nodes:
+        if node in partition:
+            p_before[comm_to_idx[partition[node]]] += 1
+
+    p_after = np.zeros(n_communities)
+    for node in after_nodes:
+        if node in partition:
+            p_after[comm_to_idx[partition[node]]] += 1
+
+    if p_before.sum() == 0 or p_after.sum() == 0:
+        return np.nan
+
+    p_before = p_before / p_before.sum()
+    p_after = p_after / p_after.sum()
+
+    js = jensenshannon(p_before, p_after)
+    return float(js**2)

--- a/scripts/compute_divergence.py
+++ b/scripts/compute_divergence.py
@@ -101,6 +101,13 @@ METHODS = {
         False,
         True,
     ),
+    "G9_community": (
+        "_divergence_community",
+        "compute_community_divergence",
+        "citation",
+        False,
+        True,
+    ),
     "C2ST_embedding": (
         "_divergence_c2st",
         "compute_c2st_embedding",

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -167,7 +167,7 @@ class TestModuleFunctions:
     def test_dispatcher_registry_complete(self):
         from compute_divergence import METHODS
 
-        assert len(METHODS) == 17
+        assert len(METHODS) == 18
         # Verify all three channels present
         channels = {v[2] for v in METHODS.values()}
         assert channels == {"semantic", "lexical", "citation"}
@@ -848,43 +848,43 @@ class TestCommunityDivergence:
         assert (df["channel"] == "citation").all()
         DivergenceSchema.validate(df)
 
-    def test_community_js_identical_graphs_near_zero(self):
-        """Identical before/after graphs should yield JS divergence near 0.
+    def test_community_js_overlapping_same_distribution(self):
+        """Overlapping before/after with equal community representation give low JS.
 
-        When G_before and G_after have the same structure, the community
-        share vectors should be identical, giving JS = 0.
+        Two cliques (A, B) form the union graph. Before and after each
+        contain equal numbers of nodes from both cliques, so community
+        share vectors are identical → JS = 0.
         """
         import networkx as nx
         from _divergence_community import _community_js_for_pair
 
-        # Build two identical star graphs with disjoint node names
-        # but identical structure (same community shares)
+        # Two cliques of 6 nodes each, well separated (no cross-clique edges)
+        clique_a = [f"A{i}" for i in range(6)]
+        clique_b = [f"B{i}" for i in range(6)]
+
+        # Before window: first 3 from each clique
         G_before = nx.DiGraph()
-        before_nodes = [f"b_{i}" for i in range(10)]
-        G_before.add_nodes_from(before_nodes)
-        for i in range(1, 10):
-            G_before.add_edge(before_nodes[i], before_nodes[0])
+        G_before.add_nodes_from(clique_a[:3] + clique_b[:3])
 
+        # After window: last 3 from each clique
         G_after = nx.DiGraph()
-        after_nodes = [f"a_{i}" for i in range(10)]
-        G_after.add_nodes_from(after_nodes)
-        for i in range(1, 10):
-            G_after.add_edge(after_nodes[i], after_nodes[0])
+        G_after.add_nodes_from(clique_a[3:] + clique_b[3:])
 
-        # Internal edges: all edges from both graphs (undirected)
+        # Internal edges: dense within each clique
         edge_rows = []
-        for i in range(1, 10):
-            edge_rows.append(
-                {"source_doi": before_nodes[i], "ref_doi": before_nodes[0]}
-            )
-            edge_rows.append({"source_doi": after_nodes[i], "ref_doi": after_nodes[0]})
+        for nodes in [clique_a, clique_b]:
+            for i, n1 in enumerate(nodes):
+                for n2 in nodes[i + 1 :]:
+                    edge_rows.append({"source_doi": n1, "ref_doi": n2})
         internal_edges = pd.DataFrame(edge_rows)
 
-        # Two identical star structures → near-zero divergence
+        # Both windows have 50/50 A/B nodes → same shares → JS near 0
         val = _community_js_for_pair(G_before, G_after, internal_edges, 1.0, 42)
         assert val is not None
         assert not np.isnan(val), "Expected a numeric result, not NaN"
-        assert val < 0.1, f"Identical structures should give near-zero JS, got {val}"
+        assert val < 0.05, (
+            f"Equal community representation should give near-zero JS, got {val}"
+        )
 
     def test_community_single_community_returns_zero(self):
         """If Louvain finds only 1 community, return 0.0.

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -823,3 +823,112 @@ class TestG1DisjointWindows:
 
         val = _compare_pagerank_distributions(pr1, pr2)
         assert 0.0 <= val <= 1.0, f"Value {val} out of [0, 1] bounds"
+
+
+# ---------------------------------------------------------------------------
+# G9 Community divergence (ticket 0054)
+# ---------------------------------------------------------------------------
+
+
+class TestCommunityDivergence:
+    """G9 community divergence: Louvain partition + Jensen-Shannon."""
+
+    def test_community_divergence_schema(self, tmp_path):
+        """Smoke test: G9 output conforms to DivergenceSchema."""
+        from schemas import DivergenceSchema
+
+        out = tmp_path / "tab_div_G9_community.csv"
+        result = _run_compute("G9_community", out)
+        assert result.returncode == 0, (
+            f"G9 failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert out.exists(), "Output CSV not created for G9_community"
+        df = pd.read_csv(out)
+        assert {"year", "channel", "window", "hyperparams", "value"} == set(df.columns)
+        assert (df["channel"] == "citation").all()
+        DivergenceSchema.validate(df)
+
+    def test_community_js_identical_graphs_near_zero(self):
+        """Identical before/after graphs should yield JS divergence near 0.
+
+        When G_before and G_after have the same structure, the community
+        share vectors should be identical, giving JS = 0.
+        """
+        import networkx as nx
+        from _divergence_community import _community_js_for_pair
+
+        # Build two identical star graphs with disjoint node names
+        # but identical structure (same community shares)
+        G_before = nx.DiGraph()
+        before_nodes = [f"b_{i}" for i in range(10)]
+        G_before.add_nodes_from(before_nodes)
+        for i in range(1, 10):
+            G_before.add_edge(before_nodes[i], before_nodes[0])
+
+        G_after = nx.DiGraph()
+        after_nodes = [f"a_{i}" for i in range(10)]
+        G_after.add_nodes_from(after_nodes)
+        for i in range(1, 10):
+            G_after.add_edge(after_nodes[i], after_nodes[0])
+
+        # Internal edges: all edges from both graphs (undirected)
+        edge_rows = []
+        for i in range(1, 10):
+            edge_rows.append(
+                {"source_doi": before_nodes[i], "ref_doi": before_nodes[0]}
+            )
+            edge_rows.append({"source_doi": after_nodes[i], "ref_doi": after_nodes[0]})
+        internal_edges = pd.DataFrame(edge_rows)
+
+        # Two identical star structures → near-zero divergence
+        val = _community_js_for_pair(G_before, G_after, internal_edges, 1.0, 42)
+        assert val is not None
+        assert not np.isnan(val), "Expected a numeric result, not NaN"
+        assert val < 0.1, f"Identical structures should give near-zero JS, got {val}"
+
+    def test_community_single_community_returns_zero(self):
+        """If Louvain finds only 1 community, return 0.0.
+
+        A complete graph (K5) will have all nodes in a single community.
+        """
+        import networkx as nx
+        from _divergence_community import _community_js_for_pair
+
+        # Complete graph K5 — Louvain on a K5 typically finds 1 community
+        nodes_before = [f"b_{i}" for i in range(5)]
+        nodes_after = [f"a_{i}" for i in range(5)]
+
+        G_before = nx.DiGraph()
+        G_before.add_nodes_from(nodes_before)
+
+        G_after = nx.DiGraph()
+        G_after.add_nodes_from(nodes_after)
+
+        all_nodes = nodes_before + nodes_after
+        edge_rows = []
+        for i, n1 in enumerate(all_nodes):
+            for n2 in all_nodes[i + 1 :]:
+                edge_rows.append({"source_doi": n1, "ref_doi": n2})
+        internal_edges = pd.DataFrame(edge_rows)
+
+        val = _community_js_for_pair(G_before, G_after, internal_edges, 1.0, 42)
+        assert val == 0.0, f"Single community should give exactly 0.0, got {val}"
+
+    def test_community_module_has_function(self):
+        """Verify _divergence_community module exposes expected function."""
+        import _divergence_community as mod
+
+        assert hasattr(mod, "compute_community_divergence")
+        assert callable(mod.compute_community_divergence)
+
+    def test_dispatcher_includes_g9(self):
+        """G9_community must be registered in the METHODS dispatcher."""
+        from compute_divergence import METHODS
+
+        assert "G9_community" in METHODS
+        module, func, channel, needs_emb, needs_cit = METHODS["G9_community"]
+        assert module == "_divergence_community"
+        assert func == "compute_community_divergence"
+        assert channel == "citation"
+        assert needs_emb is False
+        assert needs_cit is True

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -240,6 +240,7 @@ class TestSmokeCitation:
             "G6_entropy",
             "G7_disruption",
             "G8_betweenness",
+            "G9_community",
         ],
     )
     def test_compute_method(self, method, tmp_path):


### PR DESCRIPTION
## Summary
- New `_divergence_community.py`: Louvain partition on union graph + JS divergence on community share vectors
- Registered as `G9_community` in dispatcher, config, and Makefile
- 5 new tests: schema, overlapping-windows unit, single-community edge case, module check, dispatcher check

## Design
For each sliding-window pair: build union undirected graph from before+after nodes, run Louvain (seeded), compute community membership fractions for each window, return JSD².

## Test plan
- [x] `test_community_divergence_schema` — smoke via dispatcher
- [x] `test_community_js_overlapping_same_distribution` — JS ≈ 0 for equal shares
- [x] `test_community_single_community_returns_zero` — K5 → 0.0
- [x] `make check-fast` passes (800 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)