### PR TITLE
tickets 0067-0069: pipeline extensions from t0042 post-run audit

### DIFF
--- a/tickets/0042-run-real-corpus.erg
+++ b/tickets/0042-run-real-corpus.erg
@@ -7,6 +7,9 @@ Author: user
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note the actual scientific computation; blocked by robustness + GPU
 2026-04-15T21:00Z claude unblocked from 0037 and 0039 per workplan review — CPU run is fine, robustness is polish
+2026-04-16T19:27Z claude first run started on padme (GPU, cu130)
+2026-04-17T01:15Z claude first run completed cleanly: 18/18 div, 3 null (S2/L1/G9), 2 boot + summary (S2/L1), 1 changepoints, 1 convergence, 4 sensitivity, 23 figures
+2026-04-17T01:30Z claude post-run audit surfaced three blocking issues for Wave C: tickets 0067 (year bounds), 0068 (C2ST inference), 0069 (graph inference scope); ticket stays open until they land + rerun
 
 --- body ---
 ## Context

--- a/tickets/0067-per-window-year-bounds.erg
+++ b/tickets/0067-per-window-year-bounds.erg
@@ -1,0 +1,104 @@
+%erg v1
+Title: Align divergence year bounds to per-window convention (semantic + lexical)
+Status: open
+Created: 2026-04-17
+Author: claude
+Blocked-by: none
+
+--- log ---
+2026-04-17T01:30Z claude created from t0042 post-run audit
+
+--- body ---
+## Context
+
+The three channels use three different year-range conventions. This
+produces systematic miscalibration on the upper bound and narrows
+multi-signal overlap in the companion paper.
+
+Observed on the 2026-04-16 t0042 run (corpus 1990-2024, windows {2,3,4,5}):
+
+| Method | w=2 | w=3 | w=4 | w=5 |
+|--------|-----|-----|-----|-----|
+| S2_energy (embedding) | 1998-**2018** | 1998-2018 | 1998-2018 | 1998-2018 |
+| L1 (lexical) | 1998-**2023** | 1998-2023 | 1998-2023 | 1998-2023 |
+| G9_community (graph) | 1999-**2021** | 1999-2020 | 1999-2019 | 1999-2018 |
+
+Only the graph methods iterate *per window*. Semantic and lexical use
+a single buffer for all widths.
+
+## Root cause
+
+### Semantic — over-conservative
+
+`scripts/_divergence_semantic.py:74-75`:
+```python
+start_year = int(df["year"].min()) + max(windows)     # 1990 + 5 = 1995
+end_year   = int(df["year"].max()) - max(windows) - 1 # 2024 - 5 - 1 = 2018
+```
+All four window widths share `end_year=2018`. S2/S1/S3/S4/C2ST_embedding
+silently drop 2019, 2020, 2021 data at w=2 — three years of post-Paris
+/ "established field" evidence that should be testable on embeddings.
+
+### Lexical — under-conservative
+
+L1/L2/L3/C2ST_lexical reach 2023 for all window widths. At w=5, year=2023
+means the "after" window is [2024, 2028), so only 2024 is in-corpus.
+Computation is defined (JS works on any pair of distributions) but
+epistemically weak: 5 years of pre-2024 vs 1 year of 2024.
+
+### Graph — correct
+
+`scripts/_divergence_citation.py:171`:
+```python
+for year in range(year_min + w, year_max - w):  # per-window
+```
+Narrower windows naturally reach later years. This is the right rule.
+
+## Actions
+
+1. Rewrite `_get_years_and_params` in `_divergence_semantic.py` to yield
+   per-window year ranges, or refactor so each method iterates its own
+   window boundaries. Mirror the `_iter_sliding_pairs` pattern from
+   `_divergence_citation.py`.
+
+2. Apply the same per-window bound to the lexical iterator (wherever
+   L1/L2/L3/C2ST_lexical decide their upper year).
+
+3. Update `compute_divergence.py` if year-range logic lives there too.
+
+4. After the fix, semantic at w=3 reaches 2020 (was 2018); lexical at
+   w=3 reaches 2020 (was 2023). Multi-signal overlap at w=3 becomes
+   **1999-2020 (22 years)** — a clean, consistent range across all
+   six lead methods.
+
+5. Regenerate S2, L1, C2ST_embedding, C2ST_lexical `tab_div_*.csv`.
+   Then regen null + bootstrap + summary for the ones in scope.
+
+## Test
+
+```python
+def test_semantic_upper_bound_is_per_window():
+    """Semantic iterator must produce different end_years per window width."""
+    # Given a corpus ending at 2024:
+    # w=2 should reach 2022 (inclusive last year 2021)
+    # w=5 should reach 2019 (inclusive last year 2018)
+    years_by_w = {w: max(ys) for w, ys in semantic_year_ranges(cfg).items()}
+    assert years_by_w[2] > years_by_w[5]
+    assert years_by_w[2] == years_by_w[5] + 3
+
+def test_lexical_upper_bound_is_per_window():
+    """Lexical iterator must not produce asymmetric windows."""
+    # At year=2023 w=5, after-window would have ≤1 year of data — reject.
+    ys = lexical_year_ranges(cfg)
+    assert 2023 not in ys[5]
+```
+
+## Exit criteria
+
+- All three channels use the same per-window year-range rule.
+- Existing semantic tables gain ~3 years at w=2.
+- Existing lexical tables lose the 2021-2023 tail at w=5 (or intermediate
+  widths as appropriate).
+- Unit tests enforce the rule.
+- Downstream consumers (null model, bootstrap, summary) rebuild cleanly.
+- Wave C multi-signal overlap is a single uniform 1999-2020 range at w=3.

