### PR TITLE
fix(0066): validate null CSV schema before join in export_divergence_summary

### DIFF
--- a/scripts/export_divergence_summary.py
+++ b/scripts/export_divergence_summary.py
@@ -19,7 +19,7 @@ import argparse
 import numpy as np
 import pandas as pd
 from pipeline_loaders import load_analysis_config
-from schemas import DivergenceSummarySchema
+from schemas import DivergenceSummarySchema, NullModelSchema
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger
 
@@ -51,6 +51,8 @@ def build_summary(div_df, null_df, boot_df, method, subsample_df=None):
         Summary with columns matching DivergenceSummarySchema.
 
     """
+    NullModelSchema.validate(null_df)
+
     # Aggregate divergence: take mean value per (year, window) if duplicates
     div_agg = (
         div_df.groupby(["year", "window"], as_index=False)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -564,3 +564,23 @@ class TestSummaryTable:
             f"Quantiles out of order: q025={row['boot_q025']}, "
             f"median={row['boot_median']}, q975={row['boot_q975']}"
         )
+
+    def test_summary_rejects_bad_null_csv(self):
+        """Missing column in null CSV must raise SchemaError, not KeyError."""
+        import pandera as pa
+        from export_divergence_summary import build_summary
+
+        div_df = pd.DataFrame(
+            {
+                "year": [2005],
+                "channel": ["semantic"],
+                "window": ["3"],
+                "hyperparams": [""],
+                "value": [0.55],
+            }
+        )
+        bad_null_df = pd.DataFrame({"year": [2005], "window": ["3"]})
+        boot_df = _make_synthetic_boot_df(k=10)
+
+        with pytest.raises(pa.errors.SchemaError):
+            build_summary(div_df, bad_null_df, boot_df, method="S2_energy")

--- a/tickets/0066-null-csv-schema.erg
+++ b/tickets/0066-null-csv-schema.erg
@@ -1,12 +1,17 @@
 %erg v1
 Title: export_divergence_summary should validate tab_null_*.csv on read
-Status: open
+Status: doing
 Created: 2026-04-16
 Author: claude
 
 --- log ---
 2026-04-16T18:05Z claude created — follow-up from PR #683 review
 2026-04-16T20:40Z claude rewritten — items 1-3 already in tree, only item 4 remains
+2026-04-25T16:55Z HDMX-coding-agent claimed
+2026-04-25T16:55Z HDMX-coding-agent status doing
+2026-04-25T17:00Z HDMX-coding-agent RED: test_summary_rejects_bad_null_csv — asserts SchemaError, gets KeyError
+2026-04-25T17:01Z HDMX-coding-agent GREEN: NullModelSchema.validate(null_df) in build_summary(); 20/20 tests pass
+2026-04-25T17:02Z HDMX-coding-agent REFACTOR: no changes needed; make check-fast 975 pass (2 pre-existing failures)
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- `build_summary()` now calls `NullModelSchema.validate(null_df)` before accessing columns — surfaces a clear `SchemaError` instead of an opaque `KeyError` when the null CSV is malformed or missing a required column
- Test added: `test_summary_rejects_bad_null_csv` in `test_bootstrap.py`
- Fixes ticket 0066 (follow-up from PR #683 review)

## Test plan

- [ ] `test_summary_rejects_bad_null_csv` passes (SchemaError raised, not KeyError)
- [ ] `make check-fast` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)