### PR TITLE
fix(0093): move zoo-only.pdf target into zoo.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -647,11 +647,6 @@ output/content/corpus-report.pdf: content/corpus-report.qmd $(PROJECT_INCLUDES) 
 output/content/technical-report.pdf: content/technical-report.qmd $(PROJECT_INCLUDES) $(BIB) content/technical-report-vars.yml $(TECHREP_FIGS) $(COMPANION_FIGS) .lexical_tfidf.stamp
 	quarto render $< --to pdf
 
-# Zoo-only: thin wrapper over $(ZOO_INCLUDES) for reviewers or cherry-picking.
-# Mirrors the TR recipe; same vars file, same bibliography, same engine.
-output/content/zoo-only.pdf: content/zoo-only.qmd $(PROJECT_INCLUDES) $(BIB) content/technical-report-vars.yml $(ZOO_FIGS)
-	quarto render $< --to pdf
-
 output/content/data-paper.pdf: content/data-paper.qmd $(PROJECT_INCLUDES) $(BIB) content/data-paper-vars.yml
 	quarto render $< --to pdf
 

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -66,3 +66,9 @@ class TestZooMkStructure:
             "G7_disruption",
         ):
             assert expected in methods, f"{expected} missing from CROSSYEAR_METHODS"
+
+    def test_zoo_only_pdf_target_in_zoo_mk(self, zoo_mk_text):
+        """zoo-only.pdf recipe must live in zoo.mk, not only in Makefile."""
+        assert re.search(
+            r"^output/content/zoo-only\.pdf\s*:", zoo_mk_text, re.MULTILINE
+        ), "zoo-only.pdf recipe must live in zoo.mk"

--- a/zoo.mk
+++ b/zoo.mk
@@ -70,3 +70,9 @@ $(ZOO_TABLES)/tab_crossyear_%.csv: $(ZOO_TABLES)/tab_div_%.csv scripts/compute_c
 
 $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_results.py
 	$(UV_RUN) python scripts/plot_zoo_results.py --method $* --output $@
+
+# ── Zoo-only PDF render (Phase 3) ────────────────────────────────────────────
+# Zoo-only: thin wrapper over $(ZOO_INCLUDES) for reviewers or cherry-picking.
+# Mirrors the TR recipe; same vars file, same bibliography, same engine.
+output/content/zoo-only.pdf: content/zoo-only.qmd $(PROJECT_INCLUDES) $(BIB) content/technical-report-vars.yml $(ZOO_FIGS)
+	quarto render $< --to pdf


### PR DESCRIPTION
## Summary

- Adds `test_zoo_only_pdf_target_in_zoo_mk` to `TestZooMkStructure` (red → green TDD)
- Moves `output/content/zoo-only.pdf` recipe from `Makefile` into `zoo.mk`, where it belongs alongside `ZOO_FIGS`
- Removes the recipe from `Makefile`; `papers:` phony target retains the reference and the target is visible via `-include zoo.mk` (line 63)

## Test plan

- [x] New test `test_zoo_only_pdf_target_in_zoo_mk` fails before green commit, passes after
- [x] All 8 `tests/test_zoo_mk.py` tests pass
- [x] All 35 `tests/test_makefile_contract.py` + `tests/test_makefile_namespaces.py` tests pass
- [x] Pre-existing unrelated failures (test_companion_pca, test_venue_table, etc.) not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)