### PR TITLE
ticket 0086: close — null-model acceleration docs landed

### DIFF
--- a/tickets/0086-doc-null-model-acceleration.erg
+++ b/tickets/0086-doc-null-model-acceleration.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Document null model acceleration in architecture and handoff doc
-Status: open
+Status: closed
 Created: 2026-04-17
 Author: claude
 
 --- log ---
 2026-04-17T19:15Z claude created
 2026-04-21T09:00Z claude renumbered 0083 → 0086 (collision with merged sensitivity-annex ticket); narrowed scope — architecture.md + handoff doc done in-PR, technical-report deferred to structural-breaks.md rewrite (ticket 0034/0040)
+2026-04-21T12:30Z claude closed — PR #706 merged (5269e0c); exit criteria met (grep counts 3/3); padme end-to-end verified (10:00.72 at NJOBS=6, exit 0); handoff doc timings updated with measured numbers
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Close ticket 0086 (null-model acceleration docs). PR #706 merged 2026-04-21 as commit `5269e0c`; all exit criteria met.

## Evidence

- **Architecture.md**: `grep -c 'n.jobs\|NJOBS\|GPU.*null\|parallel.*permut\|_permutation_accel' .claude/rules/architecture.md` → `3`
- **Handoff doc**: `grep -c 'NJOBS\|null-model\|_permutation_accel' docs/handoff-padme-divergence.md` → `3`
- **Padme end-to-end**: `ssh padme 'make -j4 NJOBS=6 null-model'` → 10:00.72 wall, exit 0, no `uv: command not found`
- **Technical-report paragraph**: deferred (prose can't sit next to obsolete KMeans+JS description) — tracked as follow-on under 0034/0040

Housekeeping only — no code or doc changes.