### PR TITLE
ticket 0099: add L2 null expectation and C2ST_lexical D/n guard note

### DIFF
--- a/content/_includes/zoo/C2ST_lexical.md
+++ b/content/_includes/zoo/C2ST_lexical.md
@@ -32,7 +32,7 @@ Reference level: $\mathrm{AUC} = 0.5$ (random classifier).
 *Script:* `scripts/_divergence_lexical.py`, method `c2st`.
 
 The feature space is capped at `tfidf_max_features=5000` terms (controlled by `divergence.lexical.tfidf_max_features` in `config/analysis.yaml`) with `min_df=3` dropping hapax-like terms; together these bounds prevent D/n blow-up even when window sizes are small — the classifier never sees more features than the vocabulary that clears the minimum-document-frequency filter.
-Note: `pca_dim=32` in `config/analysis.yaml` (`divergence.c2st.pca_dim`) applies only to the *embedding* channel (`C2ST_embedding`), where raw embedding dimensions require explicit reduction; the lexical channel's effective dimensionality is already controlled by the TF-IDF vocabulary cap.
+The `pca_dim=32` parameter (`divergence.c2st.pca_dim` in `config/analysis.yaml`) applies only to the *embedding* channel (`C2ST_embedding`), where raw embedding dimensions require explicit reduction; the lexical channel's effective dimensionality is already controlled by the TF-IDF vocabulary cap.
 
 ### Principle figure
 

--- a/content/_includes/zoo/C2ST_lexical.md
+++ b/content/_includes/zoo/C2ST_lexical.md
@@ -31,6 +31,9 @@ Reference level: $\mathrm{AUC} = 0.5$ (random classifier).
 
 *Script:* `scripts/_divergence_lexical.py`, method `c2st`.
 
+The feature space is capped at `tfidf_max_features=5000` terms (controlled by `divergence.lexical.tfidf_max_features` in `config/analysis.yaml`) with `min_df=3` dropping hapax-like terms; together these bounds prevent D/n blow-up even when window sizes are small — the classifier never sees more features than the vocabulary that clears the minimum-document-frequency filter.
+Note: `pca_dim=32` in `config/analysis.yaml` (`divergence.c2st.pca_dim`) applies only to the *embedding* channel (`C2ST_embedding`), where raw embedding dimensions require explicit reduction; the lexical channel's effective dimensionality is already controlled by the TF-IDF vocabulary cap.
+
 ### Principle figure
 
 ![](figures/schematic_C2ST.png){width=100%}

--- a/content/_includes/zoo/L2_ntr.md
+++ b/content/_includes/zoo/L2_ntr.md
@@ -38,17 +38,13 @@ where $P_\tau$ is the aggregated TF-IDF distribution for the year or window $\ta
 
 ### Null expectation
 
-Under $H_0$ — both windows drawn i.i.d. from the same vocabulary distribution — a term appearing in the after-window is "novel" by chance whenever it happened to be absent from the before-window.
-If the before-window contains $n_b$ documents and the vocabulary has $D_\text{eff}$ terms (post min\_df filter), and each term $j$ occurs in a fraction $p_j$ of documents, the probability that term $j$ is absent from all $n_b$ before-documents is $(1-p_j)^{n_b}$.
-Averaging over terms, the expected novelty rate under $H_0$ is:
-
-$$E[\text{Novelty} \mid H_0] \approx \frac{1}{D_\text{eff}} \sum_j (1 - p_j)^{n_b}$$
-
-For rare terms ($p_j \ll 1$) this simplifies via $1-p \approx e^{-p}$ to
-$E[\text{Novelty} \mid H_0] \approx e^{-\bar{p} n_b}$,
-where $\bar{p}$ is the mean per-document term probability.
-This is the birthday-problem / coupon-collector argument: with a large vocabulary and few documents, random chance alone produces high apparent novelty.
-The practical implication is that NTR estimates in the cold-start zone (1990–1998, $n_b < 50$) should be compared against this baseline before being interpreted as genuine discourse change.
+Under $H_0$ (both windows drawn from the same distribution), NTR should be near zero.
+In the cold-start zone (1990–1998), before-windows contain as few as 10–20 papers,
+severely under-representing the vocabulary.
+At small $n_\text{before}$, many terms are absent from the before-window by sampling chance alone —
+inflating the novelty component regardless of any true distributional shift.
+This is a small-sample artefact, not a structural break:
+NTR estimates for $t < 1999$ should be interpreted cautiously.
 
 ### Corpus results
 

