### PR TITLE
ticket 0097: add null model CI bands to zoo result figures

### DIFF
--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -11,13 +11,22 @@ Usage::
     uv run python scripts/plot_zoo_results.py \\
         --method S2_energy \\
         --output content/figures/fig_zoo_S2_energy.png
+
+    # With null CI band overlay:
+    uv run python scripts/plot_zoo_results.py \\
+        --method S2_energy \\
+        --output content/figures/fig_zoo_S2_energy.png \\
+        --null-ci content/tables/tab_null_S2_energy.csv
 """
 
 import argparse
 import os
 import sys
+from pathlib import Path
 
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 from pipeline_io import save_figure
 from plot_style import DARK, FILL, LIGHT, MED, apply_style
@@ -36,6 +45,23 @@ _WINDOW_STYLES = {
 
 _Z_THRESHOLD = 2.0
 _PERIOD_BREAKS = [2007, 2013]
+
+
+def _build_method_parser() -> argparse.ArgumentParser:
+    """Return the method-level argument parser (used by tests and main)."""
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument(
+        "--method",
+        required=True,
+        help="Method name, e.g. S2_energy",
+    )
+    parser.add_argument(
+        "--null-ci",
+        metavar="PATH",
+        default=None,
+        help="Optional: tab_null_{method}.csv for CI band overlay",
+    )
+    return parser
 
 
 def _empty_figure(output_stem: str, method: str) -> None:
@@ -57,7 +83,54 @@ def _empty_figure(output_stem: str, method: str) -> None:
     plt.close(fig)
 
 
-def _plot(df: pd.DataFrame, method: str, output_stem: str) -> None:
+def _load_null_df(null_ci_path: str | None) -> pd.DataFrame | None:
+    """Load null model CSV if path provided and file exists. Returns None otherwise."""
+    if not null_ci_path:
+        return None
+    if not Path(null_ci_path).exists():
+        log.warning("Null CI file not found: %s — skipping CI band", null_ci_path)
+        return None
+    null_df = pd.read_csv(null_ci_path)
+    null_df["window"] = null_df["window"].astype(str)
+    return null_df
+
+
+def _compute_null_z_threshold(df: pd.DataFrame, null_df: pd.DataFrame) -> pd.DataFrame:
+    """Add z_threshold column to null_df.
+
+    Z_threshold = (null_mean + 1.96 * null_std - mu_w) / sigma_w
+
+    where mu_w and sigma_w are the per-window mean and std of the crossyear
+    Z-scores (from the observed data).
+    """
+    mu_w = (
+        df.groupby("window")["value"].mean()
+        if "value" in df.columns
+        else df.groupby("window")["z_score"].mean()
+    )
+    sigma_w = (
+        df.groupby("window")["value"].std()
+        if "value" in df.columns
+        else df.groupby("window")["z_score"].std()
+    )
+
+    null_df = null_df.copy()
+    null_df["z_threshold"] = null_df.apply(
+        lambda r: (
+            (r["null_mean"] + 1.96 * r["null_std"] - mu_w.get(r["window"], np.nan))
+            / sigma_w.get(r["window"], np.nan)
+        ),
+        axis=1,
+    )
+    return null_df
+
+
+def _plot(
+    df: pd.DataFrame,
+    method: str,
+    output_stem: str,
+    null_df: pd.DataFrame | None = None,
+) -> None:
     """Render the Z-score panel and save to output_stem.png."""
     fig, ax = plt.subplots(figsize=(6, 4))
 
@@ -110,6 +183,22 @@ def _plot(df: pd.DataFrame, method: str, output_stem: str) -> None:
             label=style["label"],
             zorder=3,
         )
+
+        # Null CI band: dashed line at 95th-percentile null threshold.
+        if null_df is not None:
+            ci_sub = null_df[null_df["window"] == w_str].sort_values("year")
+            if not ci_sub.empty:
+                ax.plot(
+                    ci_sub["year"],
+                    ci_sub["z_threshold"],
+                    linestyle="--",
+                    color=style["color"],
+                    linewidth=0.7,
+                    alpha=0.7,
+                    label=None,
+                    zorder=2,
+                )
+
         plotted.append(w_str)
 
     # Fallback: cumulative or single-window methods (G3, G4, G7, L3).
@@ -137,7 +226,24 @@ def _plot(df: pd.DataFrame, method: str, output_stem: str) -> None:
     if not df.empty:
         ax.set_xlim(df["year"].min() - 0.5, df["year"].max() + 0.5)
 
-    ax.legend(loc="upper left", frameon=False, fontsize=7)
+    # Add a single legend entry for the null CI band if present.
+    handles, labels = ax.get_legend_handles_labels()
+    if null_df is not None and plotted:
+        handles.append(
+            mlines.Line2D(
+                [],
+                [],
+                color="0.5",
+                linestyle="--",
+                linewidth=0.7,
+                label="null 95% CI",
+            )
+        )
+        labels.append("null 95% CI")
+
+    ax.legend(
+        handles=handles, labels=labels, loc="upper left", frameon=False, fontsize=7
+    )
     fig.tight_layout()
     save_figure(fig, output_stem, dpi=150)
     plt.close(fig)
@@ -147,12 +253,7 @@ def _plot(df: pd.DataFrame, method: str, output_stem: str) -> None:
 def main() -> None:
     io_args, extra = parse_io_args()
 
-    parser = argparse.ArgumentParser(add_help=True)
-    parser.add_argument(
-        "--method",
-        required=True,
-        help="Method name, e.g. S2_energy",
-    )
+    parser = _build_method_parser()
     args = parser.parse_args(extra)
 
     method = args.method
@@ -182,7 +283,11 @@ def main() -> None:
     # window is written as str but pd.read_csv may infer int; normalise.
     df["window"] = df["window"].astype(str)
 
-    _plot(df, method, output_stem)
+    null_df = _load_null_df(args.null_ci)
+    if null_df is not None:
+        null_df = _compute_null_z_threshold(df, null_df)
+
+    _plot(df, method, output_stem, null_df=null_df)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 from pipeline_io import save_figure
 from plot_style import DARK, FILL, LIGHT, MED, apply_style
@@ -85,7 +84,7 @@ def _empty_figure(output_stem: str, method: str) -> None:
 
 def _load_null_df(null_ci_path: str | None) -> pd.DataFrame | None:
     """Load null model CSV if path provided and file exists. Returns None otherwise."""
-    if not null_ci_path:
+    if null_ci_path is None:
         return None
     if not Path(null_ci_path).exists():
         log.warning("Null CI file not found: %s — skipping CI band", null_ci_path)
@@ -103,25 +102,16 @@ def _compute_null_z_threshold(df: pd.DataFrame, null_df: pd.DataFrame) -> pd.Dat
     where mu_w and sigma_w are the per-window mean and std of the crossyear
     Z-scores (from the observed data).
     """
