### PR TITLE
ticket 0098: bias comparison figures (plot script + Make recipes)

### DIFF
--- a/content/_includes/zoo/L1_js.md
+++ b/content/_includes/zoo/L1_js.md
@@ -47,3 +47,7 @@ Key values (w=3): peak $Z = +2.7$ at 1998, monotonic decline. Same convergence p
 
 Seminal: @lin1991divergence (Lin 1991, "Divergence measures based on the Shannon entropy", *IEEE Transactions on Information Theory*).
 Recent analogue: @hall2008studying (Hall et al. 2008, "Studying the history of ideas using topic models", EMNLP — JS on bag-of-words for intellectual history, closest to our setting).
+
+::: {.callout-note}
+All zoo results use the equal-n debiased estimator; see the bias comparison figure for the magnitude of the correction.
+:::

--- a/content/_includes/zoo/S1_mmd.md
+++ b/content/_includes/zoo/S1_mmd.md
@@ -37,3 +37,7 @@ Key values (w=3): peak $Z = +3.2$ at 1998, monotonic decline to $Z \approx -0.4$
 ### References
 
 Seminal: @gretton2012 (JMLR 13:723–773, 2012). Recent analogue: @hulkund2022interpretable (optimal transport applied to interpretable distribution-shift detection; the closest machine-learning setting to cross-window corpus comparison).
+
+::: {.callout-note}
+All zoo results use the equal-n debiased estimator; see the bias comparison figure for the magnitude of the correction.
+:::

