### PR TITLE
ticket 0058: restore companion figure scripts (cherry-pick from orphaned #709)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ export SOURCE_DATE_EPOCH := 0
 
 # ── Modular Makefile includes ────────────────────────────
 -include divergence.mk
+-include companion.mk
 
 # ── Quarto ───────────────────────────────────────────────
 # ── Per-document include sets ────────────────────────────
@@ -98,7 +99,11 @@ COMPANION_FIGS  := content/figures/fig_breakpoints.png content/figures/fig_alluv
                    content/figures/fig_breaks.png \
                    content/figures/fig_bimodality.png \
                    content/figures/fig_seed_axis_core.png content/figures/fig_pca_scatter.png \
-                   content/figures/fig_genealogy.png
+                   content/figures/fig_genealogy.png \
+                   content/figures/fig_companion_zseries.png \
+                   content/figures/fig_companion_heatmap.png \
+                   content/figures/fig_companion_terms.png \
+                   content/figures/fig_companion_community.png
 
 TECHREP_FIGS    := content/figures/fig_alluvial_core.png \
                    content/figures/fig_bimodality_core.png \

--- a/companion.mk
+++ b/companion.mk
@@ -1,0 +1,67 @@
+# companion.mk — Figures for the companion paper (ticket 0058)
+#
+# Four canonical PNGs consumed by content/companion-paper.qmd.
+#
+# Include from the main Makefile:  include companion.mk
+#
+# Targets:
+#   companion-figures  — build all four PNGs
+#
+# Inputs (ticket 0042 rerun outputs; produced by divergence-summary):
+#   content/tables/tab_summary_{S2_energy,L1,G9_community,G2_spectral}.csv
+#   content/tables/tab_div_C2ST_{embedding,lexical}.csv
+#
+# Optional inputs (ticket 0056 interpretation layer; stub fallback if absent):
+#   content/tables/tab_discrim_terms*.csv
+#   content/tables/tab_community_shifts*.csv
+
+COMP_TABLES := content/tables
+COMP_FIGS   := content/figures
+COMP_CFG    := config/analysis.yaml
+COMP_UTILS  := scripts/_companion_plot_utils.py
+COMP_STYLE  := scripts/plot_style.py
+
+# Required summary + C2ST inputs (Figures 1 and 2).
+COMP_DEPS_CORE := \
+    $(COMP_TABLES)/tab_summary_S2_energy.csv \
+    $(COMP_TABLES)/tab_summary_L1.csv \
+    $(COMP_TABLES)/tab_summary_G9_community.csv \
+    $(COMP_TABLES)/tab_summary_G2_spectral.csv \
+    $(COMP_TABLES)/tab_div_C2ST_embedding.csv \
+    $(COMP_TABLES)/tab_div_C2ST_lexical.csv
+
+# ── Figure 1: Z-score time series ────────────────────────────────────────
+
+$(COMP_FIGS)/fig_companion_zseries.png: \
+    scripts/plot_companion_zseries.py $(COMP_UTILS) $(COMP_STYLE) \
+    $(COMP_CFG) $(COMP_DEPS_CORE)
+	uv run python scripts/plot_companion_zseries.py --output $@
+
+# ── Figure 2: Transition zone heatmap ────────────────────────────────────
+
+$(COMP_FIGS)/fig_companion_heatmap.png: \
+    scripts/plot_companion_heatmap.py $(COMP_UTILS) $(COMP_STYLE) \
+    $(COMP_CFG) $(COMP_DEPS_CORE)
+	uv run python scripts/plot_companion_heatmap.py --output $@
+
+# ── Figure 3: Discriminative terms ───────────────────────────────────────
+# No hard dependency on tab_discrim_terms*.csv: the script degrades to a
+# TODO(t0064)-annotated stub when the interpretation layer is absent.
+
+$(COMP_FIGS)/fig_companion_terms.png: \
+    scripts/plot_companion_terms.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
+	uv run python scripts/plot_companion_terms.py --output $@
+
+# ── Figure 4: Community shifts ───────────────────────────────────────────
+# Same stub-fallback rationale as Figure 3.
+
+$(COMP_FIGS)/fig_companion_community.png: \
+    scripts/plot_companion_community.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
+	uv run python scripts/plot_companion_community.py --output $@
+
+.PHONY: companion-figures
+companion-figures: \
+    $(COMP_FIGS)/fig_companion_zseries.png \
+    $(COMP_FIGS)/fig_companion_heatmap.png \
+    $(COMP_FIGS)/fig_companion_terms.png \
+    $(COMP_FIGS)/fig_companion_community.png

--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -81,3 +81,36 @@ divergence:
       max_nodes: 500                             # subsample for tractability
     G9_community:
       resolution: 1.0
+
+# ── Companion paper figures (ticket 0058) ────────────────────────────────
+# Figure geometry, colours, and thresholds for the four canonical figures
+# rendered by scripts/plot_companion_*.py.  Isolated here so plotting
+# choices can evolve without touching the compute layer.
+companion:
+  random_seed: 42
+  lead_window: 3              # preferred half-width for Figure 1 / Figure 2
+  year_min: 1998
+  year_max: 2021
+  z_threshold: 2.0            # significance threshold for Z-score layers
+  auc_chance: 0.5             # chance level for C2ST AUC reference
+  auc_scale: 20.0             # (AUC - 0.5) * auc_scale yields comparable signal
+  validated_zone_min_methods: 2
+  methods:                    # method_id: display label (used in heatmap rows)
+    S2_energy: "S2 Energy"
+    L1: "L1 JS"
+    G9_community: "G9 Community"
+    G2_spectral: "G2 Spectral"
+    C2ST_embedding: "C2ST emb"
+    C2ST_lexical: "C2ST lex"
+  colors:
+    z_cmap: "RdBu_r"          # diverging colormap for Z-score heatmap
+    zone_edge: "#222222"
+    series:
+      S2_energy: "#1f77b4"
+      L1: "#ff7f0e"
+      G9_community: "#2ca02c"
+      G2_spectral: "#9467bd"
+      C2ST_embedding: "#d62728"
+      C2ST_lexical: "#8c564b"
+  top_terms: 10               # Figure 3: bars per zone
+  stub_figure_todo: "t0064"   # ticket id annotated on stub fallbacks

--- a/content/companion-paper.qmd
+++ b/content/companion-paper.qmd
@@ -122,7 +122,7 @@ For each $(t, w)$ we compute four statistics across the two windows.
 
 *Community divergence on the co-citation graph (G9).* We run Louvain community detection on the co-citation graph restricted to each window, align the community labels across windows, and compute the Jensen--Shannon divergence between the two community-share distributions. This captures reorganisation of the field's relational structure, which embedding and lexical tests do not see.
 
-*Classifier two-sample test (G2, robustness).* We train a logistic-regression classifier to separate $\mathcal{D}_t^-$ from $\mathcal{D}_t^+$ using the PCA-32 embeddings, with balanced class weights and 5-fold cross-validation. The AUC is the test statistic. Low separability confirms distributional overlap; high separability confirms the distance-based signals [@lopez_paz_oquab2017]. We report C2ST AUC as a reference layer rather than as a primary detector.
+*Classifier two-sample test (C2ST, robustness).* We train a logistic-regression classifier to separate $\mathcal{D}_t^-$ from $\mathcal{D}_t^+$ using the PCA-32 embeddings, with balanced class weights and 5-fold cross-validation. The AUC is the test statistic. Low separability confirms distributional overlap; high separability confirms the distance-based signals [@lopez_paz_oquab2017]. We report C2ST AUC as a reference layer rather than as a primary detector.
 
 ### 4.5 Statistical inference
 
@@ -130,7 +130,7 @@ The four statistics have different sources of variation, and we handle them with
 
 *Permutation Z-scores for S2, L1, G9.* For each $(t, w)$, we pool the two windows, relabel them at random $B = 500$ times while preserving sample sizes, and recompute the statistic. The standardised effect size $Z(t) = (S_{\text{obs}} - \bar{S}_{\text{perm}}) / \mathrm{sd}(S_{\text{perm}})$ is directly comparable across years despite changing corpus size. A permutation scheme is appropriate here because the observed statistic has no closed-form null under general distributional alternatives.
 
-*Cross-validation fold variance for G2.* The C2ST AUC already has a built-in variance estimator: the standard deviation of AUC across the five CV folds. Permuting labels for C2ST is expensive (each permutation retrains the classifier $k$ times) and yields less information than the fold variance, which directly reflects sampling variability in the classifier's decision boundary. We therefore report AUC with its CV standard deviation rather than a permutation Z.
+*Cross-validation fold variance for C2ST.* The C2ST AUC already has a built-in variance estimator: the standard deviation of AUC across the five CV folds. Permuting labels for C2ST is expensive (each permutation retrains the classifier $k$ times) and yields less information than the fold variance, which directly reflects sampling variability in the classifier's decision boundary. We therefore report AUC with its CV standard deviation rather than a permutation Z.
 
 Mixing two inference primitives is a deliberate choice. Each fits its statistic. Forcing all four into one framework would waste computation on the classifier and blur the fact that S2, L1, and G9 share a null while G2 stands apart.
 
@@ -173,7 +173,7 @@ The results below are stubbed: the companion compute pipeline (ticket 0064) will
 
 ### 5.1 Z-score time series
 
-@fig-zseries shows the three detection layers (S2 Energy, L1 JS, G9 community divergence) with permutation Z-scores, plus the C2ST AUC reference layer (G2) with CV fold standard deviation bands. At the default half-width $w = 3$, S2 peaks at {{< meta s2_peak_year_w3 >}} ($Z = ${{< meta s2_peak_z_w3 >}}), L1 peaks at {{< meta l1_peak_year_w3 >}} ($Z = ${{< meta l1_peak_z_w3 >}}), and G9 peaks at {{< meta g9_peak_year_w3 >}} ($Z = ${{< meta g9_peak_z_w3 >}}). The C2ST AUC trace reaches its maximum at {{< meta g2_peak_year_w3 >}} with AUC {{< meta g2_peak_auc_w3 >}} ($\sigma_{\text{CV}} = ${{< meta g2_peak_auc_sd_w3 >}}). Peaks agree within three years across the three distance layers.
+@fig-zseries shows the three detection layers (S2 Energy, L1 JS, G9 community divergence) with permutation Z-scores, plus the C2ST AUC reference layer with CV fold standard deviation bands. At the default half-width $w = 3$, S2 peaks at {{< meta s2_peak_year_w3 >}} ($Z = ${{< meta s2_peak_z_w3 >}}), L1 peaks at {{< meta l1_peak_year_w3 >}} ($Z = ${{< meta l1_peak_z_w3 >}}), and G9 peaks at {{< meta g9_peak_year_w3 >}} ($Z = ${{< meta g9_peak_z_w3 >}}). The C2ST AUC trace reaches its maximum at {{< meta g2_peak_year_w3 >}} with AUC {{< meta g2_peak_auc_w3 >}} ($\sigma_{\text{CV}} = ${{< meta g2_peak_auc_sd_w3 >}}). Peaks agree within three years across the three distance layers.
 
 Sensitivity checks at $w = 2$ and $w = 4$ move the peak locations by at most one year (see appendix table), consistent with the window half-width setting the effective temporal resolution.
 
@@ -189,7 +189,7 @@ The two-pass censored-gap analysis (§4.7) retains {{< meta n_zones_confirmed >}
 
 ### 5.4 Interpretation at validated zones
 
-For each confirmed zone, @fig-terms shows the top discriminative terms from the log-odds ratio and logistic classifier (intersection ranking), and @fig-community shows the Louvain community transitions as a flow diagram.
+For each confirmed zone, @fig-terms shows the top discriminative terms from the log-odds ratio and logistic classifier (intersection ranking), and @fig-community shows Louvain community sizes before and after the zone as a grouped bar chart.
 
 At zone 1 ({{< meta zone_1_start >}}--{{< meta zone_1_end >}}), terms gaining weight include {{< meta zone_1_top_terms_after >}}; terms losing weight include {{< meta zone_1_top_terms_before >}}. The dominant community shift moves documents from {{< meta zone_1_community_before >}} to {{< meta zone_1_community_after >}}.
 
@@ -197,13 +197,13 @@ At zone 2 ({{< meta zone_2_start >}}--{{< meta zone_2_end >}}), terms gaining we
 
 Historical interpretation is deferred to the Oeconomia manuscript [cross-ref manuscript], which situates these shifts in the field's institutional history. The companion paper's claim is methodological: the framework identifies the zones reproducibly across independent representations.
 
-![Permutation Z-scores at the lead window ($w = 3$) for the four distance-based detectors (S2 Energy, L1 JS, G9 Community, G2 Spectral) plus the C2ST AUC references (embedding and lexical). The grey band marks $|Z| < 2$, the permutation-based null 95% reference; dashed horizontals mark the $Z = \pm 2$ thresholds. C2ST AUCs are plotted against the twin right-hand axis.](figures/fig_companion_zseries.png){#fig-zseries}
+![Permutation Z-scores at the lead window ($w = 3$) for the four permutation-tested methods (S2 Energy, L1 JS, G9 Community, G2 Spectral) plus the C2ST AUC references (embedding and lexical). The grey band marks $|Z| < 2$, the permutation-based null 95% reference; dashed horizontals mark the $Z = \pm 2$ thresholds. C2ST AUCs are plotted against the twin right-hand axis.](figures/fig_companion_zseries.png){#fig-zseries}
 
-![Transition-zone validation heatmap. Rows are the six lead methods; columns are years from 1998 to 2021. Cell colour encodes the signed signal — Z-score for the four distance detectors, and $(\mathrm{AUC} - 0.5) \times 20$ for the two C2ST rows so that all rows share a comparable scale. Vertical rectangles mark years where at least two rows exceed the threshold simultaneously (validated zones).](figures/fig_companion_heatmap.png){#fig-heatmap}
+![Transition-zone validation heatmap. Rows are the six detection methods; columns are years from 1998 to 2021. Cell colour encodes the signed signal — Z-score for the four distance detectors, and $(\mathrm{AUC} - 0.5) \times 20$ for the two C2ST rows so that all rows share a comparable scale. Vertical rectangles mark years where at least two rows exceed the threshold ($|Z| > 2$, or rescaled AUC $> 2$) simultaneously (validated zones).](figures/fig_companion_heatmap.png){#fig-heatmap}
 
 ![Top ten discriminative terms per validated zone, ranked by log-odds ratio. Bars leaning right correspond to terms gaining weight after the zone; bars leaning left, to terms losing weight. Terms are taken from the intersection of the log-odds ranking and the logistic classifier ranking (§4.9).](figures/fig_companion_terms.png){#fig-terms}
 
-![Louvain community sizes on either side of each validated zone. Bar height gives the number of documents assigned to a community; the *before* bar (light) and *after* bar (dark) are plotted side by side per community identifier. Communities that shrink or swell across the zone are the ones driving the graph-layer signal.](figures/fig_companion_community.png){#fig-community}
+![Louvain community sizes on either side of each validated zone. Bar height gives the number of documents assigned to a community; the *before* bar (light) and *after* bar (dark) are plotted side by side per community identifier. Communities whose share of total documents shifts most strongly across the zone are the ones driving the graph-layer signal (G9 is a JSD on community-share distributions).](figures/fig_companion_community.png){#fig-community}
 
 
 ## 6. Discussion

--- a/content/companion-paper.qmd
+++ b/content/companion-paper.qmd
@@ -197,6 +197,14 @@ At zone 2 ({{< meta zone_2_start >}}--{{< meta zone_2_end >}}), terms gaining we
 
 Historical interpretation is deferred to the Oeconomia manuscript [cross-ref manuscript], which situates these shifts in the field's institutional history. The companion paper's claim is methodological: the framework identifies the zones reproducibly across independent representations.
 
+![Permutation Z-scores at the lead window ($w = 3$) for the four distance-based detectors (S2 Energy, L1 JS, G9 Community, G2 Spectral) plus the C2ST AUC references (embedding and lexical). The grey band marks $|Z| < 2$, the permutation-based null 95% reference; dashed horizontals mark the $Z = \pm 2$ thresholds. C2ST AUCs are plotted against the twin right-hand axis.](figures/fig_companion_zseries.png){#fig-zseries}
+
+![Transition-zone validation heatmap. Rows are the six lead methods; columns are years from 1998 to 2021. Cell colour encodes the signed signal — Z-score for the four distance detectors, and $(\mathrm{AUC} - 0.5) \times 20$ for the two C2ST rows so that all rows share a comparable scale. Vertical rectangles mark years where at least two rows exceed the threshold simultaneously (validated zones).](figures/fig_companion_heatmap.png){#fig-heatmap}
+
+![Top ten discriminative terms per validated zone, ranked by log-odds ratio. Bars leaning right correspond to terms gaining weight after the zone; bars leaning left, to terms losing weight. Terms are taken from the intersection of the log-odds ranking and the logistic classifier ranking (§4.9).](figures/fig_companion_terms.png){#fig-terms}
+
+![Louvain community sizes on either side of each validated zone. Bar height gives the number of documents assigned to a community; the *before* bar (light) and *after* bar (dark) are plotted side by side per community identifier. Communities that shrink or swell across the zone are the ones driving the graph-layer signal.](figures/fig_companion_community.png){#fig-community}
+
 
 ## 6. Discussion
 

--- a/scripts/_companion_plot_utils.py
+++ b/scripts/_companion_plot_utils.py
@@ -112,18 +112,3 @@ def window_rows(df: pd.DataFrame, window: int) -> pd.DataFrame:
     w_str = str(window)
     mask = df["window"].astype(str).eq(w_str)
     return df.loc[mask]
-
-
-def validated_zone_mask(
-    z_frame: pd.DataFrame,
-    z_threshold: float,
-    min_methods: int,
-) -> pd.Series:
-    """Return a boolean Series (indexed by year) marking validated zones.
-
-    ``z_frame`` is a year-indexed DataFrame whose columns are method IDs
-    and whose values are signed signals.  A year is validated when at
-    least ``min_methods`` columns have ``|signal| >= z_threshold``.
-    """
-    above = z_frame.abs().ge(z_threshold)
-    return above.sum(axis=1) >= min_methods

--- a/scripts/_companion_plot_utils.py
+++ b/scripts/_companion_plot_utils.py
@@ -1,0 +1,129 @@
+"""Shared helpers for the companion-paper figure scripts (ticket 0058).
+
+All four ``plot_companion_*.py`` scripts share:
+- a preferred location for their input CSVs (``content/tables/``),
+- a ``--tables-dir`` override used by the test suite,
+- the companion config block in ``config/analysis.yaml``,
+- a thin wrapper around ``pipeline_io.save_figure`` that respects
+  ``os.path.splitext(--output)[0]`` as the stem (so Make controls the path).
+
+Keeping this logic in one place avoids duplication across the four plot
+scripts while staying well inside Phase 2 rules 4 (compute/plot/include
+separate) and 5 (save_figure mandatory).
+"""
+
+import os
+from typing import Any
+
+import pandas as pd
+from pipeline_io import save_figure
+from utils import load_analysis_config
+
+DEFAULT_TABLES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "content",
+    "tables",
+)
+
+# Method IDs in the fixed lead order used by the heatmap and Z-series panels.
+DISTANCE_METHODS = ("S2_energy", "L1", "G9_community", "G2_spectral")
+C2ST_CHANNELS = ("embedding", "lexical")
+
+
+def companion_config() -> dict[str, Any]:
+    """Return the ``companion`` block of ``config/analysis.yaml``.
+
+    Raises
+    ------
+    KeyError if the block is missing — plot scripts should surface the
+    config-discipline violation rather than silently fall back to defaults.
+
+    """
+    cfg = load_analysis_config()
+    if "companion" not in cfg:
+        raise KeyError(
+            "config/analysis.yaml is missing the 'companion:' block. "
+            "Add it per ticket 0058."
+        )
+    return cfg["companion"]
+
+
+def add_tables_dir_arg(parser) -> None:
+    """Register the shared ``--tables-dir`` option on an argparse parser."""
+    parser.add_argument(
+        "--tables-dir",
+        default=DEFAULT_TABLES_DIR,
+        help=(
+            "Directory holding tab_summary_*.csv / tab_div_C2ST_*.csv / "
+            "tab_discrim_terms*.csv / tab_community_shifts*.csv. "
+            "Defaults to content/tables/."
+        ),
+    )
+
+
+def read_csv_or_none(path: str) -> pd.DataFrame | None:
+    """Return a DataFrame or ``None`` if the file is absent."""
+    if not os.path.exists(path):
+        return None
+    return pd.read_csv(path)
+
+
+def load_summary_tables(tables_dir: str) -> dict[str, pd.DataFrame]:
+    """Load tab_summary_{method}.csv for the four distance methods.
+
+    Missing tables are skipped (the caller decides whether to degrade
+    gracefully).  Returns a dict {method: DataFrame}.
+    """
+    out: dict[str, pd.DataFrame] = {}
+    for method in DISTANCE_METHODS:
+        df = read_csv_or_none(os.path.join(tables_dir, f"tab_summary_{method}.csv"))
+        if df is not None and not df.empty:
+            out[method] = df
+    return out
+
+
+def load_c2st_tables(tables_dir: str) -> dict[str, pd.DataFrame]:
+    """Load tab_div_C2ST_{embedding,lexical}.csv.
+
+    Returns a dict keyed ``'C2ST_embedding'`` / ``'C2ST_lexical'`` so the
+    four distance keys and the two C2ST keys live in the same namespace.
+    """
+    out: dict[str, pd.DataFrame] = {}
+    for channel in C2ST_CHANNELS:
+        df = read_csv_or_none(os.path.join(tables_dir, f"tab_div_C2ST_{channel}.csv"))
+        if df is not None and not df.empty:
+            out[f"C2ST_{channel}"] = df
+    return out
+
+
+def save_companion_figure(fig, output_path: str, dpi: int = 300) -> None:
+    """Strip the extension from ``output_path`` and save via ``save_figure``."""
+    stem = os.path.splitext(output_path)[0]
+    save_figure(fig, stem, dpi=dpi)
+
+
+def window_rows(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Return rows whose ``window`` column matches ``window``.
+
+    The CSVs use a string-or-int window; coerce defensively.
+    """
+    if "window" not in df.columns:
+        return df
+    w_str = str(window)
+    mask = df["window"].astype(str).eq(w_str)
+    return df.loc[mask]
+
+
+def validated_zone_mask(
+    z_frame: pd.DataFrame,
+    z_threshold: float,
+    min_methods: int,
+) -> pd.Series:
+    """Return a boolean Series (indexed by year) marking validated zones.
+
+    ``z_frame`` is a year-indexed DataFrame whose columns are method IDs
+    and whose values are signed signals.  A year is validated when at
+    least ``min_methods`` columns have ``|signal| >= z_threshold``.
+    """
+    above = z_frame.abs().ge(z_threshold)
+    return above.sum(axis=1) >= min_methods

--- a/scripts/plot_companion_community.py
+++ b/scripts/plot_companion_community.py
@@ -1,0 +1,146 @@
+"""Figure 4 (companion paper): community sizes before/after each zone.
+
+The ticket asks for an alluvial / Sankey flow between Louvain community
+structures before and after each validated zone.  Alluvial layouts are
+fragile with unknown community counts, so this script renders the
+robust fallback mentioned in the ticket: a grouped bar chart showing
+community sizes on each side of each validated zone.
+
+Reads ``tab_community_shifts.csv`` (or ``tab_community_shifts_{zone}.csv``
+parts) from ``--tables-dir``.  Falls back to a stub plot annotated with
+``TODO(t0064)`` when the file is missing, so the Make target still
+succeeds on partial upstream data.
+
+Expected schema:
+    zone, side, community_id, size[, label]
+
+Usage::
+
+    uv run python scripts/plot_companion_community.py \\
+        --output content/figures/fig_companion_community.png \\
+        [--tables-dir path/to/tables]
+"""
+
+import argparse
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from _companion_plot_utils import (
+    add_tables_dir_arg,
+    companion_config,
+    read_csv_or_none,
+    save_companion_figure,
+)
+from plot_style import DARK, DPI, FIGWIDTH, LIGHT, apply_style
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("plot_companion_community")
+apply_style()
+
+
+def _stub_frame() -> pd.DataFrame:
+    rows = []
+    for zone in ("zone 1 (stub)", "zone 2 (stub)"):
+        for side in ("before", "after"):
+            for cid in range(3):
+                rows.append(
+                    {
+                        "zone": zone,
+                        "side": side,
+                        "community_id": cid,
+                        "size": 40 + 12 * cid + (6 if side == "after" else 0),
+                        "label": f"c{cid}",
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _load_shifts(tables_dir: str) -> tuple[pd.DataFrame, bool]:
+    primary = os.path.join(tables_dir, "tab_community_shifts.csv")
+    df = read_csv_or_none(primary)
+    if df is not None and not df.empty:
+        return df, False
+    parts = []
+    if os.path.isdir(tables_dir):
+        for name in sorted(os.listdir(tables_dir)):
+            if name.startswith("tab_community_shifts_") and name.endswith(".csv"):
+                part = pd.read_csv(os.path.join(tables_dir, name))
+                if "zone" not in part.columns:
+                    part["zone"] = name[len("tab_community_shifts_") : -len(".csv")]
+                parts.append(part)
+    if parts:
+        return pd.concat(parts, ignore_index=True), False
+    log.warning(
+        "tab_community_shifts.csv missing in %s; rendering stub (TODO t0064).",
+        tables_dir,
+    )
+    return _stub_frame(), True
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    add_tables_dir_arg(parser)
+    args = parser.parse_args(extra)
+
+    cfg = companion_config()
+    stub_tag = cfg.get("stub_figure_todo", "t0064")
+
+    df, is_stub = _load_shifts(args.tables_dir)
+    zones = sorted(df["zone"].unique())
+    n_zones = max(1, len(zones))
+
+    fig, axes = plt.subplots(
+        1,
+        n_zones,
+        figsize=(FIGWIDTH, 3.2),
+        sharey=True,
+    )
+    if n_zones == 1:
+        axes = [axes]
+
+    for ax, zone in zip(axes, zones):
+        sub = df[df["zone"] == zone].copy()
+        pivot = (
+            sub.groupby(["community_id", "side"])["size"]
+            .sum()
+            .unstack("side")
+            .fillna(0.0)
+            .sort_index()
+        )
+        communities = list(pivot.index)
+        x = np.arange(len(communities))
+        width = 0.4
+
+        before = pivot.get("before", pd.Series(0, index=communities))
+        after = pivot.get("after", pd.Series(0, index=communities))
+
+        ax.bar(x - width / 2, before, width, label="before", color=LIGHT)
+        ax.bar(x + width / 2, after, width, label="after", color=DARK)
+        ax.set_xticks(x)
+        ax.set_xticklabels([f"c{int(c)}" for c in communities])
+        ax.set_title(str(zone))
+        ax.set_xlabel("Community")
+    axes[0].set_ylabel("Size (documents)")
+    axes[0].legend(frameon=False, fontsize=7)
+
+    if is_stub:
+        fig.suptitle(
+            f"Community shifts — STUB (TODO {stub_tag})",
+            fontsize=8,
+            color="#B22222",
+        )
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95 if is_stub else 1.0))
+    save_companion_figure(fig, io_args.output, dpi=DPI)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plot_companion_heatmap.py
+++ b/scripts/plot_companion_heatmap.py
@@ -1,0 +1,154 @@
+"""Figure 2 (companion paper): transition zone validation heatmap.
+
+Rows: the six lead methods (S2 Energy, L1 JS, G9 Community, G2 Spectral,
+C2ST embedding, C2ST lexical).
+Columns: years from ``companion.year_min`` to ``companion.year_max``.
+Cell value: Z-score for distance methods, (AUC − 0.5) × ``auc_scale``
+for C2ST rows — so the colormap stays on a common signal scale.
+
+Validated zones (≥ ``validated_zone_min_methods`` rows above the
+``z_threshold`` simultaneously) are marked with rectangular borders.
+
+Usage::
+
+    uv run python scripts/plot_companion_heatmap.py \\
+        --output content/figures/fig_companion_heatmap.png \\
+        [--tables-dir path/to/tables]
+"""
+
+import argparse
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from _companion_plot_utils import (
+    add_tables_dir_arg,
+    companion_config,
+    load_c2st_tables,
+    load_summary_tables,
+    save_companion_figure,
+    window_rows,
+)
+from matplotlib.patches import Rectangle
+from plot_style import DPI, FIGWIDTH, apply_style
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("plot_companion_heatmap")
+apply_style()
+
+
+def _signal_matrix(
+    summaries: dict[str, pd.DataFrame],
+    c2sts: dict[str, pd.DataFrame],
+    years: list[int],
+    window: int,
+    auc_chance: float,
+    auc_scale: float,
+    row_order: list[str],
+) -> np.ndarray:
+    """Build a (len(row_order), len(years)) signed signal matrix."""
+    mat = np.full((len(row_order), len(years)), np.nan, dtype=float)
+    year_to_col = {y: i for i, y in enumerate(years)}
+
+    for i, method in enumerate(row_order):
+        if method in summaries:
+            sub = window_rows(summaries[method], window)
+            for _, row in sub.iterrows():
+                y = int(row["year"])
+                if y in year_to_col and pd.notna(row.get("z_score")):
+                    mat[i, year_to_col[y]] = float(row["z_score"])
+        elif method in c2sts:
+            sub = window_rows(c2sts[method], window)
+            for _, row in sub.iterrows():
+                y = int(row["year"])
+                if y in year_to_col and pd.notna(row.get("value")):
+                    mat[i, year_to_col[y]] = (
+                        float(row["value"]) - auc_chance
+                    ) * auc_scale
+    return mat
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    add_tables_dir_arg(parser)
+    args = parser.parse_args(extra)
+
+    cfg = companion_config()
+    window = int(cfg["lead_window"])
+    z_thr = float(cfg["z_threshold"])
+    y0, y1 = int(cfg["year_min"]), int(cfg["year_max"])
+    min_methods = int(cfg["validated_zone_min_methods"])
+    auc_chance = float(cfg["auc_chance"])
+    auc_scale = float(cfg["auc_scale"])
+    methods_labels = cfg["methods"]
+    zone_edge = cfg["colors"]["zone_edge"]
+    cmap = cfg["colors"]["z_cmap"]
+
+    row_order = list(methods_labels.keys())
+    years = list(range(y0, y1 + 1))
+
+    summaries = load_summary_tables(args.tables_dir)
+    c2sts = load_c2st_tables(args.tables_dir)
+    mat = _signal_matrix(
+        summaries,
+        c2sts,
+        years,
+        window,
+        auc_chance,
+        auc_scale,
+        row_order,
+    )
+
+    # Symmetric normalisation around zero so the diverging cmap reads truthfully.
+    vmax = float(np.nanmax(np.abs(mat))) if np.isfinite(mat).any() else z_thr
+    vmax = max(vmax, z_thr * 1.2)
+
+    fig, ax = plt.subplots(figsize=(FIGWIDTH, 3.2))
+    im = ax.imshow(
+        mat,
+        aspect="auto",
+        cmap=cmap,
+        vmin=-vmax,
+        vmax=vmax,
+        origin="upper",
+        extent=(y0 - 0.5, y1 + 0.5, len(row_order) - 0.5, -0.5),
+        interpolation="nearest",
+    )
+
+    # Yearly validated-zone borders (per column).
+    above = np.abs(mat) >= z_thr
+    zone_cols = np.where(np.nansum(above, axis=0) >= min_methods)[0]
+    for c in zone_cols:
+        ax.add_patch(
+            Rectangle(
+                (years[c] - 0.5, -0.5),
+                1.0,
+                len(row_order),
+                fill=False,
+                edgecolor=zone_edge,
+                linewidth=1.2,
+                zorder=5,
+            )
+        )
+
+    ax.set_yticks(range(len(row_order)))
+    ax.set_yticklabels([methods_labels[m] for m in row_order])
+    ax.set_xlabel("Year")
+    ax.set_xticks([y for y in years if y % 5 == 0 or y in (y0, y1)])
+    ax.set_title(f"Transition zone heatmap (window = {window})")
+
+    cbar = fig.colorbar(im, ax=ax, shrink=0.8, pad=0.02)
+    cbar.set_label(f"Signal (Z or (AUC−{auc_chance:g})×{auc_scale:g})")
+
+    fig.tight_layout()
+    save_companion_figure(fig, io_args.output, dpi=DPI)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plot_companion_terms.py
+++ b/scripts/plot_companion_terms.py
@@ -1,0 +1,130 @@
+"""Figure 3 (companion paper): discriminative terms per validated zone.
+
+Reads ``tab_discrim_terms.csv`` (ticket 0056 interpretation layer) from
+``--tables-dir`` and renders a grouped horizontal bar chart of the top
+``companion.top_terms`` terms (by log-odds) for each validated zone.
+
+If the interpretation table is absent, the script falls back to a stub
+plot driven by synthetic placeholder data and a bold ``TODO(t0064)``
+annotation on the figure, so the Make target still succeeds on partial
+upstream data.
+
+Expected schema (one row per term × zone):
+    zone, term, log_odds, direction, rank
+
+Usage::
+
+    uv run python scripts/plot_companion_terms.py \\
+        --output content/figures/fig_companion_terms.png \\
+        [--tables-dir path/to/tables]
+"""
+
+import argparse
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from _companion_plot_utils import (
+    add_tables_dir_arg,
+    companion_config,
+    read_csv_or_none,
+    save_companion_figure,
+)
+from plot_style import DARK, DPI, FIGWIDTH, LIGHT, apply_style
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("plot_companion_terms")
+apply_style()
+
+
+def _stub_frame() -> pd.DataFrame:
+    """Placeholder terms frame used when the real CSV is missing."""
+    rows = []
+    for zone in ("zone 1 (stub)", "zone 2 (stub)"):
+        for rank in range(1, 11):
+            rows.append(
+                {
+                    "zone": zone,
+                    "term": f"term {rank}",
+                    "log_odds": (1.5 - 0.1 * rank)
+                    * (1 if zone.startswith("zone 1") else -1),
+                    "direction": "after" if zone.startswith("zone 1") else "before",
+                    "rank": rank,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _load_terms(tables_dir: str) -> tuple[pd.DataFrame, bool]:
+    """Return (frame, is_stub)."""
+    primary = os.path.join(tables_dir, "tab_discrim_terms.csv")
+    df = read_csv_or_none(primary)
+    if df is not None and not df.empty:
+        return df, False
+    # Allow per-zone files (tab_discrim_terms_{zone}.csv) — concatenate them.
+    parts = []
+    if os.path.isdir(tables_dir):
+        for name in sorted(os.listdir(tables_dir)):
+            if name.startswith("tab_discrim_terms_") and name.endswith(".csv"):
+                part = pd.read_csv(os.path.join(tables_dir, name))
+                if "zone" not in part.columns:
+                    part["zone"] = name[len("tab_discrim_terms_") : -len(".csv")]
+                parts.append(part)
+    if parts:
+        return pd.concat(parts, ignore_index=True), False
+    log.warning(
+        "tab_discrim_terms.csv missing in %s; rendering stub (TODO t0064).",
+        tables_dir,
+    )
+    return _stub_frame(), True
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    add_tables_dir_arg(parser)
+    args = parser.parse_args(extra)
+
+    cfg = companion_config()
+    top_n = int(cfg["top_terms"])
+    stub_tag = cfg.get("stub_figure_todo", "t0064")
+
+    df, is_stub = _load_terms(args.tables_dir)
+    zones = sorted(df["zone"].unique())
+    n_zones = max(1, len(zones))
+
+    fig, axes = plt.subplots(
+        1,
+        n_zones,
+        figsize=(FIGWIDTH, 1.2 + 0.22 * top_n),
+        sharey=False,
+    )
+    if n_zones == 1:
+        axes = [axes]
+
+    for ax, zone in zip(axes, zones):
+        sub = df[df["zone"] == zone].sort_values("log_odds", ascending=True).tail(top_n)
+        colors = [DARK if v >= 0 else LIGHT for v in sub["log_odds"]]
+        ax.barh(sub["term"], sub["log_odds"], color=colors)
+        ax.axvline(0, color="black", linewidth=0.6)
+        ax.set_title(str(zone))
+        ax.set_xlabel("Log-odds")
+
+    if is_stub:
+        fig.suptitle(
+            f"Discriminative terms — STUB (TODO {stub_tag})",
+            fontsize=8,
+            color="#B22222",
+        )
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95 if is_stub else 1.0))
+    save_companion_figure(fig, io_args.output, dpi=DPI)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plot_companion_zseries.py
+++ b/scripts/plot_companion_zseries.py
@@ -1,0 +1,145 @@
+"""Figure 1 (companion paper): Z-score time series at the lead window.
+
+Renders four distance-method Z-score curves (S2 Energy, L1 JS,
+G9 Community, G2 Spectral) on a primary axis plus the two C2ST AUC
+traces (embedding, lexical) on a twin axis, for the lead window
+(``companion.lead_window`` in ``config/analysis.yaml``, default 3).
+
+Inputs (all in ``--tables-dir``, default ``content/tables/``):
+  tab_summary_S2_energy.csv, tab_summary_L1.csv,
+  tab_summary_G9_community.csv, tab_summary_G2_spectral.csv
+  tab_div_C2ST_embedding.csv, tab_div_C2ST_lexical.csv
+
+Output: one PNG at the path given by ``--output`` (Make controls it).
+
+Usage::
+
+    uv run python scripts/plot_companion_zseries.py \\
+        --output content/figures/fig_companion_zseries.png \\
+        [--tables-dir path/to/tables]
+
+The script degrades gracefully: missing input tables simply omit the
+corresponding curve; the figure is still produced so the Make target
+succeeds on partial data.
+"""
+
+import argparse
+import sys
+
+import matplotlib.pyplot as plt
+from _companion_plot_utils import (
+    add_tables_dir_arg,
+    companion_config,
+    load_c2st_tables,
+    load_summary_tables,
+    save_companion_figure,
+    window_rows,
+)
+from plot_style import DPI, FIGWIDTH, MED, apply_style
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("plot_companion_zseries")
+apply_style()
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
+
+    parser = argparse.ArgumentParser()
+    add_tables_dir_arg(parser)
+    args = parser.parse_args(extra)
+
+    cfg = companion_config()
+    window = int(cfg["lead_window"])
+    z_thr = float(cfg["z_threshold"])
+    y0, y1 = int(cfg["year_min"]), int(cfg["year_max"])
+    colors = cfg["colors"]["series"]
+    methods_labels = cfg["methods"]
+
+    summaries = load_summary_tables(args.tables_dir)
+    c2sts = load_c2st_tables(args.tables_dir)
+
+    if not summaries and not c2sts:
+        log.warning(
+            "No input tables found in %s; rendering empty figure.", args.tables_dir
+        )
+
+    fig, ax = plt.subplots(figsize=(FIGWIDTH, 3.8))
+
+    # Primary axis — Z-scores for distance methods.
+    ax.axhspan(
+        -z_thr,
+        z_thr,
+        color="#E8E8E8",
+        alpha=0.6,
+        zorder=0,
+        label=f"|Z| < {z_thr:g} (null 95%)",
+    )
+    ax.axhline(z_thr, color=MED, linewidth=0.6, linestyle="--", zorder=1)
+    ax.axhline(-z_thr, color=MED, linewidth=0.6, linestyle="--", zorder=1)
+
+    max_abs_z = z_thr
+    for method, df in summaries.items():
+        sub = window_rows(df, window).sort_values("year")
+        if sub.empty:
+            continue
+        ax.plot(
+            sub["year"],
+            sub["z_score"],
+            label=methods_labels.get(method, method),
+            color=colors.get(method, None),
+            linewidth=1.2,
+            zorder=3,
+        )
+        mx = sub["z_score"].abs().max()
+        if mx and mx > max_abs_z:
+            max_abs_z = float(mx)
+
+    ax.set_xlabel("Year")
+    ax.set_ylabel(f"Z-score (window = {window})")
+    ax.set_xlim(y0, y1)
+    y_pad = max_abs_z * 1.15
+    ax.set_ylim(-y_pad, y_pad)
+
+    # Twin axis — C2ST AUCs.
+    ax2 = ax.twinx()
+    ax2.set_ylabel("C2ST AUC")
+    ax2.set_ylim(0.5, 1.0)
+    ax2.axhline(cfg["auc_chance"], color=MED, linewidth=0.4, linestyle=":", zorder=1)
+    for key, df in c2sts.items():
+        sub = window_rows(df, window).sort_values("year")
+        if sub.empty:
+            continue
+        ax2.plot(
+            sub["year"],
+            sub["value"],
+            label=methods_labels.get(key, key),
+            color=colors.get(key, None),
+            linewidth=1.0,
+            linestyle="-.",
+            zorder=2,
+        )
+
+    # Combined legend beneath the axes.
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax2.get_legend_handles_labels()
+    if h1 or h2:
+        fig.legend(
+            h1 + h2,
+            l1 + l2,
+            loc="lower center",
+            ncol=4,
+            frameon=False,
+            bbox_to_anchor=(0.5, -0.02),
+            fontsize=6.5,
+        )
+
+    fig.tight_layout()
+    save_companion_figure(fig, io_args.output, dpi=DPI)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_companion_figures.py
+++ b/tests/test_companion_figures.py
@@ -1,0 +1,235 @@
+"""Smoke tests for the four companion-paper figure scripts (ticket 0058).
+
+Each of the four scripts:
+- ``scripts/plot_companion_zseries.py``    — Figure 1 (Z-score time series)
+- ``scripts/plot_companion_heatmap.py``    — Figure 2 (transition zone heatmap)
+- ``scripts/plot_companion_terms.py``      — Figure 3 (discriminative terms)
+- ``scripts/plot_companion_community.py``  — Figure 4 (community flow)
+
+must
+
+1. exist on disk,
+2. accept ``--output <path>`` via the shared ``parse_io_args`` parser,
+3. produce a non-empty PNG when invoked on synthetic fixture data.
+
+Tests use small synthetic CSVs matching the pipeline schemas so the suite
+does not depend on the real ``tab_summary_*.csv`` / ``tab_div_C2ST_*.csv``
+outputs being present on disk.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPTS_DIR = REPO / "scripts"
+
+COMPANION_SCRIPTS = {
+    "zseries": "plot_companion_zseries.py",
+    "heatmap": "plot_companion_heatmap.py",
+    "terms": "plot_companion_terms.py",
+    "community": "plot_companion_community.py",
+}
+
+
+# ─── Fixture data ────────────────────────────────────────────────────────
+
+
+def _summary_fixture(method: str) -> pd.DataFrame:
+    """Synthetic tab_summary_{method}.csv matching the pipeline schema."""
+    rows = []
+    for year in range(1998, 2022):
+        for window in (2, 3, 4, 5):
+            # Produce a mild bump around 2009 so the plots are not flat.
+            z = 2.5 if year in (2008, 2009, 2010) else 0.4
+            rows.append(
+                {
+                    "method": method,
+                    "year": year,
+                    "window": window,
+                    "hyperparams": "default",
+                    "point_estimate": 0.05 + 0.001 * (year - 2000),
+                    "boot_median": 0.07,
+                    "boot_q025": 0.05,
+                    "boot_q975": 0.09,
+                    "z_score": z,
+                    "p_value": 0.01 if z > 2 else 0.3,
+                    "significant": bool(z > 2),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _c2st_fixture(channel: str) -> pd.DataFrame:
+    rows = []
+    for year in range(1998, 2022):
+        for window in (2, 3, 4, 5):
+            auc = 0.82 if year in (2008, 2009, 2010) else 0.55
+            rows.append(
+                {
+                    "year": year,
+                    "window": window,
+                    "hyperparams": "pca=32",
+                    "value": auc,
+                    "auc_std": 0.05,
+                    "auc_q025": auc - 0.07,
+                    "auc_q975": auc + 0.07,
+                    "n_folds": 5,
+                    "p_value_vs_chance": 0.001 if auc > 0.7 else 0.2,
+                    "channel": channel,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _terms_fixture() -> pd.DataFrame:
+    """Synthetic discriminative-terms table (one zone, ten terms)."""
+    terms = [f"term_{i}" for i in range(10)]
+    rows = []
+    for zone in ("2008-2010", "2014-2016"):
+        for t in terms:
+            rows.append(
+                {
+                    "zone": zone,
+                    "term": t,
+                    "log_odds": 0.5 if zone.startswith("2008") else -0.4,
+                    "direction": "after" if zone.startswith("2008") else "before",
+                    "rank": terms.index(t) + 1,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _community_fixture() -> pd.DataFrame:
+    """Synthetic community shifts table for zones."""
+    rows = []
+    for zone in ("2008-2010", "2014-2016"):
+        for side in ("before", "after"):
+            for cid in range(3):
+                rows.append(
+                    {
+                        "zone": zone,
+                        "side": side,
+                        "community_id": cid,
+                        "size": 50 + 10 * cid + (5 if side == "after" else 0),
+                        "label": f"c{cid}",
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def companion_tables(tmp_path: Path) -> Path:
+    """Write fixture CSVs into ``tmp_path/tables`` and return that directory."""
+    tables = tmp_path / "tables"
+    tables.mkdir()
+    for m in ("S2_energy", "L1", "G9_community", "G2_spectral"):
+        _summary_fixture(m).to_csv(tables / f"tab_summary_{m}.csv", index=False)
+    _c2st_fixture("semantic").to_csv(tables / "tab_div_C2ST_embedding.csv", index=False)
+    _c2st_fixture("lexical").to_csv(tables / "tab_div_C2ST_lexical.csv", index=False)
+    _terms_fixture().to_csv(tables / "tab_discrim_terms.csv", index=False)
+    _community_fixture().to_csv(tables / "tab_community_shifts.csv", index=False)
+    return tables
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _run(script: str, args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / script), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _assert_png(path: Path) -> None:
+    assert path.exists(), f"expected PNG at {path}"
+    assert path.stat().st_size > 1000, (
+        f"PNG at {path} is suspiciously small ({path.stat().st_size} bytes)"
+    )
+
+
+# ─── Existence & CLI contract ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("script", list(COMPANION_SCRIPTS.values()))
+def test_script_exists(script: str):
+    assert (SCRIPTS_DIR / script).is_file(), f"{script} missing"
+
+
+@pytest.mark.parametrize("script", list(COMPANION_SCRIPTS.values()))
+def test_script_requires_output(script: str):
+    """Running without --output must fail with a non-zero exit."""
+    proc = _run(script, [])
+    assert proc.returncode != 0, (
+        f"{script} should require --output; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+
+
+# ─── End-to-end smoke (fixture data → non-empty PNG) ─────────────────────
+
+
+def test_zseries_runs(tmp_path: Path, companion_tables: Path):
+    out = tmp_path / "fig_companion_zseries.png"
+    proc = _run(
+        COMPANION_SCRIPTS["zseries"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(companion_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)
+
+
+def test_heatmap_runs(tmp_path: Path, companion_tables: Path):
+    out = tmp_path / "fig_companion_heatmap.png"
+    proc = _run(
+        COMPANION_SCRIPTS["heatmap"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(companion_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)
+
+
+def test_terms_runs(tmp_path: Path, companion_tables: Path):
+    out = tmp_path / "fig_companion_terms.png"
+    proc = _run(
+        COMPANION_SCRIPTS["terms"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(companion_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)
+
+
+def test_community_runs(tmp_path: Path, companion_tables: Path):
+    out = tmp_path / "fig_companion_community.png"
+    proc = _run(
+        COMPANION_SCRIPTS["community"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(companion_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)

--- a/tests/test_companion_figures.py
+++ b/tests/test_companion_figures.py
@@ -129,7 +129,7 @@ def companion_tables(tmp_path: Path) -> Path:
     tables.mkdir()
     for m in ("S2_energy", "L1", "G9_community", "G2_spectral"):
         _summary_fixture(m).to_csv(tables / f"tab_summary_{m}.csv", index=False)
-    _c2st_fixture("semantic").to_csv(tables / "tab_div_C2ST_embedding.csv", index=False)
+    _c2st_fixture("embedding").to_csv(tables / "tab_div_C2ST_embedding.csv", index=False)
     _c2st_fixture("lexical").to_csv(tables / "tab_div_C2ST_lexical.csv", index=False)
     _terms_fixture().to_csv(tables / "tab_discrim_terms.csv", index=False)
     _community_fixture().to_csv(tables / "tab_community_shifts.csv", index=False)
@@ -148,11 +148,16 @@ def _run(script: str, args: list[str]) -> subprocess.CompletedProcess:
     )
 
 
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
 def _assert_png(path: Path) -> None:
     assert path.exists(), f"expected PNG at {path}"
-    assert path.stat().st_size > 1000, (
-        f"PNG at {path} is suspiciously small ({path.stat().st_size} bytes)"
-    )
+    size = path.stat().st_size
+    assert size > 1000, f"PNG at {path} is suspiciously small ({size} bytes)"
+    with open(path, "rb") as fh:
+        header = fh.read(len(_PNG_MAGIC))
+    assert header == _PNG_MAGIC, f"file at {path} is not a PNG (header={header!r})"
 
 
 # ─── Existence & CLI contract ────────────────────────────────────────────
@@ -229,6 +234,47 @@ def test_community_runs(tmp_path: Path, companion_tables: Path):
             str(out),
             "--tables-dir",
             str(companion_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)
+
+
+# ─── Stub-fallback smoke (no interpretation CSV → PNG still rendered) ────
+#
+# Figures 3 and 4 promise in companion.mk that the Make target succeeds
+# even when ticket 0056's interpretation layer is absent. Drive the
+# fallback path by pointing --tables-dir at an empty directory.
+
+
+def test_terms_stub_fallback(tmp_path: Path):
+    empty_tables = tmp_path / "empty_tables"
+    empty_tables.mkdir()
+    out = tmp_path / "fig_companion_terms.png"
+    proc = _run(
+        COMPANION_SCRIPTS["terms"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(empty_tables),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    _assert_png(out)
+
+
+def test_community_stub_fallback(tmp_path: Path):
+    empty_tables = tmp_path / "empty_tables"
+    empty_tables.mkdir()
+    out = tmp_path / "fig_companion_community.png"
+    proc = _run(
+        COMPANION_SCRIPTS["community"],
+        [
+            "--output",
+            str(out),
+            "--tables-dir",
+            str(empty_tables),
         ],
     )
     assert proc.returncode == 0, proc.stderr

--- a/tickets/0058-companion-paper-figures.erg
+++ b/tickets/0058-companion-paper-figures.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Create companion paper figures (4 canonical outputs)
-Status: done
+Status: doing
 Created: 2026-04-15
 Author: claude
 Blocked-by: 0050
@@ -19,7 +19,6 @@ Blocked-by: 0042
 2026-04-17T19:45Z claude refactor — drop 'from __future__ import annotations' to satisfy TestRuffModernPython
 2026-04-17T19:50Z claude verify — 12/12 companion tests pass; make check-fast residue matches t0057 pre-existing failures (no new regressions)
 2026-04-21T00:00Z claude review-response — drop unused validated_zone_mask helper; fix fixture channel arg; PNG magic-byte check; 2 stub-fallback tests; correct G2/C2ST label in §4.4+4.5+5.1; fix §5.4 flow-diagram→bar-chart; caption wording (permutation-tested, six detection methods, explicit threshold, community-share rationale)
-2026-04-21T00:00Z claude status done
 
 --- body ---
 ## Context

--- a/tickets/0058-companion-paper-figures.erg
+++ b/tickets/0058-companion-paper-figures.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Create companion paper figures (4 canonical outputs)
-Status: open
+Status: doing
 Created: 2026-04-15
 Author: claude
 Blocked-by: 0050
@@ -11,6 +11,13 @@ Blocked-by: 0042
 2026-04-15T15:30Z claude created
 2026-04-15T15:30Z claude note wave 3 of epic 0026; 4 canonical figures
 2026-04-16T13:00Z claude reimagine — add Blocked-by 0056 (Figures 3+4 need interpretation outputs). Null band (Fig 1) derivable from 0055 outputs directly, no 0050 needed for that.
+2026-04-17T19:04Z claude claimed
+2026-04-17T19:04Z claude status doing
+2026-04-17T19:10Z claude red — tests/test_companion_figures.py (12 smoke asserts: existence + --output contract + non-empty PNG on synthetic fixtures)
+2026-04-17T19:25Z claude green — scripts/plot_companion_{zseries,heatmap,terms,community}.py + scripts/_companion_plot_utils.py; companion: block added to config/analysis.yaml
+2026-04-17T19:40Z claude build — companion.mk with four targets, wired into Makefile COMPANION_FIGS; four @fig-* blocks added to content/companion-paper.qmd §5
+2026-04-17T19:45Z claude refactor — drop 'from __future__ import annotations' to satisfy TestRuffModernPython
+2026-04-17T19:50Z claude verify — 12/12 companion tests pass; make check-fast residue matches t0057 pre-existing failures (no new regressions)
 
 --- body ---
 ## Context

--- a/tickets/0058-companion-paper-figures.erg
+++ b/tickets/0058-companion-paper-figures.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Create companion paper figures (4 canonical outputs)
-Status: doing
+Status: done
 Created: 2026-04-15
 Author: claude
 Blocked-by: 0050
@@ -18,6 +18,8 @@ Blocked-by: 0042
 2026-04-17T19:40Z claude build — companion.mk with four targets, wired into Makefile COMPANION_FIGS; four @fig-* blocks added to content/companion-paper.qmd §5
 2026-04-17T19:45Z claude refactor — drop 'from __future__ import annotations' to satisfy TestRuffModernPython
 2026-04-17T19:50Z claude verify — 12/12 companion tests pass; make check-fast residue matches t0057 pre-existing failures (no new regressions)
+2026-04-21T00:00Z claude review-response — drop unused validated_zone_mask helper; fix fixture channel arg; PNG magic-byte check; 2 stub-fallback tests; correct G2/C2ST label in §4.4+4.5+5.1; fix §5.4 flow-diagram→bar-chart; caption wording (permutation-tested, six detection methods, explicit threshold, community-share rationale)
+2026-04-21T00:00Z claude status done
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Cherry-picks commit `7002203` (originally PR #709) which was orphaned by a git race condition on 2026-04-18
- Restores five scripts: `plot_companion_zseries.py`, `plot_companion_heatmap.py`, `plot_companion_terms.py`, `plot_companion_community.py`, `_companion_plot_utils.py`
- Restores `companion.mk` with four figure targets and wires them into `COMPANION_FIGS` in Makefile
- Restores `tests/test_companion_figures.py` (12 tests, all passing)

## What was orphaned and why

Three squash-merges landed within 37 seconds on 2026-04-18. A concurrent agent force-pushed main back to `31775cf` 14 seconds later, then PR #714 was merged on the reverted base — cementing the orphaning of #709 and #710. GitHub shows both as MERGED but neither is in main's ancestry.

## Test plan

- [x] `uv run pytest tests/test_companion_figures.py` — 12 passed
- [x] `uv run pytest tests/test_script_hygiene.py` — 58 passed, 3 pre-existing warnings
- [ ] `make companion-figures` (requires `tab_summary_*.csv` from padme rerun — blocked until ticket 0042 rerun)

## Notes

PR #710 (`compute_companion_vars.py` + filled §5 Results) is NOT included here — it will be redone in a follow-up ticket with the growth-bias fix (equal-n subsampling as primary Z-score).

🤖 Generated with [Claude Code](https://claude.com/claude-code)