### PR TITLE
housekeeping: epic 0026 drift — companion paper live, zoo to tech report

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -13,7 +13,7 @@ Quarto multi-document project (`_quarto.yml`). Outputs share reusable fragments 
 - `content/corpus-report.qmd` — corpus construction, data quality, corpus contents
 - `content/technical-report.qmd` — analysis methods and results (composed of includes)
 - `content/data-paper.qmd` — corpus data paper (RDJ4HSS submission)
-- `content/companion-paper.qmd` — retired (merged into technical-report)
+- `content/companion-paper.qmd` — method paper (QSS submission, epic 0026)
 
 ## Pipeline phases
 

--- a/STATE.md
+++ b/STATE.md
@@ -22,8 +22,8 @@ Under review (peer reviewers + data specialists). 2,495 words, 1 figure, 3 table
 
 ### Technical reports — restructured 2026-04-14 (PR #649)
 - `corpus-report.qmd`: corpus construction, data quality, corpus contents, software environment
-- `technical-report.qmd`: analysis methods and results (structural breaks, thematic structure, polarization, citations)
-- `companion-paper.qmd`: retired — useful content merging into analysis report (ticket 0024)
+- `technical-report.qmd`: analysis methods and results (structural breaks, thematic structure, polarization, citations); 15-method divergence zoo lives here as includes (ticket 0028)
+- `companion-paper.qmd`: method paper for QSS, reimagined 2026-04-15 (epic 0026); lean 6-method panel
 - NCC epic (0012): closed as won't-do — "Paris didn't matter" oversold the data
 
 ## Corpus (v1.1.1)
@@ -47,9 +47,9 @@ None.
 
 ## Next actions
 
-- **0024**: merge companion paper content into analysis report
 - **0025**: connective prose for corpus report
-- **0028**: modular analysis report (one include per script)
+- **0028**: modular analysis report (one include per script) — home for the 15-method divergence zoo
+- **0026 Wave C**: companion paper rewrite — 0057 (methods prose), 0058 (4 figures), 0064 (fill §5 Results)
 - Re-land arch rule 9 (corpus access through loaders only) on own branch — tickets 0043/0044 already on main
 - Run divergence pipeline on real corpus (padme, ticket 0042)
 - ESHET-HES conference slides (Nice, May 26–29)

--- a/tickets/0026-periodization-paper-epic.erg
+++ b/tickets/0026-periodization-paper-epic.erg
@@ -14,6 +14,8 @@ Author: user
 2026-04-15T15:00Z claude note reimagined as companion to Oeconomia manuscript
 2026-04-15T15:00Z claude note lean method panel (6 methods, 3 layers), not 16-method zoo
 2026-04-15T15:00Z claude note ChatGPT note as scaffolding for methods section
+2026-04-16T19:55Z claude cut §7 Supplementary; 15-method zoo moves to technical-report include (lean over comprehensive)
+2026-04-16T19:55Z claude add 0042 and 0064 to Wave 3; 0047 closed (PR #675)
 
 --- body ---
 ## Context
@@ -57,10 +59,12 @@ normalize all methods against sample-size variation.
 - Discriminative terms: both log-odds (Monroe et al. 2008) and C2ST
   coefficients — decide which to foreground after seeing results
 
-**Supplementary (available from existing pipeline):**
-- MMD, Wasserstein, Fréchet, L2/L3, G1/G3-G8 (15-method robustness)
-- PELT/DynP/KernelCPD changepoint detection
-- MC size-bias characterization, bootstrap CIs
+**Not in the companion paper:**
+The 15-method divergence zoo (MMD, Wasserstein, Fréchet, L2/L3,
+G1/G3-G8), PELT/DynP/KernelCPD changepoint detection, and MC size-bias
+characterization are internal engineering artifacts. They live in
+`content/technical-report.qmd` as includes (ticket 0028), not as a
+supplement to this paper. Lean over comprehensive.
 
 ## Paper structure (companion-paper.qmd)
 
@@ -79,7 +83,7 @@ normalize all methods against sample-size variation.
    - 4.9 Interpretation (terms, documents, communities)
 5. Results — applied to climate finance corpus
 6. Discussion — generalizability, limitations, growth-bias honesty
-7. Supplementary — full 15-method results, MC characterization
+7. Conclusion
 
 ## Sub-tickets
 
@@ -112,14 +116,16 @@ normalize all methods against sample-size variation.
 ### Wave 3 — Paper
 | Ticket | Description | Blocked by |
 |--------|-------------|------------|
+| 0042 | Run divergence pipeline on real corpus | — (dep for all Wave C) |
 | 0057 | Inject scaffolding + rewrite companion | 0050, 0056 |
 | 0058 | Companion figures (4 canonical) | 0050, 0056 |
+| 0064 | Fill §5 Results with pipeline outputs | 0042, 0057 |
 
-### Wave 4 — Supplementary
-| Ticket | Description | Blocked by |
-|--------|-------------|------------|
-| 0051 | MC size-bias characterization | 0045 |
-| 0047 | Bootstrap CIs | 0050 |
+### Wave 4 — Robustness (not a companion supplement)
+| Ticket | Description | Blocked by | Home |
+|--------|-------------|------------|------|
+| 0047 | Bootstrap CIs | 0050 | closed (PR #675) |
+| 0051 | MC size-bias characterization | 0045 | technical-report include |
 
 ### Killed
 | Ticket | Reason |


### PR DESCRIPTION
## Summary
- Three docs had stale claims from before the 2026-04-15 reimagine of epic 0026.
- [architecture.md](.claude/rules/architecture.md): companion-paper.qmd is live + QSS-bound, not retired.
- [STATE.md](STATE.md): remove ticket 0024 reference (killed in epic 0026); reflect current lean design; add Wave C ticket list.
- [tickets/0026](tickets/0026-periodization-paper-epic.erg): drop §7 Supplementary / 15-method robustness block from the paper structure. Per author direction, the zoo lives in technical-report.qmd as an include (ticket 0028), not as a paper supplement. Lean over comprehensive.

Also: add 0042 + 0064 to Wave 3 table; mark 0047 closed per PR #675.

Unblocks: Wave C executor agents (0057, 0058, 0064) will read a consistent world.

## Test plan
- [ ] `make check-fast` passes (prose + structure only; no code change).
- [ ] `grep` the three edited files confirms no remaining "retired" or "0024" references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)