### PR TITLE
fix(0118): S4_frechet empty-results guard + smoke-mode min_papers precedence

### DIFF
--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -124,19 +124,19 @@ def get_min_papers(method=None, *, cfg=None, n_works=None):
         cfg = load_analysis_config()
     div_cfg = cfg["divergence"]
 
-    # Per-method overrides take precedence over smoke mode
+    # Smoke mode (small corpus) — overrides ALL per-method thresholds
+    if n_works is not None and n_works < 200:
+        mp = div_cfg.get("min_papers_smoke", 5)
+        log.info("Smoke mode: n_works=%d < 200, min_papers=%d", n_works, mp)
+        return mp
+
+    # Per-method overrides (production only)
     if method == "S4_frechet":
         return div_cfg["semantic"]["S4_frechet"].get(
             "min_papers", div_cfg["min_papers"]
         )
     if method in ("c2st", "C2ST_embedding", "C2ST_lexical"):
         return div_cfg["c2st"].get("min_papers", div_cfg["min_papers"])
-
-    # Smoke mode (small corpus)
-    if n_works is not None and n_works < 200:
-        mp = div_cfg.get("min_papers_smoke", 5)
-        log.info("Smoke mode: n_works=%d < 200, min_papers=%d", n_works, mp)
-        return mp
 
     return div_cfg.get("min_papers", 30)
 

--- a/scripts/_divergence_io.py
+++ b/scripts/_divergence_io.py
@@ -112,8 +112,8 @@ def get_min_papers(method=None, *, cfg=None, n_works=None):
     """Return appropriate min_papers for a given method and corpus size.
 
     Lookup order:
-    1. Per-method override from config (S4_frechet=300, c2st/C2ST_*=50).
-    2. Smoke mode: if n_works < 200, use min_papers_smoke (default 5).
+    1. Smoke mode: if n_works < 200, use min_papers_smoke (default 5) — overrides all.
+    2. Per-method override from config (S4_frechet=300, c2st/C2ST_*=50).
     3. Global min_papers (default 30).
 
     When cfg is None, loads config/analysis.yaml automatically.

--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 import pandas as pd
 from _divergence_io import (
+    empty_divergence_df,
     get_min_papers,
     per_window_year_ranges,
     subsample_equal_n,
@@ -259,6 +260,8 @@ def compute_s1_mmd(df, emb, cfg):
             )
     if last_w is not None:
         log.info("S1 MMD window=%d done", last_w)
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 
@@ -337,6 +340,8 @@ def compute_s2_energy(df, emb, cfg):
         )
     if last_w is not None:
         log.info("S2 energy window=%d done", last_w)
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 
@@ -408,6 +413,8 @@ def compute_s3_wasserstein(df, emb, cfg):
             )
     if last_w is not None:
         log.info("S3 sliced Wasserstein window=%d done", last_w)
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 
@@ -542,4 +549,6 @@ def compute_s4_frechet(df, emb, cfg):
         )
     if last_w is not None:
         log.info("S4 Frechet window=%d done", last_w)
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)


### PR DESCRIPTION
## Summary

- Reorder `get_min_papers()` in `_divergence_io.py` so smoke mode (`n_works < 200`) fires **before** per-method overrides, preventing `S4_frechet` from using `min_papers=300` on the 90-row smoke fixture.
- Add `if not results: return empty_divergence_df()` guard before each `return pd.DataFrame(results)` in all four semantic compute functions (S1–S4), avoiding a zero-column DataFrame that fails `DivergenceSchema` validation.
- Add `empty_divergence_df` to the `from _divergence_io import (...)` block in `_divergence_semantic.py`.

## Test plan

- [x] RED: `pytest tests/test_divergence.py::TestSmokeSemantic::test_compute_method[S4_frechet]` failed before changes
- [x] GREEN: all 4 `TestSmokeSemantic::test_compute_method` tests pass after changes
- [x] `make check-fast` clean (967 passed, 13 skipped)

Closes ticket `tickets/0118-fix-s4-frechet-empty-results.erg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)