### PR TITLE
Extend null model to citation channel (G9_community)

### DIFF
--- a/divergence.mk
+++ b/divergence.mk
@@ -184,7 +184,8 @@ changepoints: changepoints-tables changepoints-figure
 NULL_DISPATCH := scripts/compute_null_model.py
 NULL_METHODS_SEM := S2_energy
 NULL_METHODS_LEX := L1
-NULL_METHODS := $(NULL_METHODS_SEM) $(NULL_METHODS_LEX)
+NULL_METHODS_CIT := G9_community
+NULL_METHODS := $(NULL_METHODS_SEM) $(NULL_METHODS_LEX) $(NULL_METHODS_CIT)
 NULL_CSV := $(foreach m,$(NULL_METHODS),$(DIV_TABLES)/tab_null_$(m).csv)
 
 # Semantic null models (depend on embeddings + divergence CSV)
@@ -195,6 +196,11 @@ $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv
 # Lexical null models (depend on REFINED + divergence CSV)
 $(foreach m,$(NULL_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
+	uv run python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+# Citation null models (depend on REFINED + REFINED_CIT + divergence CSV)
+$(foreach m,$(NULL_METHODS_CIT),$(eval \
+$(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_citation.py scripts/_divergence_community.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
 	uv run python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 .PHONY: null-model

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -341,6 +341,56 @@ def _run_lexical_permutations(method_name, div_df, cfg):
     return pd.DataFrame(rows)
 
 
+def _community_node_comm_map(partition):
+    """Build sorted community list and node->community-index lookup.
+
+    Returns (n_communities, comm_to_idx, node_comm) or None if < 2 communities.
+    """
+    all_communities = sorted(set(partition.values()))
+    n_communities = len(all_communities)
+    if n_communities < 2:
+        return None
+    comm_to_idx = {c: i for i, c in enumerate(all_communities)}
+    return n_communities, comm_to_idx
+
+
+def _community_null_distribution(
+    all_nodes, n_before, node_comm, n_communities, n_perm, perm_rng
+):
+    """Shuffle node-to-window assignments and compute JS^2 for each permutation.
+
+    Returns null_stats array (NaN entries removed).
+    """
+    from scipy.spatial.distance import jensenshannon
+
+    null_stats = np.empty(n_perm)
+    for i in range(n_perm):
+        perm_indices = perm_rng.permutation(len(all_nodes))
+        p_bef = np.zeros(n_communities)
+        p_aft = np.zeros(n_communities)
+
+        for j in perm_indices[:n_before]:
+            node = all_nodes[j]
+            if node in node_comm:
+                p_bef[node_comm[node]] += 1
+
+        for j in perm_indices[n_before:]:
+            node = all_nodes[j]
+            if node in node_comm:
+                p_aft[node_comm[node]] += 1
+
+        if p_bef.sum() == 0 or p_aft.sum() == 0:
+            null_stats[i] = np.nan
+            continue
+
+        p_bef = p_bef / p_bef.sum()
+        p_aft = p_aft / p_aft.sum()
+        js = jensenshannon(p_bef, p_aft)
+        null_stats[i] = float(js**2)
+
+    return null_stats[~np.isnan(null_stats)]
+
+
 def _run_citation_permutations(method_name, div_df, cfg):
     """Permutation test for citation community methods (G9).
 
@@ -360,7 +410,6 @@ def _run_citation_permutations(method_name, div_df, cfg):
         load_citation_data,
     )
     from _divergence_community import _build_union_graph, _community_js_for_pair
-    from scipy.spatial.distance import jensenshannon
 
     works, _, internal_edges = load_citation_data(None)
     div_cfg = cfg["divergence"]
@@ -410,51 +459,28 @@ def _run_citation_permutations(method_name, div_df, cfg):
             G_union, resolution=resolution, random_state=seed
         )
 
-        all_communities = sorted(set(partition.values()))
-        n_communities = len(all_communities)
-        if n_communities < 2:
+        comm_info = _community_node_comm_map(partition)
+        if comm_info is None:
             rows.append(_result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0))
             continue
 
-        comm_to_idx = {c: i for i, c in enumerate(all_communities)}
+        n_communities, comm_to_idx = comm_info
 
         # Pool all nodes for permutation
         all_nodes = before_nodes + after_nodes
         n_before = len(before_nodes)
 
-        # Build node->community-index lookup (only nodes in partition)
-        node_comm = {}
-        for node in all_nodes:
-            if node in partition:
-                node_comm[node] = comm_to_idx[partition[node]]
+        # Build node->community-index lookup
+        node_comm = {
+            node: comm_to_idx[partition[node]]
+            for node in all_nodes
+            if node in partition
+        }
 
-        null_stats = np.empty(n_perm)
-        for i in range(n_perm):
-            perm_indices = perm_rng.permutation(len(all_nodes))
-            perm_before = [all_nodes[j] for j in perm_indices[:n_before]]
-            perm_after = [all_nodes[j] for j in perm_indices[n_before:]]
+        null_stats = _community_null_distribution(
+            all_nodes, n_before, node_comm, n_communities, n_perm, perm_rng
+        )
 
-            p_bef = np.zeros(n_communities)
-            for node in perm_before:
-                if node in node_comm:
-                    p_bef[node_comm[node]] += 1
-
-            p_aft = np.zeros(n_communities)
-            for node in perm_after:
-                if node in node_comm:
-                    p_aft[node_comm[node]] += 1
-
-            if p_bef.sum() == 0 or p_aft.sum() == 0:
-                null_stats[i] = np.nan
-                continue
-
-            p_bef = p_bef / p_bef.sum()
-            p_aft = p_aft / p_aft.sum()
-            js = jensenshannon(p_bef, p_aft)
-            null_stats[i] = float(js**2)
-
-        # Remove NaN permutations
-        null_stats = null_stats[~np.isnan(null_stats)]
         if len(null_stats) == 0:
             rows.append(_nan_row(y, w))
             continue

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -28,8 +28,8 @@ from utils import get_logger
 
 log = get_logger("compute_null_model")
 
-# Methods supported for permutation testing (semantic + lexical only)
-SUPPORTED_CHANNELS = {"semantic", "lexical"}
+# Methods supported for permutation testing
+SUPPORTED_CHANNELS = {"semantic", "lexical", "citation"}
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +341,140 @@ def _run_lexical_permutations(method_name, div_df, cfg):
     return pd.DataFrame(rows)
 
 
+def _run_citation_permutations(method_name, div_df, cfg):
+    """Permutation test for citation community methods (G9).
+
+    For each (year, window):
+      1. Build before/after sliding-window graphs
+      2. Build union graph, run Louvain once (fixed partition)
+      3. Permute which nodes are 'before' vs 'after' (keeping sizes fixed)
+      4. Recompute community-share JS divergence under each permutation
+      5. Compare observed JS against the null distribution
+
+    This is computationally efficient: Louvain runs once per (year, window),
+    and only the node-label shuffle is repeated B times.
+    """
+    import community as community_louvain
+    from _divergence_citation import (
+        _sliding_window_graph,
+        load_citation_data,
+    )
+    from _divergence_community import _build_union_graph, _community_js_for_pair
+    from scipy.spatial.distance import jensenshannon
+
+    works, _, internal_edges = load_citation_data(None)
+    div_cfg = cfg["divergence"]
+    perm_cfg = div_cfg["permutation"]
+    n_perm = perm_cfg["n_perm"]
+    seed = div_cfg["random_seed"]
+
+    cit_cfg = div_cfg.get("citation", {})
+    comm_cfg = cit_cfg.get("G9_community", {})
+    resolution = comm_cfg.get("resolution", 1.0)
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+
+    rows = []
+    for _, row in year_windows.iterrows():
+        y = int(row["year"])
+        w = int(row["window"])
+
+        _, perm_rng = _make_window_rngs(seed, y, w)
+
+        # Build sliding window graphs
+        G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
+        G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
+
+        before_nodes = list(G_before.nodes())
+        after_nodes = list(G_after.nodes())
+
+        if len(before_nodes) < 3 or len(after_nodes) < 3:
+            rows.append(_nan_row(y, w))
+            continue
+
+        # Observed value: use the same function as compute_divergence
+        observed = _community_js_for_pair(
+            G_before, G_after, internal_edges, resolution, seed
+        )
+        if np.isnan(observed):
+            rows.append(_nan_row(y, w))
+            continue
+
+        # Build union graph and run Louvain once (shared partition)
+        G_union = _build_union_graph(G_before, G_after, internal_edges)
+        if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
+            rows.append(_nan_row(y, w))
+            continue
+
+        partition = community_louvain.best_partition(
+            G_union, resolution=resolution, random_state=seed
+        )
+
+        all_communities = sorted(set(partition.values()))
+        n_communities = len(all_communities)
+        if n_communities < 2:
+            rows.append(_result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0))
+            continue
+
+        comm_to_idx = {c: i for i, c in enumerate(all_communities)}
+
+        # Pool all nodes for permutation
+        all_nodes = before_nodes + after_nodes
+        n_before = len(before_nodes)
+
+        # Build node->community-index lookup (only nodes in partition)
+        node_comm = {}
+        for node in all_nodes:
+            if node in partition:
+                node_comm[node] = comm_to_idx[partition[node]]
+
+        null_stats = np.empty(n_perm)
+        for i in range(n_perm):
+            perm_indices = perm_rng.permutation(len(all_nodes))
+            perm_before = [all_nodes[j] for j in perm_indices[:n_before]]
+            perm_after = [all_nodes[j] for j in perm_indices[n_before:]]
+
+            p_bef = np.zeros(n_communities)
+            for node in perm_before:
+                if node in node_comm:
+                    p_bef[node_comm[node]] += 1
+
+            p_aft = np.zeros(n_communities)
+            for node in perm_after:
+                if node in node_comm:
+                    p_aft[node_comm[node]] += 1
+
+            if p_bef.sum() == 0 or p_aft.sum() == 0:
+                null_stats[i] = np.nan
+                continue
+
+            p_bef = p_bef / p_bef.sum()
+            p_aft = p_aft / p_aft.sum()
+            js = jensenshannon(p_bef, p_aft)
+            null_stats[i] = float(js**2)
+
+        # Remove NaN permutations
+        null_stats = null_stats[~np.isnan(null_stats)]
+        if len(null_stats) == 0:
+            rows.append(_nan_row(y, w))
+            continue
+
+        null_mean = float(np.mean(null_stats))
+        null_std = float(np.std(null_stats))
+
+        if null_std > 0:
+            z = (observed - null_mean) / null_std
+        else:
+            z = 0.0
+
+        p_value = float(np.mean(null_stats >= observed))
+
+        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p_value))
+        log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p_value)
+
+    return pd.DataFrame(rows)
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -382,6 +516,8 @@ def main():
         result = _run_semantic_permutations(method_name, div_df, cfg)
     elif channel == "lexical":
         result = _run_lexical_permutations(method_name, div_df, cfg)
+    elif channel == "citation":
+        result = _run_citation_permutations(method_name, div_df, cfg)
     else:
         raise ValueError(f"Unsupported channel: {channel}")
 

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -236,11 +236,172 @@ class TestNullModelSchema:
 # ---------------------------------------------------------------------------
 
 
+class TestCitationNullModel:
+    """Tests for citation channel null model (ticket 0050)."""
+
+    def test_citation_channel_supported(self):
+        """compute_null_model should accept citation channel."""
+        from compute_null_model import SUPPORTED_CHANNELS
+
+        assert "citation" in SUPPORTED_CHANNELS
+
+    def test_run_citation_permutations_exists(self):
+        """_run_citation_permutations should be importable."""
+        from compute_null_model import _run_citation_permutations
+
+        assert callable(_run_citation_permutations)
+
+    def test_citation_null_z_score_schema(self):
+        """Citation null model output matches NullModelSchema."""
+        from unittest.mock import patch
+
+        from compute_null_model import _run_citation_permutations
+        from schemas import NullModelSchema
+
+        # Build minimal synthetic data
+        rng = np.random.RandomState(42)
+        n_years = 15
+        papers_per_year = 20
+        years = np.repeat(np.arange(2000, 2000 + n_years), papers_per_year)
+        dois = [f"10.1000/test.{i}" for i in range(len(years))]
+        works = pd.DataFrame({"doi": dois, "year": years, "cited_by_count": 10})
+
+        # Build some citation edges
+        edges = []
+        doi_list = list(works["doi"])
+        doi_years = dict(zip(works["doi"], works["year"]))
+        for _ in range(len(doi_list) * 2):
+            src = rng.choice(doi_list)
+            ref = rng.choice(doi_list)
+            if src != ref:
+                edges.append(
+                    {
+                        "source_doi": src,
+                        "ref_doi": ref,
+                        "source_year": doi_years[src],
+                    }
+                )
+        internal_edges = pd.DataFrame(edges).drop_duplicates(
+            subset=["source_doi", "ref_doi"]
+        )
+
+        cfg = {
+            "divergence": {
+                "windows": [3],
+                "random_seed": 42,
+                "permutation": {"n_perm": 20},
+                "min_papers_fraction": 0.001,
+                "min_papers_floor": 5,
+                "citation": {
+                    "G9_community": {"resolution": 1.0},
+                },
+            }
+        }
+
+        div_df = pd.DataFrame({"year": [2005, 2007], "window": [3, 3]})
+
+        with patch(
+            "_divergence_citation.load_citation_data",
+            return_value=(works, None, internal_edges),
+        ):
+            result = _run_citation_permutations("G9_community", div_df, cfg)
+
+        # Schema validation
+        NullModelSchema.validate(result)
+
+        # Check expected columns
+        expected_cols = {
+            "year",
+            "window",
+            "observed",
+            "null_mean",
+            "null_std",
+            "z_score",
+            "p_value",
+        }
+        assert set(result.columns) == expected_cols
+        assert len(result) == 2  # one row per (year, window) pair
+
+    def test_citation_null_detects_planted_break(self):
+        """Community null model should detect a planted structural break.
+
+        We create two disconnected clusters that map cleanly to before/after,
+        so the observed JS should be high and z-score should be significant.
+        """
+        from unittest.mock import patch
+
+        from compute_null_model import _run_citation_permutations
+
+        # Cluster A: years 2000-2004, Cluster B: years 2005-2009
+        # Edges only within clusters => community structure aligns with time
+        rng = np.random.RandomState(123)
+        dois_a = [f"10.1000/a.{i}" for i in range(60)]
+        dois_b = [f"10.1000/b.{i}" for i in range(60)]
+        years_a = rng.choice(range(2000, 2005), size=60)
+        years_b = rng.choice(range(2005, 2010), size=60)
+
+        works = pd.DataFrame(
+            {
+                "doi": dois_a + dois_b,
+                "year": list(years_a) + list(years_b),
+                "cited_by_count": 10,
+            }
+        )
+
+        # Edges only within each cluster (strong community structure)
+        edges = []
+        for _ in range(300):
+            src = rng.choice(dois_a)
+            ref = rng.choice(dois_a)
+            if src != ref:
+                edges.append({"source_doi": src, "ref_doi": ref})
+        for _ in range(300):
+            src = rng.choice(dois_b)
+            ref = rng.choice(dois_b)
+            if src != ref:
+                edges.append({"source_doi": src, "ref_doi": ref})
+
+        doi_years = dict(zip(works["doi"], works["year"]))
+        for e in edges:
+            e["source_year"] = doi_years[e["source_doi"]]
+        internal_edges = pd.DataFrame(edges).drop_duplicates(
+            subset=["source_doi", "ref_doi"]
+        )
+
+        cfg = {
+            "divergence": {
+                "windows": [3],
+                "random_seed": 42,
+                "permutation": {"n_perm": 99},
+                "min_papers_fraction": 0.001,
+                "min_papers_floor": 3,
+                "citation": {
+                    "G9_community": {"resolution": 1.0},
+                },
+            }
+        }
+
+        # Test at the boundary year (2004) where before=2001-2004, after=2005-2008
+        div_df = pd.DataFrame({"year": [2004], "window": [3]})
+
+        with patch(
+            "_divergence_citation.load_citation_data",
+            return_value=(works, None, internal_edges),
+        ):
+            result = _run_citation_permutations("G9_community", div_df, cfg)
+
+        z = result["z_score"].iloc[0]
+        p = result["p_value"].iloc[0]
+        # With two disconnected clusters, the break should be highly significant
+        assert z > 1.5, f"Expected significant z-score for planted break, got z={z:.2f}"
+        assert p < 0.1, f"Expected small p-value, got p={p:.3f}"
+
+
 @pytest.mark.integration
 class TestSmokeNullModel:
     """Smoke tests for compute_null_model.py on fixture data."""
 
-    @pytest.mark.parametrize("method", ["S2_energy", "L1"])
+    @pytest.mark.parametrize("method", ["S2_energy", "L1", "G9_community"])
     def test_compute_produces_output(self, method, tmp_path):
         """Script runs and produces a valid CSV."""
         # First, generate the divergence CSV that the null model reads
@@ -275,7 +436,7 @@ class TestSmokeNullModel:
         assert expected_cols == set(df.columns), f"Columns mismatch: {set(df.columns)}"
         assert len(df) > 0
 
-    @pytest.mark.parametrize("method", ["S2_energy", "L1"])
+    @pytest.mark.parametrize("method", ["S2_energy", "L1", "G9_community"])
     def test_output_passes_schema(self, method, tmp_path):
         """Output validates against NullModelSchema."""
         from conftest import run_compute
@@ -406,6 +567,81 @@ class TestSharedRngContamination:
 
         assert z_single == z_double, (
             f"Shared-rng contamination: z(2005) alone={z_single:.6f} "
+            f"vs after 2003={z_double:.6f}"
+        )
+
+    def test_single_window_reproducible_regardless_of_prior_windows_citation(self):
+        """Citation: z-score for (year=2005, w=3) must be identical whether
+        we process it alone or after (year=2003, w=3).
+        """
+        from unittest.mock import patch
+
+        from compute_null_model import _run_citation_permutations
+
+        # Build synthetic citation graph data
+        rng = np.random.RandomState(77)
+        n_years = 20
+        papers_per_year = 30
+        years = np.repeat(np.arange(2000, 2000 + n_years), papers_per_year)
+        dois = [f"10.1000/test.{i}" for i in range(len(years))]
+        works = pd.DataFrame({"doi": dois, "year": years, "cited_by_count": 10})
+
+        # Build random internal edges (citation graph)
+        edges = []
+        doi_list = list(works["doi"])
+        doi_years = dict(zip(works["doi"], works["year"]))
+        for _ in range(len(doi_list) * 3):
+            src = rng.choice(doi_list)
+            ref = rng.choice(doi_list)
+            if src != ref:
+                edges.append(
+                    {
+                        "source_doi": src,
+                        "ref_doi": ref,
+                        "source_year": doi_years[src],
+                    }
+                )
+        internal_edges = pd.DataFrame(edges).drop_duplicates(
+            subset=["source_doi", "ref_doi"]
+        )
+
+        cfg = {
+            "divergence": {
+                "windows": [3],
+                "random_seed": 42,
+                "permutation": {"n_perm": 50},
+                "min_papers_fraction": 0.001,
+                "min_papers_floor": 5,
+                "citation": {
+                    "G9_community": {"resolution": 1.0},
+                },
+            }
+        }
+
+        div_df_single = pd.DataFrame({"year": [2005], "window": [3]})
+        div_df_double = pd.DataFrame({"year": [2003, 2005], "window": [3, 3]})
+
+        with patch(
+            "_divergence_citation.load_citation_data",
+            return_value=(works, None, internal_edges),
+        ):
+            result_single = _run_citation_permutations(
+                "G9_community", div_df_single, cfg
+            )
+
+        with patch(
+            "_divergence_citation.load_citation_data",
+            return_value=(works, None, internal_edges),
+        ):
+            result_double = _run_citation_permutations(
+                "G9_community", div_df_double, cfg
+            )
+
+        z_single = result_single.loc[result_single["year"] == 2005, "z_score"].iloc[0]
+        z_double = result_double.loc[result_double["year"] == 2005, "z_score"].iloc[0]
+
+        assert z_single == z_double, (
+            f"Shared-rng contamination (citation): z(2005) alone={z_single:.6f} "
             f"vs after 2003={z_double:.6f}"
         )
 


### PR DESCRIPTION
## Summary

- Extends the permutation Z-score null model (`compute_null_model.py`) to support the citation channel, specifically G9_community (Louvain + Jensen-Shannon divergence)
- Adds `_run_citation_permutations()` which builds union graph, runs Louvain once per (year, window), then shuffles node-to-window assignments B times to build a null distribution
- Adds Make rules in `divergence.mk` for `tab_null_G9_community.csv`
- Adds 7 new tests (4 unit + 3 integration via parametrize expansion)

The permutation approach is computationally efficient: Louvain runs once per (year, window) on the union graph, and only the node-label shuffle is repeated B times. Per-window RNG isolation via `_make_window_rngs` ensures reproducibility.

## Test plan

- [x] `TestCitationNullModel::test_citation_channel_supported` — "citation" in SUPPORTED_CHANNELS
- [x] `TestCitationNullModel::test_run_citation_permutations_exists` — function callable
- [x] `TestCitationNullModel::test_citation_null_z_score_schema` — output matches NullModelSchema
- [x] `TestCitationNullModel::test_citation_null_detects_planted_break` — z > 1.5 for two disconnected clusters
- [x] `TestSharedRngContamination::test_..._citation` — RNG isolation (same z whether alone or after prior window)
- [x] `TestSmokeNullModel::test_compute_produces_output[G9_community]` — end-to-end on fixture data
- [x] `TestSmokeNullModel::test_output_passes_schema[G9_community]` — schema validation on fixture output
- [x] `make check-fast` — 818 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)