### PR TITLE
feat: parallelize G2/G9 citation null models

### DIFF
--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -380,22 +380,63 @@ def _community_null_distribution(
     return null_stats[~np.isnan(null_stats)]
 
 
-def _run_g9_community_permutations(works, internal_edges, div_df, cfg):
-    """Permutation test for G9 community divergence.
-
-    For each (year, window):
-      1. Build before/after sliding-window graphs
-      2. Build union graph, run Louvain once (fixed partition)
-      3. Permute which nodes are 'before' vs 'after' (keeping sizes fixed)
-      4. Recompute community-share JS divergence under each permutation
-      5. Compare observed JS against the null distribution
-
-    This is computationally efficient: Louvain runs once per (year, window),
-    and only the node-label shuffle is repeated B times.
-    """
+def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution):
+    """Process one (year, window) for G9 community permutation test."""
     import community as community_louvain
     from _divergence_citation import _sliding_window_graph
     from _divergence_community import _build_union_graph, _community_js_for_pair
+
+    _, perm_rng = _make_window_rngs(seed, y, w)
+
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
+
+    before_nodes = list(G_before.nodes())
+    after_nodes = list(G_after.nodes())
+
+    if len(before_nodes) < 3 or len(after_nodes) < 3:
+        return _nan_row(y, w)
+
+    observed = _community_js_for_pair(
+        G_before, G_after, internal_edges, resolution, seed
+    )
+    if np.isnan(observed):
+        return _nan_row(y, w)
+
+    G_union = _build_union_graph(G_before, G_after, internal_edges)
+    if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
+        return _nan_row(y, w)
+
+    partition = community_louvain.best_partition(
+        G_union, resolution=resolution, random_state=seed
+    )
+
+    comm_info = _community_node_comm_map(partition)
+    if comm_info is None:
+        return _result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0)
+
+    n_communities, comm_to_idx = comm_info
+
+    all_nodes = before_nodes + after_nodes
+    n_before_count = len(before_nodes)
+
+    node_comm = {
+        node: comm_to_idx[partition[node]] for node in all_nodes if node in partition
+    }
+
+    null_stats = _community_null_distribution(
+        all_nodes, n_before_count, node_comm, n_communities, n_perm, perm_rng
+    )
+
+    if len(null_stats) == 0:
+        return _nan_row(y, w)
+
+    return _finalize_row(y, w, observed, null_stats)
+
+
+def _run_g9_community_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
+    """Permutation test for G9 community divergence (parallel across windows)."""
+    from joblib import Parallel, delayed
 
     div_cfg = cfg["divergence"]
     n_perm = div_cfg["permutation"]["n_perm"]
@@ -405,66 +446,23 @@ def _run_g9_community_permutations(works, internal_edges, div_df, cfg):
     )
 
     year_windows = div_df[["year", "window"]].drop_duplicates()
+    pairs = [
+        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
+    ]
 
-    rows = []
-    for _, row in year_windows.iterrows():
-        y = int(row["year"])
-        w = int(row["window"])
-
-        _, perm_rng = _make_window_rngs(seed, y, w)
-
-        G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
-        G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
-
-        before_nodes = list(G_before.nodes())
-        after_nodes = list(G_after.nodes())
-
-        if len(before_nodes) < 3 or len(after_nodes) < 3:
-            rows.append(_nan_row(y, w))
-            continue
-
-        observed = _community_js_for_pair(
-            G_before, G_after, internal_edges, resolution, seed
+    log.info("G9 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
+    rows = Parallel(n_jobs=n_jobs)(
+        delayed(_g9_one_window)(y, w, works, internal_edges, n_perm, seed, resolution)
+        for y, w in pairs
+    )
+    for row in rows:
+        log.info(
+            "  year=%d window=%s z=%.2f p=%.3f",
+            row["year"],
+            row["window"],
+            row["z_score"],
+            row["p_value"],
         )
-        if np.isnan(observed):
-            rows.append(_nan_row(y, w))
-            continue
-
-        G_union = _build_union_graph(G_before, G_after, internal_edges)
-        if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
-            rows.append(_nan_row(y, w))
-            continue
-
-        partition = community_louvain.best_partition(
-            G_union, resolution=resolution, random_state=seed
-        )
-
-        comm_info = _community_node_comm_map(partition)
-        if comm_info is None:
-            rows.append(_result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0))
-            continue
-
-        n_communities, comm_to_idx = comm_info
-
-        all_nodes = before_nodes + after_nodes
-        n_before = len(before_nodes)
-
-        node_comm = {
-            node: comm_to_idx[partition[node]]
-            for node in all_nodes
-            if node in partition
-        }
-
-        null_stats = _community_null_distribution(
-            all_nodes, n_before, node_comm, n_communities, n_perm, perm_rng
-        )
-
-        if len(null_stats) == 0:
-            rows.append(_nan_row(y, w))
-            continue
-
-        rows.append(_finalize_row(y, w, observed, null_stats))
-
     return pd.DataFrame(rows)
 
 
@@ -499,65 +497,69 @@ def _spectral_null_distribution(G_union, all_nodes, n_before, n_perm, perm_rng):
     return null_stats[~np.isnan(null_stats)]
 
 
-def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg):
-    """Permutation test for G2 spectral-gap divergence.
-
-    For each (year, window):
-      1. Build before/after sliding-window graphs
-      2. Compute observed |Δ spectral gap|
-      3. Pool nodes into a union graph, then permute which nodes are 'before'
-         vs 'after' (keeping sizes fixed) and recompute |Δ spectral gap|
-         on the induced subgraphs
-      4. Compare observed against the null distribution
-    """
+def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed):
+    """Process one (year, window) for G2 spectral permutation test."""
     from _citation_methods import _spectral_gap
     from _divergence_citation import _sliding_window_graph
     from _divergence_community import _build_union_graph
