### PR TITLE
fix(t0065): G4 community detection on full cumulative graph

### DIFF
--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -349,6 +349,12 @@ def compute_g4_cross_trad(works, citations, internal_edges, cfg):
     the tradition split as a corpus-level identity rather than a mid-corpus
     snapshot is what makes the tail (ticket 0065) defined at all.
 
+    Caveat: this projects the late-era community structure backward onto
+    early years (e.g., 1998–2009). "Cross-tradition" in 1999 therefore
+    means "crossing a 2024-visible tradition split," not "crossing a
+    tradition that existed in 1999." The technical-report G4 include
+    (ticket 0028) should state this explicitly.
+
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     years = _get_years(works)

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -343,6 +343,12 @@ def _bisect_communities(G_und):
 def compute_g4_cross_trad(works, citations, internal_edges, cfg):
     """Fraction of new internal citations crossing a 2-community boundary.
 
+    The 2-community bisection is computed once on the full cumulative graph
+    (all years), so every paper has a community assignment and per-year
+    cross-tradition rates are defined across the whole year range. Treating
+    the tradition split as a corpus-level identity rather than a mid-corpus
+    snapshot is what makes the tail (ticket 0065) defined at all.
+
     Returns DataFrame with columns: year, window, hyperparams, value
     """
     years = _get_years(works)
@@ -353,7 +359,7 @@ def compute_g4_cross_trad(works, citations, internal_edges, cfg):
         log.info("G4: Too few internal edges (%d), skipping", len(internal_edges))
         return _dict_to_df({y: np.nan for y in years})
 
-    ref_year = int(np.median(years))
+    ref_year = max(years)
     G_full = _cumulative_graph(works, internal_edges, ref_year)
     G_und = G_full.to_undirected()
 

--- a/tests/test_citation_sliding.py
+++ b/tests/test_citation_sliding.py
@@ -314,8 +314,13 @@ class TestUnchangedMethods:
             f"G3 windows: {df['window'].unique()}"
         )
 
-    def test_g4_still_uses_cumulative(self, data):
-        """G4 should still output window='cumulative'."""
+    def test_g4_output_window_label_is_cumulative(self, data):
+        """G4 output rows must carry window='cumulative' (schema stability).
+
+        This only checks the output label in the CSV. It does NOT assert
+        the computation is cumulative — the bisection runs once on the
+        full graph, and per-year new-edge rates are counted year-by-year.
+        """
         from _citation_methods import compute_g4_cross_trad
 
         works, citations, internal_edges, cfg = data

--- a/tests/test_citation_sliding.py
+++ b/tests/test_citation_sliding.py
@@ -325,6 +325,41 @@ class TestUnchangedMethods:
             f"G4 windows: {df['window'].unique()}"
         )
 
+    def test_g4_cross_trad_covers_year_max(self, data):
+        """G4 must produce a valid value at year_max.
+
+        Regression for ticket 0065: community detection used to snapshot at
+        the median year, so every source with year > median fell out of the
+        community dict and yielded NaN. With community detection on the full
+        cumulative graph, the last year carries a value.
+        """
+        from _citation_methods import compute_g4_cross_trad
+
+        works, citations, internal_edges, cfg = data
+        df = compute_g4_cross_trad(works, citations, internal_edges, cfg)
+
+        year_max = int(works["year"].max())
+        last = df.loc[df["year"] == year_max, "value"]
+        assert len(last) == 1
+        assert last.notna().all(), (
+            f"G4 NaN at year_max={year_max}; "
+            f"valid years: {sorted(df.loc[df['value'].notna(), 'year'].tolist())}"
+        )
+
+    def test_g4_cross_trad_nans_contiguous(self, data):
+        """G4 NaNs must form a contiguous block (cold-start only, not a tail)."""
+        from _citation_methods import compute_g4_cross_trad
+
+        works, citations, internal_edges, cfg = data
+        df = compute_g4_cross_trad(works, citations, internal_edges, cfg)
+
+        nan_years = sorted(df.loc[df["value"].isna(), "year"].tolist())
+        if not nan_years:
+            return
+        assert max(nan_years) - min(nan_years) == len(nan_years) - 1, (
+            f"Non-contiguous NaN years: {nan_years}"
+        )
+
     def test_g7_still_uses_cumulative(self, data):
         """G7 should still output window='cumulative'."""
         from _citation_methods import compute_g7_disruption


### PR DESCRIPTION
## Summary
- Changes `ref_year` in `compute_g4_cross_trad` from the median of the year range to `max(years)`, so the 2-community bisection is computed on the full cumulative graph. Every paper gets a community assignment, so per-year cross-tradition rates are defined across the whole year range instead of collapsing to NaN after the median year.
- Adds two regression tests: year_max must carry a value, and any remaining NaNs must be contiguous (cold-start only).
- Closes the tail-NaN half of ticket 0065. Audit of the other zoo tables confirmed G4 was the only serious offender (G3/G5/G7 show at most cold-start NaN; all others are complete).

## Root cause recap
The old code snapshotted community detection at `int(np.median(years))`. Any source paper published after that year was absent from the community dict. The `dropna(subset=["s_comm", "r_comm"])` step then dropped every one of its outgoing edges, collapsing `total` to zero and yielding NaN. Because citations point backward in time, the tail never recovered — in the t0042 full-corpus run, years 2010–2024 (23 of 35) were all NaN.

## Behavior change
The community split is now a corpus-level identity (driven by the final cumulative graph) rather than a mid-corpus snapshot. Existing valid years (1998–2009 in the t0042 run) may shift slightly because the bisection now sees late-era papers; the semantic interpretation moves from "how did citations relate to the mid-corpus tradition split" to "how did cross-tradition mixing evolve over time given today's two-community structure." This was explicitly the choice made in ticket 0065 (Option 2: fix).

## Test plan
- [x] New `test_g4_cross_trad_covers_year_max` fails on HEAD~2 (valid only through 2007) and passes with the fix.
- [x] New `test_g4_cross_trad_nans_contiguous` keeps NaNs to a cold-start contiguous block.
- [x] `tests/test_citation_sliding.py` full suite: 16 passed.
- [x] `tests/test_divergence.py` + `tests/test_citation_sliding.py`: 65 passed.
- [x] `make check-fast`: 836 passed, 8 skipped (all warnings are pre-existing complexity/length smells).
- [x] `make check`: same 37 failures/errors as baseline (pre-existing — worktree has no refined corpus assets).
- [ ] Re-run `make content/tables/tab_div_G4_cross_tradition.csv` on padme to confirm 0 tail NaN on the real corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)