### PR TITLE
ticket 0100: add gap=1 to window semantics across all four channels

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -23,6 +23,7 @@ divergence:
   random_seed: 42
   backend: auto        # auto (GPU if available), cpu, cuda
   windows: [2, 3, 4]
+  gap: 1               # years excluded around split: before=[t-w, t-gap], after=[t+gap, t+w]
   min_papers: 30          # per window minimum (override with 5 for smoke)
   min_papers_smoke: 5     # auto-detected when n_works < 200
   max_subsample: 2000     # cap per side for O(n²) methods

--- a/content/_includes/techrep/overview.md
+++ b/content/_includes/techrep/overview.md
@@ -4,7 +4,7 @@ This document surveys the structural break detection methods applied to the clim
 ({{< meta corpus_total >}} works, 1990--2024).
 Each method answers the same question in a different vocabulary:
 *does the distribution of works written before year $t$ differ from the distribution of works written after $t$?*
-We apply a sliding window of $w$ years on each side of the candidate break year.^[Throughout this report we show $w \in \{2, 3, 4\}$. The companion paper reports $w=3$ as the default lead window, with $w \in \{2, 4\}$ as robustness checks.]
+We apply a sliding window of $w$ years on each side of the candidate break year, excluding year $t$ itself from both windows: Before: $[t-w,\, t-1]$; After: $[t+1,\, t+w]$.^[Throughout this report we show $w \in \{2, 3, 4\}$. The companion paper reports $w=3$ as the default lead window, with $w \in \{2, 4\}$ as robustness checks. Year $t$ is excluded from both windows (gap = 1) so that the split year is a clean boundary rather than a member of the "before" distribution.]
 
 Methods are grouped into three layers:
 

--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -144,6 +144,7 @@ def compute_c2st_embedding(df, emb, cfg):
             ]
         )
 
+    gap = div_cfg.get("gap", 1)
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
@@ -154,6 +155,7 @@ def compute_c2st_embedding(df, emb, cfg):
         max_subsample,
         rng=rng,
         equal_n=equal_n,
+        gap=gap,
     ):
         if last_w is not None and w != last_w:
             log.info("C2ST_embedding window=%d done", last_w)

--- a/scripts/_divergence_citation.py
+++ b/scripts/_divergence_citation.py
@@ -121,18 +121,19 @@ def _dict_to_df(results, hyperparams=""):
 # ── Sliding window helpers (ticket 0048) ─────────────────────────────────
 
 
-def _sliding_window_graph(works, internal_edges, year, window, side):
+def _sliding_window_graph(works, internal_edges, year, window, side, gap=1):
     """Build directed graph for one half-window.
 
-    side='before': papers in [year - window, year]
-    side='after':  papers in [year + 1, year + 1 + window]
+    side='before': papers in [year - window, year - gap]
+    side='after':  papers in [year + gap, year + window]
 
+    gap=1 (default) excludes year t from both windows.
     Only edges where both endpoints are in the node set are included.
     """
     if side == "before":
-        year_lo, year_hi = year - window, year
+        year_lo, year_hi = year - window, year - gap
     else:
-        year_lo, year_hi = year + 1, year + 1 + window
+        year_lo, year_hi = year + gap, year + window
 
     G = nx.DiGraph()
     mask = (works["year"] >= year_lo) & (works["year"] <= year_hi)
