### PR TITLE
ticket 0099: L1 JS — smoothing note and low-n guard

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -59,6 +59,7 @@ divergence:
   lexical:
     tfidf_max_features: 5000
     tfidf_min_df: 3
+    low_n_threshold: 50      # warn when n_min < this in lexical window pairs
     L1_js: {}                                    # uses shared windows
     L2_novelty:
       windows: [3, 5]                            # past/future window

--- a/content/_includes/zoo/L1_js.md
+++ b/content/_includes/zoo/L1_js.md
@@ -31,6 +31,10 @@ $\text{JS} \in [0, \log 2]$; the square root is a proper metric.
 
 **Limitations.** Ignores word order and semantic similarity (synonyms treated as distinct tokens).
 
+**Smoothing:** Both the before- and after-period term-frequency distributions receive additive epsilon smoothing ($\varepsilon = 10^{-10}$) before computing the Jensen–Shannon divergence, preventing $\log(0)$ errors and bounding the statistic away from its theoretical maximum of $\log 2$.
+
+**Vocabulary dimension and sample size:** The TF-IDF vocabulary has up to $D = 5{,}000$ dimensions (after `min_df = 3` pre-filtering). A typical window contains $n = 150$–$400$ documents. The expected number of distinct vocabulary terms observed in a window of $n$ documents averaging $L \approx 150$ words is $D \cdot (1 - e^{-nL/D})$; at $n=200$ this gives approximately 98% occupancy — most terms appear at least once. Individual frequency estimates are noisier: a term observed $k$ times has relative standard error $\sim 1/\sqrt{k}$, so terms with $k < 4$ (filtered by `min_df = 3` at fit time, but not per-window) contribute mostly noise. When $n < 50$, the per-window effective vocabulary shrinks further, degrading JS divergence estimates; a warning is logged in this case.
+
 ### Corpus results
 
 ![](figures/fig_zoo_L1.png){width=100%}

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -89,6 +89,7 @@ def _iter_lexical_window_pairs(df, cfg):
     max_subsample = div_cfg["max_subsample"]
     tfidf_max_features = lex_cfg.get("tfidf_max_features", 5000)
     tfidf_min_df = lex_cfg.get("tfidf_min_df", 3)
+    low_n_threshold = lex_cfg.get("low_n_threshold", LOW_N_LEXICAL_THRESHOLD)
     equal_n = div_cfg.get("equal_n", False)
     seed = div_cfg["random_seed"]
     rng = np.random.RandomState(seed)
@@ -133,13 +134,13 @@ def _iter_lexical_window_pairs(df, cfg):
             X_after = vec.transform(texts_after)
 
             n_min = min(len(texts_before), len(texts_after))
-            if n_min < LOW_N_LEXICAL_THRESHOLD:
+            if n_min < low_n_threshold:
                 log.warning(
                     "lexical year=%d w=%d: n_min=%d < %d — JS estimates may be unreliable",
                     y,
                     w,
                     n_min,
-                    LOW_N_LEXICAL_THRESHOLD,
+                    low_n_threshold,
                 )
 
             yield y, w, X_before, X_after, vec

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -19,6 +19,8 @@ from utils import get_logger
 
 log = get_logger("_divergence_lexical")
 
+LOW_N_LEXICAL_THRESHOLD = 50
+
 
 # ── Data loading ───────────────────────────────────────────────────────────
 
@@ -129,6 +131,17 @@ def _iter_lexical_window_pairs(df, cfg):
 
             X_before = vec.transform(texts_before)
             X_after = vec.transform(texts_after)
+
+            n_min = min(len(texts_before), len(texts_after))
+            if n_min < LOW_N_LEXICAL_THRESHOLD:
+                log.warning(
+                    "lexical year=%d w=%d: n_min=%d < %d — JS estimates may be unreliable",
+                    y,
+                    w,
+                    n_min,
+                    LOW_N_LEXICAL_THRESHOLD,
+                )
+
             yield y, w, X_before, X_after, vec
 
 

--- a/tests/test_lexical_dimension_guard.py
+++ b/tests/test_lexical_dimension_guard.py
@@ -1,0 +1,17 @@
+"""TDD guard: LOW_N_LEXICAL_THRESHOLD must be defined in _divergence_lexical.py."""
+
+
+def test_l1_has_low_n_lexical_threshold():
+    """_divergence_lexical.py must define LOW_N_LEXICAL_THRESHOLD."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_divergence_lexical",
+        "scripts/_divergence_lexical.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert hasattr(mod, "LOW_N_LEXICAL_THRESHOLD"), (
+        "LOW_N_LEXICAL_THRESHOLD not defined in _divergence_lexical.py"
+    )
+    assert mod.LOW_N_LEXICAL_THRESHOLD == 50


### PR DESCRIPTION
## Summary

- Adds `LOW_N_LEXICAL_THRESHOLD = 50` to `scripts/_divergence_lexical.py` with a `log.warning` when either window in `_iter_lexical_window_pairs` has fewer than 50 documents (JS estimates degrade at small n).
- Adds two **Limitations** paragraphs to `content/_includes/zoo/L1_js.md`: one on epsilon-additive smoothing ($\varepsilon = 10^{-10}$), one on vocabulary dimension and per-window sample size.

## Test plan

- [x] `tests/test_lexical_dimension_guard.py::test_l1_has_low_n_lexical_threshold` — RED then GREEN (constant exists and equals 50)
- [x] `make check-fast` — 17 pre-existing failures, 880 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)