-    mu_w = (
-        df.groupby("window")["value"].mean()
-        if "value" in df.columns
-        else df.groupby("window")["z_score"].mean()
-    )
-    sigma_w = (
-        df.groupby("window")["value"].std()
-        if "value" in df.columns
-        else df.groupby("window")["z_score"].std()
-    )
+    # tab_crossyear_*.csv always has both 'value' (raw D) and 'z_score'; use 'value'
+    # to match the original Z-score normalization: Z = (D - mu_w) / sigma_w.
+    col = "value" if "value" in df.columns else "z_score"
+    mu_w = df.groupby("window")[col].mean()
+    sigma_w = df.groupby("window")[col].std()
 
     null_df = null_df.copy()
-    null_df["z_threshold"] = null_df.apply(
-        lambda r: (
-            (r["null_mean"] + 1.96 * r["null_std"] - mu_w.get(r["window"], np.nan))
-            / sigma_w.get(r["window"], np.nan)
-        ),
-        axis=1,
-    )
+    null_df["z_threshold"] = (
+        null_df["null_mean"] + 1.96 * null_df["null_std"] - null_df["window"].map(mu_w)
+    ) / null_df["window"].map(sigma_w)
     return null_df
 
 

--- a/tests/test_zoo_null_ci.py
+++ b/tests/test_zoo_null_ci.py
@@ -1,0 +1,43 @@
+"""Tests for --null-ci argument in plot_zoo_results.py."""
+
+import argparse
+import os
+import sys
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+
+def _build_method_parser() -> argparse.ArgumentParser:
+    """Return the method-level argument parser from plot_zoo_results.
+
+    This mirrors the parser constructed inside main() so we can test its
+    help text without running the full script (which requires --output and
+    live data).
+    """
+    import plot_zoo_results
+
+    return plot_zoo_results._build_method_parser()
+
+
+def test_plot_zoo_results_accepts_null_ci_arg():
+    """plot_zoo_results.py must accept --null-ci argument."""
+    parser = _build_method_parser()
+    help_text = parser.format_help()
+    assert "--null-ci" in help_text, "--null-ci argument not found in parser help"
+
+
+def test_null_ci_defaults_to_none():
+    """--null-ci should default to None (optional)."""
+    parser = _build_method_parser()
+    args = parser.parse_args(["--method", "S2_energy"])
+    assert args.null_ci is None
+
+
+def test_null_ci_accepts_path():
+    """--null-ci should accept a path string."""
+    parser = _build_method_parser()
+    args = parser.parse_args(
+        ["--method", "S2_energy", "--null-ci", "/tmp/tab_null_S2_energy.csv"]
+    )
+    assert args.null_ci == "/tmp/tab_null_S2_energy.csv"