@@ -151,7 +152,7 @@ def _iter_sliding_pairs(works, internal_edges, cfg):
     """Yield (year, window, G_before, G_after) for each valid sliding pair.
 
     Mirrors the semantic _iter_window_pairs pattern:
-      before = [year - w, year], after = [year + 1, year + 1 + w]
+      before = [year - w, year - gap], after = [year + gap, year + w]
     Skips pairs where either half has fewer than min_papers nodes.
 
     TODO: G1/G2/G5/G6/G8 each call this independently, rebuilding graphs
@@ -162,12 +163,17 @@ def _iter_sliding_pairs(works, internal_edges, cfg):
 
     div_cfg = cfg["divergence"]
     windows = div_cfg["windows"]
-    min_papers = get_min_papers(len(works), cfg)
+    gap = div_cfg.get("gap", 1)
+    min_papers = get_min_papers(cfg=cfg, n_works=len(works))
 
     for w, years in per_window_year_ranges(works, windows).items():
         for year in years:
-            G_before = _sliding_window_graph(works, internal_edges, year, w, "before")
-            G_after = _sliding_window_graph(works, internal_edges, year, w, "after")
+            G_before = _sliding_window_graph(
+                works, internal_edges, year, w, "before", gap=gap
+            )
+            G_after = _sliding_window_graph(
+                works, internal_edges, year, w, "after", gap=gap
+            )
             if G_before.number_of_nodes() < min_papers:
                 continue
             if G_after.number_of_nodes() < min_papers:

--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -225,6 +225,7 @@ def iter_semantic_windows(div_df, cfg):
     df, emb = load_semantic_data(None)
     div_cfg = cfg["divergence"]
     seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
 
     _, min_papers, max_subsample, equal_n = _get_years_and_params(df, emb, cfg)
 
@@ -237,10 +238,26 @@ def iter_semantic_windows(div_df, cfg):
         subsample_rng, extra_rng = _make_window_rngs(seed, y, w)
 
         X = _get_window_embeddings(
-            df, emb, y, w, "before", min_papers, max_subsample, rng=subsample_rng
+            df,
+            emb,
+            y,
+            w,
+            "before",
+            min_papers,
+            max_subsample,
+            rng=subsample_rng,
+            gap=gap,
         )
         Y = _get_window_embeddings(
-            df, emb, y, w, "after", min_papers, max_subsample, rng=subsample_rng
+            df,
+            emb,
+            y,
+            w,
+            "after",
+            min_papers,
+            max_subsample,
+            rng=subsample_rng,
+            gap=gap,
         )
         if X is None or Y is None:
             continue
@@ -271,6 +288,7 @@ def iter_lexical_windows(div_df, cfg):
     df = load_lexical_data(None)
     div_cfg = cfg["divergence"]
     seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
 
     min_papers = get_min_papers(cfg=cfg, n_works=len(df))
     equal_n = div_cfg.get("equal_n", False)
@@ -283,8 +301,8 @@ def iter_lexical_windows(div_df, cfg):
 
         subsample_rng, extra_rng = _make_window_rngs(seed, y, w)
 
-        mask_before = (df["year"] >= y - w) & (df["year"] <= y)
-        mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)
+        mask_before = (df["year"] >= y - w) & (df["year"] <= y - gap)
+        mask_after = (df["year"] >= y + gap) & (df["year"] <= y + w)
 
         texts_before = df.loc[mask_before, "abstract"].tolist()
         texts_after = df.loc[mask_after, "abstract"].tolist()

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -85,7 +85,8 @@ def _iter_lexical_window_pairs(df, cfg):
     div_cfg = cfg["divergence"]
     lex_cfg = div_cfg.get("lexical", {})
     windows = div_cfg["windows"]
-    min_papers = _get_min_papers(len(df), cfg)
+    gap = div_cfg.get("gap", 1)
+    min_papers = _get_min_papers(cfg=cfg, n_works=len(df))
     max_subsample = div_cfg["max_subsample"]
     tfidf_max_features = lex_cfg.get("tfidf_max_features", 5000)
     tfidf_min_df = lex_cfg.get("tfidf_min_df", 3)
@@ -107,8 +108,8 @@ def _iter_lexical_window_pairs(df, cfg):
 
     for w, years in years_by_window.items():
         for y in years:
-            mask_before = (df["year"] >= y - w) & (df["year"] <= y)
-            mask_after = (df["year"] >= y + 1) & (df["year"] <= y + 1 + w)
+            mask_before = (df["year"] >= y - w) & (df["year"] <= y - gap)
+            mask_after = (df["year"] >= y + gap) & (df["year"] <= y + w)
 
             texts_before = df.loc[mask_before, "abstract"].tolist()
             texts_after = df.loc[mask_after, "abstract"].tolist()
@@ -194,7 +195,7 @@ def compute_l2_novelty(df, cfg):
     lex_cfg = div_cfg["lexical"]
 
     l2_windows = lex_cfg["L2_novelty"]["windows"]
-    min_papers = _get_min_papers(len(df), cfg)
+    min_papers = _get_min_papers(cfg=cfg, n_works=len(df))
     tfidf_max_features = lex_cfg["tfidf_max_features"]
     tfidf_min_df = lex_cfg["tfidf_min_df"]
 

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -83,17 +83,19 @@ def _get_years_and_params(df, emb, cfg, method=None):
 
 
 def _get_window_embeddings(
-    df, emb, year, window, side, min_papers, max_subsample, rng=None
+    df, emb, year, window, side, min_papers, max_subsample, rng=None, gap=1
 ):
     """Extract embeddings for a time window.
 
