### PR TITLE
ticket 0066: validate tab_null_*.csv on read in export_divergence_summary

### DIFF
--- a/tickets/0066-null-csv-schema.erg
+++ b/tickets/0066-null-csv-schema.erg
@@ -1,12 +1,12 @@
 %erg v1
-Title: Add Pandera schema for tab_null_*.csv (null-model output contract)
+Title: export_divergence_summary should validate tab_null_*.csv on read
 Status: open
-Priority: backlog
 Created: 2026-04-16
 Author: claude
 
 --- log ---
 2026-04-16T18:05Z claude created — follow-up from PR #683 review
+2026-04-16T20:40Z claude rewritten — items 1-3 already in tree, only item 4 remains
 
 --- body ---
 ## Context
@@ -17,60 +17,50 @@ The divergence pipeline produces four CSV contract files per method:
 |--------------------------|----------------------------------|--------------------------|
 | `tab_div_{method}.csv`   | `compute_divergence.py`          | `DivergenceSchema` ✓     |
 | `tab_boot_{method}.csv`  | `compute_divergence_bootstrap.py`| `BootstrapSchema` ✓      |
-| `tab_null_{method}.csv`  | `compute_null_model.py`          | **none**                 |
+| `tab_null_{method}.csv`  | `compute_null_model.py`          | `NullModelSchema` ✓      |
 | `tab_summary_{method}.csv`| `export_divergence_summary.py`  | `DivergenceSummarySchema`✓|
 
