### PR TITLE
fix: forward z_score through divergence summary table

### DIFF
--- a/scripts/export_divergence_summary.py
+++ b/scripts/export_divergence_summary.py
@@ -59,8 +59,9 @@ def build_summary(div_df, null_df, boot_df, method):
         boot_q975=lambda x: float(np.nanquantile(x, 0.975)),
     )
 
-    # Select p_value from null model
-    null_cols = null_df[["year", "window", "p_value"]].copy()
+    # Forward z_score and p_value from null model (Z > 2 is the paper's
+    # primary threshold; p-value alone loses the direction/magnitude)
+    null_cols = null_df[["year", "window", "z_score", "p_value"]].copy()
 
     # Ensure consistent types for joining
     div_agg["year"] = div_agg["year"].astype(int)
@@ -89,6 +90,7 @@ def build_summary(div_df, null_df, boot_df, method):
             "boot_median",
             "boot_q025",
             "boot_q975",
+            "z_score",
             "p_value",
             "significant",
         ]

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -147,6 +147,7 @@ DivergenceSummarySchema = DataFrameSchema(
         "boot_median": Column(float, nullable=True),
         "boot_q025": Column(float, nullable=True),
         "boot_q975": Column(float, nullable=True),
+        "z_score": Column(float, nullable=True),
         "p_value": Column(float, nullable=True),
         "significant": Column(bool),
     },

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -218,6 +218,7 @@ class TestDivergenceSummarySchema:
                 "boot_median": [0.54],
                 "boot_q025": [0.40],
                 "boot_q975": [0.70],
+                "z_score": [2.5],
                 "p_value": [0.01],
                 "significant": [True],
             }
@@ -237,6 +238,7 @@ class TestDivergenceSummarySchema:
                 "boot_median": [0.54],
                 "boot_q025": [0.40],
                 "boot_q975": [0.70],
+                "z_score": [2.5],
                 "p_value": [0.01],
                 "significant": [True],
                 "extra": ["oops"],
@@ -281,6 +283,7 @@ class TestSummaryTable:
             "boot_median",
             "boot_q025",
             "boot_q975",
+            "z_score",
             "p_value",
             "significant",
         }
@@ -288,6 +291,8 @@ class TestSummaryTable:
             f"Columns mismatch: {set(result.columns)}"
         )
         assert len(result) == 2  # one row per (year, window)
+        # z_score is forwarded verbatim from the null model
+        assert list(result.sort_values("year")["z_score"]) == [2.5, 3.33]
 
     def test_summary_significant_flag(self):
         """significant should be True when p_value < 0.05."""


### PR DESCRIPTION
## Summary
- [export_divergence_summary.py](scripts/export_divergence_summary.py) was cherry-picking only `p_value` from the null model output and dropping `z_score` on the floor.
- The companion paper (epic 0026) reports Z-scores with a Z > 2 threshold as its primary inference. Downstream consumers (Wave C plot scripts for 0058, §5 prose for 0064) need `z_score` in the summary table so they don't have to re-join `tab_null_*.csv` and `tab_summary_*.csv` separately.
- Deriving Z from two-sided `p_value` loses sign, so this isn't a cosmetic gap.

## Changes
- `scripts/export_divergence_summary.py`: add `z_score` to the `null_cols` projection and the final column order (+2 lines, one-line comment).
- `scripts/schemas.py`: add `z_score: float (nullable)` to `DivergenceSummarySchema`.
- `tests/test_bootstrap.py`: update three tests (two schema fixtures + `expected_cols` set + a verbatim-forwarding assertion).

## Test plan
- [x] `uv run python -m pytest tests/test_bootstrap.py::TestDivergenceSummarySchema tests/test_bootstrap.py::TestSummaryTable -q` → 5 passed
- [ ] Re-run `make divergence-summary` on the t0042 pipeline outputs; `tab_summary_*.csv` should gain a `z_score` column.
- [ ] `make check-fast` passes.

## Context
Found while verifying that ticket 0064's placeholder vocabulary matches what the pipeline actually produces (PR #680). The first summary row to land (`tab_summary_S2_energy.csv`) had everything except z-score; null table at same timestamp had z-score under a different schema. Small surgical fix before Wave C executors start consuming the summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)