--- a/tickets/0068-c2st-cv-variance.erg
+++ b/tickets/0068-c2st-cv-variance.erg
@@ -1,0 +1,118 @@
+%erg v1
+Title: C2ST — emit CV fold variance, not permutation null
+Status: open
+Created: 2026-04-17
+Author: claude
+Blocked-by: none
+
+--- log ---
+2026-04-17T01:30Z claude created from Wave C inference design review
+
+--- body ---
+## Context
+
+The companion paper (epic 0026) uses C2ST (classifier two-sample test)
+as the **robustness** method for both embedding and lexical channels:
+
+| Layer | Lead | Robustness |
+|-------|------|------------|
+| Embedding | Energy distance (S2) | C2ST on PCA-32 |
+| Lexical | JS divergence (L1) | C2ST on TF-IDF |
+
+Initial instinct was to add C2ST_embedding and C2ST_lexical to
+NULL_METHODS_* and run the standard permutation framework. Analysis
+showed this is **epistemically the wrong primitive for C2ST**.
+
+## Why permutation null is wrong for C2ST
+
+The pipeline's null model permutes the before/after labels of documents
+and recomputes the test statistic. Under H0 (same distribution), the
+statistic should be near zero / near chance.
+
+For distance statistics (S2 energy, L1 JS, G9 community JS, G2 spectral
+gap) this is the right framework: under H0, the distance *is* small, and
+the permutation gives its sampling distribution.
+
+For C2ST, the test statistic is **already a hypothesis test**: AUC from a
+cross-validated classifier. Its null is theoretically centered at 0.5.
+Wrapping it in a permutation test asks: *"does a classifier trained on
+real labels outperform one trained on random labels?"* — answer is
+trivially yes when there is signal. The permutation Z-score then just
+measures "how much above 0.5 are we", which you already know from the
+mean AUC. Tautological, computationally expensive.
+
+## The right inference primitive for C2ST
+
+`scripts/_divergence_c2st.py:68-70` already runs 5-fold CV via sklearn's
+`cross_val_score`, producing K per-fold AUCs:
+
+```python
+cv = StratifiedKFold(n_splits=cv_folds, shuffle=True, random_state=seed)
+scores = cross_val_score(clf, features, labels, cv=cv, scoring="roc_auc")
+return float(np.mean(scores))  # throws away per-fold variance!
+```
+
+The per-fold variance is the data-derived measure of uncertainty. The
+paper should report **AUC ± SE** from the CV folds, or a bootstrap CI
+over predicted probabilities. The null-vs-chance test is a one-sample
+t-test of the K scores against 0.5 (equivalent to binomial normal
+approximation on correct predictions).
+
+## Actions
+
+1. Patch `_divergence_c2st.py` to return `(mean, std, q025, q975)` or
+   at minimum `(mean, std)`. Do not throw away the per-fold scores.
+
+2. Extend the C2ST output schema (likely in `scripts/schemas.py`; may
+   need a `C2STDivergenceSchema` variant or extra columns in the shared
+   `DivergenceSchema`). New columns: `auc_std`, maybe `auc_q025`,
+   `auc_q975`, and `n_folds`.
+
+3. Remove any plan to include C2ST_embedding or C2ST_lexical in
+   `NULL_METHODS_SEM` / `NULL_METHODS_LEX`. They will NOT get a null
+   model and do not need one.
+
+4. Update consumers:
+   - `plot_divergence.py`: for C2ST methods, plot mean ± 1.96·std / CI
+     instead of looking for a null envelope.
+   - `export_divergence_summary.py`: decide whether C2ST methods get
+     their own summary table or use a separate `tab_c2st_summary_*.csv`
+     schema. Summary should report AUC + CI + significance-vs-0.5.
+
+5. Tests:
+   - `tests/test_c2st.py`: assert per-fold variance is computed and
+     exported.
+   - schema test: reject C2ST rows without the new variance columns.
+
+## Test
+
+```python
+def test_c2st_returns_fold_variance():
+    """compute_c2st_embedding returns per-fold variance."""
+    from _divergence_c2st import compute_c2st_embedding
+    df, emb = synthetic_binary_data(n=100, d=32)
+    row = compute_c2st_embedding(df, emb, cfg)
+    assert "auc_std" in row
+    assert row["auc_std"] > 0
+    # One-sample t vs 0.5 should give p < 0.05 on well-separated data
+    assert row["p_value_vs_chance"] < 0.05
+```
+
+## Why this matters for Wave C
+
+- Figure 1 (Z-score time series): the C2ST panels will plot AUC with CI
+  envelope, not Z-score. Document this in the figure caption.
+- Figure 2 (transition heatmap): mixed inference primitives across rows
+  (Z for distance methods, AUC for C2ST). Normalize both to a common
+  "significance at threshold" bit and color by that.
+- §4.5 of the paper (Statistical inference): add a paragraph explaining
+  why C2ST uses CV variance and the distance methods use permutation.
+  This is a legitimate methodological point, not a limitation.
+
+## Exit criteria
+
+- `_divergence_c2st.py` returns per-fold variance structure.
+- C2ST schema updated and validated at write time.
+- Null model makefile targets do NOT include C2ST methods.
+- Downstream plots / summaries handle the C2ST inference primitive.
+- Tests enforce the new schema.

