### PR TITLE
docs: STATE/ROADMAP refresh — correct chain, deduplicate conferences, align paper numbering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Submitted to Oeconomia (Varia) on 2026-03-18. Waiting for referee reports (~3 mo
 
 - [ ] Wait for reviewers feedback
 - [ ] Revise and Resubmit
-- [ ] Prepare ESHET-HES conference slides (Nice, May 26–29, 2026)
+- [ ] Prepare Econom'IA conference slides (Cergy, May 27–28, 2026; present aedist results)
 - [ ] Continue Tier 1 reading plan (defence against reviewer questions)
 
 ## Data paper manuscript next steps
@@ -31,8 +31,9 @@ Submitted data paper to RDJ4HSS (diamond OA).
 
 ## Next articles
 
-- [ ] **Multilingual epistemic blind spots** — Lexical bibliometrics cannot compare across languages; multilingual embeddings are a minimum requirement for mapping fields that span the North-South divide. Contribution: two-axis (language × geography) isolation scores + citation directionality on ~31K works. Research note: `docs/research-note-multilingual.md`. Journals: Scientometrics, QSS.
-- [ ] **Companion methods paper** — How can embedding-based clustering reveal intellectual structure in a heterogeneous, policy-entangled scholarly field? Contribution: a replicable pipeline for mapping fields where bibliometric boundaries are contested. Journals: Quantitative Science Studies, Scientometrics.
+- [ ] **Paper 4 — Multilingual: "Whose evidence shapes climate policy?"** (ticket 0014) — Empirical finding paper. The $300B NCQG was constructed from English-indexed scholarship alone; Chinese (South-South, Belt-and-Road) and Brazilian (deforestation finance) traditions were invisible. Two-axis design (language × geography) disentangles linguistic from epistemic barriers. Blocked on Paper 5 (corpus v2.0). Journals: Global Environmental Change, World Development, Nature Climate Change Analysis. Supersedes the older "epistemic blind spots" framing (multilingual-paper epic on hold per ticket 0001).
+- [ ] **Paper 5 — Corpus v2.0** (ticket 0013) — Add CNKI (Chinese) and SciELO (Portuguese/Spanish) to raise non-English share from 7% to 20-30%. Enables Paper 4. Journal TBD; methods-heavy, Scientometrics or QSS if submitted standalone.
+- [ ] **Paper 3 — Companion methods paper** (epic 0026) — Multi-layer detection and validation of structural change in text corpora. Lean 6-method panel across 3 layers (embedding / lexical / graph) with permutation Z-scores and transition zones. Wave C in flight, blocked on 0042 pipeline rerun. Journal: Quantitative Science Studies (QSS, chosen).
 - [ ] **OECD vs. Oxfam** — How do competing accounting frameworks produce divergent truths from the same financial flows? Contribution: a sociology-of-quantification case study showing how measurement conventions perform political positions on North-South climate debt. Requires document-to-evidence extraction capabilities (cf. [AEDIST](https://github.com/MinhHaDuong/aedist) stage 2). Journals: Accounting, Organizations and Society; Social Studies of Science.
 - [ ] **MDB greening pivot** — How did multilateral development banks reframe existing portfolios as "climate finance" without changing what they fund? Contribution: an economization analysis of institutional relabeling as performative category work. Requires document-to-evidence extraction capabilities (cf. AEDIST stage 2). Journals: Review of International Political Economy, New Political Economy.
 - [ ] **Carbon markets as failed performativity** — Why did the CDM fail to produce the efficient abatement market it modeled, and is Article 6 repeating the same design flaws? Contribution: a MacKenzie-style analysis of how market devices for North-South carbon transfers failed to perform the world they assumed. Journals: Economy and Society, Journal of Cultural Economy.

--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # State
 
-Last updated: 2026-04-15
+Last updated: 2026-04-17
 
-## Status: TWO PAPERS SUBMITTED + DIVERGENCE PIPELINE MERGED
+## Status: TWO PAPERS SUBMITTED + DIVERGENCE PIPELINE MERGED, FIRST REAL-CORPUS RUN DONE
 
 ### Oeconomia (Varia) — submitted 2026-03-18
 Under double-blind review. ~8,860 words, 61 bib entries, 2 figures, 2 tables.
@@ -36,7 +36,7 @@ Under review (peer reviewers + data specialists). 2,495 words, 1 figure, 3 table
 
 ## Blockers
 
-None.
+Wave C (0057/0058/0064) is waiting on ticket 0042 rerun. All three ticket-level blockers of 0042 (0067 year bounds, 0068 C2ST CV variance, 0069 G2 null + graph boot) are closed on main. Next compute step is: rerun `make divergence null-model bootstrap-tables divergence-summary changepoints sensitivity` on padme with the updated code + corpus 1.1.2.
 
 ### Divergence pipeline — merged 2026-04-15 (PR #650)
 - 15 divergence methods (S1-S4 semantic, L1-L3 lexical, G1-G8 citation graph)
@@ -49,9 +49,8 @@ None.
 
 - **0025**: connective prose for corpus report
 - **0028**: modular analysis report (one include per script) — home for the 15-method divergence zoo
-- **0026 Wave C**: companion paper rewrite — 0057 (methods prose), 0058 (4 figures), 0064 (fill §5 Results)
+- **0042**: rerun divergence pipeline on padme with updated code (post-0067/0068/0069 fixes) — unblocks Wave C
+- **0026 Wave C**: companion paper rewrite — 0057 (methods prose), 0058 (4 figures), 0064 (fill §5 Results) — blocked on 0042
+- **0070 bias audit** + child tickets 0071-0078: pre-submission defence-in-depth for the companion paper's §4.8 and §6.4
 - Re-land arch rule 9 (corpus access through loaders only) on own branch — tickets 0043/0044 already on main
-- Run divergence pipeline on real corpus (padme, ticket 0042)
-- Econom'IA conference slides (Cergy, May 27–28; present aedist results)
-- Charles Gide conference paper (Vannes, July 2–4; paper due June 15)
 - Waiting for corpus 1.1.2 to finish building


### PR DESCRIPTION
Summary at top of commit message. Two docs only, no code changes.

STATE.md: date bumped; Wave C blocker chain stated explicitly; 0042 now the critical-path item; 0070 bias audit surfaced; conferences removed (duplicate of ROADMAP).

ROADMAP.md: Nice→Cergy; multilingual article reframed per ticket 0014; Paper 4/Paper 5 numbering; Companion renamed Paper 3 for consistency.

No roadmap material in STATE; no current-state material in ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)