### PR TITLE
ticket 0098 (partial): growing-corpus bias theory + --no-equal-n flag

### DIFF
--- a/content/_includes/techrep/overview.md
+++ b/content/_includes/techrep/overview.md
@@ -29,19 +29,20 @@ majority window grows.
 
 **Size-dependent bias.** Many statistics — including energy distance, MMD, and
 JS divergence — have non-zero expected value under the null $d = 0$ when
-$|1/n_\text{before} - 1/n_\text{after}|$ is large. The bias is not an artefact of a
-true shift; it is a finite-sample effect that grows with the size imbalance. Without
-correction, the series would show artificially elevated divergence in early and late
-years simply because the two windows are unequal in size.
+$|1/n_\text{before} - 1/n_\text{after}|$ is large [@gretton2012; @perezcruz2008].
+The bias is not an artefact of a true shift; it is a finite-sample effect that grows
+with the size imbalance. Without correction, the series would show artificially
+elevated divergence in early and late years simply because the two windows are unequal
+in size.
 
 **Equal-$n$ subsampling.** Before computing $D$, we subsample the larger window to
 $\min(n_\text{before}, n_\text{after})$ papers, drawn without replacement. This
 equalises both the variance contribution and eliminates the size-dependent bias
 component. The cost is a power loss proportional to the dropped fraction — largest in
-the middle years of the corpus where one window may be several times larger than the
-other. To reduce the variance introduced by a single random draw, we use R = 3
-median-of-three subsampling (see §Annex): the statistic is the median over three
-independent subsample draws at each anchor year.
+the early and late years of the corpus where imbalance is greatest. To reduce the
+variance introduced by a single random draw, we repeat the subsampling $R = 3$ times
+and take the median: the reported statistic is the median over three independent draws
+at each anchor year.
 
 **Configuration.** Equal-$n$ subsampling is controlled by `divergence.equal_n: true`
 in `config/analysis.yaml` (default). It can be disabled at runtime with

--- a/content/_includes/techrep/overview.md
+++ b/content/_includes/techrep/overview.md
@@ -12,3 +12,38 @@ Methods are grouped into three layers:
 - **Part L — Lexical.** Compare TF-IDF vocabulary distributions. Complementary to semantic methods; more interpretable (discriminating terms are directly readable).
 - **Part G — Citation graph.** Compare citation network topology: degree distributions, community structure, centrality. These methods detect changes in *how knowledge flows* rather than *what is said*.
 - **C2ST (Classifier two-sample tests).** C2ST\_embedding lives in Part S; C2ST\_lexical lives in Part L. Each asks the same meta-check question — can a classifier distinguish "before" from "after" better than chance? — in its respective feature space.
+
+## Growing-corpus bias and equal-n debiasing
+
+The climate finance corpus grew roughly 15× between 1995 and 2020, so the "after"
+window for any anchor year $t$ systematically contains more papers than the "before"
+window. This asymmetry introduces two problems.
+
+**Variance imbalance.** For a distance statistic $D$ estimating $d(P_\text{before},
+P_\text{after})$, the finite-sample estimator has variance $O(1/n_\text{before} +
+1/n_\text{after})$. When $n_\text{after} \gg n_\text{before}$ (early anchor years) or
+$n_\text{before} \gg n_\text{after}$ (late anchor years, where indexing lag shrinks
+the after window), the estimator variance is dominated by whichever sample is smaller.
+The effective precision is limited by the minority window no matter how large the
+majority window grows.
+
+**Size-dependent bias.** Many statistics — including energy distance, MMD, and
+JS divergence — have non-zero expected value under the null $d = 0$ when
+$|1/n_\text{before} - 1/n_\text{after}|$ is large. The bias is not an artefact of a
+true shift; it is a finite-sample effect that grows with the size imbalance. Without
+correction, the series would show artificially elevated divergence in early and late
+years simply because the two windows are unequal in size.
+
+**Equal-$n$ subsampling.** Before computing $D$, we subsample the larger window to
+$\min(n_\text{before}, n_\text{after})$ papers, drawn without replacement. This
+equalises both the variance contribution and eliminates the size-dependent bias
+component. The cost is a power loss proportional to the dropped fraction — largest in
+the middle years of the corpus where one window may be several times larger than the
+other. To reduce the variance introduced by a single random draw, we use R = 3
+median-of-three subsampling (see §Annex): the statistic is the median over three
+independent subsample draws at each anchor year.
+
+**Configuration.** Equal-$n$ subsampling is controlled by `divergence.equal_n: true`
+in `config/analysis.yaml` (default). It can be disabled at runtime with
+`--no-equal-n` to reproduce the biased series and assess the magnitude of the
+correction.

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1481,3 +1481,12 @@
   pages   = {87--100},
   doi     = {10.1016/j.joi.2010.09.002}
 }
