### PR TITLE
docs: rename Paper B/C → Paper 4/5 (unify with numbered series)

### DIFF
--- a/tickets/0013-global-corpus-expansion.erg
+++ b/tickets/0013-global-corpus-expansion.erg
@@ -1,5 +1,5 @@
 %erg v1
-Title: Expand corpus to CNKI and SciELO for global coverage (paper C)
+Title: Expand corpus to CNKI and SciELO for global coverage (Paper 5 — Corpus v2.0)
 Status: open
 Created: 2026-04-13
 Author: user

--- a/tickets/0014-whose-evidence-finding-paper.erg
+++ b/tickets/0014-whose-evidence-finding-paper.erg
@@ -1,5 +1,5 @@
 %erg v1
-Title: Submit "Whose evidence shapes climate policy?" finding paper (paper B)
+Title: Submit "Whose evidence shapes climate policy?" finding paper (Paper 4 — Multilingual)
 Status: open
 Created: 2026-04-13
 Author: user


### PR DESCRIPTION
Title-line rename on two ticket files to adopt the numbered scheme used in STATE.md and memory. No body edits.

- 0013: Paper C → Paper 5 — Corpus v2.0
- 0014: Paper B → Paper 4 — Multilingual

`erg validate` → PASS (76 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)