--- a/tickets/0069-extend-graph-inference.erg
+++ b/tickets/0069-extend-graph-inference.erg
@@ -1,0 +1,97 @@
+%erg v1
+Title: Extend graph-channel inference — G2 null + graph bootstrap
+Status: open
+Created: 2026-04-17
+Author: claude
+Blocked-by: none
+
+--- log ---
+2026-04-17T01:30Z claude created from t0042 scope gap
+
+--- body ---
+## Context
+
+The companion paper (epic 0026) uses these graph methods:
+
+| Role | Method | Current inference | Needed |
+|------|--------|-------------------|--------|
+| Lead | G9_community | ✓ null model | + bootstrap CI |
+| Robustness | G2_spectral | raw value only | + null model, + bootstrap CI |
+
+The t0042 pipeline run (2026-04-16) computed divergence for all 18
+methods but the Makefile scopes null/bootstrap to a narrow set:
+
+```makefile
+NULL_METHODS_CIT := G9_community         # missing G2
+BOOT_METHODS     := S2_energy L1         # missing G9, G2
+```
+
+Wave C figures (Z-score time series, transition heatmap) and prose
+(§5 Results) need Z-scores for G2_spectral and bootstrap CIs for the
+two graph methods.
+
+## Actions
+
+1. Edit `divergence.mk`:
+   ```makefile
+   NULL_METHODS_CIT := G9_community G2_spectral
+   BOOT_METHODS_CIT := G9_community G2_spectral    # new bucket
+   BOOT_METHODS := $(BOOT_METHODS_SEM) $(BOOT_METHODS_LEX) $(BOOT_METHODS_CIT)
+   ```
+   Add citation-channel bootstrap target rule mirroring the semantic
+   and lexical ones (depends on REFINED + REFINED_CIT + divergence CSV).
+
+2. Verify `compute_null_model.py` handles G2_spectral via the existing
+   citation-channel dispatcher (line 285+). G2's `_spectral_gap` is in
+   `_citation_methods.py`; the null iteration permutes document labels
+   within the window and recomputes the gap. Should slot in with
+   minor wiring.
+
+3. Verify `compute_divergence_bootstrap.py` handles citation-channel
+   methods. If not, add a citation branch mirroring the semantic
+   branch (resample rows with replacement, rebuild subgraph, recompute
+   metric).
+
+4. Make target dependency updates:
+   - `make null-model` now produces tab_null_G2_spectral.csv
+   - `make bootstrap-tables` now produces tab_boot_G9.csv, tab_boot_G2.csv
+   - `make divergence-summary` naturally expands to include these
+
+5. Tests:
+   - `tests/test_null_model.py`: add G2_spectral to citation-channel
+     parametrize list (if `TestSmokeCitation` exists).
+   - `tests/test_bootstrap.py`: similar.
+
+## Compute cost
+
+On padme GPU: G2 null ~10-15 min (spectral gap is fast); graph
+bootstrap ~5-10 min per method. Total additional: ~25-35 min after
+the Makefile + code changes.
+
+## Test
+
+```python
+def test_g2_spectral_has_null_model():
+    """G2_spectral must produce a null CSV with z_score column."""
+    path = Path("content/tables/tab_null_G2_spectral.csv")
+    assert path.exists()
+    df = pd.read_csv(path)
+    assert "z_score" in df.columns
+    assert df["z_score"].notna().any()
+
+def test_graph_methods_have_bootstrap():
+    """G9 and G2 must produce bootstrap CIs."""
+    for m in ["G9_community", "G2_spectral"]:
+        path = Path(f"content/tables/tab_boot_{m}.csv")
+        assert path.exists()
+        df = pd.read_csv(path)
+        assert len(df) > 0
+```
+
+## Exit criteria
+
+- `tab_null_G2_spectral.csv` landed (z_score + p_value populated).
+- `tab_boot_G9_community.csv` and `tab_boot_G2_spectral.csv` landed.
+- `tab_summary_G9_community.csv` and `tab_summary_G2_spectral.csv`
+  landed (joined from div + null + boot).
+- Null/bootstrap tests cover citation-channel parametrization.


