### PR TITLE
ticket 0058: close — PR #717 merged

### DIFF
--- a/tickets/0058-companion-paper-figures.erg
+++ b/tickets/0058-companion-paper-figures.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Create companion paper figures (4 canonical outputs)
-Status: doing
+Status: closed
 Created: 2026-04-15
 Author: claude
 Blocked-by: 0050
@@ -19,6 +19,7 @@ Blocked-by: 0042
 2026-04-17T19:45Z claude refactor — drop 'from __future__ import annotations' to satisfy TestRuffModernPython
 2026-04-17T19:50Z claude verify — 12/12 companion tests pass; make check-fast residue matches t0057 pre-existing failures (no new regressions)
 2026-04-21T00:00Z claude review-response — drop unused validated_zone_mask helper; fix fixture channel arg; PNG magic-byte check; 2 stub-fallback tests; correct G2/C2ST label in §4.4+4.5+5.1; fix §5.4 flow-diagram→bar-chart; caption wording (permutation-tested, six detection methods, explicit threshold, community-share rationale)
+2026-04-21T13:25Z claude status closed PR #717 merged (cherry-pick from orphaned #709, merge commit 364c133)
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Flip ticket 0058 from `doing` → `closed` now that PR #717 (cherry-pick restore of orphaned #709) has merged at 364c133.
- Tracker 0026 remains open: 0057 (doing) and 0064 (open) are the remaining Wave 3 sub-tickets.

## Test plan

- [x] `tickets/tools/go/erg validate tickets` — PASS (85 tickets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)