--- a/scripts/plot_zoo_bias_comparison.py
+++ b/scripts/plot_zoo_bias_comparison.py
@@ -1,0 +1,136 @@
+"""Bias comparison figure: biased vs debiased raw divergence series.
+
+Plots the raw `value` column (not Z-score) for one method, overlaying the
+biased series (equal_n=False) against the debiased series (equal_n=True).
+One panel per call, one method per figure.
+
+Usage::
+
+    uv run python scripts/plot_zoo_bias_comparison.py \\
+        --method S2_energy \\
+        --input content/tables/tab_div_S2_energy.csv \\
+        --biased-csv content/tables/tab_div_biased_S2_energy.csv \\
+        --output content/figures/fig_zoo_bias_S2_energy.png
+"""
+
+import argparse
+import os
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from pipeline_io import save_figure
+from script_io_args import parse_io_args, validate_io
+
+
+def _load_series(csv_path: str, window_val: int) -> pd.DataFrame:
+    """Load CSV and return rows for the chosen window, sorted by year."""
+    df = pd.read_csv(csv_path)
+    # window column may be int or string after CSV roundtrip — coerce to int
+    df["window"] = pd.to_numeric(df["window"], errors="coerce")
+    subset = df[df["window"] == window_val].copy()
+    subset = subset.sort_values("year")
+    return subset
+
+
+def _pick_window(csv_path: str) -> int:
+    """Return the smallest integer window value present in the CSV."""
+    df = pd.read_csv(csv_path)
+    df["window"] = pd.to_numeric(df["window"], errors="coerce")
+    windows = sorted(df["window"].dropna().unique().astype(int))
+    if not windows:
+        raise ValueError(f"No numeric window values found in {csv_path}")
+    # Prefer window=3 if available, else fall back to smallest
+    return 3 if 3 in windows else windows[0]
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output, inputs=io_args.input)
+
+    parser = argparse.ArgumentParser(description="Zoo bias comparison figure")
+    parser.add_argument("--method", required=True, help="Method name (e.g. S2_energy)")
+    parser.add_argument(
+        "--biased-csv",
+        required=True,
+        help="Path to biased divergence table (equal_n=False)",
+    )
+    args = parser.parse_args(extra)
+
+    # Validate biased CSV exists
+    if not os.path.exists(args.biased_csv):
+        raise FileNotFoundError(f"Biased CSV not found: {args.biased_csv}")
+
+    debiased_path = io_args.input[0]
+    biased_path = args.biased_csv
+
+    # Pick window (prefer w=3 if available)
+    window = _pick_window(debiased_path)
+
+    df_deb = _load_series(debiased_path, window)
+    df_bias = _load_series(biased_path, window)
+
+    if df_deb.empty:
+        raise ValueError(
+            f"No rows for window={window} in debiased CSV: {debiased_path}"
+        )
+    if df_bias.empty:
+        raise ValueError(f"No rows for window={window} in biased CSV: {biased_path}")
+
+    # ── Plot ──────────────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(7, 3.5))
+
+    color_deb = "#1f77b4"  # blue — debiased
+    color_bias = "#d62728"  # red  — biased
+
+    ax.plot(
+        df_bias["year"],
+        df_bias["value"],
+        color=color_bias,
+        linewidth=1.4,
+        linestyle="-",
+        label=f"Biased (equal_n=False), w={window}",
+    )
+    ax.plot(
+        df_deb["year"],
+        df_deb["value"],
+        color=color_deb,
+        linewidth=1.4,
+        linestyle="--",
+        label=f"Debiased (equal_n=True), w={window}",
+    )
+
+    # Shade the gap between series where years align
+    merged = pd.merge(
+        df_bias[["year", "value"]].rename(columns={"value": "v_bias"}),
+        df_deb[["year", "value"]].rename(columns={"value": "v_deb"}),
+        on="year",
+    ).sort_values("year")
+    if not merged.empty:
+        ax.fill_between(
+            merged["year"],
+            merged["v_deb"],
+            merged["v_bias"],
+            alpha=0.2,
+            color="#888888",
+            label="Bias magnitude",
+        )
+
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Raw divergence value")
+    ax.set_title(
+        f"{args.method}: biased vs debiased divergence (w={window})",
+        fontsize=10,
+    )
+    ax.legend(fontsize=8, frameon=False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    fig.tight_layout()
+
+    stem = os.path.splitext(io_args.output)[0]
+    save_figure(fig, stem, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_zoo_bias_comparison.py
+++ b/scripts/plot_zoo_bias_comparison.py
@@ -19,28 +19,31 @@ import os
 import matplotlib.pyplot as plt
 import pandas as pd
 from pipeline_io import save_figure
+from plot_style import apply_style
 from script_io_args import parse_io_args, validate_io
 
+apply_style()
 
-def _load_series(csv_path: str, window_val: int) -> pd.DataFrame:
-    """Load CSV and return rows for the chosen window, sorted by year."""
+
+def _load_window_df(csv_path: str) -> tuple[pd.DataFrame, int]:
+    """Load CSV, coerce window to int, pick preferred window (w=3 or smallest).
+
+    Returns the full dataframe with numeric window column and the chosen window value.
+    Caller filters to the chosen window so the CSV is read only once.
+    """
     df = pd.read_csv(csv_path)
     # window column may be int or string after CSV roundtrip — coerce to int
-    df["window"] = pd.to_numeric(df["window"], errors="coerce")
-    subset = df[df["window"] == window_val].copy()
-    subset = subset.sort_values("year")
-    return subset
-
-
-def _pick_window(csv_path: str) -> int:
-    """Return the smallest integer window value present in the CSV."""
-    df = pd.read_csv(csv_path)
     df["window"] = pd.to_numeric(df["window"], errors="coerce")
     windows = sorted(df["window"].dropna().unique().astype(int))
     if not windows:
         raise ValueError(f"No numeric window values found in {csv_path}")
-    # Prefer window=3 if available, else fall back to smallest
-    return 3 if 3 in windows else windows[0]
+    window = 3 if 3 in windows else windows[0]
+    return df, window
+
+
+def _filter_series(df: pd.DataFrame, window_val: int) -> pd.DataFrame:
+    """Return rows for the chosen window, sorted by year."""
+    return df[df["window"] == window_val].sort_values("year").copy()
 
 
 def main() -> None:
@@ -56,18 +59,15 @@ def main() -> None:
     )
     args = parser.parse_args(extra)
 
-    # Validate biased CSV exists
-    if not os.path.exists(args.biased_csv):
-        raise FileNotFoundError(f"Biased CSV not found: {args.biased_csv}")
-
     debiased_path = io_args.input[0]
     biased_path = args.biased_csv
 
-    # Pick window (prefer w=3 if available)
-    window = _pick_window(debiased_path)
+    df_deb_full, window = _load_window_df(debiased_path)
+    df_bias_full = pd.read_csv(biased_path)
+    df_bias_full["window"] = pd.to_numeric(df_bias_full["window"], errors="coerce")
 
-    df_deb = _load_series(debiased_path, window)
-    df_bias = _load_series(biased_path, window)
+    df_deb = _filter_series(df_deb_full, window)
+    df_bias = _filter_series(df_bias_full, window)
 
     if df_deb.empty:
         raise ValueError(
@@ -122,8 +122,6 @@ def main() -> None:
         fontsize=10,
     )
     ax.legend(fontsize=8, frameon=False)
-    ax.spines["top"].set_visible(False)
-    ax.spines["right"].set_visible(False)
 
     fig.tight_layout()
 

--- a/tests/test_zoo_bias_comparison.py
+++ b/tests/test_zoo_bias_comparison.py
@@ -1,0 +1,47 @@
+"""Tests for zoo bias comparison plot (ticket 0098)."""
+
+import os
+import subprocess
+import sys
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture()
+def bias_csvs(tmp_path):
+    cols = {"year": [2005, 2006, 2007], "window": ["3"] * 3, "hyperparams": [None] * 3}
+    df_deb = pd.DataFrame({**cols, "value": [0.10, 0.15, 0.12]})
+    df_bias = pd.DataFrame({**cols, "value": [0.20, 0.30, 0.25]})
+    p_deb = tmp_path / "tab_div_S2_energy.csv"
+    df_deb.to_csv(p_deb, index=False)
+    p_bias = tmp_path / "tab_div_biased_S2_energy.csv"
+    df_bias.to_csv(p_bias, index=False)
+    return str(p_deb), str(p_bias)
+
+
+def test_plot_zoo_bias_creates_figure(tmp_path, bias_csvs):
+    p_deb, p_bias = bias_csvs
+    out = str(tmp_path / "fig_zoo_bias_S2_energy.png")
+    script = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "plot_zoo_bias_comparison.py"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            script,
+            "--method",
+            "S2_energy",
+            "--input",
+            p_deb,
+            "--biased-csv",
+            p_bias,
+            "--output",
+            out,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Script failed:\n{result.stderr}"
+    assert os.path.exists(out), "Output PNG not created"
+    assert os.path.getsize(out) > 1000, "Output PNG suspiciously small"

--- a/zoo.mk
+++ b/zoo.mk
@@ -86,6 +86,38 @@ $(ZOO_FIGS)/fig_zoo_G2_spectral.png: $(ZOO_TABLES)/tab_crossyear_G2_spectral.csv
 $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_results.py
 	$(UV_RUN) python scripts/plot_zoo_results.py --method $* --output $@
 
+# ── Bias comparison tables (equal_n=false) ───────────────────────────────────
+#
+# Four representative methods: two semantic, one lexical, one C2ST.
+# Each recipe mirrors the corresponding debiased recipe but adds --no-equal-n.
+
+BIAS_METHODS := S1_MMD S2_energy L1 C2ST_embedding
+
+$(ZOO_TABLES)/tab_div_biased_S1_MMD.csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
+	$(UV_RUN) python $(DIV_DISPATCH) --method S1_MMD --no-equal-n --output $@
+
+$(ZOO_TABLES)/tab_div_biased_S2_energy.csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
+	$(UV_RUN) python $(DIV_DISPATCH) --method S2_energy --no-equal-n --output $@
+
+$(ZOO_TABLES)/tab_div_biased_L1.csv: $(DIV_DISPATCH) scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG)
+	$(UV_RUN) python $(DIV_DISPATCH) --method L1 --no-equal-n --output $@
+
+$(ZOO_TABLES)/tab_div_biased_C2ST_embedding.csv: $(DIV_DISPATCH) scripts/_divergence_c2st.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
+	$(UV_RUN) python $(DIV_DISPATCH) --method C2ST_embedding --no-equal-n --output $@
+
+BIAS_FIGS := $(foreach m,$(BIAS_METHODS),$(ZOO_FIGS)/fig_zoo_bias_$(m).png)
+
+$(ZOO_FIGS)/fig_zoo_bias_%.png: scripts/plot_zoo_bias_comparison.py \
+    $(ZOO_TABLES)/tab_div_%.csv $(ZOO_TABLES)/tab_div_biased_%.csv
+	$(UV_RUN) python scripts/plot_zoo_bias_comparison.py --method $* \
+	    --input $(ZOO_TABLES)/tab_div_$*.csv \
+	    --biased-csv $(ZOO_TABLES)/tab_div_biased_$*.csv \
+	    --output $@
+
+.PHONY: bias-tables bias-figures
+bias-tables: $(foreach m,$(BIAS_METHODS),$(ZOO_TABLES)/tab_div_biased_$(m).csv)
+bias-figures: $(BIAS_FIGS)
+
 # ── Zoo PDF render (Phase 3) ─────────────────────────────────────────────────
 # Thin wrapper over $(ZOO_INCLUDES) for reviewers or cherry-picking.
 # Mirrors the TR recipe; same vars file, same bibliography, same engine.


### PR DESCRIPTION
## Summary
- New `scripts/plot_zoo_bias_comparison.py`: overlaid biased vs debiased raw divergence series for one method per figure, with shaded bias magnitude
- `zoo.mk`: `bias-tables` and `bias-figures` phony targets for 4 representative methods (S1_MMD, S2_energy, L1, C2ST_embedding)
- `content/_includes/zoo/S1_mmd.md` and `L1_js.md`: note that zoo results use the equal-n debiased estimator with pointer to bias comparison figure

## Test plan
- [x] `uv run pytest tests/test_zoo_bias_comparison.py` passes
- [x] `uv run pytest tests/test_bias_flag.py` passes
- [x] Make recipes syntactically valid (`make --dry-run bias-tables` returns RC=0)

## Skipped (already done)
- Action 1 (theory prose in overview.md): PR #748
- Action 2 (--no-equal-n CLI flag): already at `scripts/compute_divergence.py:136-149`

🤖 Generated with [Claude Code](https://claude.com/claude-code)