### PR DESCRIPTION
## Summary

Three blocking items for Wave C's six-method lead panel, discovered while sanity-checking the 2026-04-16 pipeline run on real corpus (27,336 works, ticket 0042).

| # | Title | Essence |
|---|-------|---------|
| 0067 | Align year bounds to per-window convention | Semantic over-reserves (all windows end at 2018), lexical under-reserves (w=5 at 2023 = 1 yr of after). Fix to graph's per-window rule. After-fix multi-signal overlap at w=3: **1999-2020 (22 yrs)**. |
| 0068 | C2ST: CV fold variance, not permutation null | Permutation null is tautological for a classifier-AUC test statistic. Use `cross_val_score` per-fold scores (currently discarded at `_divergence_c2st.py:70`). Report AUC ± CI. |
| 0069 | Extend graph-channel inference | Add G2_spectral to NULL_METHODS_CIT; add G9_community + G2_spectral to BOOT_METHODS. Compute: ~25-35 min more on padme GPU. |

## Why batch

All three are docs-only additions that describe separate concerns. Implementation PRs will be separate (one per ticket).

## Dependency chain

- Wave C (tickets 0057, 0058, 0064) blocked by ticket 0042.
- Ticket 0042 blocked by these three fixes + a rerun.
- After 0067-0069 merge → implement → rerun pipeline → 0042 completes → Wave C unblocks.

## Test plan

- [ ] %erg v1 validator accepts all three files (pre-commit hook).
- [ ] No %erg format regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)