### PR TITLE
ticket 0067: per-window year bounds (semantic + lexical)

### DIFF
--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -91,11 +91,11 @@ def compute_c2st_embedding(df, emb, cfg):
     seed = div_cfg["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years_by_window, min_papers, max_subsample, _windows, equal_n = (
-        _get_years_and_params(df, emb, cfg)
+    years_by_window, min_papers, max_subsample, equal_n = _get_years_and_params(
+        df, emb, cfg
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
+        return empty_divergence_df()
 
     results = []
     last_w = None

--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -91,10 +91,10 @@ def compute_c2st_embedding(df, emb, cfg):
     seed = div_cfg["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
-        df, emb, cfg
+    years_by_window, min_papers, max_subsample, _windows, equal_n = (
+        _get_years_and_params(df, emb, cfg)
     )
-    if not years:
+    if not any(years_by_window.values()):
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     results = []
@@ -102,8 +102,7 @@ def compute_c2st_embedding(df, emb, cfg):
     for y, w, X, Y in _iter_window_pairs(
         df,
         emb,
-        years,
-        windows,
+        years_by_window,
         min_papers,
         max_subsample,
         rng=rng,

--- a/scripts/_divergence_citation.py
+++ b/scripts/_divergence_citation.py
@@ -158,17 +158,14 @@ def _iter_sliding_pairs(works, internal_edges, cfg):
     for the same (year, window) pairs. A cache dict keyed by (year, w) could
     avoid redundant graph construction when multiple methods run sequentially.
     """
-    from _divergence_io import get_min_papers
+    from _divergence_io import get_min_papers, per_window_year_ranges
 
     div_cfg = cfg["divergence"]
     windows = div_cfg["windows"]
     min_papers = get_min_papers(len(works), cfg)
 
-    year_min = int(works["year"].min())
-    year_max = int(works["year"].max())
-
-    for w in windows:
-        for year in range(year_min + w, year_max - w):
+    for w, years in per_window_year_ranges(works, windows).items():
+        for year in years:
             G_before = _sliding_window_graph(works, internal_edges, year, w, "before")
             G_after = _sliding_window_graph(works, internal_edges, year, w, "after")
             if G_before.number_of_nodes() < min_papers:

--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -127,8 +127,7 @@ def per_window_year_ranges(df, windows):
 
     For each window width w, the anchor year y must satisfy
     year_min <= y - w and y + 1 + w <= year_max so both windows fit
-    inside the corpus. That gives y in range(year_min + w, year_max - w),
-    matching `_iter_sliding_pairs` in `_divergence_citation.py`.
+    inside the corpus. That gives y in range(year_min + w, year_max - w).
 
     Returns a dict mapping each w to its sorted list of valid years.
     Narrower windows reach later years; wider windows stop earlier.
@@ -136,6 +135,15 @@ def per_window_year_ranges(df, windows):
     year_min = int(df["year"].min())
     year_max = int(df["year"].max())
     return {w: list(range(year_min + w, year_max - w)) for w in windows}
+
+
+def empty_divergence_df():
+    """Empty DataFrame with the divergence-output column schema.
+
+    Used by compute_* functions as a short-circuit return when the
+    corpus has no valid (year, window) anchors.
+    """
+    return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
 
 def subsample_equal_n(before, after, min_papers, rng):
@@ -199,7 +207,7 @@ def iter_semantic_windows(div_df, cfg):
     div_cfg = cfg["divergence"]
     seed = div_cfg["random_seed"]
 
-    _, min_papers, max_subsample, _, equal_n = _get_years_and_params(df, emb, cfg)
+    _, min_papers, max_subsample, equal_n = _get_years_and_params(df, emb, cfg)
 
     year_windows = div_df[["year", "window"]].drop_duplicates()
 

--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -122,6 +122,22 @@ def get_min_papers(n_works, cfg):
     return div_cfg.get("min_papers", 30)
 
 
+def per_window_year_ranges(df, windows):
+    """Per-window valid anchor years for sliding-pair iteration.
+
+    For each window width w, the anchor year y must satisfy
+    year_min <= y - w and y + 1 + w <= year_max so both windows fit
+    inside the corpus. That gives y in range(year_min + w, year_max - w),
+    matching `_iter_sliding_pairs` in `_divergence_citation.py`.
+
+    Returns a dict mapping each w to its sorted list of valid years.
+    Narrower windows reach later years; wider windows stop earlier.
+    """
+    year_min = int(df["year"].min())
+    year_max = int(df["year"].max())
+    return {w: list(range(year_min + w, year_max - w)) for w in windows}
+
+
 def subsample_equal_n(before, after, min_papers, rng):
     """Subsample the larger collection to match the smaller.
 

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -77,8 +77,8 @@ def _iter_lexical_window_pairs(df, cfg):
     yielding sparse TF-IDF matrices for before/after windows.
     Shared by L1 and C2ST_lexical.
 
-    Uses per-window year ranges (ticket 0067) so the after-window always
-    fits inside the corpus — narrower windows reach later years.
+    Uses per-window year ranges so the after-window always fits inside
+    the corpus — narrower windows reach later years.
     """
     div_cfg = cfg["divergence"]
     lex_cfg = div_cfg.get("lexical", {})

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -67,7 +67,7 @@ def _smooth_distribution(v, eps=1e-10):
 
 
 from _divergence_io import get_min_papers as _get_min_papers
-from _divergence_io import subsample_equal_n
+from _divergence_io import per_window_year_ranges, subsample_equal_n
 
 
 def _iter_lexical_window_pairs(df, cfg):
@@ -76,6 +76,9 @@ def _iter_lexical_window_pairs(df, cfg):
     Fits a global TF-IDF vectorizer, then iterates over (window, year),
     yielding sparse TF-IDF matrices for before/after windows.
     Shared by L1 and C2ST_lexical.
+
+    Uses per-window year ranges (ticket 0067) so the after-window always
+    fits inside the corpus — narrower windows reach later years.
     """
     div_cfg = cfg["divergence"]
     lex_cfg = div_cfg.get("lexical", {})
@@ -88,7 +91,7 @@ def _iter_lexical_window_pairs(df, cfg):
     seed = div_cfg["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years = sorted(df["year"].unique())
+    years_by_window = per_window_year_ranges(df, windows)
     all_texts = df["abstract"].tolist()
 
     vec = TfidfVectorizer(
@@ -99,7 +102,7 @@ def _iter_lexical_window_pairs(df, cfg):
     )
     vec.fit(all_texts)
 
-    for w in windows:
+    for w, years in years_by_window.items():
         for y in years:
             mask_before = (df["year"] >= y - w) & (df["year"] <= y)
             mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -14,7 +14,11 @@ import os
 
 import numpy as np
 import pandas as pd
-from _divergence_io import get_min_papers, subsample_equal_n
+from _divergence_io import (
+    get_min_papers,
+    per_window_year_ranges,
+    subsample_equal_n,
+)
 from pipeline_loaders import load_analysis_corpus
 from sklearn.decomposition import PCA
 from utils import get_logger
@@ -60,9 +64,13 @@ def load_semantic_data(input_paths):
 
 
 def _get_years_and_params(df, emb, cfg):
-    """Derive year range and smoke-safe parameters from config.
+    """Derive per-window year ranges and smoke-safe parameters from config.
 
-    Returns (years, min_papers, max_subsample, windows, equal_n).
+    Returns (years_by_window, min_papers, max_subsample, windows, equal_n).
+
+    years_by_window maps each window width w to the list of valid anchor
+    years range(year_min + w, year_max - w) — narrower windows reach
+    later years (ticket 0067, mirrors `_iter_sliding_pairs`).
     """
     div_cfg = cfg["divergence"]
     windows = div_cfg["windows"]
@@ -70,15 +78,8 @@ def _get_years_and_params(df, emb, cfg):
     equal_n = div_cfg.get("equal_n", False)
 
     min_papers = get_min_papers(len(df), cfg)
-
-    start_year = int(df["year"].min()) + max(windows)
-    end_year = int(df["year"].max()) - max(windows) - 1
-    if start_year > end_year:
-        start_year = int(df["year"].min()) + min(windows)
-        end_year = int(df["year"].max()) - min(windows) - 1
-
-    years = list(range(start_year, end_year + 1))
-    return years, min_papers, max_subsample, windows, equal_n
+    years_by_window = per_window_year_ranges(df, windows)
+    return years_by_window, min_papers, max_subsample, windows, equal_n
 
 
 def _get_window_embeddings(
@@ -110,7 +111,7 @@ def _get_window_embeddings(
 
 
 def _iter_window_pairs(
-    df, emb, years, windows, min_papers, max_subsample, rng=None, equal_n=False
+    df, emb, years_by_window, min_papers, max_subsample, rng=None, equal_n=False
 ):
     """Yield (year, window, X, Y) for each valid before/after window pair.
 
@@ -118,7 +119,7 @@ def _iter_window_pairs(
     When equal_n is True, the larger window is subsampled to match
     the smaller, removing growth-rate bias (ticket 0045).
     """
-    for w in windows:
+    for w, years in years_by_window.items():
         for y in years:
             X = _get_window_embeddings(
                 df, emb, y, w, "before", min_papers, max_subsample, rng=rng
@@ -216,10 +217,10 @@ def compute_s1_mmd(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
-        df, emb, cfg
+    years_by_window, min_papers, max_subsample, _windows, equal_n = (
+        _get_years_and_params(df, emb, cfg)
     )
-    if not years:
+    if not any(years_by_window.values()):
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     sem_cfg = cfg["divergence"]["semantic"]
@@ -230,8 +231,7 @@ def compute_s1_mmd(df, emb, cfg):
     for y, w, X, Y in _iter_window_pairs(
         df,
         emb,
-        years,
-        windows,
+        years_by_window,
         min_papers,
         max_subsample,
         rng=rng,
@@ -296,10 +296,10 @@ def compute_s2_energy(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
-        df, emb, cfg
+    years_by_window, min_papers, max_subsample, _windows, equal_n = (
+        _get_years_and_params(df, emb, cfg)
     )
-    if not years:
+    if not any(years_by_window.values()):
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     results = []
@@ -307,8 +307,7 @@ def compute_s2_energy(df, emb, cfg):
     for y, w, X, Y in _iter_window_pairs(
         df,
         emb,
-        years,
-        windows,
+        years_by_window,
         min_papers,
         max_subsample,
         rng=rng,
@@ -353,10 +352,10 @@ def compute_s3_wasserstein(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
-        df, emb, cfg
+    years_by_window, min_papers, max_subsample, _windows, equal_n = (
+        _get_years_and_params(df, emb, cfg)
     )
-    if not years:
+    if not any(years_by_window.values()):
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     sem_cfg = cfg["divergence"]["semantic"]
@@ -367,8 +366,7 @@ def compute_s3_wasserstein(df, emb, cfg):
     for y, w, X, Y in _iter_window_pairs(
         df,
         emb,
-        years,
-        windows,
+        years_by_window,
         min_papers,
         max_subsample,
         rng=rng,
@@ -489,10 +487,10 @@ def compute_s4_frechet(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years, min_papers, max_subsample, windows, equal_n = _get_years_and_params(
-        df, emb, cfg
+    years_by_window, min_papers, max_subsample, _windows, equal_n = (
+        _get_years_and_params(df, emb, cfg)
     )
-    if not years:
+    if not any(years_by_window.values()):
         return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
 
     # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
@@ -506,8 +504,7 @@ def compute_s4_frechet(df, emb, cfg):
     for y, w, X, Y in _iter_window_pairs(
         df,
         emb,
-        years,
-        windows,
+        years_by_window,
         min_papers,
         max_subsample,
         rng=rng,

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -66,11 +66,11 @@ def load_semantic_data(input_paths):
 def _get_years_and_params(df, emb, cfg):
     """Derive per-window year ranges and smoke-safe parameters from config.
 
-    Returns (years_by_window, min_papers, max_subsample, windows, equal_n).
+    Returns (years_by_window, min_papers, max_subsample, equal_n).
 
     years_by_window maps each window width w to the list of valid anchor
     years range(year_min + w, year_max - w) — narrower windows reach
-    later years (ticket 0067, mirrors `_iter_sliding_pairs`).
+    later years.
     """
     div_cfg = cfg["divergence"]
     windows = div_cfg["windows"]
@@ -79,7 +79,7 @@ def _get_years_and_params(df, emb, cfg):
 
     min_papers = get_min_papers(len(df), cfg)
     years_by_window = per_window_year_ranges(df, windows)
-    return years_by_window, min_papers, max_subsample, windows, equal_n
+    return years_by_window, min_papers, max_subsample, equal_n
 
 
 def _get_window_embeddings(
@@ -217,11 +217,11 @@ def compute_s1_mmd(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years_by_window, min_papers, max_subsample, _windows, equal_n = (
-        _get_years_and_params(df, emb, cfg)
+    years_by_window, min_papers, max_subsample, equal_n = _get_years_and_params(
+        df, emb, cfg
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
+        return empty_divergence_df()
 
     sem_cfg = cfg["divergence"]["semantic"]
     bandwidth_multipliers = sem_cfg["S1_MMD"]["bandwidth_multipliers"]
@@ -296,11 +296,11 @@ def compute_s2_energy(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years_by_window, min_papers, max_subsample, _windows, equal_n = (
-        _get_years_and_params(df, emb, cfg)
+    years_by_window, min_papers, max_subsample, equal_n = _get_years_and_params(
+        df, emb, cfg
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
+        return empty_divergence_df()
 
     results = []
     last_w = None
@@ -352,11 +352,11 @@ def compute_s3_wasserstein(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years_by_window, min_papers, max_subsample, _windows, equal_n = (
-        _get_years_and_params(df, emb, cfg)
+    years_by_window, min_papers, max_subsample, equal_n = _get_years_and_params(
+        df, emb, cfg
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
+        return empty_divergence_df()
 
     sem_cfg = cfg["divergence"]["semantic"]
     n_projections_list = sem_cfg["S3_sliced_wasserstein"]["n_projections"]
@@ -487,11 +487,11 @@ def compute_s4_frechet(df, emb, cfg):
     seed = cfg["divergence"]["random_seed"]
     rng = np.random.RandomState(seed)
 
-    years_by_window, min_papers, max_subsample, _windows, equal_n = (
-        _get_years_and_params(df, emb, cfg)
+    years_by_window, min_papers, max_subsample, equal_n = _get_years_and_params(
+        df, emb, cfg
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(columns=["year", "window", "hyperparams", "value"])
+        return empty_divergence_df()
 
     # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
     # (2) sqrtm is O(d³), and (3) sensitivity analysis shows breaks

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -566,16 +566,15 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=True)
-        years, min_papers, max_subsample, windows, _equal_n = _get_years_and_params(
-            df, emb, cfg
+        years_by_window, min_papers, max_subsample, _windows, _equal_n = (
+            _get_years_and_params(df, emb, cfg)
         )
         rng = np.random.RandomState(42)
 
         for y, w, X, Y in _iter_window_pairs(
             df,
             emb,
-            years,
-            windows,
+            years_by_window,
             min_papers,
             max_subsample,
             rng=rng,
@@ -591,8 +590,8 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=False)
-        years, min_papers, max_subsample, windows, _equal_n = _get_years_and_params(
-            df, emb, cfg
+        years_by_window, min_papers, max_subsample, _windows, _equal_n = (
+            _get_years_and_params(df, emb, cfg)
         )
         rng = np.random.RandomState(42)
 
@@ -600,8 +599,7 @@ class TestEqualN:
         for y, w, X, Y in _iter_window_pairs(
             df,
             emb,
-            years,
-            windows,
+            years_by_window,
             min_papers,
             max_subsample,
             rng=rng,

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -566,8 +566,8 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=True)
-        years_by_window, min_papers, max_subsample, _windows, _equal_n = (
-            _get_years_and_params(df, emb, cfg)
+        years_by_window, min_papers, max_subsample, _equal_n = _get_years_and_params(
+            df, emb, cfg
         )
         rng = np.random.RandomState(42)
 
@@ -590,8 +590,8 @@ class TestEqualN:
 
         df, emb = _make_growth_data()
         cfg = _equal_n_cfg(equal_n=False)
-        years_by_window, min_papers, max_subsample, _windows, _equal_n = (
-            _get_years_and_params(df, emb, cfg)
+        years_by_window, min_papers, max_subsample, _equal_n = _get_years_and_params(
+            df, emb, cfg
         )
         rng = np.random.RandomState(42)
 
@@ -725,7 +725,7 @@ class TestPerWindowYearBounds:
 
         df, emb = _make_growth_data(n_years=20, start_year=2000)  # years 2000..2019
         cfg = self._bounds_cfg(windows=[2, 5])
-        years_by_window, _, _, _, _ = _get_years_and_params(df, emb, cfg)
+        years_by_window, _, _, _ = _get_years_and_params(df, emb, cfg)
 
         # For year_max=2019: w=2 last year is 2016; w=5 last year is 2013.
         assert max(years_by_window[2]) == 2016

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -687,6 +687,72 @@ class TestEqualN:
 
 
 # ---------------------------------------------------------------------------
+# Per-window year bounds (ticket 0067)
+# ---------------------------------------------------------------------------
+
+
+class TestPerWindowYearBounds:
+    """All three channels must use the same per-window year-range rule.
+
+    For window width w on a corpus spanning [year_min, year_max], valid
+    anchor years are range(year_min + w, year_max - w) — mirrors
+    _iter_sliding_pairs in _divergence_citation.py. Narrower windows
+    reach later years; wider windows must stop earlier so the after-window
+    fits inside the data.
+    """
+
+    def _bounds_cfg(self, windows):
+        cfg = _smoke_cfg(seed=42)
+        cfg["divergence"]["windows"] = windows
+        cfg["divergence"]["max_subsample"] = 5000
+        cfg["divergence"]["equal_n"] = False
+        return cfg
+
+    def test_per_window_year_ranges_helper(self):
+        """Helper returns range(year_min+w, year_max-w) per window."""
+        from _divergence_io import per_window_year_ranges
+
+        df = pd.DataFrame({"year": list(range(1990, 2025))})
+        ranges = per_window_year_ranges(df, [2, 3, 4, 5])
+        assert max(ranges[2]) == 2021
+        assert max(ranges[3]) == 2020
+        assert max(ranges[4]) == 2019
+        assert max(ranges[5]) == 2018
+        assert min(ranges[2]) == 1992
+        assert min(ranges[5]) == 1995
+
+    def test_semantic_upper_bound_is_per_window(self):
+        """Semantic iterator must reach later years for narrower windows."""
+        from _divergence_semantic import _get_years_and_params
+
+        df, emb = _make_growth_data(n_years=20, start_year=2000)  # years 2000..2019
+        cfg = self._bounds_cfg(windows=[2, 5])
+        years_by_window, _, _, _, _ = _get_years_and_params(df, emb, cfg)
+
+        # For year_max=2019: w=2 last year is 2016; w=5 last year is 2013.
+        assert max(years_by_window[2]) == 2016
+        assert max(years_by_window[5]) == 2013
+        assert max(years_by_window[2]) - max(years_by_window[5]) == 3
+
+    def test_lexical_upper_bound_is_per_window(self):
+        """Lexical iterator must not produce asymmetric upper-bound windows."""
+        from _divergence_lexical import _iter_lexical_window_pairs
+
+        df = _make_growth_text_data(n_years=20, start_year=2000)  # years 2000..2019
+        cfg = self._bounds_cfg(windows=[2, 5])
+
+        years_by_w = {}
+        for y, w, _xb, _xa, _vec in _iter_lexical_window_pairs(df, cfg):
+            years_by_w.setdefault(w, []).append(y)
+
+        # year_max=2019: at w=5 anchor year 2017 would give a 2-year after-
+        # window (2018, 2019) — must be rejected. Last valid anchor is 2013.
+        assert 2017 not in years_by_w.get(5, [])
+        assert max(years_by_w[5]) == 2013
+        assert max(years_by_w[2]) == 2016
+
+
+# ---------------------------------------------------------------------------
 # G1 PageRank on disjoint sliding windows (ticket 0059)
 # ---------------------------------------------------------------------------
 

--- a/tickets/0067-per-window-year-bounds.erg
+++ b/tickets/0067-per-window-year-bounds.erg
@@ -1,12 +1,14 @@
 %erg v1
 Title: Align divergence year bounds to per-window convention (semantic + lexical)
-Status: open
+Status: doing
 Created: 2026-04-17
 Author: claude
 Blocked-by: none
 
 --- log ---
 2026-04-17T01:30Z claude created from t0042 post-run audit
+2026-04-17T07:12Z claude claimed
+2026-04-17T07:12Z claude status doing
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Closes #67 (ticket 0067).

All three divergence channels now share the same per-window year-range
rule that `_iter_sliding_pairs` in `_divergence_citation.py` already uses:
for window width `w`, valid anchor years are `range(year_min + w, year_max - w)`.
Narrower windows reach later years; wider windows stop earlier so the
after-window fits inside the corpus.

Before this change:
- **Semantic** capped the upper bound at `year_max - max(w) - 1` for all widths — over-conservative, silently drops 3 years of post-Paris evidence at `w=2`.
- **Lexical** used every year in the corpus — under-conservative, produces asymmetric windows at wide `w` (e.g. `y=2023, w=5` with `year_max=2024` has a 1-year after-window).
- **Graph** was already correct.

## Changes

- Add `per_window_year_ranges(df, windows)` helper to [scripts/_divergence_io.py](scripts/_divergence_io.py) — returns `dict[int, list[int]]` mapping each `w` to its valid year list.
- Rewrite `_get_years_and_params` in [scripts/_divergence_semantic.py](scripts/_divergence_semantic.py) to return `years_by_window` instead of a flat `years`.
- Update `_iter_window_pairs` and all S1–S4 / C2ST_embedding callers.
- Update `_iter_lexical_window_pairs` in [scripts/_divergence_lexical.py](scripts/_divergence_lexical.py) to drop asymmetric upper-bound windows.
- New tests in `TestPerWindowYearBounds` ([tests/test_divergence.py](tests/test_divergence.py)) enforce the rule for helper, semantic, and lexical.

## Effect

On a corpus 1990-2024:
- Semantic at `w=2` now reaches 2021 (was 2018).
- Semantic at `w=3` now reaches 2020 (was 2018).
- Lexical at `w=5` now stops at 2018 (was 2023).
- Multi-signal overlap at `w=3` becomes a clean 1999-2020 range.

## Test plan

- [x] New TDD tests (Red → Green) in `TestPerWindowYearBounds` pass.
- [x] Full `tests/test_divergence.py` passes (52 tests).
- [x] `make check-fast` passes (838 tests).
- [ ] Downstream regenerate: S2, L1, C2ST_embedding, C2ST_lexical `tab_div_*.csv`, then null + bootstrap + summary (follow-up, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)