### PR TITLE
refactor(0111): split compute_null_model.py into dispatcher + private modules

### DIFF
--- a/scripts/_permutation_c2st.py
+++ b/scripts/_permutation_c2st.py
@@ -1,0 +1,125 @@
+"""Permutation null model drivers for C2ST methods.
+
+C2ST_embedding — PCA-reduced embeddings + logistic regression AUC
+C2ST_lexical   — TF-IDF sparse features + logistic regression AUC
+
+Private module — no main, no argparse.  Called by compute_null_model.py.
+"""
+
+import numpy as np
+import pandas as pd
+from _permutation_io import _result_row, permutation_test
+from utils import get_logger
+
+log = get_logger("_permutation_c2st")
+
+
+def _run_c2st_embedding_permutations(div_df, cfg):
+    """Permutation null model for C2ST_embedding.
+
+    For each (year, window): loads raw embeddings via iter_semantic_windows,
+    PCA-reduces the combined pool (fit once, same transform for all permutations),
+    then calls permutation_test with _c2st_auc as the statistic.
+
+    PCA is fit on the combined pool before permutation so that all permuted
+    splits share the same feature space.  n_components is clamped to avoid
+    sklearn errors on small smoke windows.
+    """
+    from _divergence_c2st import _c2st_auc
+    from _divergence_io import iter_semantic_windows
+    from sklearn.decomposition import PCA
+
+    div_cfg = cfg["divergence"]
+    c2st_cfg = div_cfg.get("c2st", {})
+    pca_dim = c2st_cfg.get("pca_dim", 32)
+    cv_folds = c2st_cfg.get("cv_folds", 5)
+    class_weight = c2st_cfg.get("class_weight", "balanced")
+    seed = div_cfg["random_seed"]
+    n_perm = div_cfg["permutation"]["n_perm"]
+
+    rows = []
+    for y, w, X_raw, Y_raw, perm_rng in iter_semantic_windows(div_df, cfg):
+        # Clamp n_components as in compute_c2st_embedding (ticket 0068)
+        n_components = max(
+            2, min(pca_dim, min(len(X_raw), len(Y_raw)) - 1, X_raw.shape[1])
+        )
+        pca = PCA(n_components=n_components, random_state=seed)
+        combined_r = pca.fit_transform(np.vstack([X_raw, Y_raw]))
+        X_pca = combined_r[: len(X_raw)]
+        Y_pca = combined_r[len(X_raw) :]
+
+        def statistic_fn(X, Y, _seed=seed):
+            return _c2st_auc(
+                X, Y, cv_folds=cv_folds, class_weight=class_weight, seed=_seed
+            )["mean"]
+
+        observed, null_mean, null_std, z, p = permutation_test(
+            X_pca, Y_pca, statistic_fn, n_perm, perm_rng
+        )
+        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
+        log.info("  C2ST_embedding year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
+
+    return pd.DataFrame(rows)
+
+
+def _run_c2st_lexical_permutations(div_df, cfg):
+    """Permutation null model for C2ST_lexical.
+
+    For each (year, window): vectorizes the combined text pool once, then
+    runs a manual permutation loop (sparse-matrix slicing) to build the
+    null AUC distribution, calling _c2st_auc directly on sparse row slices.
+    permutation_test() is skipped because it calls np.vstack which converts
+    sparse matrices to dense, breaking sklearn's sparse-aware path.
+    """
+    from _divergence_c2st import _c2st_auc
+    from _divergence_io import fit_lexical_vectorizer, iter_lexical_windows
+
+    div_cfg = cfg["divergence"]
+    c2st_cfg = div_cfg.get("c2st", {})
+    cv_folds = c2st_cfg.get("cv_folds", 5)
+    class_weight = c2st_cfg.get("class_weight", "balanced")
+    seed = div_cfg["random_seed"]
+    n_perm = div_cfg["permutation"]["n_perm"]
+
+    vectorizer = fit_lexical_vectorizer(cfg)
+
+    rows = []
+    for y, w, texts_before, texts_after, perm_rng in iter_lexical_windows(div_df, cfg):
+        all_texts = texts_before + texts_after
+        X_all = vectorizer.transform(all_texts)
+        n_before = len(texts_before)
+
+        # Observed statistic on un-permuted split
+        observed = _c2st_auc(
+            X_all[:n_before],
+            X_all[n_before:],
+            cv_folds=cv_folds,
+            class_weight=class_weight,
+            seed=seed,
+        )["mean"]
+
+        # Manual permutation loop — sparse slicing avoids dense conversion
+        null_stats = []
+        for i in range(n_perm):
+            idx = perm_rng.permutation(X_all.shape[0])
+            X_perm_before = X_all[idx[:n_before]]
+            X_perm_after = X_all[idx[n_before:]]
+            null_auc = _c2st_auc(
+                X_perm_before,
+                X_perm_after,
+                cv_folds=cv_folds,
+                class_weight=class_weight,
+                seed=seed + i,
+            )["mean"]
+            null_stats.append(null_auc)
+
+        null_stats_arr = np.array(null_stats)
+        null_mean = float(np.mean(null_stats_arr))
+        null_std = float(np.std(null_stats_arr))
+        z = (observed - null_mean) / null_std if null_std > 0 else 0.0
+        p = float(np.mean(null_stats_arr >= observed))
+
+        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
+        log.info("  C2ST_lexical year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
+
+    return pd.DataFrame(rows)

--- a/scripts/_permutation_citation.py
+++ b/scripts/_permutation_citation.py
@@ -11,39 +11,10 @@ All drivers follow the _build_union_digraph / node-permutation pattern:
 import numpy as np
 import pandas as pd
 from _divergence_io import _make_window_rngs
+from _permutation_io import _finalize_row, _nan_row
 from utils import get_logger
 
 log = get_logger("_permutation_citation")
-
-
-# ---------------------------------------------------------------------------
-# Tiny row helpers (mirrored from compute_null_model._result_row etc.)
-# ---------------------------------------------------------------------------
-
-
-def _result_row(year, window, observed, null_mean, null_std, z, p):
-    return {
-        "year": year,
-        "window": str(window),
-        "observed": observed,
-        "null_mean": null_mean,
-        "null_std": null_std,
-        "z_score": z,
-        "p_value": p,
-    }
-
-
-def _nan_row(year, window):
-    return _result_row(year, window, np.nan, np.nan, np.nan, np.nan, np.nan)
-
-
-def _finalize_row(y, w, observed, null_stats):
-    null_mean = float(np.mean(null_stats))
-    null_std = float(np.std(null_stats))
-    z = (observed - null_mean) / null_std if null_std > 0 else 0.0
-    p_value = float(np.mean(null_stats >= observed))
-    log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p_value)
-    return _result_row(y, w, observed, null_mean, null_std, z, p_value)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/_permutation_graph.py
+++ b/scripts/_permutation_graph.py
@@ -1,0 +1,250 @@
+"""Permutation null model drivers for undirected graph methods (G2, G9).
+
+G2 — spectral gap divergence (|Δ spectral gap|)
+G9 — community divergence (JS^2 of community distributions)
+
+Private module — no main, no argparse.  Called by compute_null_model.py.
+"""
+
+import numpy as np
+import pandas as pd
+from _permutation_io import _finalize_row, _make_window_rngs, _nan_row, _result_row
+from utils import get_logger
+
+log = get_logger("_permutation_graph")
+
+
+# ---------------------------------------------------------------------------
+# G9: Community divergence
+# ---------------------------------------------------------------------------
+
+
+def _community_node_comm_map(partition):
+    """Build sorted community list and node->community-index lookup.
+
+    Returns (n_communities, comm_to_idx) or None if < 2 communities.
+    """
+    all_communities = sorted(set(partition.values()))
+    n_communities = len(all_communities)
+    if n_communities < 2:
+        return None
+    comm_to_idx = {c: i for i, c in enumerate(all_communities)}
+    return n_communities, comm_to_idx
+
+
+def _community_null_distribution(
+    all_nodes, n_before, node_comm, n_communities, n_perm, perm_rng
+):
+    """Shuffle node-to-window assignments and compute JS^2 for each permutation.
+
+    Returns null_stats array (NaN entries removed).
+    """
+    from scipy.spatial.distance import jensenshannon
+
+    null_stats = np.empty(n_perm)
+    for i in range(n_perm):
+        perm_indices = perm_rng.permutation(len(all_nodes))
+        p_bef = np.zeros(n_communities)
+        p_aft = np.zeros(n_communities)
+
+        for j in perm_indices[:n_before]:
+            node = all_nodes[j]
+            if node in node_comm:
+                p_bef[node_comm[node]] += 1
+
+        for j in perm_indices[n_before:]:
+            node = all_nodes[j]
+            if node in node_comm:
+                p_aft[node_comm[node]] += 1
+
+        if p_bef.sum() == 0 or p_aft.sum() == 0:
+            null_stats[i] = np.nan
+            continue
+
+        p_bef = p_bef / p_bef.sum()
+        p_aft = p_aft / p_aft.sum()
+        js = jensenshannon(p_bef, p_aft)
+        null_stats[i] = float(js**2)
+
+    return null_stats[~np.isnan(null_stats)]
+
+
+def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution, gap=1):
+    """Process one (year, window) for G9 community permutation test."""
+    import community as community_louvain
+    from _divergence_citation import _sliding_window_graph
+    from _divergence_community import _build_union_graph, _community_js_for_pair
+
+    _, perm_rng = _make_window_rngs(seed, y, w)
+
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
+
+    before_nodes = list(G_before.nodes())
+    after_nodes = list(G_after.nodes())
+
+    if len(before_nodes) < 3 or len(after_nodes) < 3:
+        return _nan_row(y, w)
+
+    observed = _community_js_for_pair(
+        G_before, G_after, internal_edges, resolution, seed
+    )
+    if np.isnan(observed):
+        return _nan_row(y, w)
+
+    G_union = _build_union_graph(G_before, G_after, internal_edges)
+    if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
+        return _nan_row(y, w)
+
+    partition = community_louvain.best_partition(
+        G_union, resolution=resolution, random_state=seed
+    )
+
+    comm_info = _community_node_comm_map(partition)
+    if comm_info is None:
+        return _result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0)
+
+    n_communities, comm_to_idx = comm_info
+
+    all_nodes = before_nodes + after_nodes
+    n_before_count = len(before_nodes)
+
+    node_comm = {
+        node: comm_to_idx[partition[node]] for node in all_nodes if node in partition
+    }
+
+    null_stats = _community_null_distribution(
+        all_nodes, n_before_count, node_comm, n_communities, n_perm, perm_rng
+    )
+
+    if len(null_stats) == 0:
+        return _nan_row(y, w)
+
+    return _finalize_row(y, w, observed, null_stats)
+
+
+def _run_g9_community_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
+    """Permutation test for G9 community divergence (parallel across windows)."""
+    from joblib import Parallel, delayed
+
+    div_cfg = cfg["divergence"]
+    n_perm = div_cfg["permutation"]["n_perm"]
+    seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
+    resolution = (
+        div_cfg.get("citation", {}).get("G9_community", {}).get("resolution", 1.0)
+    )
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+    pairs = [
+        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
+    ]
+
+    log.info("G9 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
+    rows = Parallel(n_jobs=n_jobs)(
+        delayed(_g9_one_window)(
+            y, w, works, internal_edges, n_perm, seed, resolution, gap=gap
+        )
+        for y, w in pairs
+    )
+    for row in rows:
+        log.info(
+            "  year=%d window=%s z=%.2f p=%.3f",
+            row["year"],
+            row["window"],
+            row["z_score"],
+            row["p_value"],
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# G2: Spectral gap divergence
+# ---------------------------------------------------------------------------
+
+
+def _spectral_null_distribution(G_union, all_nodes, n_before, n_perm, perm_rng):
+    """Shuffle node-to-window assignments and recompute |Δ spectral gap|."""
+    from _citation_methods import _spectral_gap
+
+    null_stats = np.empty(n_perm)
+    for i in range(n_perm):
+        perm = perm_rng.permutation(len(all_nodes))
+        before_set = {all_nodes[j] for j in perm[:n_before]}
+        after_set = {all_nodes[j] for j in perm[n_before:]}
+        gap_b = _spectral_gap(G_union.subgraph(before_set))
+        gap_a = _spectral_gap(G_union.subgraph(after_set))
+        if np.isnan(gap_b) or np.isnan(gap_a):
+            null_stats[i] = np.nan
+        else:
+            null_stats[i] = abs(gap_a - gap_b)
+    return null_stats[~np.isnan(null_stats)]
+
+
+def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed, gap=1):
+    """Process one (year, window) for G2 spectral permutation test."""
+    from _citation_methods import _spectral_gap
+    from _divergence_citation import _sliding_window_graph
+    from _divergence_community import _build_union_graph
+
+    _, perm_rng = _make_window_rngs(seed, y, w)
+
+    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
+    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
+
+    before_nodes = list(G_before.nodes())
+    after_nodes = list(G_after.nodes())
+
+    if len(before_nodes) < 3 or len(after_nodes) < 3:
+        return _nan_row(y, w)
+
+    gap_b_obs = _spectral_gap(G_before)
+    gap_a_obs = _spectral_gap(G_after)
+    if np.isnan(gap_b_obs) or np.isnan(gap_a_obs):
+        return _nan_row(y, w)
+    observed = abs(gap_a_obs - gap_b_obs)
+
+    G_union = _build_union_graph(G_before, G_after, internal_edges)
+    all_nodes = before_nodes + after_nodes
+    n_before_count = len(before_nodes)
+
+    null_stats = _spectral_null_distribution(
+        G_union, all_nodes, n_before_count, n_perm, perm_rng
+    )
+
+    if len(null_stats) == 0:
+        return _nan_row(y, w)
+
+    return _finalize_row(y, w, observed, null_stats)
+
+
+def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
+    """Permutation test for G2 spectral-gap divergence (parallel across windows)."""
+    from joblib import Parallel, delayed
+
+    div_cfg = cfg["divergence"]
+    n_perm = div_cfg["permutation"]["n_perm"]
+    seed = div_cfg["random_seed"]
+    gap = div_cfg.get("gap", 1)
+
+    year_windows = div_df[["year", "window"]].drop_duplicates()
+    pairs = [
+        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
+    ]
+
+    log.info("G2 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
+    rows = Parallel(n_jobs=n_jobs)(
+        delayed(_g2_spectral_one_window)(
+            y, w, works, internal_edges, n_perm, seed, gap=gap
+        )
+        for y, w in pairs
+    )
+    for row in rows:
+        log.info(
+            "  year=%d window=%s z=%.2f p=%.3f",
+            row["year"],
+            row["window"],
+            row["z_score"],
+            row["p_value"],
+        )
+    return pd.DataFrame(rows)

--- a/scripts/_permutation_io.py
+++ b/scripts/_permutation_io.py
@@ -1,0 +1,160 @@
+"""Shared I/O helpers for permutation null model drivers.
+
+Core algorithm, row helpers, and window-iteration utilities used by all
+``_permutation_*.py`` private modules.  No imports from other
+``_permutation_*`` modules — this is the leaf of the dependency graph.
+"""
+
+import numpy as np
+import pandas as pd
+from _divergence_io import _make_window_rngs  # noqa: F401 — re-export
+from utils import get_logger
+
+log = get_logger("_permutation_io")
+
+
+# ---------------------------------------------------------------------------
+# Core permutation test
+# ---------------------------------------------------------------------------
+
+
+def permutation_test(X_before, Y_after, statistic_fn, n_perm, rng):
+    """Run a permutation test on two samples.
+
+    Parameters
+    ----------
+    X_before, Y_after : array-like
+        The two samples (numpy arrays or lists).
+    statistic_fn : callable
+        Function(a, b) -> float that computes the test statistic.
+    n_perm : int
+        Number of permutations.
+    rng : np.random.RandomState
+        Random state for reproducibility.
+
+    Returns
+    -------
+    (observed, null_mean, null_std, z_score, p_value)
+
+    """
+    observed = statistic_fn(X_before, Y_after)
+
+    is_array = isinstance(X_before, np.ndarray)
+    if is_array:
+        pooled = np.vstack([X_before, Y_after])
+    else:
+        pooled = list(X_before) + list(Y_after)
+
+    n_before = len(X_before)
+    null_stats = []
+
+    for _ in range(n_perm):
+        if is_array:
+            rng.shuffle(pooled)
+            perm_before = pooled[:n_before]
+            perm_after = pooled[n_before:]
+        else:
+            indices = rng.permutation(len(pooled))
+            perm_before = [pooled[i] for i in indices[:n_before]]
+            perm_after = [pooled[i] for i in indices[n_before:]]
+
+        null_stats.append(statistic_fn(perm_before, perm_after))
+
+    null_stats = np.array(null_stats)
+    null_mean = float(np.mean(null_stats))
+    null_std = float(np.std(null_stats))
+
+    if null_std > 0:
+        z = (observed - null_mean) / null_std
+    else:
+        z = 0.0
+
+    p = float(np.mean(null_stats >= observed))
+
+    return observed, null_mean, null_std, z, p
+
+
+# ---------------------------------------------------------------------------
+# Row helpers
+# ---------------------------------------------------------------------------
+
+
+def _result_row(year, window, observed, null_mean, null_std, z, p):
+    """Return a row dict with computed permutation test results."""
+    return {
+        "year": year,
+        "window": str(window),
+        "observed": observed,
+        "null_mean": null_mean,
+        "null_std": null_std,
+        "z_score": z,
+        "p_value": p,
+    }
+
+
+def _nan_row(year, window):
+    """Return a row dict with NaN entries for skipped (year, window) pairs."""
+    return _result_row(year, window, np.nan, np.nan, np.nan, np.nan, np.nan)
+
+
+def _finalize_row(y, w, observed, null_stats):
+    """Compute z, p, mean, std from a finite null distribution and log."""
+    null_mean = float(np.mean(null_stats))
+    null_std = float(np.std(null_stats))
+    if null_std > 0:
+        z = (observed - null_mean) / null_std
+    else:
+        z = 0.0
+    p_value = float(np.mean(null_stats >= observed))
+    log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p_value)
+    return _result_row(y, w, observed, null_mean, null_std, z, p_value)
+
+
+# ---------------------------------------------------------------------------
+# Shared row collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_permutation_rows(window_iter, statistic_fn, n_perm, n_jobs=1):
+    """Run permutation test over window iterator, collecting result rows.
+
+    Shared logic for both semantic and lexical channels.
+
+    Parameters
+    ----------
+    n_jobs : int
+        Number of parallel workers.  1 = sequential (original path),
+        -1 = all available cores.
+
+    """
+    if n_jobs == 1:
+        rows = []
+        for y, w, X, Y, perm_rng in window_iter:
+            observed, null_mean, null_std, z, p = permutation_test(
+                X, Y, statistic_fn, n_perm, perm_rng
+            )
+            rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
+            log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
+        return pd.DataFrame(rows)
+
+    from joblib import Parallel, delayed
+
+    pairs = list(window_iter)
+    log.info("Parallel: %d (year, window) pairs on %d jobs", len(pairs), n_jobs)
+
+    def _process(y, w, X, Y, perm_rng):
+        obs, nm, ns, z, p = permutation_test(X, Y, statistic_fn, n_perm, perm_rng)
+        return _result_row(y, w, obs, nm, ns, z, p)
+
+    results = Parallel(n_jobs=n_jobs)(
+        delayed(_process)(y, w, X, Y, rng) for y, w, X, Y, rng in pairs
+    )
+    for row in results:
+        log.info(
+            "  year=%d window=%s z=%.2f p=%.3f",
+            row["year"],
+            row["window"],
+            row["z_score"],
+            row["p_value"],
+        )
+    return pd.DataFrame(results)

--- a/scripts/_permutation_lexical.py
+++ b/scripts/_permutation_lexical.py
@@ -1,7 +1,8 @@
-"""Permutation null model drivers for L2 (NTR) and L3 (term bursts).
+"""Permutation null model drivers for lexical methods (L1, L2, L3).
 
 Private module — no main, no argparse.  Called by compute_null_model.py.
 
+L1 — Jensen-Shannon divergence on TF-IDF (precomputed sparse permutation)
 L2 — Novelty / Transience / Resonance (Barron et al. 2018)
     Past/future pool-shuffle: pool past and future texts; for each permutation
     randomly assign pool docs into buckets of size |past| and |future| and
@@ -14,27 +15,10 @@ L3 — Burst detection (z-score term frequency, Kleinberg-style)
 
 import numpy as np
 import pandas as pd
+from _permutation_io import _nan_row, _result_row
 from utils import get_logger
 
 log = get_logger("_permutation_lexical")
-
-
-def _result_row(year, window, observed, null_mean, null_std, z, p):
-    """Return a null-model result row dict."""
-    return {
-        "year": year,
-        "window": str(window),
-        "observed": observed,
-        "null_mean": null_mean,
-        "null_std": null_std,
-        "z_score": z,
-        "p_value": p,
-    }
-
-
-def _nan_row(year, window):
-    """Return a null-model result row with NaN entries."""
-    return _result_row(year, window, np.nan, np.nan, np.nan, np.nan, np.nan)
 
 
 def run_l3_permutations(div_df, cfg):
@@ -237,5 +221,55 @@ def run_l2_permutations(div_df, cfg):
 
         rows.append(_result_row(y, str(w), observed, nm, ns, z, p))
         log.info("  year=%d window=%d z=%.2f p=%.3f [L2]", y, w, z, p)
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# L1: Jensen-Shannon on TF-IDF
+# ---------------------------------------------------------------------------
+
+
+def _make_lexical_statistic(vectorizer):
+    """Return a statistic_fn(texts_before, texts_after) -> float for L1 JS."""
+    from _divergence_lexical import _smooth_distribution
+    from scipy.spatial.distance import jensenshannon
+
+    def js_fn(texts_before, texts_after):
+        X_before = vectorizer.transform(texts_before)
+        X_after = vectorizer.transform(texts_after)
+        agg_before = np.asarray(X_before.mean(axis=0)).flatten()
+        agg_after = np.asarray(X_after.mean(axis=0)).flatten()
+        p = _smooth_distribution(agg_before)
+        q = _smooth_distribution(agg_after)
+        return float(jensenshannon(p, q))
+
+    return js_fn
+
+
+def _run_lexical_permutations(method_name, div_df, cfg):
+    """Permutation test for lexical methods (L1).
+
+    Precomputes TF-IDF for each (year, window) pool once, then permutes
+    row indices into the sparse matrix — avoids 2 x n_perm redundant
+    vectorizer.transform() calls per window.
+    """
+    from _divergence_io import fit_lexical_vectorizer, iter_lexical_windows
+    from _permutation_accel import precomputed_lexical_permutation
+
+    vectorizer = fit_lexical_vectorizer(cfg)
+    n_perm = cfg["divergence"]["permutation"]["n_perm"]
+
+    rows = []
+    for y, w, texts_before, texts_after, perm_rng in iter_lexical_windows(div_df, cfg):
+        all_texts = texts_before + texts_after
+        X_all = vectorizer.transform(all_texts)
+        n_before = len(texts_before)
+
+        obs, nm, ns, z, p = precomputed_lexical_permutation(
+            X_all, n_before, n_perm, perm_rng
+        )
+        rows.append(_result_row(y, w, obs, nm, ns, z, p))
+        log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
 
     return pd.DataFrame(rows)

--- a/scripts/_permutation_semantic.py
+++ b/scripts/_permutation_semantic.py
@@ -1,0 +1,137 @@
+"""Permutation null model drivers for semantic methods (S1-S4).
+
+Private module — no main, no argparse.  Called by compute_null_model.py.
+"""
+
+import numpy as np
+from _permutation_io import _collect_permutation_rows, _result_row
+from utils import get_logger
+
+log = get_logger("_permutation_semantic")
+
+# Methods with GPU-vectorized permutation paths
+_GPU_METHODS = {"S2_energy", "S1_MMD"}
+
+
+# ---------------------------------------------------------------------------
+# Statistic wrappers
+# ---------------------------------------------------------------------------
+
+
+def _make_semantic_statistic(method_name, cfg):
+    """Return a statistic_fn(X, Y) -> float for a semantic method."""
+    if method_name == "S2_energy":
+        from _divergence_backend import get_backend
+
+        backend = get_backend(cfg)
+        if backend == "torch":
+            from _divergence_semantic import _energy_distance_torch
+
+            return _energy_distance_torch
+        else:
+            import dcor
+
+            def energy_fn(X, Y):
+                return float(dcor.energy_distance(X, Y))
+
+            return energy_fn
+
+    elif method_name == "S1_MMD":
+        from _divergence_semantic import _median_heuristic, compute_mmd_rbf
+
+        def mmd_fn(X, Y):
+            med = _median_heuristic(X, Y)
+            return compute_mmd_rbf(X, Y, med)
+
+        return mmd_fn
+
+    elif method_name == "S3_sliced_wasserstein":
+        import ot
+
+        seed = cfg["divergence"]["random_seed"]
+        # Use middle value from config's n_projections list for null model.
+        # The main divergence pipeline sweeps all values; the null model
+        # uses a single representative projection count for tractability.
+        n_proj = cfg["divergence"]["semantic"]["S3_sliced_wasserstein"][
+            "n_projections"
+        ][1]
+
+        def sw_fn(X, Y):
+            return float(
+                ot.sliced_wasserstein_distance(X, Y, n_projections=n_proj, seed=seed)
+            )
+
+        return sw_fn
+
+    elif method_name == "S4_frechet":
+        from _divergence_semantic import compute_frechet_distance
+
+        return compute_frechet_distance
+
+    else:
+        raise ValueError(f"Unsupported semantic method: {method_name}")
+
+
+# ---------------------------------------------------------------------------
+# GPU-accelerated permutations
+# ---------------------------------------------------------------------------
+
+
+def _run_semantic_gpu(method_name, div_df, cfg):
+    """GPU-vectorized permutation test for S2_energy and S1_MMD.
+
+    Precomputes the distance/kernel matrix once on GPU, then batches all
+    n_perm statistics in a single matmul pass per (year, window).
+    """
+    from _divergence_io import iter_semantic_windows
+    from _permutation_accel import gpu_energy_permutations, gpu_mmd_permutations
+
+    n_perm = cfg["divergence"]["permutation"]["n_perm"]
+    seed = cfg["divergence"]["random_seed"]
+
+    rows = []
+    for y, w, X, Y, _perm_rng in iter_semantic_windows(div_df, cfg):
+        perm_seed = seed + y * 100 + w + 50000
+
+        if method_name == "S2_energy":
+            obs, nm, ns, z, p = gpu_energy_permutations(X, Y, n_perm, perm_seed)
+        elif method_name == "S1_MMD":
+            from _divergence_semantic import _median_heuristic
+
+            med = _median_heuristic(X, Y, rng=np.random.RandomState(perm_seed))
+            obs, nm, ns, z, p = gpu_mmd_permutations(X, Y, med, n_perm, perm_seed)
+        else:
+            raise ValueError(f"No GPU path for {method_name}")
+
+        rows.append(_result_row(y, w, obs, nm, ns, z, p))
+        log.info("  year=%d window=%d z=%.2f p=%.3f [GPU]", y, w, z, p)
+
+    import pandas as pd
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Main semantic driver
+# ---------------------------------------------------------------------------
+
+
+def _run_semantic_permutations(method_name, div_df, cfg, n_jobs=1):
+    """Permutation test for semantic methods (S1-S4).
+
+    Auto-selects GPU-vectorized path for S2_energy and S1_MMD when CUDA
+    is available; falls back to CPU (optionally parallel).
+    """
+    from _divergence_backend import get_backend
+    from _divergence_io import iter_semantic_windows
+
+    backend = get_backend(cfg)
+    if backend == "torch" and method_name in _GPU_METHODS:
+        log.info("Using GPU-vectorized permutation for %s", method_name)
+        return _run_semantic_gpu(method_name, div_df, cfg)
+
+    statistic_fn = _make_semantic_statistic(method_name, cfg)
+    n_perm = cfg["divergence"]["permutation"]["n_perm"]
+    return _collect_permutation_rows(
+        iter_semantic_windows(div_df, cfg), statistic_fn, n_perm, n_jobs=n_jobs
+    )

--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -18,13 +18,37 @@ Usage:
 
 import argparse
 
-import numpy as np
 import pandas as pd
+from _permutation_c2st import (
+    _run_c2st_embedding_permutations,
+    _run_c2st_lexical_permutations,
+)
 from _permutation_citation import (
     _run_g1_permutations,
     _run_g5_permutations,
     _run_g6_permutations,
     _run_g8_permutations,
+)
+from _permutation_graph import (
+    _run_g2_spectral_permutations,
+    _run_g9_community_permutations,
+)
+from _permutation_io import (  # noqa: F401 — re-exports for backward compat
+    _collect_permutation_rows,
+    _finalize_row,
+    _nan_row,
+    _result_row,
+    permutation_test,
+)
+from _permutation_lexical import (
+    _make_lexical_statistic,  # noqa: F401 — re-export
+    _run_lexical_permutations,
+    run_l2_permutations,
+    run_l3_permutations,
+)
+from _permutation_semantic import (
+    _make_semantic_statistic,  # noqa: F401 — re-export
+    _run_semantic_permutations,
 )
 from compute_divergence import METHODS
 from pipeline_loaders import load_analysis_config
@@ -39,673 +63,9 @@ SUPPORTED_CHANNELS = {"semantic", "lexical", "citation"}
 
 
 # ---------------------------------------------------------------------------
-# Core permutation test
-# ---------------------------------------------------------------------------
-
-
-def permutation_test(X_before, Y_after, statistic_fn, n_perm, rng):
-    """Run a permutation test on two samples.
-
-    Parameters
-    ----------
-    X_before, Y_after : array-like
-        The two samples (numpy arrays or lists).
-    statistic_fn : callable
-        Function(a, b) -> float that computes the test statistic.
-    n_perm : int
-        Number of permutations.
-    rng : np.random.RandomState
-        Random state for reproducibility.
-
-    Returns
-    -------
-    (observed, null_mean, null_std, z_score, p_value)
-
-    """
-    observed = statistic_fn(X_before, Y_after)
-
-    is_array = isinstance(X_before, np.ndarray)
-    if is_array:
-        pooled = np.vstack([X_before, Y_after])
-    else:
-        pooled = list(X_before) + list(Y_after)
-
-    n_before = len(X_before)
-    null_stats = []
-
-    for _ in range(n_perm):
-        if is_array:
-            rng.shuffle(pooled)
-            perm_before = pooled[:n_before]
-            perm_after = pooled[n_before:]
-        else:
-            indices = rng.permutation(len(pooled))
-            perm_before = [pooled[i] for i in indices[:n_before]]
-            perm_after = [pooled[i] for i in indices[n_before:]]
-
-        null_stats.append(statistic_fn(perm_before, perm_after))
-
-    null_stats = np.array(null_stats)
-    null_mean = float(np.mean(null_stats))
-    null_std = float(np.std(null_stats))
-
-    if null_std > 0:
-        z = (observed - null_mean) / null_std
-    else:
-        z = 0.0
-
-    p = float(np.mean(null_stats >= observed))
-
-    return observed, null_mean, null_std, z, p
-
-
-# ---------------------------------------------------------------------------
-# Statistic wrappers (call the same method functions used by divergence)
-# ---------------------------------------------------------------------------
-
-
-def _make_semantic_statistic(method_name, cfg):
-    """Return a statistic_fn(X, Y) -> float for a semantic method."""
-    if method_name == "S2_energy":
-        from _divergence_backend import get_backend
-
-        backend = get_backend(cfg)
-        if backend == "torch":
-            from _divergence_semantic import _energy_distance_torch
-
-            return _energy_distance_torch
-        else:
-            import dcor
-
-            def energy_fn(X, Y):
-                return float(dcor.energy_distance(X, Y))
-
-            return energy_fn
-
-    elif method_name == "S1_MMD":
-        from _divergence_semantic import _median_heuristic, compute_mmd_rbf
-
-        def mmd_fn(X, Y):
-            med = _median_heuristic(X, Y)
-            return compute_mmd_rbf(X, Y, med)
-
-        return mmd_fn
-
-    elif method_name == "S3_sliced_wasserstein":
-        import ot
-
-        seed = cfg["divergence"]["random_seed"]
-        # Use middle value from config's n_projections list for null model.
-        # The main divergence pipeline sweeps all values; the null model
-        # uses a single representative projection count for tractability.
-        n_proj = cfg["divergence"]["semantic"]["S3_sliced_wasserstein"][
-            "n_projections"
-        ][1]
-
-        def sw_fn(X, Y):
-            return float(
-                ot.sliced_wasserstein_distance(X, Y, n_projections=n_proj, seed=seed)
-            )
-
-        return sw_fn
-
-    elif method_name == "S4_frechet":
-        from _divergence_semantic import compute_frechet_distance
-
-        return compute_frechet_distance
-
-    else:
-        raise ValueError(f"Unsupported semantic method: {method_name}")
-
-
-def _make_lexical_statistic(vectorizer):
-    """Return a statistic_fn(texts_before, texts_after) -> float for L1 JS."""
-    from _divergence_lexical import _smooth_distribution
-    from scipy.spatial.distance import jensenshannon
-
-    def js_fn(texts_before, texts_after):
-        X_before = vectorizer.transform(texts_before)
-        X_after = vectorizer.transform(texts_after)
-        agg_before = np.asarray(X_before.mean(axis=0)).flatten()
-        agg_after = np.asarray(X_after.mean(axis=0)).flatten()
-        p = _smooth_distribution(agg_before)
-        q = _smooth_distribution(agg_after)
-        return float(jensenshannon(p, q))
-
-    return js_fn
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _result_row(year, window, observed, null_mean, null_std, z, p):
-    """Return a row dict with computed permutation test results."""
-    return {
-        "year": year,
-        "window": str(window),
-        "observed": observed,
-        "null_mean": null_mean,
-        "null_std": null_std,
-        "z_score": z,
-        "p_value": p,
-    }
-
-
-def _nan_row(year, window):
-    """Return a row dict with NaN entries for skipped (year, window) pairs."""
-    return _result_row(year, window, np.nan, np.nan, np.nan, np.nan, np.nan)
-
-
-# ---------------------------------------------------------------------------
-# Per-channel permutation drivers
-# ---------------------------------------------------------------------------
-
-# Re-export for backward compatibility (moved to _divergence_io in simplify review).
-from _divergence_io import _make_window_rngs
-
-
-def _collect_permutation_rows(window_iter, statistic_fn, n_perm, n_jobs=1):
-    """Run permutation test over window iterator, collecting result rows.
-
-    Shared logic for both semantic and lexical channels.
-
-    Parameters
-    ----------
-    n_jobs : int
-        Number of parallel workers.  1 = sequential (original path),
-        -1 = all available cores.
-
-    """
-    if n_jobs == 1:
-        rows = []
-        for y, w, X, Y, perm_rng in window_iter:
-            observed, null_mean, null_std, z, p = permutation_test(
-                X, Y, statistic_fn, n_perm, perm_rng
-            )
-            rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
-            log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
-        return pd.DataFrame(rows)
-
-    from joblib import Parallel, delayed
-
-    pairs = list(window_iter)
-    log.info("Parallel: %d (year, window) pairs on %d jobs", len(pairs), n_jobs)
-
-    def _process(y, w, X, Y, perm_rng):
-        obs, nm, ns, z, p = permutation_test(X, Y, statistic_fn, n_perm, perm_rng)
-        return _result_row(y, w, obs, nm, ns, z, p)
-
-    results = Parallel(n_jobs=n_jobs)(
-        delayed(_process)(y, w, X, Y, rng) for y, w, X, Y, rng in pairs
-    )
-    for row in results:
-        log.info(
-            "  year=%d window=%s z=%.2f p=%.3f",
-            row["year"],
-            row["window"],
-            row["z_score"],
-            row["p_value"],
-        )
-    return pd.DataFrame(results)
-
-
-# GPU-accelerated semantic permutations
-_GPU_METHODS = {"S2_energy", "S1_MMD"}
-
-
-def _run_semantic_gpu(method_name, div_df, cfg):
-    """GPU-vectorized permutation test for S2_energy and S1_MMD.
-
-    Precomputes the distance/kernel matrix once on GPU, then batches all
-    n_perm statistics in a single matmul pass per (year, window).
-    """
-    from _divergence_io import iter_semantic_windows
-    from _permutation_accel import gpu_energy_permutations, gpu_mmd_permutations
-
-    n_perm = cfg["divergence"]["permutation"]["n_perm"]
-    seed = cfg["divergence"]["random_seed"]
-
-    rows = []
-    for y, w, X, Y, _perm_rng in iter_semantic_windows(div_df, cfg):
-        perm_seed = seed + y * 100 + w + 50000
-
-        if method_name == "S2_energy":
-            obs, nm, ns, z, p = gpu_energy_permutations(X, Y, n_perm, perm_seed)
-        elif method_name == "S1_MMD":
-            from _divergence_semantic import _median_heuristic
-
-            med = _median_heuristic(X, Y, rng=np.random.RandomState(perm_seed))
-            obs, nm, ns, z, p = gpu_mmd_permutations(X, Y, med, n_perm, perm_seed)
-        else:
-            raise ValueError(f"No GPU path for {method_name}")
-
-        rows.append(_result_row(y, w, obs, nm, ns, z, p))
-        log.info("  year=%d window=%d z=%.2f p=%.3f [GPU]", y, w, z, p)
-
-    return pd.DataFrame(rows)
-
-
-def _run_semantic_permutations(method_name, div_df, cfg, n_jobs=1):
-    """Permutation test for semantic methods (S1-S4).
-
-    Auto-selects GPU-vectorized path for S2_energy and S1_MMD when CUDA
-    is available; falls back to CPU (optionally parallel).
-    """
-    from _divergence_backend import get_backend
-    from _divergence_io import iter_semantic_windows
-
-    backend = get_backend(cfg)
-    if backend == "torch" and method_name in _GPU_METHODS:
-        log.info("Using GPU-vectorized permutation for %s", method_name)
-        return _run_semantic_gpu(method_name, div_df, cfg)
-
-    statistic_fn = _make_semantic_statistic(method_name, cfg)
-    n_perm = cfg["divergence"]["permutation"]["n_perm"]
-    return _collect_permutation_rows(
-        iter_semantic_windows(div_df, cfg), statistic_fn, n_perm, n_jobs=n_jobs
-    )
-
-
-def _run_lexical_permutations(method_name, div_df, cfg):
-    """Permutation test for lexical methods (L1).
-
-    Precomputes TF-IDF for each (year, window) pool once, then permutes
-    row indices into the sparse matrix — avoids 2 × n_perm redundant
-    vectorizer.transform() calls per window.
-    """
-    from _divergence_io import fit_lexical_vectorizer, iter_lexical_windows
-    from _permutation_accel import precomputed_lexical_permutation
-
-    vectorizer = fit_lexical_vectorizer(cfg)
-    n_perm = cfg["divergence"]["permutation"]["n_perm"]
-
-    rows = []
-    for y, w, texts_before, texts_after, perm_rng in iter_lexical_windows(div_df, cfg):
-        all_texts = texts_before + texts_after
-        X_all = vectorizer.transform(all_texts)
-        n_before = len(texts_before)
-
-        obs, nm, ns, z, p = precomputed_lexical_permutation(
-            X_all, n_before, n_perm, perm_rng
-        )
-        rows.append(_result_row(y, w, obs, nm, ns, z, p))
-        log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
-
-    return pd.DataFrame(rows)
-
-
-def _run_l3_permutations(div_df, cfg):
-    """Year-label permutation null model for L3.  See _permutation_lexical."""
-    from _permutation_lexical import run_l3_permutations
-
-    return run_l3_permutations(div_df, cfg)
-
-
-def _run_l2_permutations(div_df, cfg):
-    """Past/future pool-shuffle null model for L2.  See _permutation_lexical."""
-    from _permutation_lexical import run_l2_permutations
-
-    return run_l2_permutations(div_df, cfg)
-
-
-def _community_node_comm_map(partition):
-    """Build sorted community list and node->community-index lookup.
-
-    Returns (n_communities, comm_to_idx, node_comm) or None if < 2 communities.
-    """
-    all_communities = sorted(set(partition.values()))
-    n_communities = len(all_communities)
-    if n_communities < 2:
-        return None
-    comm_to_idx = {c: i for i, c in enumerate(all_communities)}
-    return n_communities, comm_to_idx
-
-
-def _community_null_distribution(
-    all_nodes, n_before, node_comm, n_communities, n_perm, perm_rng
-):
-    """Shuffle node-to-window assignments and compute JS^2 for each permutation.
-
-    Returns null_stats array (NaN entries removed).
-    """
-    from scipy.spatial.distance import jensenshannon
-
-    null_stats = np.empty(n_perm)
-    for i in range(n_perm):
-        perm_indices = perm_rng.permutation(len(all_nodes))
-        p_bef = np.zeros(n_communities)
-        p_aft = np.zeros(n_communities)
-
-        for j in perm_indices[:n_before]:
-            node = all_nodes[j]
-            if node in node_comm:
-                p_bef[node_comm[node]] += 1
-
-        for j in perm_indices[n_before:]:
-            node = all_nodes[j]
-            if node in node_comm:
-                p_aft[node_comm[node]] += 1
-
-        if p_bef.sum() == 0 or p_aft.sum() == 0:
-            null_stats[i] = np.nan
-            continue
-
-        p_bef = p_bef / p_bef.sum()
-        p_aft = p_aft / p_aft.sum()
-        js = jensenshannon(p_bef, p_aft)
-        null_stats[i] = float(js**2)
-
-    return null_stats[~np.isnan(null_stats)]
-
-
-def _g9_one_window(y, w, works, internal_edges, n_perm, seed, resolution, gap=1):
-    """Process one (year, window) for G9 community permutation test."""
-    import community as community_louvain
-    from _divergence_citation import _sliding_window_graph
-    from _divergence_community import _build_union_graph, _community_js_for_pair
-
-    _, perm_rng = _make_window_rngs(seed, y, w)
-
-    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
-    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
-
-    before_nodes = list(G_before.nodes())
-    after_nodes = list(G_after.nodes())
-
-    if len(before_nodes) < 3 or len(after_nodes) < 3:
-        return _nan_row(y, w)
-
-    observed = _community_js_for_pair(
-        G_before, G_after, internal_edges, resolution, seed
-    )
-    if np.isnan(observed):
-        return _nan_row(y, w)
-
-    G_union = _build_union_graph(G_before, G_after, internal_edges)
-    if G_union.number_of_nodes() < 3 or G_union.number_of_edges() < 1:
-        return _nan_row(y, w)
-
-    partition = community_louvain.best_partition(
-        G_union, resolution=resolution, random_state=seed
-    )
-
-    comm_info = _community_node_comm_map(partition)
-    if comm_info is None:
-        return _result_row(y, w, observed, 0.0, 0.0, 0.0, 1.0)
-
-    n_communities, comm_to_idx = comm_info
-
-    all_nodes = before_nodes + after_nodes
-    n_before_count = len(before_nodes)
-
-    node_comm = {
-        node: comm_to_idx[partition[node]] for node in all_nodes if node in partition
-    }
-
-    null_stats = _community_null_distribution(
-        all_nodes, n_before_count, node_comm, n_communities, n_perm, perm_rng
-    )
-
-    if len(null_stats) == 0:
-        return _nan_row(y, w)
-
-    return _finalize_row(y, w, observed, null_stats)
-
-
-def _run_g9_community_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
-    """Permutation test for G9 community divergence (parallel across windows)."""
-    from joblib import Parallel, delayed
-
-    div_cfg = cfg["divergence"]
-    n_perm = div_cfg["permutation"]["n_perm"]
-    seed = div_cfg["random_seed"]
-    gap = div_cfg.get("gap", 1)
-    resolution = (
-        div_cfg.get("citation", {}).get("G9_community", {}).get("resolution", 1.0)
-    )
-
-    year_windows = div_df[["year", "window"]].drop_duplicates()
-    pairs = [
-        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
-    ]
-
-    log.info("G9 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
-    rows = Parallel(n_jobs=n_jobs)(
-        delayed(_g9_one_window)(
-            y, w, works, internal_edges, n_perm, seed, resolution, gap=gap
-        )
-        for y, w in pairs
-    )
-    for row in rows:
-        log.info(
-            "  year=%d window=%s z=%.2f p=%.3f",
-            row["year"],
-            row["window"],
-            row["z_score"],
-            row["p_value"],
-        )
-    return pd.DataFrame(rows)
-
-
-def _finalize_row(y, w, observed, null_stats):
-    """Compute z, p, mean, std from a finite null distribution and log."""
-    null_mean = float(np.mean(null_stats))
-    null_std = float(np.std(null_stats))
-    if null_std > 0:
-        z = (observed - null_mean) / null_std
-    else:
-        z = 0.0
-    p_value = float(np.mean(null_stats >= observed))
-    log.info("  year=%d window=%d z=%.2f p=%.3f", y, w, z, p_value)
-    return _result_row(y, w, observed, null_mean, null_std, z, p_value)
-
-
-def _spectral_null_distribution(G_union, all_nodes, n_before, n_perm, perm_rng):
-    """Shuffle node-to-window assignments and recompute |Δ spectral gap|."""
-    from _citation_methods import _spectral_gap
-
-    null_stats = np.empty(n_perm)
-    for i in range(n_perm):
-        perm = perm_rng.permutation(len(all_nodes))
-        before_set = {all_nodes[j] for j in perm[:n_before]}
-        after_set = {all_nodes[j] for j in perm[n_before:]}
-        gap_b = _spectral_gap(G_union.subgraph(before_set))
-        gap_a = _spectral_gap(G_union.subgraph(after_set))
-        if np.isnan(gap_b) or np.isnan(gap_a):
-            null_stats[i] = np.nan
-        else:
-            null_stats[i] = abs(gap_a - gap_b)
-    return null_stats[~np.isnan(null_stats)]
-
-
-def _g2_spectral_one_window(y, w, works, internal_edges, n_perm, seed, gap=1):
-    """Process one (year, window) for G2 spectral permutation test."""
-    from _citation_methods import _spectral_gap
-    from _divergence_citation import _sliding_window_graph
-    from _divergence_community import _build_union_graph
-
-    _, perm_rng = _make_window_rngs(seed, y, w)
-
-    G_before = _sliding_window_graph(works, internal_edges, y, w, "before", gap=gap)
-    G_after = _sliding_window_graph(works, internal_edges, y, w, "after", gap=gap)
-
-    before_nodes = list(G_before.nodes())
-    after_nodes = list(G_after.nodes())
-
-    if len(before_nodes) < 3 or len(after_nodes) < 3:
-        return _nan_row(y, w)
-
-    gap_b_obs = _spectral_gap(G_before)
-    gap_a_obs = _spectral_gap(G_after)
-    if np.isnan(gap_b_obs) or np.isnan(gap_a_obs):
-        return _nan_row(y, w)
-    observed = abs(gap_a_obs - gap_b_obs)
-
-    G_union = _build_union_graph(G_before, G_after, internal_edges)
-    all_nodes = before_nodes + after_nodes
-    n_before_count = len(before_nodes)
-
-    null_stats = _spectral_null_distribution(
-        G_union, all_nodes, n_before_count, n_perm, perm_rng
-    )
-
-    if len(null_stats) == 0:
-        return _nan_row(y, w)
-
-    return _finalize_row(y, w, observed, null_stats)
-
-
-def _run_g2_spectral_permutations(works, internal_edges, div_df, cfg, n_jobs=1):
-    """Permutation test for G2 spectral-gap divergence (parallel across windows)."""
-    from joblib import Parallel, delayed
-
-    div_cfg = cfg["divergence"]
-    n_perm = div_cfg["permutation"]["n_perm"]
-    seed = div_cfg["random_seed"]
-    gap = div_cfg.get("gap", 1)
-
-    year_windows = div_df[["year", "window"]].drop_duplicates()
-    pairs = [
-        (int(row["year"]), int(row["window"])) for _, row in year_windows.iterrows()
-    ]
-
-    log.info("G2 parallel: %d (year, window) pairs, n_jobs=%d", len(pairs), n_jobs)
-    rows = Parallel(n_jobs=n_jobs)(
-        delayed(_g2_spectral_one_window)(
-            y, w, works, internal_edges, n_perm, seed, gap=gap
-        )
-        for y, w in pairs
-    )
-    for row in rows:
-        log.info(
-            "  year=%d window=%s z=%.2f p=%.3f",
-            row["year"],
-            row["window"],
-            row["z_score"],
-            row["p_value"],
-        )
-    return pd.DataFrame(rows)
-
-
-# ---------------------------------------------------------------------------
-# C2ST permutation drivers
-# ---------------------------------------------------------------------------
-
-
-def _run_c2st_embedding_permutations(div_df, cfg):
-    """Permutation null model for C2ST_embedding.
-
-    For each (year, window): loads raw embeddings via iter_semantic_windows,
-    PCA-reduces the combined pool (fit once, same transform for all permutations),
-    then calls permutation_test with _c2st_auc as the statistic.
-
-    PCA is fit on the combined pool before permutation so that all permuted
-    splits share the same feature space.  n_components is clamped to avoid
-    sklearn errors on small smoke windows.
-    """
-    from _divergence_c2st import _c2st_auc
-    from _divergence_io import iter_semantic_windows
-    from sklearn.decomposition import PCA
-
-    div_cfg = cfg["divergence"]
-    c2st_cfg = div_cfg.get("c2st", {})
-    pca_dim = c2st_cfg.get("pca_dim", 32)
-    cv_folds = c2st_cfg.get("cv_folds", 5)
-    class_weight = c2st_cfg.get("class_weight", "balanced")
-    seed = div_cfg["random_seed"]
-    n_perm = div_cfg["permutation"]["n_perm"]
-
-    rows = []
-    for y, w, X_raw, Y_raw, perm_rng in iter_semantic_windows(div_df, cfg):
-        # Clamp n_components as in compute_c2st_embedding (ticket 0068)
-        n_components = max(
-            2, min(pca_dim, min(len(X_raw), len(Y_raw)) - 1, X_raw.shape[1])
-        )
-        pca = PCA(n_components=n_components, random_state=seed)
-        combined_r = pca.fit_transform(np.vstack([X_raw, Y_raw]))
-        X_pca = combined_r[: len(X_raw)]
-        Y_pca = combined_r[len(X_raw) :]
-
-        def statistic_fn(X, Y, _seed=seed):
-            return _c2st_auc(
-                X, Y, cv_folds=cv_folds, class_weight=class_weight, seed=_seed
-            )["mean"]
-
-        observed, null_mean, null_std, z, p = permutation_test(
-            X_pca, Y_pca, statistic_fn, n_perm, perm_rng
-        )
-        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
-        log.info("  C2ST_embedding year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
-
-    return pd.DataFrame(rows)
-
-
-def _run_c2st_lexical_permutations(div_df, cfg):
-    """Permutation null model for C2ST_lexical.
-
-    For each (year, window): vectorizes the combined text pool once, then
-    runs a manual permutation loop (sparse-matrix slicing) to build the
-    null AUC distribution, calling _c2st_auc directly on sparse row slices.
-    permutation_test() is skipped because it calls np.vstack which converts
-    sparse matrices to dense, breaking sklearn's sparse-aware path.
-    """
-    from _divergence_c2st import _c2st_auc
-    from _divergence_io import fit_lexical_vectorizer, iter_lexical_windows
-
-    div_cfg = cfg["divergence"]
-    c2st_cfg = div_cfg.get("c2st", {})
-    cv_folds = c2st_cfg.get("cv_folds", 5)
-    class_weight = c2st_cfg.get("class_weight", "balanced")
-    seed = div_cfg["random_seed"]
-    n_perm = div_cfg["permutation"]["n_perm"]
-
-    vectorizer = fit_lexical_vectorizer(cfg)
-
-    rows = []
-    for y, w, texts_before, texts_after, perm_rng in iter_lexical_windows(div_df, cfg):
-        all_texts = texts_before + texts_after
-        X_all = vectorizer.transform(all_texts)
-        n_before = len(texts_before)
-
-        # Observed statistic on un-permuted split
-        observed = _c2st_auc(
-            X_all[:n_before],
-            X_all[n_before:],
-            cv_folds=cv_folds,
-            class_weight=class_weight,
-            seed=seed,
-        )["mean"]
-
-        # Manual permutation loop — sparse slicing avoids dense conversion
-        null_stats = []
-        for i in range(n_perm):
-            idx = perm_rng.permutation(X_all.shape[0])
-            X_perm_before = X_all[idx[:n_before]]
-            X_perm_after = X_all[idx[n_before:]]
-            null_auc = _c2st_auc(
-                X_perm_before,
-                X_perm_after,
-                cv_folds=cv_folds,
-                class_weight=class_weight,
-                seed=seed + i,
-            )["mean"]
-            null_stats.append(null_auc)
-
-        null_stats_arr = np.array(null_stats)
-        null_mean = float(np.mean(null_stats_arr))
-        null_std = float(np.std(null_stats_arr))
-        z = (observed - null_mean) / null_std if null_std > 0 else 0.0
-        p = float(np.mean(null_stats_arr >= observed))
-
-        rows.append(_result_row(y, w, observed, null_mean, null_std, z, p))
-        log.info("  C2ST_lexical year=%d window=%d z=%.2f p=%.3f", y, w, z, p)
-
-    return pd.DataFrame(rows)
-
-
 # Citation-channel dispatcher: method_name -> permutation driver.
+# ---------------------------------------------------------------------------
+
 _CITATION_PERMUTATION_DRIVERS = {
     "G1_pagerank": _run_g1_permutations,
     "G2_spectral": _run_g2_spectral_permutations,
@@ -717,7 +77,7 @@ _CITATION_PERMUTATION_DRIVERS = {
 
 
 def _run_citation_permutations(method_name, div_df, cfg, n_jobs=1):
-    """Permutation test for citation-channel methods (G2, G9)."""
+    """Permutation test for citation-channel methods (G1-G9)."""
     from _divergence_citation import load_citation_data
 
     driver = _CITATION_PERMUTATION_DRIVERS.get(method_name)
@@ -729,6 +89,21 @@ def _run_citation_permutations(method_name, div_df, cfg, n_jobs=1):
 
     works, _, internal_edges = load_citation_data(None)
     return driver(works, internal_edges, div_df, cfg, n_jobs=n_jobs)
+
+
+# ---------------------------------------------------------------------------
+# Thin lexical stubs
+# ---------------------------------------------------------------------------
+
+
+def _run_l3_permutations(div_df, cfg):
+    """Year-label permutation null model for L3.  See _permutation_lexical."""
+    return run_l3_permutations(div_df, cfg)
+
+
+def _run_l2_permutations(div_df, cfg):
+    """Past/future pool-shuffle null model for L2.  See _permutation_lexical."""
+    return run_l2_permutations(div_df, cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/tickets/0111-extract-permutation-c2st.erg
+++ b/tickets/0111-extract-permutation-c2st.erg
@@ -1,0 +1,106 @@
+%erg v1
+Title: Refactor compute_null_model.py into a pure dispatcher — mirror compute_divergence.py
+Status: doing
+Created: 2026-04-24
+Author: claude
+
+--- log ---
+2026-04-24T16:30Z claude created — god-module symptom triggered by /verify-gate REROLL on PR #759
+2026-04-24T16:45Z reimagine: not a one-file extraction; the dispatcher/module split that works for compute_divergence.py was never fully applied here
+2026-04-24T20:00Z claude claimed — starting dispatcher/module split
+
+--- body ---
+## Diagnosis
+
+`compute_null_model.py` is 818 lines. The god-module ratchet (`test_no_god_modules`,
+limit 800) is a symptom. The structural issue: the file is both dispatcher *and*
+method implementations, unlike `compute_divergence.py` (192 lines, pure dispatcher
+backed by 7 `_divergence_*.py` private modules).
+
+Current state of inline implementations in `compute_null_model.py`:
+- `permutation_test` (~61L) — core algorithm, should be shared
+- `_result_row`, `_nan_row`, `_finalize_row`, `_collect_permutation_rows` — helpers
+  duplicated across `compute_null_model.py`, `_permutation_citation.py`,
+  `_permutation_lexical.py` (3 copies)
+- `_make_semantic_statistic`, `_run_semantic_gpu`, `_run_semantic_permutations` — S1–S4
+- `_run_lexical_permutations` — L1 (L2/L3 already delegated via thin stubs)
+- `_community_node_comm_map`, `_community_null_distribution`, `_g9_one_window`,
+  `_run_g9_community_permutations` — G9, ~140L fully inline
+- `_spectral_null_distribution`, `_g2_spectral_one_window`,
+  `_run_g2_spectral_permutations` — G2, ~92L fully inline
+- `_run_c2st_embedding_permutations`, `_run_c2st_lexical_permutations` — ~122L inline
+
+`_permutation_citation.py` and `_permutation_lexical.py` already show the right
+pattern. They need to be completed and joined by peers.
+
+## Target architecture
+
+```
+compute_null_model.py  (~200L)   — dispatch only, like compute_divergence.py
+_permutation_io.py               — permutation_test, _result_row, _nan_row,
+                                   _finalize_row, _collect_permutation_rows
+_permutation_semantic.py         — S1_MMD, S2_energy, S3_sliced_wasserstein,
+                                   S4_frechet; _make_semantic_statistic, _run_semantic_gpu
+_permutation_lexical.py (exists) — L1, L2, L3; migrate to use _permutation_io helpers
+_permutation_graph.py            — G2_spectral, G9_community (undirected graph methods)
+_permutation_citation.py (exists)— G1, G5, G6, G8; migrate to use _permutation_io helpers
+_permutation_c2st.py             — C2ST_embedding, C2ST_lexical
+```
+
+`compute_divergence.py` (192L) is the model to follow exactly.
+
+## Actions
+
+1. Create `scripts/_permutation_io.py`:
+   - Move `permutation_test`, `_result_row`, `_nan_row`, `_finalize_row`,
+     `_collect_permutation_rows` from `compute_null_model.py`.
+   - No imports from other `_permutation_*` modules (no circular deps).
+
+2. Create `scripts/_permutation_semantic.py`:
+   - Move `_make_semantic_statistic`, `_run_semantic_gpu`,
+     `_run_semantic_permutations` from `compute_null_model.py`.
+   - Import row helpers from `_permutation_io`.
+
+3. Create `scripts/_permutation_graph.py`:
+   - Move G9 drivers (`_community_*`, `_g9_one_window`, `_run_g9_community_permutations`)
+     and G2 drivers (`_spectral_*`, `_g2_spectral_one_window`,
+     `_run_g2_spectral_permutations`) from `compute_null_model.py`.
+   - Import row helpers from `_permutation_io`.
+
+4. Create `scripts/_permutation_c2st.py`:
+   - Move `_run_c2st_embedding_permutations`, `_run_c2st_lexical_permutations`.
+   - Import row helpers from `_permutation_io`.
+
+5. Migrate `_permutation_citation.py` and `_permutation_lexical.py`:
+   - Replace local copies of `_result_row`, `_nan_row`, `_finalize_row` with
+     imports from `_permutation_io`.
+
+6. Slim `compute_null_model.py` to dispatcher only (~200L):
+   - Imports from the 5 private modules.
+   - Thin wrapper stubs where needed (like `_run_l2_permutations` already is).
+   - `main()` dispatch block.
+
+7. Update `test_script_hygiene.py` god-module ratchet if needed:
+   - `compute_null_model.py` should now be well under 300L.
+   - New private modules should each be under 400L.
+
+## Test
+
+First test (Red): `test_no_god_modules` currently fails (818L). Should pass after.
+
+```bash
+uv run python -m pytest tests/test_script_hygiene.py::TestModuleLength -v
+```
+
+All existing null-model tests must continue to pass:
+```bash
+uv run python -m pytest tests/test_null_model*.py tests/test_zoo_null_ci.py -v
+```
+
+## Exit criteria
+
+1. `compute_null_model.py` ≤ 250 lines (dispatcher only).
+2. `_permutation_io.py` exists; no duplicate helper functions across `_permutation_*.py`.
+3. `test_no_god_modules` passes for all scripts.
+4. All `test_null_model*.py` and `test_zoo_null_ci.py` tests pass.
+5. `make check-fast` clean (2 pre-existing failures allowed).

--- a/tickets/0111-extract-permutation-c2st.erg
+++ b/tickets/0111-extract-permutation-c2st.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Refactor compute_null_model.py into a pure dispatcher — mirror compute_divergence.py
-Status: doing
+Status: done
 Created: 2026-04-24
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-24T16:30Z claude created — god-module symptom triggered by /verify-gate REROLL on PR #759
 2026-04-24T16:45Z reimagine: not a one-file extraction; the dispatcher/module split that works for compute_divergence.py was never fully applied here
 2026-04-24T20:00Z claude claimed — starting dispatcher/module split
+2026-04-24T21:00Z GREEN — dispatcher 193L; 4 new modules + 2 migrated; 47/49 tests pass (2 C2ST smoke timeouts are pre-existing on main)
 
 --- body ---
 ## Diagnosis


### PR DESCRIPTION
## Summary
- Splits `compute_null_model.py` (818L → 193L) into a pure dispatcher + 4 new private modules
- Creates `_permutation_io.py` (shared helpers), `_permutation_semantic.py` (S1-S4), `_permutation_graph.py` (G2/G9), `_permutation_c2st.py` (C2ST)
- Migrates `_permutation_lexical.py` and `_permutation_citation.py` to use shared helpers from `_permutation_io`, eliminating 3 copies of row helper functions
- Re-exports maintain backward compatibility for all downstream consumers (no test changes needed)

Triggered by `test_no_god_modules` failure (818L > 800L ratchet), which was caught by `/verify-gate` REROLL on PR #759.

## Test plan
- [x] `test_no_god_modules` passes (was failing at 818L)
- [x] 47/49 `test_null_model*.py` tests pass
- [x] 2 C2ST smoke timeouts are pre-existing (also fail on main)
- [x] `test_zoo_null_ci.py` passes (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)