-    side='before': [year - window, year]
-    side='after':  [year + 1, year + 1 + window]
+    side='before': [year - window, year - gap]
+    side='after':  [year + gap, year + window]
+
+    gap=1 (default) excludes year t from both windows.
     """
     if side == "before":
-        mask = (df["year"] >= year - window) & (df["year"] <= year)
+        mask = (df["year"] >= year - window) & (df["year"] <= year - gap)
     else:
-        mask = (df["year"] >= year + 1) & (df["year"] <= year + 1 + window)
+        mask = (df["year"] >= year + gap) & (df["year"] <= year + window)
 
     idx = df.index[mask]
     if len(idx) < min_papers:
@@ -111,7 +113,7 @@ def _get_window_embeddings(
 
 
 def _iter_window_pairs(
-    df, emb, years_by_window, min_papers, max_subsample, rng=None, equal_n=False
+    df, emb, years_by_window, min_papers, max_subsample, rng=None, equal_n=False, gap=1
 ):
     """Yield (year, window, X, Y) for each valid before/after window pair.
 
@@ -122,10 +124,10 @@ def _iter_window_pairs(
     for w, years in years_by_window.items():
         for y in years:
             X = _get_window_embeddings(
-                df, emb, y, w, "before", min_papers, max_subsample, rng=rng
+                df, emb, y, w, "before", min_papers, max_subsample, rng=rng, gap=gap
             )
             Y = _get_window_embeddings(
-                df, emb, y, w, "after", min_papers, max_subsample, rng=rng
+                df, emb, y, w, "after", min_papers, max_subsample, rng=rng, gap=gap
             )
             if X is None or Y is None:
                 continue
@@ -223,6 +225,7 @@ def compute_s1_mmd(df, emb, cfg):
     if not any(years_by_window.values()):
         return empty_divergence_df()
 
+    gap = cfg["divergence"].get("gap", 1)
     sem_cfg = cfg["divergence"]["semantic"]
     bandwidth_multipliers = sem_cfg["S1_MMD"]["bandwidth_multipliers"]
 
@@ -236,6 +239,7 @@ def compute_s1_mmd(df, emb, cfg):
         max_subsample,
         rng=rng,
         equal_n=equal_n,
+        gap=gap,
     ):
         if last_w is not None and w != last_w:
             log.info("S1 MMD window=%d done", last_w)
@@ -302,6 +306,7 @@ def compute_s2_energy(df, emb, cfg):
     if not any(years_by_window.values()):
         return empty_divergence_df()
 
+    gap = cfg["divergence"].get("gap", 1)
     results = []
     last_w = None
     for y, w, X, Y in _iter_window_pairs(
@@ -312,6 +317,7 @@ def compute_s2_energy(df, emb, cfg):
         max_subsample,
         rng=rng,
         equal_n=equal_n,
+        gap=gap,
     ):
         if last_w is not None and w != last_w:
             log.info("S2 energy window=%d done", last_w)
@@ -358,6 +364,7 @@ def compute_s3_wasserstein(df, emb, cfg):
     if not any(years_by_window.values()):
         return empty_divergence_df()
 
+    gap = cfg["divergence"].get("gap", 1)
     sem_cfg = cfg["divergence"]["semantic"]
     n_projections_list = sem_cfg["S3_sliced_wasserstein"]["n_projections"]
 
