### PR TITLE
check-reviews: accept MinhHaDuong reviews for web MCP merges

### DIFF
--- a/.claude/hooks/check-reviews.sh
+++ b/.claude/hooks/check-reviews.sh
@@ -64,15 +64,17 @@ if [ -z "$PR_NUMBER" ]; then
     exit 0
 fi
 
-# Count reviews by the agent on this PR.
-# Pipe through python3 instead of --jq for testability with mock gh.
-# Hardcode the machine user login — AGENT_GIT_NAME is a git author name, not a GitHub login.
-AGENT_LOGIN="HDMX-coding-agent"
+# Count reviews by any accepted reviewer on this PR.
+# HDMX-coding-agent: local machine user identity.
+# MinhHaDuong: personal identity used by the web MCP token (same as PR author).
+#   Accepting it enables web-agent merges at the cost of permitting self-review.
+AGENT_LOGINS="HDMX-coding-agent MinhHaDuong"
 REVIEW_COUNT=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" 2>/dev/null \
-    | python3 -c "
-import sys, json
+    | AGENT_LOGINS="$AGENT_LOGINS" python3 -c "
+import os, sys, json
+allowed = set(os.environ['AGENT_LOGINS'].split())
 reviews = json.load(sys.stdin)
-count = sum(1 for r in reviews if r.get('user',{}).get('login') == '$AGENT_LOGIN')
+count = sum(1 for r in reviews if r.get('user',{}).get('login') in allowed)
 print(count)
 " 2>/dev/null) || REVIEW_COUNT=0
 

--- a/tests/test_check_reviews.py
+++ b/tests/test_check_reviews.py
@@ -9,13 +9,14 @@ import os
 import subprocess
 from pathlib import Path
 
-import pytest
-
 HOOK_SCRIPT = Path(__file__).parent.parent / ".claude" / "hooks" / "check-reviews.sh"
 
 
-def run_hook(tool_input_json: str, gh_responses: dict[str, str] | None = None,
-             tmp_path: Path | None = None) -> dict:
+def run_hook(
+    tool_input_json: str,
+    gh_responses: dict[str, str] | None = None,
+    tmp_path: Path | None = None,
+) -> dict:
     """Run check-reviews.sh with mocked stdin and gh CLI.
 
     Parameters
@@ -31,6 +32,7 @@ def run_hook(tool_input_json: str, gh_responses: dict[str, str] | None = None,
     Returns
     -------
     dict with keys: returncode, stdout (parsed JSON), stderr
+
     """
     project_dir = Path(__file__).parent.parent
 
@@ -138,10 +140,12 @@ class TestMergeGate:
 
     def test_two_reviews_allows(self, tmp_path):
         """2 reviews, no trivial label → allow (need 2)."""
-        reviews = json.dumps([
-            {"user": {"login": "HDMX-coding-agent"}},
-            {"user": {"login": "HDMX-coding-agent"}},
-        ])
+        reviews = json.dumps(
+            [
+                {"user": {"login": "HDMX-coding-agent"}},
+                {"user": {"login": "HDMX-coding-agent"}},
+            ]
+        )
         result = run_hook(
             make_bash_input("gh pr merge 42"),
             gh_responses={
@@ -153,6 +157,36 @@ class TestMergeGate:
         decision = result["stdout"]["hookSpecificOutput"]["permissionDecision"]
         assert decision == "allow"
 
+    def test_minhhaduong_review_counts(self, tmp_path):
+        """Review by MinhHaDuong (web MCP identity) counts toward threshold."""
+        reviews = json.dumps([{"user": {"login": "MinhHaDuong"}}])
+        labels = json.dumps([{"name": "review:trivial"}])
+        result = run_hook(
+            make_bash_input("gh pr merge 42"),
+            gh_responses={
+                "pulls/42/reviews": reviews,
+                "issues/42/labels": labels,
+            },
+            tmp_path=tmp_path,
+        )
+        decision = result["stdout"]["hookSpecificOutput"]["permissionDecision"]
+        assert decision == "allow"
+
+    def test_unknown_reviewer_ignored(self, tmp_path):
+        """Review by a login not in the allowlist does not count toward threshold."""
+        reviews = json.dumps([{"user": {"login": "random-outsider"}}])
+        labels = json.dumps([{"name": "review:trivial"}])
+        result = run_hook(
+            make_bash_input("gh pr merge 42"),
+            gh_responses={
+                "pulls/42/reviews": reviews,
+                "issues/42/labels": labels,
+            },
+            tmp_path=tmp_path,
+        )
+        decision = result["stdout"]["hookSpecificOutput"]["permissionDecision"]
+        assert decision == "deny"
+
 
 # --- PR number extraction ---
 
@@ -162,10 +196,12 @@ class TestPRNumberExtraction:
 
     def test_bash_gh_pr_merge(self, tmp_path):
         """Extracts from 'gh pr merge 42'."""
-        reviews = json.dumps([
-            {"user": {"login": "HDMX-coding-agent"}},
-            {"user": {"login": "HDMX-coding-agent"}},
-        ])
+        reviews = json.dumps(
+            [
+                {"user": {"login": "HDMX-coding-agent"}},
+                {"user": {"login": "HDMX-coding-agent"}},
+            ]
+        )
         result = run_hook(
             make_bash_input("gh pr merge 42"),
             gh_responses={
@@ -179,10 +215,12 @@ class TestPRNumberExtraction:
 
     def test_mcp_merge_tool(self, tmp_path):
         """Extracts from MCP tool input with pullNumber (camelCase)."""
-        reviews = json.dumps([
-            {"user": {"login": "HDMX-coding-agent"}},
-            {"user": {"login": "HDMX-coding-agent"}},
-        ])
+        reviews = json.dumps(
+            [
+                {"user": {"login": "HDMX-coding-agent"}},
+                {"user": {"login": "HDMX-coding-agent"}},
+            ]
+        )
         result = run_hook(
             make_mcp_input(42),
             gh_responses={
@@ -204,10 +242,12 @@ class TestPRNumberExtraction:
 
     def test_url_format(self, tmp_path):
         """Extracts PR number from URL in command."""
-        reviews = json.dumps([
-            {"user": {"login": "HDMX-coding-agent"}},
-            {"user": {"login": "HDMX-coding-agent"}},
-        ])
+        reviews = json.dumps(
+            [
+                {"user": {"login": "HDMX-coding-agent"}},
+                {"user": {"login": "HDMX-coding-agent"}},
+            ]
+        )
         result = run_hook(
             make_bash_input(
                 "gh pr merge https://github.com/minhhaduong/oeconomia-climate-finance/pull/42"


### PR DESCRIPTION
## Summary
- Merge gate hook (.claude/hooks/check-reviews.sh) previously counted only reviews by HDMX-coding-agent; web MCP tokens authenticate as MinhHaDuong, so web agents kept bouncing off the hook (see #706, #719).
- Widen the allowlist to `{HDMX-coding-agent, MinhHaDuong}`. Still requires at least one recorded review — just accepts either identity.
- Tradeoff: MinhHaDuong is always the PR author on this solo repo, so this effectively permits self-review. Acceptable here; no change to the 2-review default or the review:trivial path.

## Test plan
- [x] `uv run pytest tests/test_check_reviews.py` (10 pass, including 2 new: minhhaduong counts, unknown login ignored)
- [ ] Merge this PR from web MCP as smoke test of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)