--- a/tests/test_zoo_null_ci.py
+++ b/tests/test_zoo_null_ci.py
@@ -4,6 +4,9 @@ import argparse
 import os
 import sys
 
+import pandas as pd
+import pytest
+
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
@@ -41,3 +44,47 @@ def test_null_ci_accepts_path():
         ["--method", "S2_energy", "--null-ci", "/tmp/tab_null_S2_energy.csv"]
     )
     assert args.null_ci == "/tmp/tab_null_S2_energy.csv"
+
+
+def test_load_null_df_returns_none_when_path_is_none():
+    """_load_null_df(None) must return None without raising."""
+    import plot_zoo_results
+
+    assert plot_zoo_results._load_null_df(None) is None
+
+
+def test_load_null_df_returns_none_for_missing_file():
+    """_load_null_df with a non-existent path returns None (graceful)."""
+    import plot_zoo_results
+
+    assert plot_zoo_results._load_null_df("/nonexistent/path/tab_null.csv") is None
+
+
+def test_compute_null_z_threshold_adds_column():
+    """_compute_null_z_threshold adds z_threshold column using vectorized map."""
+    import plot_zoo_results
+
+    df = pd.DataFrame(
+        {
+            "year": [2005, 2006, 2007, 2008],
+            "window": ["3", "3", "3", "3"],
+            "value": [1.0, 2.0, 3.0, 4.0],
+            "z_score": [0.5, 1.0, 1.5, 2.0],
+        }
+    )
+    null_df = pd.DataFrame(
+        {
+            "year": [2005, 2006, 2007, 2008],
+            "window": ["3", "3", "3", "3"],
+            "null_mean": [1.5, 1.5, 1.5, 1.5],
+            "null_std": [0.5, 0.5, 0.5, 0.5],
+        }
+    )
+    result = plot_zoo_results._compute_null_z_threshold(df, null_df)
+    assert "z_threshold" in result.columns
+    assert not result["z_threshold"].isna().any()
+    # z_threshold = (null_mean + 1.96*null_std - mu_w) / sigma_w
+    mu_w = df["value"].mean()  # window "3" only
+    sigma_w = df["value"].std()
+    expected = (1.5 + 1.96 * 0.5 - mu_w) / sigma_w
+    assert pytest.approx(result["z_threshold"].iloc[0], rel=1e-6) == expected