@@ -371,6 +378,7 @@ def compute_s3_wasserstein(df, emb, cfg):
         max_subsample,
         rng=rng,
         equal_n=equal_n,
+        gap=gap,
     ):
         if last_w is not None and w != last_w:
             log.info("S3 sliced Wasserstein window=%d done", last_w)
@@ -493,6 +501,7 @@ def compute_s4_frechet(df, emb, cfg):
     if not any(years_by_window.values()):
         return empty_divergence_df()
 
+    gap = cfg["divergence"].get("gap", 1)
     # Always PCA-reduce for Fréchet: (1) covariance needs n >> d,
     # (2) sqrtm is O(d³), and (3) sensitivity analysis shows breaks
     # are stable from d=32 to d=1024.
@@ -509,6 +518,7 @@ def compute_s4_frechet(df, emb, cfg):
         max_subsample,
         rng=rng,
         equal_n=equal_n,
+        gap=gap,
     ):
         if last_w is not None and w != last_w:
             log.info("S4 Frechet window=%d done", last_w)

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -380,7 +380,7 @@ def _community_null_distribution(
     return null_stats[~np.isnan(null_stats)]
 
 
-def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution):
+def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution, gap=1):
     """Process one (year, window) for G9 community permutation test."""
     import community as community_louvain
     from _divergence_citation import _sliding_window_graph
@@ -388,8 +388,8 @@ def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution):
 
     _, perm_rng = _make_window_rngs(seed, y, w)
 
-    G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
-    G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
 
     before_nodes = list(G_before.nodes())
     after_nodes = list(G_after.nodes())
@@ -441,6 +441,7 @@ def _run_g9_community_permutations(works, internal_edges, div_df, cfg, n_jobs=1)
     div_cfg = cfg["divergence"]
     n_perm = div_cfg["permutation"]["n_perm"]
     seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
     resolution = (
         div_cfg.get("citation", {}).get("G9_community", {}).get("resolution", 1.0)
     )
@@ -452,7 +453,9 @@ def _run_g9_community_permutations(works, internal_edges, div_df, cfg, n_jobs=1)
 
     log.info("G9 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
     rows = Parallel(n_jobs=n_jobs)(
-        delayed(_g9_one_window)(y, w, works, internal_edges, n_perm, seed, resolution)
+        delayed(_g9_one_window)(
+            y, w, works, internal_edges, n_perm, seed, resolution, gap=gap
+        )
         for y, w in pairs
     )
     for row in rows:
@@ -497,7 +500,7 @@ def _spectral_null_distribution(G_union, all_nodes, n_before, n_perm, perm_rng):
     return null_stats[~np.isnan(null_stats)]
 
 
-def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed):
+def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed, gap=1):
     """Process one (year, window) for G2 spectral permutation test."""
     from _citation_methods import _spectral_gap
     from _divergence_citation import _sliding_window_graph
@@ -505,8 +508,8 @@ def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed):
 
     _, perm_rng = _make_window_rngs(seed, y, w)
 
-    G_before = _sliding_window_graph(works, internal_edges, y, w, "before")
-    G_after = _sliding_window_graph(works, internal_edges, y, w, "after")
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
 
     before_nodes = list(G_before.nodes())
     after_nodes = list(G_after.nodes())