+
+    _, perm_rng = _make_window_rngs(seed, y, w)
+
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
+
+    before_nodes = list(G_before.nodes())
+    after_nodes = list(G_after.nodes())
+
+    if len(before_nodes) < 3 or len(after_nodes) < 3:
+        return _nan_row(y, w)
+
+    gap_b_obs = _spectral_gap(G_before)
+    gap_a_obs = _spectral_gap(G_after)
+    if np.isnan(gap_b_obs) or np.isnan(gap_a_obs):
+        return _nan_row(y, w)
+    observed = abs(gap_a_obs - gap_b_obs)
+
+    G_union = _build_union_graph(G_before, G_after, internal_edges)
+    all_nodes = before_nodes + after_nodes
+    n_before_count = len(before_nodes)
+
+    null_stats = _spectral_null_distribution(
+        G_union, all_nodes, n_before_count, n_perm, perm_rng
+    )
+
+    if len(null_stats) == 0:
+        return _nan_row(y, w)
+
+    return _finalize_row(y, w, observed, null_stats)
+
+
+def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
+    """Permutation test for G2 spectral-gap divergence (parallel across windows)."""
+    from joblib import Parallel, delayed
 
     div_cfg = cfg["divergence"]
     n_perm = div_cfg["permutation"]["n_perm"]
     seed = div_cfg["random_seed"]
 
     year_windows = div_df[["year", "window"]].drop_duplicates()
+    pairs = [
+        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
+    ]
 
-    rows = []
-    for _, row in year_windows.iterrows():
-        y = int(row["year"])
-        w = int(row["window"])
-
-        _, perm_rng = _make_window_rngs(seed, y, w)
-
-        G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
-        G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
-
-        before_nodes = list(G_before.nodes())
-        after_nodes = list(G_after.nodes())
-
-        if len(before_nodes) < 3 or len(after_nodes) < 3:
-            rows.append(_nan_row(y, w))
-            continue
-
-        gap_b_obs = _spectral_gap(G_before)
-        gap_a_obs = _spectral_gap(G_after)
-        if np.isnan(gap_b_obs) or np.isnan(gap_a_obs):
-            rows.append(_nan_row(y, w))
-            continue
-        observed = abs(gap_a_obs - gap_b_obs)
-
-        G_union = _build_union_graph(G_before, G_after, internal_edges)
-        all_nodes = before_nodes + after_nodes
-        n_before = len(before_nodes)
-
-        null_stats = _spectral_null_distribution(
-            G_union, all_nodes, n_before, n_perm, perm_rng
+    log.info("G2 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
+    rows = Parallel(n_jobs=n_jobs)(
+        delayed(_g2_spectral_one_window)(y, w, works, internal_edges, n_perm, seed)
+        for y, w in pairs
+    )
+    for row in rows:
+        log.info(
+            "  year=%d window=%s z=%.2f p=%.3f",
+            row["year"],
+            row["window"],
+            row["z_score"],
+            row["p_value"],
         )
-
-        if len(null_stats) == 0:
-            rows.append(_nan_row(y, w))
-            continue
-
-        rows.append(_finalize_row(y, w, observed, null_stats))
-
     return pd.DataFrame(rows)
 
 
@@ -568,7 +570,7 @@ _CITATION_PERMUTATION_DRIVERS = {
 }
 
 
-def _run_citation_permutations(method_name, div_df, cfg):
+def _run_citation_permutations(method_name, div_df, cfg, n_jobs=1):
     """Permutation test for citation-channel methods (G2, G9)."""
     from _divergence_citation import load_citation_data
 
@@ -580,7 +582,7 @@ def _run_citation_permutations(method_name, div_df, cfg):
         )
 
     works, _, internal_edges = load_citation_data(None)
-    return driver(works, internal_edges, div_df, cfg)
+    return driver(works, internal_edges, div_df, cfg, n_jobs=n_jobs)
 
 
 # ---------------------------------------------------------------------------
@@ -637,7 +639,9 @@ def main():
     elif channel == "lexical":
         result = _run_lexical_permutations(method_name, div_df, cfg)
     elif channel == "citation":
-        result = _run_citation_permutations(method_name, div_df, cfg)
+        result = _run_citation_permutations(
+            method_name, div_df, cfg, n_jobs=args.n_jobs
+        )
     else:
         raise ValueError(f"Unsupported channel: {channel}")
 


### PR DESCRIPTION
## Summary

- Extract per-window logic from `_run_g2_spectral_permutations` and `_run_g9_community_permutations` into standalone functions (`_g2_spectral_one_window`, `_g9_one_window`)
- Dispatch via `joblib.Parallel` across (year, window) pairs
- Default `n_jobs=1` for API callers (preserves test determinism); CLI `--n-jobs=-1` enables all cores
- Wire `n_jobs` through `_run_citation_permutations` dispatcher → drivers → main

Follow-up to #702. G2 spectral was the remaining bottleneck (~22 min sequential). With 24 cores on padme: expected ~1 min.

## Test plan

- [x] 16 citation/smoke/contamination tests pass locally (doudou)
- [ ] Run on padme with `--n-jobs=-1` and compare timing vs sequential

🤖 Generated with [Claude Code](https://claude.com/claude-code)