### PR TITLE
feat: bootstrap CIs on divergence (ticket 0047)

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -35,6 +35,9 @@ divergence:
     n_perm: 500
     z_threshold: 2.0    # consumed by compute_transition_zones.py (ticket 0055b)
 
+  bootstrap:
+    k: 200               # replicates for estimation CIs (ticket 0047, opt-in)
+
   c2st:
     pca_dim: 32
     cv_folds: 5

--- a/divergence.mk
+++ b/divergence.mk
@@ -199,6 +199,48 @@ $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv
 .PHONY: null-model
 null-model: $(NULL_CSV)
 
+# ── Bootstrap CIs (ticket 0047) ──────────────────────────────────────────
+#
+# NOT part of default divergence — run explicitly:
+#   make bootstrap-tables
+#   make divergence-summary
+#
+# For each method, resample with replacement K times and recompute
+# the statistic.  Output: tab_boot_{method}.csv
+
+BOOT_DISPATCH := scripts/compute_divergence_bootstrap.py
+BOOT_METHODS_SEM := S2_energy
+BOOT_METHODS_LEX := L1
+BOOT_METHODS := $(BOOT_METHODS_SEM) $(BOOT_METHODS_LEX)
+BOOT_CSV := $(foreach m,$(BOOT_METHODS),$(DIV_TABLES)/tab_boot_$(m).csv)
+
+# Semantic bootstrap (depends on embeddings + divergence CSV)
+$(foreach m,$(BOOT_METHODS_SEM),$(eval \
+$(DIV_TABLES)/tab_boot_$(m).csv: $(BOOT_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
+	uv run python $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+# Lexical bootstrap (depends on REFINED + divergence CSV)
+$(foreach m,$(BOOT_METHODS_LEX),$(eval \
+$(DIV_TABLES)/tab_boot_$(m).csv: $(BOOT_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
+	uv run python $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+.PHONY: bootstrap-tables
+bootstrap-tables: $(BOOT_CSV)
+
+# ── Divergence summary (ticket 0047) ────────────────────────────────────
+#
+# Joins point estimates + bootstrap CIs + null model into one table per method.
+
+SUMM_DISPATCH := scripts/export_divergence_summary.py
+SUMM_CSV := $(foreach m,$(BOOT_METHODS),$(DIV_TABLES)/tab_summary_$(m).csv)
+
+$(foreach m,$(BOOT_METHODS),$(eval \
+$(DIV_TABLES)/tab_summary_$(m).csv: $(SUMM_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv $(DIV_TABLES)/tab_boot_$(m).csv $(DIV_TABLES)/tab_null_$(m).csv ; \
+	uv run python $(SUMM_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --boot-csv $(DIV_TABLES)/tab_boot_$(m).csv --null-csv $(DIV_TABLES)/tab_null_$(m).csv --output $$@))
+
+.PHONY: divergence-summary
+divergence-summary: $(SUMM_CSV)
+
 # ── Top-level ────────────────────────────────────────────────────────────
 
 .PHONY: divergence

--- a/scripts/compute_divergence_bootstrap.py
+++ b/scripts/compute_divergence_bootstrap.py
@@ -67,15 +67,13 @@ def bootstrap_one_window(X_before, Y_after, statistic_fn, k, seed):
     replicates = []
     for i in range(k):
         rng = np.random.RandomState(seed + i * 1000)
+        idx_b = rng.choice(n_before, n_before, replace=True)
+        idx_a = rng.choice(n_after, n_after, replace=True)
 
         if is_array:
-            idx_b = rng.choice(n_before, n_before, replace=True)
-            idx_a = rng.choice(n_after, n_after, replace=True)
             boot_before = X_before[idx_b]
             boot_after = Y_after[idx_a]
         else:
-            idx_b = rng.choice(n_before, n_before, replace=True)
-            idx_a = rng.choice(n_after, n_after, replace=True)
             boot_before = [X_before[j] for j in idx_b]
             boot_after = [Y_after[j] for j in idx_a]
 

--- a/scripts/compute_divergence_bootstrap.py
+++ b/scripts/compute_divergence_bootstrap.py
@@ -242,8 +242,8 @@ def main():
     parser.add_argument(
         "--k",
         type=int,
-        default=200,
-        help="Number of bootstrap replicates (default 200)",
+        default=None,
+        help="Number of bootstrap replicates (default: from config bootstrap.k)",
     )
     args = parser.parse_args(extra)
 
@@ -257,15 +257,16 @@ def main():
         )
 
     cfg = load_analysis_config()
-    log.info("=== Bootstrap: %s (channel=%s, k=%d) ===", method_name, channel, args.k)
+    k = args.k if args.k is not None else cfg["divergence"]["bootstrap"]["k"]
+    log.info("=== Bootstrap: %s (channel=%s, k=%d) ===", method_name, channel, k)
 
     div_df = pd.read_csv(args.div_csv)
     log.info("Loaded %d rows from %s", len(div_df), args.div_csv)
 
     if channel == "semantic":
-        result = _run_semantic_bootstrap(method_name, div_df, cfg, args.k)
+        result = _run_semantic_bootstrap(method_name, div_df, cfg, k)
     elif channel == "lexical":
-        result = _run_lexical_bootstrap(method_name, div_df, cfg, args.k)
+        result = _run_lexical_bootstrap(method_name, div_df, cfg, k)
     else:
         raise ValueError(f"Unsupported channel: {channel}")
 

--- a/scripts/compute_divergence_bootstrap.py
+++ b/scripts/compute_divergence_bootstrap.py
@@ -1,0 +1,282 @@
+"""Compute bootstrap CIs for one divergence method (ticket 0047).
+
+For each (year, window) in the existing divergence CSV, resample
+with replacement K times and recompute the statistic to build a
+bootstrap distribution for confidence intervals.
+
+Usage:
+    uv run python scripts/compute_divergence_bootstrap.py --method S2_energy \
+        --output content/tables/tab_boot_S2_energy.csv \
+        --div-csv content/tables/tab_div_S2_energy.csv
+
+    # Smoke fixture:
+    CLIMATE_FINANCE_DATA=tests/fixtures/smoke \
+        uv run python scripts/compute_divergence_bootstrap.py --method S2_energy \
+        --output /tmp/tab_boot_S2_energy.csv \
+        --div-csv /tmp/tab_div_S2_energy.csv
+"""
+
+import argparse
+
+import numpy as np
+import pandas as pd
+from compute_divergence import METHODS
+from compute_null_model import (
+    SUPPORTED_CHANNELS,
+    _make_lexical_statistic,
+    _make_semantic_statistic,
+    _make_window_rngs,
+)
+from pipeline_loaders import load_analysis_config
+from schemas import BootstrapSchema
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("compute_divergence_bootstrap")
+
+
+# ---------------------------------------------------------------------------
+# Core bootstrap
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_one_window(X_before, Y_after, statistic_fn, k, seed):
+    """Run bootstrap resampling on two samples.
+
+    Parameters
+    ----------
+    X_before, Y_after : array-like
+        The two samples (numpy arrays or lists).
+    statistic_fn : callable
+        Function(a, b) -> float that computes the test statistic.
+    k : int
+        Number of bootstrap replicates.
+    seed : int
+        Base seed for reproducibility.
+
+    Returns
+    -------
+    list[float]
+        K bootstrap replicate values.
+
+    """
+    is_array = isinstance(X_before, np.ndarray)
+    n_before = len(X_before)
+    n_after = len(Y_after)
+
+    replicates = []
+    for i in range(k):
+        rng = np.random.RandomState(seed + i * 1000)
+
+        if is_array:
+            idx_b = rng.choice(n_before, n_before, replace=True)
+            idx_a = rng.choice(n_after, n_after, replace=True)
+            boot_before = X_before[idx_b]
+            boot_after = Y_after[idx_a]
+        else:
+            idx_b = rng.choice(n_before, n_before, replace=True)
+            idx_a = rng.choice(n_after, n_after, replace=True)
+            boot_before = [X_before[j] for j in idx_b]
+            boot_after = [Y_after[j] for j in idx_a]
+
+        replicates.append(float(statistic_fn(boot_before, boot_after)))
+
+    return replicates
+
+
+# ---------------------------------------------------------------------------
+# Per-channel bootstrap drivers
+# ---------------------------------------------------------------------------
+
+
+def _run_semantic_bootstrap(method_name, div_df, cfg, k):
+    """Bootstrap for semantic methods (S1-S4)."""
+    from _divergence_io import subsample_equal_n
+    from _divergence_semantic import (
+        _get_window_embeddings,
+        _get_years_and_params,
+        load_semantic_data,
+    )
+
+    df, emb = load_semantic_data(None)
+    div_cfg = cfg["divergence"]
+    seed = div_cfg["random_seed"]
+
+    _, min_papers, max_subsample, _, equal_n = _get_years_and_params(df, emb, cfg)
+
+    statistic_fn = _make_semantic_statistic(method_name, cfg)
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+
+    rows = []
+    for _, row in year_windows.iterrows():
+        y = int(row["year"])
+        w = int(row["window"])
+
+        subsample_rng, _ = _make_window_rngs(seed, y, w)
+
+        X = _get_window_embeddings(
+            df, emb, y, w, "before", min_papers, max_subsample, rng=subsample_rng
+        )
+        Y = _get_window_embeddings(
+            df, emb, y, w, "after", min_papers, max_subsample, rng=subsample_rng
+        )
+        if X is None or Y is None:
+            continue
+
+        if equal_n and len(X) != len(Y):
+            eq_result = subsample_equal_n(X, Y, min_papers, subsample_rng)
+            if eq_result is None:
+                continue
+            X, Y = eq_result
+
+        # Per-window deterministic seed for bootstrap
+        boot_seed = seed + y * 100 + w
+        values = bootstrap_one_window(X, Y, statistic_fn, k, boot_seed)
+
+        for rep, val in enumerate(values):
+            rows.append(
+                {
+                    "method": method_name,
+                    "year": y,
+                    "window": str(w),
+                    "hyperparams": "",
+                    "replicate": rep,
+                    "value": val,
+                }
+            )
+        log.info("  year=%d window=%d k=%d", y, w, k)
+
+    return pd.DataFrame(rows)
+
+
+def _run_lexical_bootstrap(method_name, div_df, cfg, k):
+    """Bootstrap for lexical methods (L1)."""
+    from _divergence_io import get_min_papers, subsample_equal_n
+    from _divergence_lexical import load_lexical_data
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
+    df = load_lexical_data(None)
+    div_cfg = cfg["divergence"]
+    lex_cfg = div_cfg["lexical"]
+    seed = div_cfg["random_seed"]
+
+    min_papers = get_min_papers(len(df), cfg)
+    equal_n = div_cfg.get("equal_n", False)
+
+    tfidf_max_features = lex_cfg["tfidf_max_features"]
+    tfidf_min_df = lex_cfg["tfidf_min_df"]
+
+    all_texts = df["abstract"].tolist()
+    vec = TfidfVectorizer(
+        stop_words="english",
+        max_features=tfidf_max_features,
+        min_df=min(tfidf_min_df, max(1, len(all_texts) - 1)),
+        sublinear_tf=True,
+    )
+    vec.fit(all_texts)
+
+    statistic_fn = _make_lexical_statistic(vec)
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+
+    rows = []
+    for _, row in year_windows.iterrows():
+        y = int(row["year"])
+        w = int(row["window"])
+
+        subsample_rng, _ = _make_window_rngs(seed, y, w)
+
+        mask_before = (df["year"] >= y - w) & (df["year"] <= y)
+        mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)
+
+        texts_before = df.loc[mask_before, "abstract"].tolist()
+        texts_after = df.loc[mask_after, "abstract"].tolist()
+
+        if len(texts_before) < min_papers or len(texts_after) < min_papers:
+            continue
+
+        if equal_n and len(texts_before) != len(texts_after):
+            eq_result = subsample_equal_n(
+                texts_before, texts_after, min_papers, subsample_rng
+            )
+            if eq_result is None:
+                continue
+            texts_before, texts_after = eq_result
+
+        boot_seed = seed + y * 100 + w
+        values = bootstrap_one_window(
+            texts_before, texts_after, statistic_fn, k, boot_seed
+        )
+
+        for rep, val in enumerate(values):
+            rows.append(
+                {
+                    "method": method_name,
+                    "year": y,
+                    "window": str(w),
+                    "hyperparams": "",
+                    "replicate": rep,
+                    "value": val,
+                }
+            )
+        log.info("  year=%d window=%d k=%d", y, w, k)
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--method", required=True, choices=METHODS.keys())
+    parser.add_argument(
+        "--div-csv",
+        required=True,
+        help="Path to the existing tab_div_{method}.csv",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=200,
+        help="Number of bootstrap replicates (default 200)",
+    )
+    args = parser.parse_args(extra)
+
+    method_name = args.method
+    _, _, channel, _, _ = METHODS[method_name]
+
+    if channel not in SUPPORTED_CHANNELS:
+        raise ValueError(
+            f"Bootstrap not yet supported for channel '{channel}'. "
+            f"Supported: {SUPPORTED_CHANNELS}"
+        )
+
+    cfg = load_analysis_config()
+    log.info("=== Bootstrap: %s (channel=%s, k=%d) ===", method_name, channel, args.k)
+
+    div_df = pd.read_csv(args.div_csv)
+    log.info("Loaded %d rows from %s", len(div_df), args.div_csv)
+
+    if channel == "semantic":
+        result = _run_semantic_bootstrap(method_name, div_df, cfg, args.k)
+    elif channel == "lexical":
+        result = _run_lexical_bootstrap(method_name, div_df, cfg, args.k)
+    else:
+        raise ValueError(f"Unsupported channel: {channel}")
+
+    # Validate contract
+    BootstrapSchema.validate(result)
+
+    result.to_csv(io_args.output, index=False)
+    log.info("Saved %s (%d rows) -> %s", method_name, len(result), io_args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_divergence_summary.py
+++ b/scripts/export_divergence_summary.py
@@ -1,0 +1,134 @@
+"""Export divergence summary table joining point estimates, bootstrap CIs, and null model (ticket 0047).
+
+Joins three sources by (year, window):
+- Divergence CSV (point estimates)
+- Bootstrap CSV (replicates -> median, q025, q975)
+- Null model CSV (p-values)
+
+Usage:
+    uv run python scripts/export_divergence_summary.py \
+        --div-csv content/tables/tab_div_S2_energy.csv \
+        --boot-csv content/tables/tab_boot_S2_energy.csv \
+        --null-csv content/tables/tab_null_S2_energy.csv \
+        --method S2_energy \
+        --output content/tables/tab_divergence_summary.csv
+"""
+
+import argparse
+
+import numpy as np
+import pandas as pd
+from schemas import DivergenceSummarySchema
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("export_divergence_summary")
+
+
+def build_summary(div_df, null_df, boot_df, method):
+    """Build summary table from three sources.
+
+    Parameters
+    ----------
+    div_df : pd.DataFrame
+        Divergence point estimates (year, window, hyperparams, value).
+    null_df : pd.DataFrame
+        Null model results (year, window, p_value, ...).
+    boot_df : pd.DataFrame
+        Bootstrap replicates (method, year, window, replicate, value).
+    method : str
+        Method name to label the output.
+
+    Returns
+    -------
+    pd.DataFrame
+        Summary with columns matching DivergenceSummarySchema.
+
+    """
+    # Aggregate divergence: take mean value per (year, window) if duplicates
+    div_agg = (
+        div_df.groupby(["year", "window"], as_index=False)
+        .agg({"value": "mean", "hyperparams": "first"})
+        .rename(columns={"value": "point_estimate"})
+    )
+
+    # Aggregate bootstrap: compute quantiles per (year, window)
+    boot_agg = boot_df.groupby(["year", "window"], as_index=False)["value"].agg(
+        boot_median="median",
+        boot_q025=lambda x: float(np.nanquantile(x, 0.025)),
+        boot_q975=lambda x: float(np.nanquantile(x, 0.975)),
+    )
+
+    # Select p_value from null model
+    null_cols = null_df[["year", "window", "p_value"]].copy()
+
+    # Ensure consistent types for joining
+    div_agg["year"] = div_agg["year"].astype(int)
+    div_agg["window"] = div_agg["window"].astype(str)
+    boot_agg["year"] = boot_agg["year"].astype(int)
+    boot_agg["window"] = boot_agg["window"].astype(str)
+    null_cols["year"] = null_cols["year"].astype(int)
+    null_cols["window"] = null_cols["window"].astype(str)
+
+    # Join all three
+    result = div_agg.merge(boot_agg, on=["year", "window"], how="left")
+    result = result.merge(null_cols, on=["year", "window"], how="left")
+
+    # Add method and significant flag
+    result["method"] = method
+    result["significant"] = result["p_value"] < 0.05
+
+    # Reorder columns to match schema
+    result = result[
+        [
+            "method",
+            "year",
+            "window",
+            "hyperparams",
+            "point_estimate",
+            "boot_median",
+            "boot_q025",
+            "boot_q975",
+            "p_value",
+            "significant",
+        ]
+    ]
+
+    return result
+
+
+def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--div-csv", required=True, help="Divergence point estimates CSV"
+    )
+    parser.add_argument("--boot-csv", required=True, help="Bootstrap replicates CSV")
+    parser.add_argument("--null-csv", required=True, help="Null model CSV")
+    parser.add_argument("--method", required=True, help="Method name")
+    args = parser.parse_args(extra)
+
+    div_df = pd.read_csv(args.div_csv)
+    boot_df = pd.read_csv(args.boot_csv)
+    null_df = pd.read_csv(args.null_csv)
+
+    log.info(
+        "Loaded: div=%d rows, boot=%d rows, null=%d rows",
+        len(div_df),
+        len(boot_df),
+        len(null_df),
+    )
+
+    result = build_summary(div_df, null_df, boot_df, method=args.method)
+
+    # Validate contract
+    DivergenceSummarySchema.validate(result)
+
+    result.to_csv(io_args.output, index=False)
+    log.info("Saved summary (%d rows) -> %s", len(result), io_args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -5,12 +5,16 @@ Declares the expected shape of:
 - refined_citations.csv — citation edges (Phase 1→2 contract)
 - refined_embeddings.npz — embedding vectors (validated via function)
 - DivergenceSchema — per-method divergence CSV (Phase 2 internal contract)
+- BootstrapSchema — bootstrap replicates CSV (ticket 0047)
+- DivergenceSummarySchema — summary table joining point/boot/null (ticket 0047)
 
 Used by:
 - corpus_align.py (writer side): validate before writing
 - pipeline_loaders.py (reader side): validate on load
 - compute_divergence.py: validate divergence output
-- tests/test_schema_contracts.py, tests/test_divergence.py
+- compute_divergence_bootstrap.py: validate bootstrap output
+- export_divergence_summary.py: validate summary output
+- tests/test_schema_contracts.py, tests/test_divergence.py, tests/test_bootstrap.py
 """
 
 import pandera.pandas as pa
@@ -107,6 +111,44 @@ NullModelSchema = DataFrameSchema(
         "null_std": Column(float, nullable=True),
         "z_score": Column(float, nullable=True),
         "p_value": Column(float, nullable=True),
+    },
+    strict=True,
+    coerce=True,
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap replicates CSV (ticket 0047)
+# ---------------------------------------------------------------------------
+
+BootstrapSchema = DataFrameSchema(
+    columns={
+        "method": Column(str),
+        "year": Column(int),
+        "window": Column(str),
+        "hyperparams": Column(str, nullable=True),
+        "replicate": Column(int),
+        "value": Column(float, nullable=True),
+    },
+    strict=True,
+    coerce=True,
+)
+
+# ---------------------------------------------------------------------------
+# Divergence summary CSV (ticket 0047)
+# ---------------------------------------------------------------------------
+
+DivergenceSummarySchema = DataFrameSchema(
+    columns={
+        "method": Column(str),
+        "year": Column(int),
+        "window": Column(str),
+        "hyperparams": Column(str, nullable=True),
+        "point_estimate": Column(float, nullable=True),
+        "boot_median": Column(float, nullable=True),
+        "boot_q025": Column(float, nullable=True),
+        "boot_q975": Column(float, nullable=True),
+        "p_value": Column(float, nullable=True),
+        "significant": Column(bool),
     },
     strict=True,
     coerce=True,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,373 @@
+"""Tests for bootstrap CI computation (ticket 0047).
+
+Tests:
+1. Bootstrap output schema — required columns and types
+2. Bootstrap produces K replicates per (method, year, window)
+3. Bootstrap replicates vary (resampling introduces variation)
+4. Summary table joins all sources correctly
+5. Significant flag logic
+6. Schema validation for BootstrapSchema and DivergenceSummarySchema
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_div_df():
+    """Minimal divergence CSV for testing bootstrap."""
+    return pd.DataFrame(
+        {
+            "year": [2005, 2005, 2006, 2006],
+            "channel": ["semantic", "semantic", "semantic", "semantic"],
+            "window": ["3", "3", "3", "3"],
+            "hyperparams": ["", "", "", ""],
+            "value": [0.5, 0.6, 0.7, 0.8],
+        }
+    )
+
+
+def _make_synthetic_null_df():
+    """Minimal null model CSV for testing summary."""
+    return pd.DataFrame(
+        {
+            "year": [2005, 2006],
+            "window": ["3", "3"],
+            "observed": [0.55, 0.75],
+            "null_mean": [0.30, 0.35],
+            "null_std": [0.10, 0.12],
+            "z_score": [2.5, 3.33],
+            "p_value": [0.01, 0.002],
+        }
+    )
+
+
+def _make_synthetic_boot_df(k=10):
+    """Minimal bootstrap replicates CSV for testing summary."""
+    rows = []
+    rng = np.random.RandomState(42)
+    for year in [2005, 2006]:
+        for rep in range(k):
+            rows.append(
+                {
+                    "method": "S2_energy",
+                    "year": year,
+                    "window": "3",
+                    "hyperparams": "",
+                    "replicate": rep,
+                    "value": rng.uniform(0.4, 0.9),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap computation tests
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapComputation:
+    """Test the bootstrap_one_window function."""
+
+    def test_bootstrap_output_schema(self):
+        """Bootstrap output has required columns."""
+        from compute_divergence_bootstrap import bootstrap_one_window
+
+        rng = np.random.RandomState(42)
+        X = rng.randn(30, 10)
+        Y = rng.randn(30, 10)
+
+        def stat_fn(a, b):
+            return float(np.mean(np.abs(a.mean(axis=0) - b.mean(axis=0))))
+
+        result = bootstrap_one_window(X, Y, stat_fn, k=5, seed=42)
+
+        assert isinstance(result, list)
+        assert len(result) == 5
+        # Each element should be a float
+        for v in result:
+            assert isinstance(v, float)
+
+    def test_bootstrap_produces_k_replicates(self):
+        """bootstrap_one_window should produce exactly K replicates."""
+        from compute_divergence_bootstrap import bootstrap_one_window
+
+        rng = np.random.RandomState(42)
+        X = rng.randn(50, 10)
+        Y = rng.randn(50, 10)
+
+        def stat_fn(a, b):
+            return float(np.linalg.norm(a.mean(axis=0) - b.mean(axis=0)))
+
+        for k in [1, 5, 20]:
+            result = bootstrap_one_window(X, Y, stat_fn, k=k, seed=42)
+            assert len(result) == k, f"Expected {k} replicates, got {len(result)}"
+
+    def test_bootstrap_replicates_vary(self):
+        """Replicates should not all be identical."""
+        from compute_divergence_bootstrap import bootstrap_one_window
+
+        rng = np.random.RandomState(42)
+        X = rng.randn(50, 10)
+        Y = rng.randn(50, 10)
+
+        def stat_fn(a, b):
+            return float(np.linalg.norm(a.mean(axis=0) - b.mean(axis=0)))
+
+        result = bootstrap_one_window(X, Y, stat_fn, k=20, seed=42)
+        # Not all values should be identical
+        assert len(set(result)) > 1, "All bootstrap replicates are identical"
+
+    def test_bootstrap_reproducible(self):
+        """Same seed produces same replicates."""
+        from compute_divergence_bootstrap import bootstrap_one_window
+
+        rng = np.random.RandomState(42)
+        X = rng.randn(30, 10)
+        Y = rng.randn(30, 10)
+
+        def stat_fn(a, b):
+            return float(np.linalg.norm(a.mean(axis=0) - b.mean(axis=0)))
+
+        r1 = bootstrap_one_window(X, Y, stat_fn, k=10, seed=99)
+        r2 = bootstrap_one_window(X, Y, stat_fn, k=10, seed=99)
+        assert r1 == r2, "Bootstrap not reproducible with same seed"
+
+    def test_bootstrap_list_inputs(self):
+        """bootstrap_one_window works with list inputs (for lexical channel)."""
+        from compute_divergence_bootstrap import bootstrap_one_window
+
+        texts_before = [f"word{i} climate finance" for i in range(30)]
+        texts_after = [f"word{i} green bond" for i in range(30)]
+
+        def stat_fn(a, b):
+            return float(len(set(a)) + len(set(b)))
+
+        result = bootstrap_one_window(texts_before, texts_after, stat_fn, k=5, seed=42)
+        assert len(result) == 5
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapSchema:
+    """BootstrapSchema validation."""
+
+    def test_valid_dataframe_passes(self):
+        from schemas import BootstrapSchema
+
+        df = pd.DataFrame(
+            {
+                "method": ["S2_energy", "S2_energy"],
+                "year": [2010, 2010],
+                "window": ["3", "3"],
+                "hyperparams": ["", ""],
+                "replicate": [0, 1],
+                "value": [0.5, 0.6],
+            }
+        )
+        BootstrapSchema.validate(df)
+
+    def test_extra_column_rejected(self):
+        from schemas import BootstrapSchema
+
+        df = pd.DataFrame(
+            {
+                "method": ["S2_energy"],
+                "year": [2010],
+                "window": ["3"],
+                "hyperparams": [""],
+                "replicate": [0],
+                "value": [0.5],
+                "extra": ["oops"],
+            }
+        )
+        with pytest.raises(Exception):
+            BootstrapSchema.validate(df)
+
+    def test_coercion_works(self):
+        from schemas import BootstrapSchema
+
+        df = pd.DataFrame(
+            {
+                "method": ["S2_energy"],
+                "year": ["2010"],
+                "window": ["3"],
+                "hyperparams": [""],
+                "replicate": ["0"],
+                "value": ["0.5"],
+            }
+        )
+        validated = BootstrapSchema.validate(df)
+        assert validated["year"].dtype in (int, "int64")
+
+
+class TestDivergenceSummarySchema:
+    """DivergenceSummarySchema validation."""
+
+    def test_valid_dataframe_passes(self):
+        from schemas import DivergenceSummarySchema
+
+        df = pd.DataFrame(
+            {
+                "method": ["S2_energy"],
+                "year": [2010],
+                "window": ["3"],
+                "hyperparams": [""],
+                "point_estimate": [0.55],
+                "boot_median": [0.54],
+                "boot_q025": [0.40],
+                "boot_q975": [0.70],
+                "p_value": [0.01],
+                "significant": [True],
+            }
+        )
+        DivergenceSummarySchema.validate(df)
+
+    def test_extra_column_rejected(self):
+        from schemas import DivergenceSummarySchema
+
+        df = pd.DataFrame(
+            {
+                "method": ["S2_energy"],
+                "year": [2010],
+                "window": ["3"],
+                "hyperparams": [""],
+                "point_estimate": [0.55],
+                "boot_median": [0.54],
+                "boot_q025": [0.40],
+                "boot_q975": [0.70],
+                "p_value": [0.01],
+                "significant": [True],
+                "extra": ["oops"],
+            }
+        )
+        with pytest.raises(Exception):
+            DivergenceSummarySchema.validate(df)
+
+
+# ---------------------------------------------------------------------------
+# Summary table tests
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryTable:
+    """Test export_divergence_summary logic."""
+
+    def test_summary_joins_all_sources(self):
+        """Summary table has all expected columns from the three sources."""
+        from export_divergence_summary import build_summary
+
+        div_df = pd.DataFrame(
+            {
+                "year": [2005, 2006],
+                "channel": ["semantic", "semantic"],
+                "window": ["3", "3"],
+                "hyperparams": ["", ""],
+                "value": [0.55, 0.75],
+            }
+        )
+        null_df = _make_synthetic_null_df()
+        boot_df = _make_synthetic_boot_df(k=10)
+
+        result = build_summary(div_df, null_df, boot_df, method="S2_energy")
+
+        expected_cols = {
+            "method",
+            "year",
+            "window",
+            "hyperparams",
+            "point_estimate",
+            "boot_median",
+            "boot_q025",
+            "boot_q975",
+            "p_value",
+            "significant",
+        }
+        assert expected_cols == set(result.columns), (
+            f"Columns mismatch: {set(result.columns)}"
+        )
+        assert len(result) == 2  # one row per (year, window)
+
+    def test_summary_significant_flag(self):
+        """significant should be True when p_value < 0.05."""
+        from export_divergence_summary import build_summary
+
+        div_df = pd.DataFrame(
+            {
+                "year": [2005, 2006],
+                "channel": ["semantic", "semantic"],
+                "window": ["3", "3"],
+                "hyperparams": ["", ""],
+                "value": [0.55, 0.75],
+            }
+        )
+        null_df = pd.DataFrame(
+            {
+                "year": [2005, 2006],
+                "window": ["3", "3"],
+                "observed": [0.55, 0.75],
+                "null_mean": [0.30, 0.35],
+                "null_std": [0.10, 0.12],
+                "z_score": [2.5, 0.5],
+                "p_value": [0.01, 0.30],  # first significant, second not
+            }
+        )
+        boot_df = _make_synthetic_boot_df(k=10)
+
+        result = build_summary(div_df, null_df, boot_df, method="S2_energy")
+
+        row_2005 = result[result["year"] == 2005].iloc[0]
+        row_2006 = result[result["year"] == 2006].iloc[0]
+
+        assert row_2005["significant"] is True or row_2005["significant"] == True
+        assert row_2006["significant"] is False or row_2006["significant"] == False
+
+    def test_summary_bootstrap_quantiles(self):
+        """Bootstrap quantiles should bracket the median."""
+        from export_divergence_summary import build_summary
+
+        div_df = pd.DataFrame(
+            {
+                "year": [2005],
+                "channel": ["semantic"],
+                "window": ["3"],
+                "hyperparams": [""],
+                "value": [0.55],
+            }
+        )
+        null_df = pd.DataFrame(
+            {
+                "year": [2005],
+                "window": ["3"],
+                "observed": [0.55],
+                "null_mean": [0.30],
+                "null_std": [0.10],
+                "z_score": [2.5],
+                "p_value": [0.01],
+            }
+        )
+        boot_df = _make_synthetic_boot_df(k=50)
+        # Filter to year 2005 only
+        boot_df = boot_df[boot_df["year"] == 2005].reset_index(drop=True)
+
+        result = build_summary(div_df, null_df, boot_df, method="S2_energy")
+        row = result.iloc[0]
+
+        assert row["boot_q025"] <= row["boot_median"] <= row["boot_q975"], (
+            f"Quantiles out of order: q025={row['boot_q025']}, "
+            f"median={row['boot_median']}, q975={row['boot_q975']}"
+        )


### PR DESCRIPTION
## Summary

- Add `compute_divergence_bootstrap.py`: resample K times per (year, window) with deterministic per-replicate seeds, reusing statistic functions from `compute_null_model.py`
- Add `export_divergence_summary.py`: join point estimates + bootstrap quantiles + null model p-values into one summary table per method
- Add `BootstrapSchema` and `DivergenceSummarySchema` to `schemas.py`
- Add opt-in Makefile targets `bootstrap-tables` and `divergence-summary` in `divergence.mk` (NOT part of default `make divergence`)

## Test plan

- [x] 13 unit tests in `test_bootstrap.py` covering bootstrap computation, schema validation, summary join logic, significant flag, and quantile ordering
- [x] `make check-fast` passes (1 pre-existing failure in `test_robustness_observability.py`, unrelated)
- [ ] Integration: `make bootstrap-tables divergence-summary` on full corpus (overnight GPU run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)