@@ -541,6 +544,7 @@ def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
     div_cfg = cfg["divergence"]
     n_perm = div_cfg["permutation"]["n_perm"]
     seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
 
     year_windows = div_df[["year", "window"]].drop_duplicates()
     pairs = [
@@ -549,7 +553,9 @@ def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
 
     log.info("G2 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
     rows = Parallel(n_jobs=n_jobs)(
-        delayed(_g2_spectral_one_window)(y, w, works, internal_edges, n_perm, seed)
+        delayed(_g2_spectral_one_window)(
+            y, w, works, internal_edges, n_perm, seed, gap=gap
+        )
         for y, w in pairs
     )
     for row in rows:

--- a/tests/test_gap_year.py
+++ b/tests/test_gap_year.py
@@ -1,0 +1,159 @@
+"""Tests that year t is excluded from both windows when gap=1."""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+def test_split_year_excluded_from_before_window():
+    """Year t must not appear in before-window when gap=1."""
+    from _divergence_semantic import _get_window_embeddings
+
+    # Build synthetic df: papers at years 2000-2005
+    df = pd.DataFrame({"year": list(range(2000, 2006)), "work_id": range(6)})
+    emb = np.eye(6)
+    cfg = {"divergence": {"gap": 1, "max_subsample": 1000}}
+
+    # Split year t=2003, window=2: before should be [2001, 2002], not including 2003
+    result = _get_window_embeddings(
+        df, emb, year=2003, window=2, side="before", min_papers=1, max_subsample=1000
+    )
+    # result is array of embeddings for years 2001-2002
+    # Confirm year 2003 row (index 3) is NOT in result
+    assert result is not None
+    # The before window should have exactly 2 papers (years 2001, 2002)
+    assert len(result) == 2
+
+
+def test_split_year_excluded_from_after_window():
+    """Year t must not appear in after-window when gap=1."""
+    from _divergence_semantic import _get_window_embeddings
+
+    # Build synthetic df: papers at years 2000-2005
+    df = pd.DataFrame({"year": list(range(2000, 2006)), "work_id": range(6)})
+    emb = np.eye(6)
+
+    # Split year t=2003, window=2: after should be [2004, 2005], not including 2003
+    result = _get_window_embeddings(
+        df, emb, year=2003, window=2, side="after", min_papers=1, max_subsample=1000
+    )
+    assert result is not None
+    # The after window should have exactly 2 papers (years 2004, 2005)
+    assert len(result) == 2
+
+
+def test_before_window_with_explicit_gap_param():
+    """_get_window_embeddings accepts gap parameter and uses it."""
+    from _divergence_semantic import _get_window_embeddings
+
+    df = pd.DataFrame({"year": list(range(2000, 2010)), "work_id": range(10)})
+    emb = np.eye(10)
+
+    # gap=2: before=[2001, 2002], after=[2007, 2008] for t=2004, w=3
+    before = _get_window_embeddings(
+        df,
+        emb,
+        year=2004,
+        window=3,
+        side="before",
+        min_papers=1,
+        max_subsample=1000,
+        gap=2,
+    )
+    assert before is not None
+    assert len(before) == 2  # years 2001, 2002 only
+
+    after = _get_window_embeddings(
+        df,
+        emb,
+        year=2004,
+        window=3,
+        side="after",
+        min_papers=1,
+        max_subsample=1000,
+        gap=2,
+    )
+    assert after is not None
+    assert len(after) == 2  # years 2006, 2007... wait: t+gap=2006, t+w=2007 -> 2 years
+
+
+def test_citation_window_gap_before():
+    """_sliding_window_graph before-window excludes year t when gap=1."""
+    from _divergence_citation import _sliding_window_graph
+
+    works = pd.DataFrame(
+        {
+            "doi": [f"doi:{y}" for y in range(2000, 2006)],
+            "year": list(range(2000, 2006)),
+        }
+    )
+    internal_edges = pd.DataFrame(columns=["source_doi", "ref_doi", "source_year"])
+
+    # t=2003, w=2, gap=1 (default): before=[2001, 2002], not 2003
+    G = _sliding_window_graph(works, internal_edges, year=2003, window=2, side="before")
+    node_years = {int(doi.split(":")[1]) for doi in G.nodes()}
+    assert 2003 not in node_years, (
+        f"Year 2003 should not be in before-window, got: {node_years}"
+    )
+    assert node_years == {2001, 2002}, f"Expected {{2001, 2002}}, got {node_years}"
+
+
+def test_citation_window_gap_after():
+    """_sliding_window_graph after-window excludes year t when gap=1."""
+    from _divergence_citation import _sliding_window_graph
+
+    works = pd.DataFrame(
+        {
+            "doi": [f"doi:{y}" for y in range(2000, 2006)],
+            "year": list(range(2000, 2006)),
+        }
+    )
+    internal_edges = pd.DataFrame(columns=["source_doi", "ref_doi", "source_year"])
+
+    # t=2003, w=2, gap=1 (default): after=[2004, 2005]
+    G = _sliding_window_graph(works, internal_edges, year=2003, window=2, side="after")
+    node_years = {int(doi.split(":")[1]) for doi in G.nodes()}
+    assert 2003 not in node_years, (
+        f"Year 2003 should not be in after-window, got: {node_years}"
+    )
+    assert node_years == {2004, 2005}, f"Expected {{2004, 2005}}, got {node_years}"
+
+
+def test_lexical_iter_excludes_split_year():
+    """_iter_lexical_window_pairs before-window excludes year t when gap=1."""
+    from _divergence_lexical import _iter_lexical_window_pairs
+
+    # Build synthetic df with abstracts
+    years = list(range(2000, 2010))
+    df = pd.DataFrame(
+        {
+            "year": years,
+            "abstract": [f"climate finance policy year {y}" for y in years],
+        }
+    )
+    cfg = {
+        "divergence": {
+            "gap": 1,
+            "windows": [2],
+            "max_subsample": 1000,
+            "random_seed": 42,
+            "equal_n": False,
+            "lexical": {
+                "tfidf_max_features": 100,
+                "tfidf_min_df": 1,
+                "low_n_threshold": 1,
+            },
+        }
+    }
+
+    for y, w, X_before, X_after, _vec in _iter_lexical_window_pairs(df, cfg):
+        # The before window for split year y should NOT include year y itself
+        n_before = X_before.shape[0]
+        # For w=2 and gap=1: before=[y-2, y-1] has 2 papers, after=[y+1, y+2] has 2 papers
+        assert n_before == 2, (
+            f"For year={y}, w={w}: expected 2 before-papers (gap=1), got {n_before}"
+        )

--- a/tests/test_gap_year.py
+++ b/tests/test_gap_year.py
@@ -78,7 +78,7 @@ def test_before_window_with_explicit_gap_param():
         gap=2,
     )
     assert after is not None
-    assert len(after) == 2  # years 2006, 2007... wait: t+gap=2006, t+w=2007 -> 2 years
+    assert len(after) == 2  # t+gap=2006, t+w=2007: years 2006, 2007
 
 
 def test_citation_window_gap_before():

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -934,8 +934,9 @@ class TestBackendComparison:
         vec.fit(df["abstract"].tolist())
         stat_fn = _make_lexical_statistic(vec)
 
-        mask_b = (df["year"] >= 2005 - 3) & (df["year"] <= 2005)
-        mask_a = (df["year"] >= 2006) & (df["year"] <= 2006 + 3)
+        # gap=1: before=[t-w, t-1], after=[t+1, t+w]
+        mask_b = (df["year"] >= 2005 - 3) & (df["year"] <= 2004)
+        mask_a = (df["year"] >= 2006) & (df["year"] <= 2005 + 3)
         texts_b = df.loc[mask_b, "abstract"].tolist()
         texts_a = df.loc[mask_a, "abstract"].tolist()
 


### PR DESCRIPTION
## Summary

- Add `gap: 1` to `config/analysis.yaml` under `divergence:` — before window is now `[t-w, t-1]`, after window is `[t+1, t+w]`, split year excluded from both
- Propagate gap parameter through all four divergence channels: semantic (`_divergence_semantic.py`), lexical (`_divergence_lexical.py`), citation (`_divergence_citation.py`), and shared iterators (`_divergence_io.py`)
- Update `compute_null_model.py` G9 and G2 spectral permutations to pass gap parameter
- Update `content/_includes/techrep/overview.md` prose to document the gap=1 semantics with footnote
- Fix two pre-existing `get_min_papers` positional-arg bugs exposed during the change

## Test plan

- [x] `tests/test_gap_year.py` — 6 new tests: split year excluded from before/after windows (semantic, citation, lexical channels), explicit gap parameter
- [x] `tests/test_null_model.py::test_precomputed_lexical_vs_original` — updated reference masks to match gap=1 semantics
- [x] `make check-fast` — 18 pre-existing failures (unrelated to gap), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)