### PR TITLE
refactor: simplify community divergence (post-merge review)

### DIFF
--- a/scripts/_divergence_community.py
+++ b/scripts/_divergence_community.py
@@ -51,15 +51,20 @@ def compute_community_divergence(works, citations, internal_edges, cfg):
 
 
 def _build_union_graph(G_before, G_after, internal_edges):
-    """Build undirected union graph with cross-window edges."""
+    """Build undirected union graph with cross-window edges.
+
+    Uses vectorized pandas .isin() filtering (same pattern as
+    _divergence_citation._build_internal_edges) instead of iterrows().
+    """
     union_nodes = set(G_before.nodes()) | set(G_after.nodes())
     G_union = nx.Graph()
     G_union.add_nodes_from(union_nodes)
 
-    for _, row in internal_edges.iterrows():
-        src, ref = row["source_doi"], row["ref_doi"]
-        if src in union_nodes and ref in union_nodes:
-            G_union.add_edge(src, ref)
+    mask = internal_edges["source_doi"].isin(union_nodes) & internal_edges[
+        "ref_doi"
+    ].isin(union_nodes)
+    edges = internal_edges.loc[mask, ["source_doi", "ref_doi"]].values
+    G_union.add_edges_from(edges)
 
     return G_union
 


### PR DESCRIPTION
## Summary

- **Vectorize `_build_union_graph`**: replace `iterrows()` loop over `internal_edges` with pandas `.isin()` filtering, matching the established pattern in `_divergence_citation._build_internal_edges`. This eliminates per-row Python overhead when filtering edges for each sliding-window pair.

Post-merge simplify review of PR #674 (ticket 0054 -- G9 community divergence). Full findings below.

## Review findings

**Fixed:**
- `_build_union_graph` used `iterrows()` to scan every row of `internal_edges` for each window pair. The rest of the citation pipeline uses vectorized numpy/pandas filtering (e.g., `_build_internal_edges`, `_sliding_window_graph`). Replaced with `.isin()` + `.values` for consistency and performance.

**Reviewed, no action needed:**
- **Separate module justified**: G9 pulls in `python-louvain` as an extra dependency, so keeping it in `_divergence_community.py` (separate from `_citation_methods.py`) is a reasonable isolation choice.
- **No dead code**: all functions are reachable; `pd` import is used for `pd.DataFrame(results)`.
- **No unnecessary complexity**: the community-share counting loops (lines 89-96) iterate over node sets, not DataFrames, so they are already efficient. The `comm_to_idx` mapping is clean.
- **Config access pattern** (`div_cfg.get("citation", {}).get("G9_community", {})`) provides safe defaults and matches G1-G8 patterns.
- **Test coverage** is adequate: smoke test, equal-distribution test, single-community edge case, dispatcher registration.
- **Makefile integration** is correct: G9 is in `DIV_METHODS_CIT`, inherits citation method dependencies.

## Test plan

- [x] `uv run make check-fast` passes (813 passed, 9 skipped)


🤖 Generated with [Claude Code](https://claude.com/claude-code)