### PR TITLE
feat(0096): create multilayer-detection-techrep.qmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ analysis-stats: stats
 
 manuscript: output/content/manuscript.pdf output/content/manuscript.docx
 
-papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/breakpoint-detect-method-zoo.pdf output/content/data-paper.pdf output/content/multilayer-detection.pdf
+papers: check-corpus output/content/corpus-report.pdf output/content/technical-report.pdf output/content/breakpoint-detect-method-zoo.pdf output/content/data-paper.pdf output/content/multilayer-detection.pdf output/content/multilayer-detection-techrep.pdf
 
 # ── Namespaced aliases (Phase 3) ────────────────────────
 manuscript-render: manuscript

--- a/content/multilayer-detection-techrep.qmd
+++ b/content/multilayer-detection-techrep.qmd
@@ -1,0 +1,58 @@
+---
+title: "Multi-layer Detection: Technical Supplement"
+subtitle: "Methods for the six detectors used in the companion paper"
+author: "Minh Ha-Duong"
+date: "2026-04-17"
+metadata-files: [technical-report-vars.yml]
+bibliography: bibliography/main.bib
+format:
+  pdf:
+    pdf-engine: xelatex
+    number-sections: true
+---
+
+This supplement documents the six detection methods used in the companion paper
+(Ha-Duong, "Multi-layer Detection and Validation of Structural Change in Text Corpora").
+Three methods vote on transition zones (S2, L1, G9); two serve as reference layers
+(G2, C2ST). All share the same corpus of {{< meta corpus_total >}} works (1990--2024)
+and the same sliding-window protocol described in §4 of the companion paper.
+
+For the full 18-method comparative survey see the technical report.
+
+{{< include _includes/techrep/overview.md >}}
+
+{{< include _includes/techrep/zscore.md >}}
+
+{{< include _includes/techrep/null-model.md >}}
+
+\newpage
+
+---
+
+# Voting detectors
+
+{{< include _includes/zoo/S2_energy.md >}}
+
+---
+
+{{< include _includes/zoo/L1_js.md >}}
+
+---
+
+{{< include _includes/zoo/G9_community.md >}}
+
+\newpage
+
+---
+
+# Reference layers
+
+{{< include _includes/zoo/G2_spectral.md >}}
+
+---
+
+{{< include _includes/zoo/C2ST_embedding.md >}}
+
+---
+
+{{< include _includes/zoo/C2ST_lexical.md >}}

--- a/content/multilayer-detection-techrep.qmd
+++ b/content/multilayer-detection-techrep.qmd
@@ -2,7 +2,7 @@
 title: "Multi-layer Detection: Technical Supplement"
 subtitle: "Methods for the six detectors used in the companion paper"
 author: "Minh Ha-Duong"
-date: "2026-04-17"
+date: today
 metadata-files: [technical-report-vars.yml]
 bibliography: bibliography/main.bib
 format:
@@ -13,8 +13,8 @@ format:
 
 This supplement documents the six detection methods used in the companion paper
 (Ha-Duong, "Multi-layer Detection and Validation of Structural Change in Text Corpora").
-Three methods vote on transition zones (S2, L1, G9); two serve as reference layers
-(G2, C2ST). All share the same corpus of {{< meta corpus_total >}} works (1990--2024)
+Three methods vote on transition zones (S2, L1, G9); three serve as reference layers
+(G2, C2ST-embedding, C2ST-lexical). All share the same corpus of {{< meta corpus_total >}} works (1990--2024)
 and the same sliding-window protocol described in §4 of the companion paper.
 
 For the full 18-method comparative survey see the technical report.

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -101,3 +101,6 @@ output/content/multilayer-detection-techrep.pdf: \
     $(BIB) \
     content/technical-report-vars.yml
 	quarto render $< --to pdf
+
+.PHONY: multilayer-techrep
+multilayer-techrep: output/content/multilayer-detection-techrep.pdf

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -81,3 +81,23 @@ $(COMP_FIGS)/fig_companion_sensitivity.png: \
 companion-sensitivity: \
     $(COMP_TABLES)/tab_sensitivity_grid.csv \
     $(COMP_FIGS)/fig_companion_sensitivity.png
+
+# ── Technical supplement (ticket 0096) ───────────────────────────────────
+
+MULTILAYER_TECHREP_INCLUDES := \
+    content/_includes/techrep/overview.md \
+    content/_includes/techrep/zscore.md \
+    content/_includes/techrep/null-model.md \
+    content/_includes/zoo/S2_energy.md \
+    content/_includes/zoo/L1_js.md \
+    content/_includes/zoo/G9_community.md \
+    content/_includes/zoo/G2_spectral.md \
+    content/_includes/zoo/C2ST_embedding.md \
+    content/_includes/zoo/C2ST_lexical.md
+
+output/content/multilayer-detection-techrep.pdf: \
+    content/multilayer-detection-techrep.qmd \
+    $(MULTILAYER_TECHREP_INCLUDES) \
+    $(BIB) \
+    content/technical-report-vars.yml
+	quarto render $< --to pdf

--- a/tickets/0025-corpus-report-prose.erg
+++ b/tickets/0025-corpus-report-prose.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Write connective prose for corpus report
-Status: open
+Status: closed
 Created: 2026-04-14
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-14T14:40Z claude created
 2026-04-14T14:40Z claude note includes are placed but glue text is missing
 2026-04-21Z orchestrator reimagine: ~10 short transitions + 3 UMAP paragraphs. CJK font fix (Action 5) out of scope here. Worst: Corpus Contents (UMAP narrative) + section bridges.
+2026-04-23T00:00Z claude closed — merged PR #730
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Creates `content/multilayer-detection-techrep.qmd` — the focused technical supplement for the QSS companion paper. Assembles 9 `_includes/` fragments from the existing pool (no prose duplication):

**Preamble sections** (shared with `technical-report.qmd`):
- `_includes/techrep/overview.md` — corpus and window protocol framing
- `_includes/techrep/zscore.md` — Z-score standardisation
- `_includes/techrep/null-model.md` — permutation null model

**Voting detectors** (S2, L1, G9 — the three methods that elect transition zones):
- `_includes/zoo/S2_energy.md`
- `_includes/zoo/L1_js.md`
- `_includes/zoo/G9_community.md`

**Reference layers** (G2 + C2ST — enter as evidence, not votes):
- `_includes/zoo/G2_spectral.md`
- `_includes/zoo/C2ST_embedding.md`
- `_includes/zoo/C2ST_lexical.md`

Also:
- `multilayer-detection.mk`: `MULTILAYER_TECHREP_INCLUDES` variable + `output/content/multilayer-detection-techrep.pdf` target (depends on the 9 includes + BIB + `technical-report-vars.yml`)
- `Makefile`: target added to `papers:` phony

## Test plan

- [x] `grep -c 'include _includes' content/multilayer-detection-techrep.qmd` → 9 (≥ 6)
- [x] `grep multilayer-detection-techrep.pdf Makefile multilayer-detection.mk` → both present
- [x] `uv run python -m pytest tests/test_multilayer_detection_sections.py tests/test_multilayer_detection_prose.py tests/test_multilayer_detection_pca.py` → 34 passed
- [x] `uv run python -m pytest tests/test_arch_compliance.py` → 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)