+
+@inproceedings{perezcruz2008,
+  author    = {Fernando Pérez-Cruz},
+  title     = {Kullback-Leibler Divergence Estimation of Continuous Distributions},
+  booktitle = {2008 IEEE International Symposium on Information Theory},
+  year      = {2008},
+  pages     = {1666--1670},
+  doi       = {10.1109/ISIT.2008.4595271}
+}

--- a/scripts/compute_divergence.py
+++ b/scripts/compute_divergence.py
@@ -133,9 +133,21 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--method", required=True, choices=METHODS.keys())
+    parser.add_argument(
+        "--no-equal-n",
+        dest="equal_n",
+        action="store_false",
+        default=None,
+        help="Disable equal-n subsampling (override config equal_n: true)",
+    )
     args = parser.parse_args(extra)
 
     cfg = load_analysis_config()
+
+    # CLI override: --no-equal-n sets cfg["divergence"]["equal_n"] = False,
+    # propagating to all private modules that read div_cfg.get("equal_n").
+    if args.equal_n is not None:
+        cfg["divergence"]["equal_n"] = args.equal_n
     module_name, func_name, channel, needs_emb, needs_cit = METHODS[args.method]
 
     # Lazy import

--- a/scripts/compute_divergence.py
+++ b/scripts/compute_divergence.py
@@ -144,8 +144,7 @@ def main():
 
     cfg = load_analysis_config()
 
-    # CLI override: --no-equal-n sets cfg["divergence"]["equal_n"] = False,
-    # propagating to all private modules that read div_cfg.get("equal_n").
+    # Mutate cfg so private modules pick up the override without API changes.
     if args.equal_n is not None:
         cfg["divergence"]["equal_n"] = args.equal_n
     module_name, func_name, channel, needs_emb, needs_cit = METHODS[args.method]

--- a/tests/test_bias_flag.py
+++ b/tests/test_bias_flag.py
@@ -1,0 +1,47 @@
+"""Test that compute_divergence.py accepts --no-equal-n flag.
+
+RED: fails because --no-equal-n is not yet defined.
+GREEN: passes after flag is added to the argparse parser.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def test_no_equal_n_flag_accepted(tmp_path):
+    """compute_divergence.py must accept --no-equal-n flag without argparse error.
+
+    Uses the smoke fixture to run a real (short) computation.
+    Before the flag exists: argparse rejects it with 'unrecognized arguments',
+    rc=2.  After the flag is added: the run either succeeds or fails for other
+    reasons — but never with 'unrecognized arguments: --no-equal-n'.
+    """
+    smoke_dir = os.path.join(os.path.dirname(__file__), "fixtures", "smoke")
+    script = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "compute_divergence.py"
+    )
+    out_csv = str(tmp_path / "tab_div_L1.csv")
+
+    env = os.environ.copy()
+    env["CLIMATE_FINANCE_DATA"] = smoke_dir
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            script,
+            "--method",
+            "L1",
+            "--output",
+            out_csv,
+            "--no-equal-n",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # The flag must not be rejected by argparse.
+    assert "unrecognized arguments: --no-equal-n" not in result.stderr, (
+        f"Flag rejected by argparse.\nstderr: {result.stderr}"
+    )

--- a/tests/test_bias_flag.py
+++ b/tests/test_bias_flag.py
@@ -1,7 +1,7 @@
-"""Test that compute_divergence.py accepts --no-equal-n flag.
+"""Tests for the --no-equal-n flag on compute_divergence.py.
 
-RED: fails because --no-equal-n is not yet defined.
-GREEN: passes after flag is added to the argparse parser.
+test_no_equal_n_flag_accepted: checks that argparse accepts the flag.
+test_bias_flag_produces_different_output: checks that the flag changes values.
 """
 
 import os
