### PR TITLE
housekeeping: close stale tickets 0065/0067/0070 + fix %erg format errors

### DIFF
--- a/tickets/0065-g4-nan-tail.erg
+++ b/tickets/0065-g4-nan-tail.erg
@@ -1,12 +1,14 @@
 %erg v1
 Title: G4_cross_tradition NaN tail (2010–2024) — investigate and fix or document
-Status: open
-Priority: backlog
+Status: closed
 Created: 2026-04-16
 Author: user
 
 --- log ---
 2026-04-16T20:00Z claude created from t0042 pipeline sanity check
+2026-04-17T07:30Z claude note PR #686 merged (bisection on full cumulative graph; tail now populated; cold-start 1990-1997 NaN only, per design)
+2026-04-17T10:30Z claude status closed
+2026-04-17T10:30Z claude note drop invalid `Priority` header (not in %erg v1 schema)
 
 --- body ---
 ## Context

--- a/tickets/0067-per-window-year-bounds.erg
+++ b/tickets/0067-per-window-year-bounds.erg
@@ -1,14 +1,15 @@
 %erg v1
 Title: Align divergence year bounds to per-window convention (semantic + lexical)
-Status: doing
+Status: closed
 Created: 2026-04-17
 Author: claude
-Blocked-by: none
 
 --- log ---
 2026-04-17T01:30Z claude created from t0042 post-run audit
 2026-04-17T07:12Z claude claimed
 2026-04-17T07:12Z claude status doing
+2026-04-17T08:07Z claude note PR #689 merged (per-window bounds implemented + simplify pass applied)
+2026-04-17T10:30Z claude status closed
 
 --- body ---
 ## Context

--- a/tickets/0068-c2st-cv-variance.erg
+++ b/tickets/0068-c2st-cv-variance.erg
@@ -3,7 +3,6 @@ Title: C2ST — emit CV fold variance, not permutation null
 Status: closed
 Created: 2026-04-17
 Author: claude
-Blocked-by: none
 
 --- log ---
 2026-04-17T01:30Z claude created from Wave C inference design review

--- a/tickets/0069-extend-graph-inference.erg
+++ b/tickets/0069-extend-graph-inference.erg
@@ -3,7 +3,6 @@ Title: Extend graph-channel inference — G2 null + graph bootstrap
 Status: doing
 Created: 2026-04-17
 Author: claude
-Blocked-by: none
 
 --- log ---
 2026-04-17T01:30Z claude created from t0042 scope gap

--- a/tickets/0070-bias-audit-companion-paper.erg
+++ b/tickets/0070-bias-audit-companion-paper.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Statistical bias audit — defend companion paper against reviewer-raised biases
-Status: doing
+Status: closed
 Created: 2026-04-17
 Author: user
 
@@ -10,6 +10,8 @@ Author: user
 2026-04-17T07:26Z claude status doing starting audit
 2026-04-17T07:45Z claude note docs/bias-audit-companion-paper.md drafted, all 12 biases classified
 2026-04-17T07:45Z claude note child tickets 0071-0078 opened for each gap
+2026-04-17T08:17Z claude note PR #690 merged (audit doc + 8 child tickets)
+2026-04-17T10:30Z claude status closed
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- Three tickets stale on main after their PRs merged: 0065 (#686), 0067 (#689), 0070 (#690). Close them.
- Fix %erg validation errors: drop invalid \`Priority: backlog\` header from 0065, drop \`Blocked-by: none\` lines from 0067/0068/0069.
- \`go run ./tickets/tools/go validate tickets\` goes from **3 errors** → **PASS (76 tickets)**.

0068 stays Status: closed (PR #692 merged in parallel chat). 0069 stays Status: doing (verified in parallel chat).

## Test plan
- [x] Validator: `go run ./tickets/tools/go validate tickets` → PASS
- [ ] `make check-fast` — not touched by ticket-only changes but should stay green

## Follow-up (local-only, not in this PR)
- Release `.git/ticket-wip/0067.wip` and `0070.wip` (never committed)
- Remove stale worktrees `merge-pr-682`, `polish-t684-fixture`, `review-pr-682`

🤖 Generated with [Claude Code](https://claude.com/claude-code)