-Only `tab_null_*.csv` lacks a schema. The downstream summary export (PR #683)
-reads the null CSV projection `["year", "window", "z_score", "p_value"]`
-implicitly; a schema upstream would make that contract explicit and catch
-a missing column at write time, not join time.
+All four files are schema-covered at write time:
+- `NullModelSchema` lives in [scripts/schemas.py:105](scripts/schemas.py#L105).
+- `compute_null_model.py` validates before writing at [scripts/compute_null_model.py:442](scripts/compute_null_model.py#L442).
+- `TestNullModelSchema` in [tests/test_null_model.py:163](tests/test_null_model.py#L163) covers
+  `test_valid_dataframe_passes`, `test_extra_column_rejected`, `test_coercion_works`,
+  plus a production-output validation test.
 
-## Actions
+The remaining gap is on the **read** side: `export_divergence_summary.py` joins
+the null CSV on `["year", "window", "z_score", "p_value"]` without schema
+validation, so any upstream drift (renamed column, type flip) would surface as
+an opaque join error rather than a Pandera message pointing at the column.
 
-1. Add `NullModelSchema` to `scripts/schemas.py`. Columns from
-   `tab_null_S2_energy.csv` inspection (2026-04-16 run):
+## Action
 
-   ```python
-   NullModelSchema = DataFrameSchema(
-       columns={
-           "year": Column(int),
-           "window": Column(str),
-           "observed": Column(float, nullable=True),
-           "null_mean": Column(float, nullable=True),
-           "null_std": Column(float, nullable=True),
-           "z_score": Column(float, nullable=True),
-           "p_value": Column(float, nullable=True),
-       },
-       strict=True,
-       coerce=True,
-   )
-   ```
+Make `export_divergence_summary.py` validate the null CSV on load:
 
-2. Validate in `compute_null_model.py` before writing:
-   `NullModelSchema.validate(df)`.
+```python
+from schemas import NullModelSchema
+null_df = pd.read_csv(args.null_csv)
+NullModelSchema.validate(null_df)
+```
 
-3. Add schema tests in `tests/test_bootstrap.py` (or a new
-   `tests/test_null_model.py` if the file gets crowded), mirroring the
-   pattern in `TestDivergenceSummarySchema`: `test_valid_dataframe_passes`,
-   `test_extra_column_rejected`, `test_coercion_works`.
-
-4. Optional: verify `export_divergence_summary.py` reads the null CSV via
-   `pipeline_loaders` or at least calls `NullModelSchema.validate()` on
-   load, so schema violations surface at join time with a useful error.
+Or, equivalently, add a thin loader in `pipeline_loaders.py` (`load_null_model(path)`)
+that validates on read — consistent with the contract-reader pattern used for
+`refined_works` etc.
 
 ## Test
 
 ```python
-def test_null_model_schema_validates_production_output():
-    """Real tab_null_*.csv files must pass the schema."""
-    for path in Path("content/tables").glob("tab_null_*.csv"):
-        df = pd.read_csv(path)
-        NullModelSchema.validate(df)
+def test_summary_export_rejects_bad_null_csv(tmp_path):
+    """Missing column in null CSV must raise at load, not at join."""
+    bad = pd.DataFrame({"year": [2010], "window": ["cumulative"]})  # no z_score
+    path = tmp_path / "tab_null_bad.csv"
+    bad.to_csv(path, index=False)
+    with pytest.raises(pa.errors.SchemaError):
+        load_null_model(path)  # or direct NullModelSchema.validate
 ```
 
 ## Exit criteria
 
-- `NullModelSchema` declared in `scripts/schemas.py`.
-- `compute_null_model.py` validates before writing.
-- Schema tests added and passing.
-- The four-file divergence contract has full schema coverage.
+- `export_divergence_summary.py` validates the null CSV against `NullModelSchema`
+  before the join (directly or via a `pipeline_loaders` helper).
+- A regression test asserts that a malformed null CSV raises a Pandera error,
+  not a pandas merge/join error.

--- a/tickets/0066-null-csv-schema.erg
+++ b/tickets/0066-null-csv-schema.erg
@@ -1,0 +1,76 @@
+%erg v1
+Title: Add Pandera schema for tab_null_*.csv (null-model output contract)
+Status: open
+Priority: backlog
+Created: 2026-04-16
+Author: claude
+
+--- log ---
+2026-04-16T18:05Z claude created — follow-up from PR #683 review
+
+--- body ---
+## Context
+
+The divergence pipeline produces four CSV contract files per method:
+
+| File                     | Producer                         | Pandera schema           |
+|--------------------------|----------------------------------|--------------------------|
+| `tab_div_{method}.csv`   | `compute_divergence.py`          | `DivergenceSchema` ✓     |
+| `tab_boot_{method}.csv`  | `compute_divergence_bootstrap.py`| `BootstrapSchema` ✓      |
+| `tab_null_{method}.csv`  | `compute_null_model.py`          | **none**                 |
+| `tab_summary_{method}.csv`| `export_divergence_summary.py`  | `DivergenceSummarySchema`✓|
+
+Only `tab_null_*.csv` lacks a schema. The downstream summary export (PR #683)
+reads the null CSV projection `["year", "window", "z_score", "p_value"]`
+implicitly; a schema upstream would make that contract explicit and catch
+a missing column at write time, not join time.
+
+## Actions
+
+1. Add `NullModelSchema` to `scripts/schemas.py`. Columns from
+   `tab_null_S2_energy.csv` inspection (2026-04-16 run):
+
+   ```python
+   NullModelSchema = DataFrameSchema(
+       columns={
+           "year": Column(int),
+           "window": Column(str),
+           "observed": Column(float, nullable=True),
+           "null_mean": Column(float, nullable=True),
+           "null_std": Column(float, nullable=True),
+           "z_score": Column(float, nullable=True),
+           "p_value": Column(float, nullable=True),
+       },
+       strict=True,
+       coerce=True,
+   )
+   ```
+
+2. Validate in `compute_null_model.py` before writing:
+   `NullModelSchema.validate(df)`.
+
+3. Add schema tests in `tests/test_bootstrap.py` (or a new
+   `tests/test_null_model.py` if the file gets crowded), mirroring the
+   pattern in `TestDivergenceSummarySchema`: `test_valid_dataframe_passes`,
+   `test_extra_column_rejected`, `test_coercion_works`.
+
+4. Optional: verify `export_divergence_summary.py` reads the null CSV via
+   `pipeline_loaders` or at least calls `NullModelSchema.validate()` on
+   load, so schema violations surface at join time with a useful error.
+
+## Test
+
+```python
+def test_null_model_schema_validates_production_output():
+    """Real tab_null_*.csv files must pass the schema."""
+    for path in Path("content/tables").glob("tab_null_*.csv"):
+        df = pd.read_csv(path)
+        NullModelSchema.validate(df)
+```
+
+## Exit criteria
+
+- `NullModelSchema` declared in `scripts/schemas.py`.
+- `compute_null_model.py` validates before writing.
+- Schema tests added and passing.
+- The four-file divergence contract has full schema coverage.


### PR DESCRIPTION
## Summary
- Original PR scope assumed tab_null_*.csv had no schema at all. Items 1–3 are already in tree: `NullModelSchema` lives in [scripts/schemas.py:105](scripts/schemas.py#L105), `compute_null_model.py` validates before write at [L442](scripts/compute_null_model.py#L442), and `TestNullModelSchema` in [tests/test_null_model.py:163](tests/test_null_model.py#L163) covers pass/extra-column/coercion + a production-output validation.
- Only the **read-side** gap remains: `export_divergence_summary.py` joins the null CSV without validating, so upstream drift surfaces as an opaque merge error.
- Ticket body rewritten to reflect the narrowed scope — one action (validate on read) and one regression test (malformed CSV raises Pandera error, not merge error).

## Test plan
- [x] Verified `NullModelSchema` declared in [scripts/schemas.py](scripts/schemas.py).
- [x] Verified validation before write in [scripts/compute_null_model.py](scripts/compute_null_model.py).
- [x] Verified schema tests in [tests/test_null_model.py](tests/test_null_model.py).
- [ ] Implementation of the read-side validation is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)