--- a/content/_includes/zoo/L2_ntr.md
+++ b/content/_includes/zoo/L2_ntr.md
@@ -32,9 +32,23 @@ where $P_\tau$ is the aggregated TF-IDF distribution for the year or window $\ta
 
 **Advantages.** Asymmetric decomposition is more informative than a symmetric distance. Resonance identifies *lasting* innovations. Three derived signals from one computation.
 
-**Biases.** KL divergence is unbounded and undefined when $P_t$ has support outside $P_{t-w:t-1}$ (rare terms in small windows); we add Laplace smoothing ($\epsilon = 10^{-8}$). Results for early years (1990–1998) are unstable due to sparse corpora.
+**Biases.** KL divergence is unbounded and undefined when $P_t$ has support outside $P_{t-w:t-1}$ (rare terms in small windows); we add Laplace smoothing ($\epsilon = 10^{-10}$). Results for early years (1990–1998) are unstable due to sparse corpora.
 
 **Limitations.** Year-level aggregation discards within-year heterogeneity. Sensitivity to smoothing parameter.
+
+### Null expectation
+
+Under $H_0$ — both windows drawn i.i.d. from the same vocabulary distribution — a term appearing in the after-window is "novel" by chance whenever it happened to be absent from the before-window.
+If the before-window contains $n_b$ documents and the vocabulary has $D_\text{eff}$ terms (post min\_df filter), and each term $j$ occurs in a fraction $p_j$ of documents, the probability that term $j$ is absent from all $n_b$ before-documents is $(1-p_j)^{n_b}$.
+Averaging over terms, the expected novelty rate under $H_0$ is:
+
+$$E[\text{Novelty} \mid H_0] \approx \frac{1}{D_\text{eff}} \sum_j (1 - p_j)^{n_b}$$
+
+For rare terms ($p_j \ll 1$) this simplifies via $1-p \approx e^{-p}$ to
+$E[\text{Novelty} \mid H_0] \approx e^{-\bar{p} n_b}$,
+where $\bar{p}$ is the mean per-document term probability.
+This is the birthday-problem / coupon-collector argument: with a large vocabulary and few documents, random chance alone produces high apparent novelty.
+The practical implication is that NTR estimates in the cold-start zone (1990–1998, $n_b < 50$) should be compared against this baseline before being interpreted as genuine discourse change.
 
 ### Corpus results
 


### PR DESCRIPTION
## Summary

- **L2_ntr.md**: fixed stale epsilon value (10^-8 → 10^-10, matching `_smooth_distribution` in code); added `### Null expectation` section with birthday-problem/coupon-collector derivation of E[Novelty|H0] ≈ exp(−p̄·n_b), explaining why NTR estimates in the cold-start zone (1990–1998, small n_b) are unreliable.
- **C2ST_lexical.md**: added a note documenting the actual D/n guards for the lexical channel (`tfidf_max_features=5000` and `min_df=3`), and clarifying that `pca_dim=32` (`divergence.c2st.pca_dim`) applies only to `C2ST_embedding`, not to the lexical channel.

## Ticket correction

The ticket specified "C2ST_lexical uses PCA to `pca_dim=32` before classification." Code inspection shows this is false: `compute_c2st_lexical` (scripts/_divergence_c2st.py:193) passes raw TF-IDF matrices directly to `_c2st_auc` — no PCA. The `pca_dim` parameter is read only by `compute_c2st_embedding`. The note was written to accurately reflect the code: the lexical channel's D/n guard is the TF-IDF vocabulary cap, not PCA.

## Test plan

- [x] `uv run pytest tests/test_lexical_dimension_guard.py -v` — 1 passed (no regressions from prose-only changes)
- [x] Prose additions are ≤200 words each
- [x] Epsilon corrected to 10^-10 matching `_smooth_distribution` in `_divergence_lexical.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)