### PR TITLE
refactor: move zoo-breakpoint-detection-methods to end of render list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ analysis-stats: stats
 
 manuscript: output/content/manuscript.pdf output/content/manuscript.docx
 
-papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/zoo-breakpoint-detection-methods.pdf output/content/data-paper.pdf output/content/multilayer-detection.pdf
+papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/data-paper.pdf output/content/multilayer-detection.pdf output/content/zoo-breakpoint-detection-methods.pdf
 
 # ── Namespaced aliases (Phase 3) ────────────────────────
 manuscript-render: manuscript

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,9 +5,9 @@ project:
     - content/manuscript.qmd
     - content/corpus-report.qmd
     - content/technical-report.qmd
-    - content/zoo-breakpoint-detection-methods.qmd
     - content/data-paper.qmd
     - content/multilayer-detection.qmd
+    - content/zoo-breakpoint-detection-methods.qmd
 
 bibliography: content/bibliography/main.bib
 


### PR DESCRIPTION
Alphabetically "z" comes last — move the zoo document after multilayer-detection in both `_quarto.yml` and the `papers` Makefile target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)