@@ -44,4 +44,60 @@ def test_no_equal_n_flag_accepted(tmp_path):
     # The flag must not be rejected by argparse.
     assert "unrecognized arguments: --no-equal-n" not in result.stderr, (
         f"Flag rejected by argparse.\nstderr: {result.stderr}"
+    )
+
+
+def test_bias_flag_produces_different_output(tmp_path):
+    """--no-equal-n and default equal_n produce different divergence values.
+
+    Uses the smoke fixture (100 works, unequal year distribution: few papers
+    in early years, many in late years).  S2_energy is sample-size-sensitive:
+    energy distance depends on the actual vectors used, not just their mean,
+    so subsampling the larger window to match the smaller one changes the
+    statistic.  L1 (JS on mean TF-IDF) is not sensitive enough for this check.
+
+    The test asserts mean(value) differs between runs, confirming that the
+    flag propagates to the private computation module.
+    """
+    smoke_dir = os.path.join(os.path.dirname(__file__), "fixtures", "smoke")
+    script = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "compute_divergence.py"
+    )
+    out_equal = str(tmp_path / "tab_div_equal.csv")
+    out_unequal = str(tmp_path / "tab_div_unequal.csv")
+
+    env = os.environ.copy()
+    env["CLIMATE_FINANCE_DATA"] = smoke_dir
+
+    base_cmd = [sys.executable, script, "--method", "S2_energy"]
+
+    # Run with equal_n=True (config default, no flag)
+    r_equal = subprocess.run(
+        base_cmd + ["--output", out_equal],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert r_equal.returncode == 0, f"equal_n run failed:\n{r_equal.stderr}"
+
+    # Run with equal_n=False (--no-equal-n override)
+    r_unequal = subprocess.run(
+        base_cmd + ["--output", out_unequal, "--no-equal-n"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert r_unequal.returncode == 0, f"--no-equal-n run failed:\n{r_unequal.stderr}"
+
+    import pandas as pd
+
+    df_equal = pd.read_csv(out_equal)
+    df_unequal = pd.read_csv(out_unequal)
+
+    mean_equal = df_equal["value"].mean()
+    mean_unequal = df_unequal["value"].mean()
+
+    assert abs(mean_equal - mean_unequal) > 1e-6, (
+        f"--no-equal-n had no effect on S2_energy output: "
+        f"mean_equal={mean_equal:.6f}, mean_unequal={mean_unequal:.6f}"
     )


### PR DESCRIPTION
## Summary

- Adds a subsection "Growing-corpus bias and equal-n debiasing" to `content/_includes/techrep/overview.md` (≤300 words) explaining variance imbalance, size-dependent bias under H₀, equal-n subsampling as the correction, and the R=3 median-of-three annex reference.
- Adds `--no-equal-n` CLI flag to `scripts/compute_divergence.py`. Mutating `cfg["divergence"]["equal_n"]` before dispatch propagates to all private modules (`_divergence_semantic`, `_divergence_lexical`, `_divergence_io`, `_divergence_c2st`) without touching them.
- TDD: RED commit (`test_no_equal_n_flag_accepted` fails — argparse rejects flag), GREEN commit (flag accepted).

## Deferred (needs padme rerun)

- `tab_div_biased_*.csv` tables
- `plot_zoo_bias_comparison.py` and figures
- `zoo.mk` recipes for biased targets

## Test plan

- [x] `tests/test_bias_flag.py::test_no_equal_n_flag_accepted` passes GREEN
- [x] `make check-fast` — 18 pre-existing failures, no new failures introduced
- [ ] Prose review of overview.md addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)