--- a/zoo.mk
+++ b/zoo.mk
@@ -71,9 +71,6 @@ $(ZOO_TABLES)/tab_crossyear_%.csv: $(ZOO_TABLES)/tab_div_%.csv scripts/compute_c
 # Methods with null model tables get an explicit target that passes --null-ci
 # so the CI band overlay is rendered.  The pattern rule handles all others.
 
-# Methods with null model tables (subset of CROSSYEAR_METHODS).
-NULL_TABLE_METHODS := S2_energy L1 G9_community G2_spectral
-
 $(ZOO_FIGS)/fig_zoo_S2_energy.png: $(ZOO_TABLES)/tab_crossyear_S2_energy.csv $(ZOO_TABLES)/tab_null_S2_energy.csv scripts/plot_zoo_results.py
 	$(UV_RUN) python scripts/plot_zoo_results.py --method S2_energy --output $@ --null-ci $(ZOO_TABLES)/tab_null_S2_energy.csv
 

--- a/zoo.mk
+++ b/zoo.mk
@@ -67,6 +67,24 @@ $(ZOO_TABLES)/tab_crossyear_%.csv: $(ZOO_TABLES)/tab_div_%.csv scripts/compute_c
 #
 # One diagnostic figure per method showing Z(t,w) for w=2..5.
 # Degrades gracefully: writes a placeholder figure if the CSV is absent.
+#
+# Methods with null model tables get an explicit target that passes --null-ci
+# so the CI band overlay is rendered.  The pattern rule handles all others.
+
+# Methods with null model tables (subset of CROSSYEAR_METHODS).
+NULL_TABLE_METHODS := S2_energy L1 G9_community G2_spectral
+
+$(ZOO_FIGS)/fig_zoo_S2_energy.png: $(ZOO_TABLES)/tab_crossyear_S2_energy.csv $(ZOO_TABLES)/tab_null_S2_energy.csv scripts/plot_zoo_results.py
+	$(UV_RUN) python scripts/plot_zoo_results.py --method S2_energy --output $@ --null-ci $(ZOO_TABLES)/tab_null_S2_energy.csv
+
+$(ZOO_FIGS)/fig_zoo_L1.png: $(ZOO_TABLES)/tab_crossyear_L1.csv $(ZOO_TABLES)/tab_null_L1.csv scripts/plot_zoo_results.py
+	$(UV_RUN) python scripts/plot_zoo_results.py --method L1 --output $@ --null-ci $(ZOO_TABLES)/tab_null_L1.csv
+
+$(ZOO_FIGS)/fig_zoo_G9_community.png: $(ZOO_TABLES)/tab_crossyear_G9_community.csv $(ZOO_TABLES)/tab_null_G9_community.csv scripts/plot_zoo_results.py
+	$(UV_RUN) python scripts/plot_zoo_results.py --method G9_community --output $@ --null-ci $(ZOO_TABLES)/tab_null_G9_community.csv
+
+$(ZOO_FIGS)/fig_zoo_G2_spectral.png: $(ZOO_TABLES)/tab_crossyear_G2_spectral.csv $(ZOO_TABLES)/tab_null_G2_spectral.csv scripts/plot_zoo_results.py
+	$(UV_RUN) python scripts/plot_zoo_results.py --method G2_spectral --output $@ --null-ci $(ZOO_TABLES)/tab_null_G2_spectral.csv
 
 $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_results.py
 	$(UV_RUN) python scripts/plot_zoo_results.py --method $* --output $@


### PR DESCRIPTION
Add `--null-ci` argument to `plot_zoo_results.py`. For the 4 methods that have null model tables (S2_energy, L1, G9_community, G2_spectral), overlays a dashed 95% CI band derived from the permutation null distribution, expressed in cross-year Z-score units.

Zoo.mk updated with explicit targets for those 4 methods.

Closes the code portion of ticket 0097 (prose already landed in #743).

🤖 Generated with [Claude Code](https://claude.com/claude-code)