### PR TITLE
Zoo-only render target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ ZOO_RESULT_FIGS := content/figures/fig_zoo_S1_MMD.png \
 
 ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 
+# ZOO_FIGS deliberately excluded from ALL_FIGS / make figures: plot scripts not yet wired.
+# Add to ALL_FIGS when plot_schematic_*.py and plot_zoo_results.py have Makefile targets.
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(COMPANION_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,32 @@ COMPANION_INCLUDES := content/_includes/embedding-generation.md \
 		content/_includes/pca-scatter.md \
 		content/_includes/core-vs-full.md
 
+# Method-zoo include tree: one composer + 18 per-method entries.
+# Used by the zoo-only wrapper and transitively by technical-report.qmd.
+ZOO_INCLUDES := content/_includes/techrep-zoo.md \
+		content/_includes/zoo/S1_mmd.md \
+		content/_includes/zoo/S2_energy.md \
+		content/_includes/zoo/S3_sliced_wasserstein.md \
+		content/_includes/zoo/S4_frechet.md \
+		content/_includes/zoo/C2ST_embedding.md \
+		content/_includes/zoo/L1_js.md \
+		content/_includes/zoo/L2_ntr.md \
+		content/_includes/zoo/L3_term_burst.md \
+		content/_includes/zoo/C2ST_lexical.md \
+		content/_includes/zoo/G1_pagerank.md \
+		content/_includes/zoo/G2_spectral.md \
+		content/_includes/zoo/G3_coupling_age.md \
+		content/_includes/zoo/G4_cross_tradition.md \
+		content/_includes/zoo/G5_pref_attachment.md \
+		content/_includes/zoo/G6_entropy.md \
+		content/_includes/zoo/G7_disruption.md \
+		content/_includes/zoo/G8_betweenness.md \
+		content/_includes/zoo/G9_community.md
+
 # Quarto resolves includes across ALL project files (_quarto.yml render list),
 # even when rendering a single document. Every render target needs the full set.
 PROJECT_INCLUDES := $(MANUSCRIPT_INCLUDES) $(TECHREP_INCLUDES) \
-		$(DATAPAPER_INCLUDES) $(COMPANION_INCLUDES)
+		$(DATAPAPER_INCLUDES) $(COMPANION_INCLUDES) $(ZOO_INCLUDES)
 
 # ── Per-document figure sets ─────────────────────────────
 MANUSCRIPT_FIGS := content/figures/fig_bars_v1.png content/figures/fig_composition.png
@@ -130,6 +152,47 @@ NCC_FIGS        := content/figures/fig_ncc_divergence.png \
                    content/figures/fig_ncc_core_comparison.png \
                    content/figures/fig_ncc_bimodality.png \
                    content/figures/fig_ncc_alluvial.png
+
+# Method-zoo figures (17 schematics + 18 zoo result panels).
+# schematic_C2ST.png serves both C2ST_embedding and C2ST_lexical, hence 17 schematics for 18 methods.
+ZOO_SCHEMATICS := content/figures/schematic_S1_mmd.png \
+                  content/figures/schematic_S2_energy.png \
+                  content/figures/schematic_S3_sliced_wasserstein.png \
+                  content/figures/schematic_S4_frechet.png \
+                  content/figures/schematic_C2ST.png \
+                  content/figures/schematic_L1_js.png \
+                  content/figures/schematic_L2_ntr.png \
+                  content/figures/schematic_L3_burst.png \
+                  content/figures/schematic_G1_pagerank.png \
+                  content/figures/schematic_G2_spectral.png \
+                  content/figures/schematic_G3_coupling_age.png \
+                  content/figures/schematic_G4_cross_tradition.png \
+                  content/figures/schematic_G5_pref_attachment.png \
+                  content/figures/schematic_G6_entropy.png \
+                  content/figures/schematic_G7_disruption.png \
+                  content/figures/schematic_G8_betweenness.png \
+                  content/figures/schematic_G9_community.png
+
+ZOO_RESULT_FIGS := content/figures/fig_zoo_S1_MMD.png \
+                   content/figures/fig_zoo_S2_energy.png \
+                   content/figures/fig_zoo_S3_sliced_wasserstein.png \
+                   content/figures/fig_zoo_S4_frechet.png \
+                   content/figures/fig_zoo_C2ST_embedding.png \
+                   content/figures/fig_zoo_C2ST_lexical.png \
+                   content/figures/fig_zoo_L1.png \
+                   content/figures/fig_zoo_L2.png \
+                   content/figures/fig_zoo_L3.png \
+                   content/figures/fig_zoo_G1_pagerank.png \
+                   content/figures/fig_zoo_G2_spectral.png \
+                   content/figures/fig_zoo_G3_coupling_age.png \
+                   content/figures/fig_zoo_G4_cross_tradition.png \
+                   content/figures/fig_zoo_G5_pref_attachment.png \
+                   content/figures/fig_zoo_G6_entropy.png \
+                   content/figures/fig_zoo_G7_disruption.png \
+                   content/figures/fig_zoo_G8_betweenness.png \
+                   content/figures/fig_zoo_G9_community.png
+
+ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(COMPANION_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
@@ -560,7 +623,7 @@ analysis-stats: stats
 
 manuscript: output/content/manuscript.pdf output/content/manuscript.docx
 
-papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/data-paper.pdf output/content/companion-paper.pdf
+papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/zoo-only.pdf output/content/data-paper.pdf output/content/companion-paper.pdf
 
 # ── Namespaced aliases (Phase 3) ────────────────────────
 manuscript-render: manuscript
@@ -579,6 +642,11 @@ output/content/corpus-report.pdf: content/corpus-report.qmd $(PROJECT_INCLUDES) 
 	quarto render $< --to pdf
 
 output/content/technical-report.pdf: content/technical-report.qmd $(PROJECT_INCLUDES) $(BIB) content/technical-report-vars.yml $(TECHREP_FIGS) $(COMPANION_FIGS) .lexical_tfidf.stamp
+	quarto render $< --to pdf
+
+# Zoo-only: thin wrapper over $(ZOO_INCLUDES) for reviewers or cherry-picking.
+# Mirrors the TR recipe; same vars file, same bibliography, same engine.
+output/content/zoo-only.pdf: content/zoo-only.qmd $(PROJECT_INCLUDES) $(BIB) content/technical-report-vars.yml $(ZOO_FIGS)
 	quarto render $< --to pdf
 
 output/content/data-paper.pdf: content/data-paper.qmd $(PROJECT_INCLUDES) $(BIB) content/data-paper-vars.yml

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,7 @@ project:
     - content/manuscript.qmd
     - content/corpus-report.qmd
     - content/technical-report.qmd
+    - content/zoo-only.qmd
     - content/data-paper.qmd
     - content/companion-paper.qmd
 

--- a/content/zoo-only.qmd
+++ b/content/zoo-only.qmd
@@ -1,0 +1,14 @@
+---
+title: "The Zoo: 18 Methods for Corpus Change Detection"
+subtitle: "Technical reference (excerpt from *Analysis Methods and Results*)"
+author: "Minh Ha-Duong"
+date: "2026-04-21"
+metadata-files: [technical-report-vars.yml]
+bibliography: bibliography/main.bib
+format:
+  pdf:
+    pdf-engine: xelatex
+    number-sections: true
+---
+
+{{< include _includes/techrep-zoo.md >}}

--- a/tickets/0090-zoo-only-render.erg
+++ b/tickets/0090-zoo-only-render.erg
@@ -1,0 +1,42 @@
+%erg v1
+Title: Add zoo-only render target for standalone method zoo PDF
+Status: open
+Created: 2026-04-21
+Author: claude
+
+--- log ---
+2026-04-21T15:00Z claude created
+
+--- body ---
+## Context
+PR #718 refactored the technical report zoo into per-method includes
+under `content/_includes/zoo/`, composed by `content/_includes/techrep-zoo.md`.
+This small follow-up adds a thin wrapper `content/zoo-only.qmd` so the
+method zoo alone can be rendered (for reviewers or cherry-picking),
+without the surrounding corpus construction / overview framing of
+`content/technical-report.qmd`.
+
+## Actions
+1. Create `content/zoo-only.qmd` — one-line body including
+   `_includes/techrep-zoo.md`, YAML header matching technical-report.qmd
+   (same pdf engine, same vars file, same bibliography).
+2. Add `output/content/zoo-only.pdf` target to the Makefile. Mirror the
+   dependency shape of `output/content/technical-report.pdf`: the zoo
+   include plus the 18 per-method `.md` files plus the figure references
+   each contains (`figures/schematic_*.png` and `figures/fig_zoo_*.png`).
+3. Register `content/zoo-only.qmd` in `_quarto.yml` render list so Quarto
+   resolves includes consistently.
+
+## Test
+`quarto render content/zoo-only.qmd --to pdf` (or `--to html` if
+xelatex is unavailable) succeeds. Rendered document contains every
+method section heading: S1–S4, C2ST (embedding + lexical), L1–L3,
+G1–G9. Count check: 18 method sections.
+
+## Exit criteria
+- `content/zoo-only.qmd` exists and renders.
+- Makefile target for `output/content/zoo-only.pdf` exists and mirrors
+  the TR target's recipe.
+- `_quarto.yml` lists the new wrapper.
+- `content/technical-report.qmd` unchanged (still renders full framing).
+- PR opened and linked here.

--- a/tickets/0090-zoo-only-render.erg
+++ b/tickets/0090-zoo-only-render.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Add zoo-only render target for standalone method zoo PDF
-Status: open
+Status: closed
 Created: 2026-04-21
 Author: claude
 
 --- log ---
 2026-04-21T15:00Z claude created
+2026-04-21T14:54Z claude status closed PR #725
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- Thin wrapper `content/zoo-only.qmd` composes just `_includes/techrep-zoo.md`, so the 18-method zoo can be rendered standalone (for reviewers or cherry-picking). Enabled by PR #718's refactor to per-method includes under `_includes/zoo/`.
- New Makefile target `output/content/zoo-only.pdf` mirrors the `technical-report.pdf` recipe. Added `ZOO_INCLUDES` (1 composer + 18 method files) and `ZOO_FIGS` (17 schematics + 18 result panels, gathered by grepping the zoo includes). Included in the `papers:` aggregate.
- `_quarto.yml` registers `content/zoo-only.qmd` in the render list for consistent include resolution.

`content/technical-report.qmd` is unchanged and still renders with full framing. No zoo include content was edited.

Closes ticket 0090.

## Test plan
- [x] `quarto render content/zoo-only.qmd --to html` — output created, all 18 method headings present (`S1–S4`, `S5` (C2ST\_embedding), `L1–L3`, `L4` (C2ST\_lexical), `G1–G9`).
- [x] `quarto render content/zoo-only.qmd --to pdf` — xelatex build succeeds end-to-end (smoke-tested with stubbed zoo figures while the upstream plot scripts are not yet wired to Makefile targets).
- [ ] Once `schematic_*.png` and `fig_zoo_*.png` are generated from `scripts/plot_schematic_*.py` and `scripts/plot_zoo_results.py`, reviewers can run `make output/content/zoo-only.pdf` against real figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)