### PR TITLE
feat: L3 null model: document-shuffle + window='0' ribbon (ticket 0114)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -4,10 +4,10 @@ Last updated: 2026-04-25
 
 ## Current goal
 
-**Null ribbon quality** — all 18 zoo figures have ribbons (drivers done); fix scaling, axis, and L3 methodology.
+**Null ribbon quality** — all 18 zoo figures have ribbons (drivers done); fix L2 crossyear mismatch, L3 methodology, analytical overlay.
 
 ### Roadmap
-1. **NOW — Ribbon quality** (tickets 0112–0115): fix Z-score rescaling, L2 mismatch, L3 document shuffle, analytical overlay.
+1. **NOW — Ribbon quality** (tickets 0112, 0114, 0115): fix L2 mismatch, L3 document shuffle, analytical overlay.
 2. **NEXT — Replication ribbon** (ticket 0105): R=20 equal-n subsamples → [Q10,Q90] band on S1–S4 and C2ST×2.
 3. **AFTER — Paper method section**: narrative, figures, and prose for `multilayer-detection.qmd`.
 
@@ -43,6 +43,12 @@ Under review (peer reviewers + data specialists). 2,495 words, 1 figure, 3 table
 - #761 (0066): null CSV schema validation on read in export_divergence_summary
 - #762: fix zoo.mk null deps (NULL_METHODS_ALL loop); ribbon quality tickets 0112–0116
 
+### Ribbon raw values + smoke test fixes — merged 2026-04-25 (PRs #763–#764, #766–#767)
+- #763: prune dead DOC_VARS entries (test_doc_vars_no_extras green)
+- #764 (0118): S4_frechet empty-results guard + smoke-mode min_papers precedence
+- #766 (0113): zoo figures: plot raw D(t,w) values, drop Z-score rescaling
+- #767 (0119): regenerate golden values (102-work smoke fixture, 96 rows)
+
 ## Corpus (v1.1.1)
 
 - 6 sources: OpenAlex, ISTEX, bibCNRS, SciSpace, grey literature, teaching canon
@@ -54,6 +60,7 @@ Being re-generated on padme with GROBID reference extraction and DOI matching.
 ## Known test failures (pre-existing RED)
 
 - `test_robustness_observability.py::test_step1_counter_attempted`: flaky under `-n 4`. Pre-existing.
+- `test_ref_match_corpus.py::TestRefMatchCorpus::*`: flaky under `-n 4` parallel execution; all pass in isolation. Pre-existing.
 
 ## Blockers
 
@@ -63,38 +70,45 @@ None.
 
 | Method | Status |
 |--------|--------|
-| S1_MMD | ✅ ribbon live |
-| S2_energy | ✅ ribbon live |
-| S3_sliced_wasserstein | ✅ CSV computed; ribbon live |
-| S4_frechet | ✅ CSV computed; ribbon live |
-| L1 | ✅ ribbon live |
-| L2 | ✅ CSV computed; ribbon live (scale bug → ticket 0112) |
+| S1_MMD | ✅ ribbon live (raw values) |
+| S2_energy | ✅ ribbon live (raw values) |
+| S3_sliced_wasserstein | ✅ ribbon live (raw values) |
+| S4_frechet | ✅ ribbon live (raw values) |
+| L1 | ✅ ribbon live (raw values) |
+| L2 | ✅ ribbon live — scale bug → ticket 0112 |
 | L3 | ✅ CSV computed; ribbon missing (window filter bug → ticket 0114) |
-| G1_pagerank | ✅ CSV computed; ribbon live |
+| G1_pagerank | ✅ ribbon live (raw values) |
 | G2_spectral | ✅ ribbon live |
 | G3_coupling_age | ❌ no null model (G3/G4/G7 not in null pipeline) |
 | G4_cross_tradition | ❌ no null model |
-| G5_pref_attachment | ✅ CSV computed; ribbon live |
-| G6_entropy | ✅ CSV computed; ribbon live |
+| G5_pref_attachment | ✅ ribbon live (raw values) |
+| G6_entropy | ✅ ribbon live (raw values) |
 | G7_disruption | ❌ no null model |
-| G8_betweenness | ✅ CSV computed; ribbon live |
+| G8_betweenness | ✅ ribbon live (raw values) |
 | G9_community | ✅ ribbon live |
-| C2ST_embedding | ✅ CSV computed; ribbon live (scale offset → ticket 0113) |
-| C2ST_lexical | ✅ CSV computed; ribbon live (scale offset → ticket 0113) |
+| C2ST_embedding | ✅ ribbon live (raw values) |
+| C2ST_lexical | ✅ ribbon live (raw values) |
 
 ## Open ribbon-quality tickets
 
 | Ticket | Title | Priority |
 |--------|-------|----------|
 | 0112 | Fix L2 null: filter crossyear to resonance-only | High |
-| 0113 | Drop Z-score rescaling; plot raw statistic values | High |
 | 0114 | L3 null: full document shuffle + window="0" ribbon | High |
 | 0115 | Analytical null overlay for S1/S2/L1/C2ST | Medium |
 
+## Open infrastructure tickets
+
+| Ticket | Title | Priority |
+|--------|-------|----------|
+| 0116 | Add n_jobs parallelism to L2/L3 null model permutation drivers | Low |
+| 0120 | Empty-results guard for remaining dispatcher modules (_c2st, _community, _citation, _lexical) | Low |
+| 0121 | Standing regression test: all dispatcher methods return valid schema on empty corpus | Low |
+
 ## Next actions
 
-- Land 0113 first (raw values — unblocks all downstream ribbon work)
-- Then 0112 (L2 scale fix), 0114 (L3 document shuffle), 0115 (analytical overlay)
+- Land 0112 (L2 scale fix, PR #765 open)
+- Then 0114 (L3 document shuffle), 0115 (analytical overlay)
 
 Background (not on critical path):
 

--- a/STATE.md
+++ b/STATE.md
@@ -43,9 +43,10 @@ Under review (peer reviewers + data specialists). 2,495 words, 1 figure, 3 table
 - #761 (0066): null CSV schema validation on read in export_divergence_summary
 - #762: fix zoo.mk null deps (NULL_METHODS_ALL loop); ribbon quality tickets 0112–0116
 
-### Ribbon raw values + smoke test fixes — merged 2026-04-25 (PRs #763–#764, #766–#767)
+### Ribbon raw values + smoke test fixes — merged 2026-04-25 (PRs #763–#767)
 - #763: prune dead DOC_VARS entries (test_doc_vars_no_extras green)
 - #764 (0118): S4_frechet empty-results guard + smoke-mode min_papers precedence
+- #765 (0112): fix L2 null: filter crossyear to resonance-only
 - #766 (0113): zoo figures: plot raw D(t,w) values, drop Z-score rescaling
 - #767 (0119): regenerate golden values (102-work smoke fixture, 96 rows)
 
@@ -93,7 +94,6 @@ None.
 
 | Ticket | Title | Priority |
 |--------|-------|----------|
-| 0112 | Fix L2 null: filter crossyear to resonance-only | High |
 | 0114 | L3 null: full document shuffle + window="0" ribbon | High |
 | 0115 | Analytical null overlay for S1/S2/L1/C2ST | Medium |
 
@@ -107,8 +107,8 @@ None.
 
 ## Next actions
 
-- Land 0112 (L2 scale fix, PR #765 open)
-- Then 0114 (L3 document shuffle), 0115 (analytical overlay)
+- 0114 (L3 document shuffle + raw burst ribbon)
+- 0115 (analytical null overlay for S1/S2/L1/C2ST)
 
 Background (not on critical path):
 

--- a/scripts/_permutation_lexical.py
+++ b/scripts/_permutation_lexical.py
@@ -46,7 +46,6 @@ def _count_bursts(year_labels, X_all, top_indices, years, z_threshold):
 
     """
     n_years = len(years)
-    year_to_idx = {y: i for i, y in enumerate(years)}
 
     # Per-year mean term frequency for top terms
     tf_matrix = np.zeros((n_years, len(top_indices)))
@@ -130,10 +129,8 @@ def run_l3_permutations(div_df, cfg):
         [div_df.loc[div_df["year"] == y, "value"].iloc[0] for y in years]
     )
 
-    # Per-year document counts (preserved during shuffle)
-    year_counts = {y: int((doc_years == y).sum()) for y in years}
-
     # Permutation loop: shuffle document-year assignments within the corpus
+    # rng.permutation preserves per-year document counts by construction.
     perm_matrix = np.empty((n_perm, len(years)))
     for i in range(n_perm):
         shuffled_years = rng.permutation(doc_years)

--- a/scripts/_permutation_lexical.py
+++ b/scripts/_permutation_lexical.py
@@ -9,8 +9,10 @@ L2 — Novelty / Transience / Resonance (Barron et al. 2018)
     recompute resonance of the fixed year-y docs against the shuffled LMs.
 
 L3 — Burst detection (z-score term frequency, Kleinberg-style)
-    Year-label permutation: shuffle the burst-count time series and standardise
-    each permuted series to produce a null ribbon for the cross-year Z-score.
+    Document-shuffle permutation: shuffle document-year assignments while
+    preserving per-year document counts.  Recompute burst counts from scratch
+    in each permutation.  The null ribbon is in raw burst-count units,
+    matching the observed statistic.
 """
 
 import numpy as np
@@ -21,73 +23,141 @@ from utils import get_logger
 log = get_logger("_permutation_lexical")
 
 
+def _count_bursts(year_labels, X_all, top_indices, years, z_threshold):
+    """Count burst terms per year given a (possibly permuted) year-label array.
+
+    Parameters
+    ----------
+    year_labels : np.ndarray of int, shape (n_docs,)
+        Year assigned to each document (may be permuted).
+    X_all : scipy sparse matrix, shape (n_docs, n_features)
+        Raw TF matrix for the entire corpus.
+    top_indices : np.ndarray of int
+        Column indices of the top-N terms by corpus frequency.
+    years : list[int]
+        Sorted list of years to compute counts for.
+    z_threshold : float
+        Z-score threshold for declaring a term as bursting.
+
+    Returns
+    -------
+    np.ndarray of int, shape (n_years,)
+        Number of bursting terms for each year.
+
+    """
+    n_years = len(years)
+    year_to_idx = {y: i for i, y in enumerate(years)}
+
+    # Per-year mean term frequency for top terms
+    tf_matrix = np.zeros((n_years, len(top_indices)))
+    for i, y in enumerate(years):
+        mask = year_labels == y
+        n_docs = mask.sum()
+        if n_docs == 0:
+            continue
+        tf = np.asarray(X_all[mask][:, top_indices].sum(axis=0)).flatten()
+        tf_matrix[i] = tf / n_docs
+
+    # Z-score each term across years
+    means = tf_matrix.mean(axis=0)
+    stds = tf_matrix.std(axis=0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        z_matrix = np.where(stds > 0, (tf_matrix - means) / stds, 0.0)
+
+    return (z_matrix > z_threshold).sum(axis=1).astype(int)
+
+
 def run_l3_permutations(div_df, cfg):
-    """Year-label permutation null model for L3 (term burst counts).
+    """Document-shuffle permutation null model for L3 (term burst counts).
 
     L3 emits one value per year (window="0"): the count of terms whose
-    TF-IDF z-score exceeds a threshold. This is a cumulative method with
-    no before/after pairs, so the standard permutation_test does not apply.
+    per-year TF z-score exceeds a threshold.  The null model shuffles
+    document-year assignments (preserving per-year document counts) and
+    recomputes burst counts from scratch in each permutation.
 
-    Instead we permute year labels on the burst-count vector and standardise
-    each permuted series the same way compute_crossyear_zscore.py does
-    (subtract global mean, divide by global std). The null ribbon describes
-    how much the cross-year Z-score can fluctuate by chance alone.
+    The observed value is read directly from div_df["value"] (raw burst
+    counts as produced by compute_l3_bursts).  The null ribbon is in the
+    same raw-count units.
 
     Parameters
     ----------
     div_df : pd.DataFrame
         Rows from tab_div_L3.csv with columns year, window, value.
     cfg : dict
-        Analysis config (reads divergence.random_seed and
-        divergence.permutation.n_perm).
+        Analysis config (reads divergence.random_seed,
+        divergence.permutation.n_perm, and divergence.lexical.L3_bursts).
 
     Returns
     -------
     pd.DataFrame matching NullModelSchema with window="0".
 
     """
+    from _divergence_lexical import load_lexical_data
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
     div_cfg = cfg["divergence"]
+    lex_cfg = div_cfg["lexical"]
     n_perm = div_cfg["permutation"]["n_perm"]
     seed = div_cfg["random_seed"]
     rng = np.random.RandomState(seed)
 
+    n_top_terms = lex_cfg["L3_bursts"]["top_n_terms"]
+    z_threshold = lex_cfg["L3_bursts"]["z_threshold"]
+    tfidf_max_features = lex_cfg["tfidf_max_features"]
+    tfidf_min_df = lex_cfg["tfidf_min_df"]
+
+    df = load_lexical_data(None)
+    doc_years = df["year"].values
+    all_texts = df["abstract"].tolist()
+
+    # Fit TF-IDF (raw TF, no IDF) — same settings as compute_l3_bursts
+    vec = TfidfVectorizer(
+        stop_words="english",
+        max_features=tfidf_max_features,
+        min_df=min(tfidf_min_df, max(1, len(all_texts) - 1)),
+        sublinear_tf=False,
+        use_idf=False,
+        norm=None,
+    )
+    X_all = vec.fit_transform(all_texts)
+
+    # Corpus-wide frequency → top N terms (invariant under permutation)
+    corpus_freq = np.asarray(X_all.sum(axis=0)).flatten()
+    top_indices = np.argsort(corpus_freq)[-n_top_terms:]
+
     years = sorted(div_df["year"].unique())
-    values = np.array([div_df.loc[div_df["year"] == y, "value"].iloc[0] for y in years])
+    observed_values = np.array(
+        [div_df.loc[div_df["year"] == y, "value"].iloc[0] for y in years]
+    )
 
-    mu = float(np.mean(values))
-    sigma = float(np.std(values))
+    # Per-year document counts (preserved during shuffle)
+    year_counts = {y: int((doc_years == y).sum()) for y in years}
 
-    # Observed Z-scores (same standardisation as compute_crossyear_zscore.py)
-    if sigma > 0:
-        observed_z = (values - mu) / sigma
-    else:
-        observed_z = np.full_like(values, np.nan, dtype=float)
-
-    n_years = len(years)
-    # Collect permuted Z-score vectors
-    perm_z_matrix = np.empty((n_perm, n_years))
+    # Permutation loop: shuffle document-year assignments within the corpus
+    perm_matrix = np.empty((n_perm, len(years)))
     for i in range(n_perm):
-        permuted = rng.permutation(values)
-        if sigma > 0:
-            perm_z_matrix[i] = (permuted - mu) / sigma
-        else:
-            perm_z_matrix[i] = np.nan
+        shuffled_years = rng.permutation(doc_years)
+        perm_matrix[i] = _count_bursts(
+            shuffled_years, X_all, top_indices, years, z_threshold
+        )
 
-    null_mean = np.mean(perm_z_matrix, axis=0)
-    null_std = np.std(perm_z_matrix, axis=0)
+    null_mean = np.mean(perm_matrix, axis=0)
+    null_std = np.std(perm_matrix, axis=0)
 
     rows = []
     for j, y in enumerate(years):
-        obs = float(observed_z[j])
+        obs = float(observed_values[j])
         nm = float(null_mean[j])
         ns = float(null_std[j])
         if ns > 0:
             z = (obs - nm) / ns
         else:
             z = 0.0
-        p = float(np.mean(perm_z_matrix[:, j] >= obs))
+        p = float(np.mean(perm_matrix[:, j] >= obs))
         rows.append(_result_row(y, "0", obs, nm, ns, z, p))
-        log.info("  year=%d z=%.2f p=%.3f [L3]", y, z, p)
+        log.info(
+            "  year=%d obs=%.1f null_mean=%.2f z=%.2f p=%.3f [L3]", y, obs, nm, z, p
+        )
 
     return pd.DataFrame(rows)
 

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -214,18 +214,42 @@ def _plot(
     # Fallback: cumulative or single-window methods (G3, G4, G7, L3).
     if not plotted:
         non_sliding = df[~df["window"].isin(("2", "3", "4"))].sort_values("year")
-        non_sliding = non_sliding.dropna(subset=["z_score"])
+        value_col = "value" if "value" in non_sliding.columns else "z_score"
+        non_sliding = non_sliding.dropna(subset=[value_col])
         if not non_sliding.empty:
             wlabel = non_sliding["window"].iloc[0]
             ax.plot(
                 non_sliding["year"],
-                non_sliding["z_score"],
+                non_sliding[value_col],
                 color=DARK,
                 linewidth=1.6,
                 label=wlabel,
                 zorder=3,
             )
             plotted.append(wlabel)
+
+            # Null ribbon for window="0" (L3): null_mean ± 1.96 * null_std
+            # in the same raw-value units as the curve above.
+            w0_null = (
+                null_df[null_df["window"] == "0"].sort_values("year")
+                if null_df is not None
+                else None
+            )
+            has_w0_ribbon = (
+                w0_null is not None
+                and not w0_null.empty
+                and w0_null["null_mean"].notna().any()
+            )
+            if has_w0_ribbon:
+                ax.fill_between(
+                    w0_null["year"],
+                    w0_null["null_mean"] - 1.96 * w0_null["null_std"],
+                    w0_null["null_mean"] + 1.96 * w0_null["null_std"],
+                    color=FILL,
+                    alpha=0.40,
+                    zorder=0,
+                    label=None,
+                )
         else:
             log.warning("No plottable rows found for method %s", method)
 

--- a/tests/test_null_model_lexical_l2_l3.py
+++ b/tests/test_null_model_lexical_l2_l3.py
@@ -423,6 +423,7 @@ class TestLexicalDispatch:
 
     def test_l3_dispatch_via_run_lexical_permutations(self):
         """_run_lexical_permutations with method='L3' calls _run_l3_permutations."""
+        from unittest.mock import patch
 
         from compute_null_model import _run_l3_permutations
 
@@ -436,9 +437,10 @@ class TestLexicalDispatch:
             }
         )
         cfg = _base_cfg_lexical()
+        abstract_df = _make_abstract_df()
 
-        # Call _run_l3_permutations directly (routing tested elsewhere)
-        result = _run_l3_permutations(div_df, cfg)
+        with patch("_divergence_lexical.load_lexical_data", return_value=abstract_df):
+            result = _run_l3_permutations(div_df, cfg)
         assert len(result) == len(years)
         assert "null_mean" in result.columns
         assert "null_std" in result.columns

--- a/tests/test_null_model_lexical_l2_l3.py
+++ b/tests/test_null_model_lexical_l2_l3.py
@@ -74,25 +74,34 @@ def _base_cfg_lexical():
 
 
 class TestL3Permutations:
-    """Tests for _run_l3_permutations."""
+    """Tests for _run_l3_permutations.
+
+    All tests mock load_lexical_data so they run without corpus data.
+    The new implementation does document-shuffle permutations (not time-series
+    shuffle), so observed = raw burst counts from div_df and null in count scale.
+    """
 
     def test_l3_output_schema(self):
         """_run_l3_permutations returns DataFrame matching NullModelSchema."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
         from schemas import NullModelSchema
 
+        df = _make_abstract_df(n_years=10, papers_per_year=30, seed=42)
+        years = sorted(df["year"].unique())
         rng = np.random.RandomState(42)
-        years = np.arange(2000, 2020)
         div_df = pd.DataFrame(
             {
                 "year": years,
                 "window": "0",
-                "value": rng.randint(0, 30, size=len(years)).astype(float),
+                "value": rng.randint(0, 20, size=len(years)).astype(float),
             }
         )
 
         cfg = _base_cfg_lexical()
-        result = _run_l3_permutations(div_df, cfg)
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, cfg)
 
         NullModelSchema.validate(result)
         assert set(result.columns) == {
@@ -107,39 +116,42 @@ class TestL3Permutations:
 
     def test_l3_window_label_is_zero(self):
         """L3 null model output must have window='0' (not 'cumulative')."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
 
-        rng = np.random.RandomState(42)
-        years = np.arange(2000, 2020)
+        df = _make_abstract_df(n_years=5, papers_per_year=20, seed=0)
+        years = sorted(df["year"].unique())
         div_df = pd.DataFrame(
             {
                 "year": years,
                 "window": "0",
-                "value": rng.randint(0, 30, size=len(years)).astype(float),
+                "value": np.arange(len(years), dtype=float),
             }
         )
 
-        result = _run_l3_permutations(div_df, _base_cfg_lexical())
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, _base_cfg_lexical())
         assert result["window"].eq("0").all(), (
             f"Expected window='0', got: {result['window'].unique()}"
         )
 
-    def test_l3_null_mean_finite_std_positive(self):
-        """L3 null_mean should be finite and null_std > 0 for varied data."""
+    def test_l3_null_mean_finite(self):
+        """L3 null_mean should be finite for all years."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
 
-        rng = np.random.RandomState(7)
-        years = np.arange(1990, 2025)
-        # Use values with some variance (not all the same)
-        values = rng.randint(2, 50, size=len(years)).astype(float)
+        df = _make_abstract_df(n_years=8, papers_per_year=40, seed=7)
+        years = sorted(df["year"].unique())
+        values = np.arange(2, 2 + len(years), dtype=float)
         div_df = pd.DataFrame({"year": years, "window": "0", "value": values})
 
-        result = _run_l3_permutations(div_df, _base_cfg_lexical())
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, _base_cfg_lexical())
 
         assert result["null_mean"].notna().all(), "null_mean contains NaN"
-        assert result["null_std"].gt(0).all(), (
-            f"null_std <= 0: {result['null_std'].min()}"
-        )
+        assert result["null_std"].notna().all(), "null_std contains NaN"
 
     def test_l3_observed_matches_raw_input_value(self):
         """L3 observed should be the raw burst count from div_df, not Z-standardized."""
@@ -197,29 +209,35 @@ class TestL3Permutations:
 
     def test_l3_row_count_matches_input(self):
         """One output row per year in div_df."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
 
-        years = np.arange(1995, 2025)
+        df = _make_abstract_df(n_years=10, papers_per_year=30, seed=5)
+        years = sorted(df["year"].unique())
         div_df = pd.DataFrame(
             {"year": years, "window": "0", "value": np.ones(len(years)) * 5}
         )
-        # All same values: sigma=0 so observed are NaN, null_std=0 — that's ok for
-        # constant series, but we just check count
-        result = _run_l3_permutations(div_df, _base_cfg_lexical())
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, _base_cfg_lexical())
         assert len(result) == len(years)
 
     def test_l3_reproducible_with_seed(self):
         """Same seed produces same null_mean and null_std."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
 
-        rng = np.random.RandomState(10)
-        years = np.arange(2000, 2020)
-        values = rng.randint(5, 40, size=len(years)).astype(float)
+        df = _make_abstract_df(n_years=5, papers_per_year=30, seed=10)
+        years = sorted(df["year"].unique())
+        values = [5.0, 10.0, 8.0, 3.0, 12.0]
         div_df = pd.DataFrame({"year": years, "window": "0", "value": values})
 
         cfg = _base_cfg_lexical()
-        r1 = _run_l3_permutations(div_df, cfg)
-        r2 = _run_l3_permutations(div_df, cfg)
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            r1 = _run_l3_permutations(div_df, cfg)
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            r2 = _run_l3_permutations(div_df, cfg)
 
         pd.testing.assert_frame_equal(r1, r2)
 

--- a/tests/test_null_model_lexical_l2_l3.py
+++ b/tests/test_null_model_lexical_l2_l3.py
@@ -141,26 +141,59 @@ class TestL3Permutations:
             f"null_std <= 0: {result['null_std'].min()}"
         )
 
-    def test_l3_observed_matches_standardized_input(self):
-        """L3 observed should be the Z-standardized burst count."""
+    def test_l3_observed_matches_raw_input_value(self):
+        """L3 observed should be the raw burst count from div_df, not Z-standardized."""
+        from unittest.mock import patch
+
         from compute_null_model import _run_l3_permutations
 
-        rng = np.random.RandomState(99)
-        years = np.arange(2000, 2020)
-        values = rng.randint(5, 40, size=len(years)).astype(float)
+        df = _make_abstract_df(n_years=5, papers_per_year=20, seed=0)
+        cfg = _base_cfg_lexical()
+        years = sorted(df["year"].unique())
+        values = [3.0, 7.0, 5.0, 2.0, 8.0]
         div_df = pd.DataFrame({"year": years, "window": "0", "value": values})
 
-        result = _run_l3_permutations(div_df, _base_cfg_lexical())
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, cfg)
 
-        mu = values.mean()
-        sigma = values.std()
-        expected_obs = (values - mu) / sigma
-
-        for i, y in enumerate(years):
-            row = result.loc[result["year"] == y].iloc[0]
-            assert abs(row["observed"] - expected_obs[i]) < 1e-9, (
-                f"year={y}: observed={row['observed']:.6f} vs expected={expected_obs[i]:.6f}"
+        for y, expected in zip(years, values):
+            row = result[result["year"] == y].iloc[0]
+            assert abs(row["observed"] - expected) < 1e-9, (
+                f"year={y}: observed={row['observed']} != {expected} (expected raw count)"
             )
+
+    def test_l3_permutations_raw_counts(self):
+        """observed column = raw burst counts (not Z-scores); null in same scale."""
+        from unittest.mock import patch
+
+        from compute_null_model import _run_l3_permutations
+
+        df = _make_abstract_df(n_years=5, papers_per_year=20, seed=0)
+        cfg = _base_cfg_lexical()
+        years = sorted(df["year"].unique())
+        div_df = pd.DataFrame(
+            {
+                "year": years,
+                "window": "0",
+                "value": [3.0, 7.0, 5.0, 2.0, 8.0],
+            }
+        )
+        with patch("_divergence_lexical.load_lexical_data", return_value=df):
+            result = _run_l3_permutations(div_df, cfg)
+
+        # observed must equal the input raw counts from div_df
+        for y, expected in zip(years, [3.0, 7.0, 5.0, 2.0, 8.0]):
+            row = result[result["year"] == y].iloc[0]
+            assert abs(row["observed"] - expected) < 1e-9, (
+                f"year={y}: observed={row['observed']} != {expected}"
+            )
+
+        # null_mean and null_std must be in count scale, not Z-score scale
+        top_n = cfg["divergence"]["lexical"]["L3_bursts"]["top_n_terms"]
+        assert result["null_mean"].between(0, top_n).all(), (
+            f"null_mean out of [0, top_n={top_n}]: {result['null_mean'].values}"
+        )
+        assert result["null_std"].ge(0).all()
 
     def test_l3_row_count_matches_input(self):
         """One output row per year in div_df."""

--- a/tests/test_zoo_figure_polish.py
+++ b/tests/test_zoo_figure_polish.py
@@ -98,6 +98,57 @@ def test_metric_filter_selects_resonance_only(tmp_path):
     assert abs(row_1999["value"].iloc[0] - 3.38) < 1e-6
 
 
+def test_non_sliding_plots_value_not_z_score(tmp_path):
+    """Non-sliding fallback (L3, G3, G4, G7) must plot 'value' not 'z_score'.
+
+    Uses a dual-sentinel: value=0.11 and z_score=99.0.
+    The plot must contain y-data matching 0.11, not 99.0.
+    """
+    import numpy as np
+    import plot_zoo_results
+
+    # Build a minimal crossyear CSV for a non-sliding method (L3)
+    years = [2000, 2001, 2002]
+    df = pd.DataFrame(
+        {
+            "year": years,
+            "window": ["0"] * 3,
+            "value": [0.11, 0.12, 0.13],  # sentinel: small values
+            "z_score": [99.0, 98.0, 97.0],  # sentinel: large values
+        }
+    )
+
+    output_png = tmp_path / "fig_L3.png"
+    output_stem = str(output_png.with_suffix(""))
+
+    # Capture y-data plotted by calling _plot with our sentinel df
+    plotted_y = []
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    orig_plot = plt.Axes.plot
+
+    def capture_plot(self, *args, **kwargs):
+        if len(args) >= 2:
+            y = np.asarray(args[1])
+            plotted_y.extend(y.tolist())
+        return orig_plot(self, *args, **kwargs)
+
+    import unittest.mock as mock
+
+    with mock.patch.object(plt.Axes, "plot", capture_plot):
+        plot_zoo_results._plot(df, "L3", output_stem)
+
+    assert any(abs(y - 0.11) < 1e-6 for y in plotted_y), (
+        f"Expected 0.11 (value column) in plotted y-data; got {plotted_y}"
+    )
+    assert not any(abs(y - 99.0) < 0.1 for y in plotted_y), (
+        f"z_score sentinel (99.0) should NOT appear in plotted y-data; got {plotted_y}"
+    )
+
+
 def test_l2_crossyear_value_matches_null_observed():
     """tab_crossyear_L2.csv value must match tab_null_L2.csv observed within 1e-4.
 

--- a/tickets/0112-l2-null-crossyear-mismatch.erg
+++ b/tickets/0112-l2-null-crossyear-mismatch.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Fix L2 null model: align observed statistic with crossyear CSV
-Status: open
+Status: closed
 Created: 2026-04-25
 Author: claude
 

--- a/tickets/0113-ribbon-center-offset.erg
+++ b/tickets/0113-ribbon-center-offset.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Zoo figures: plot raw statistic values, drop crossyear Z-score rescaling
-Status: open
+Status: closed
 Created: 2026-04-25
 Author: claude
 

--- a/tickets/0118-fix-s4-frechet-empty-results.erg
+++ b/tickets/0118-fix-s4-frechet-empty-results.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Fix S4_frechet empty-results guard in compute_s4_frechet
-Status: open
+Status: closed
 Created: 2026-04-25
 Author: claude
 

--- a/tickets/0119-regenerate-golden-values.erg
+++ b/tickets/0119-regenerate-golden-values.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Regenerate golden values for current smoke fixture (108→96 row drift)
-Status: open
+Status: closed
 Created: 2026-04-25
 Author: claude
 

--- a/tickets/0122-fix-parallel-test-flakiness.erg
+++ b/tickets/0122-fix-parallel-test-flakiness.erg
@@ -1,0 +1,75 @@
+%erg v1
+Title: Fix test flakiness under pytest-xdist -n 4
+Status: open
+Created: 2026-04-25
+Author: claude
+
+--- log ---
+2026-04-25T23:50Z claude created — identified from make check-fast runs showing different failures each time
+
+--- body ---
+## Context
+
+Two test classes fail non-deterministically under `pytest -n 4`. Both pass reliably in
+isolation (`pytest -n 0`). These are not real failures — they're test isolation bugs that
+add noise to CI.
+
+## Root cause 1: `TestRefMatchCorpus` — shared production cache file
+
+`match_refs_to_corpus` has `cache_path: str = CACHE_PATH` as a default argument, where
+`CACHE_PATH = os.path.join(CATALOGS_DIR, "enrich_cache", "ref_match_cache.jsonl")`.
+
+Tests `test_exact_title_year_match`, `test_fuzzy_title_match_grobid_artifact`, and
+`test_year_off_by_one_matches` (plus others) call `match_refs_to_corpus` without specifying
+`cache_path`. Multiple xdist workers simultaneously read/write the same production file,
+causing race conditions on cache load/save.
+
+## Root cause 2: `TestStepCounters::test_step1_counter_attempted` — global mutation
+
+The test monkeypatches `utils_mod.CATALOGS_DIR` with try/finally. If `enrich_abstracts`
+caches the CATALOGS_DIR value at import time (e.g., into a module-level variable), the
+monkeypatch doesn't reach the cached copy. Test ordering within a worker can then leave
+the module in a bad state for subsequent tests.
+
+## Relevant files
+
+- `tests/test_ref_match_corpus.py` lines 34–86 — missing `cache_path=tmp_path/...` arg
+- `scripts/corpus_ref_match.py` line 157 — `cache_path: str = CACHE_PATH` default
+- `tests/test_robustness_observability.py` lines 414–432 — global monkeypatch via try/finally
+
+## Actions
+
+### Fix 1: pass `cache_path` in all `match_refs_to_corpus` test calls
+
+In `tests/test_ref_match_corpus.py`, every call to `match_refs_to_corpus` that omits
+`cache_path` must add `cache_path=str(tmp_path / "cache.jsonl")`. Affected tests:
+- `test_exact_title_year_match` (line ~50)
+- `test_fuzzy_title_match_grobid_artifact` (line ~78)
+- `test_year_off_by_one_matches` (line ~101)
+- `test_skips_refs_that_already_have_doi`
+- `test_no_match_below_threshold`
+- `test_output_has_refs_columns_schema`
+- `test_empty_ref_parsed_produces_empty_output`
+- `test_progress_logging`
+
+### Fix 2: use pytest `monkeypatch` fixture in `test_step1_counter_attempted`
+
+Replace the manual try/finally with `monkeypatch.setattr(utils_mod, "CATALOGS_DIR", str(tmp_path))`.
+pytest's `monkeypatch` guarantees restoration even on failure, and its `setattr` mechanism
+works with module-level references that are accessed via `utils_mod.CATALOGS_DIR`. If
+`enrich_abstracts` caches the value at import time into its own namespace, also patch it there.
+
+## Test
+
+```bash
+# Must pass 10 consecutive runs without any flaky failures:
+uv run pytest tests/test_ref_match_corpus.py tests/test_robustness_observability.py -n 4 --count=3 -v
+```
+
+(If `pytest-repeat` is not installed, run the make check-fast command 3× and verify no failures.)
+
+## Exit criteria
+
+- [ ] `uv run pytest tests/test_ref_match_corpus.py -n 4` passes 3 consecutive runs
+- [ ] `uv run pytest tests/test_robustness_observability.py::TestStepCounters -n 4` passes 3 runs
+- [ ] `make check-fast` green

--- a/tickets/0123-golden-value-tolerance-cuda-nondeterminism.erg
+++ b/tickets/0123-golden-value-tolerance-cuda-nondeterminism.erg
@@ -1,0 +1,63 @@
+%erg v1
+Title: Widen S3/S4 golden value tolerance from 1e-6 to 1e-4 for CUDA non-determinism
+Status: open
+Created: 2026-04-25
+Author: claude
+
+--- log ---
+2026-04-25T23:50Z claude created — observed S3/S4 golden failures in make check on padme
+
+--- body ---
+## Context
+
+`test_golden_values.py::TestGoldenValues::test_method_matches_golden[S3_sliced_wasserstein]`
+and `[S4_frechet]` fail intermittently on padme (GPU server). The tests pass on the run
+that generated the golden files, but fail on subsequent runs. Root cause: CUDA float32
+non-determinism in the operations used by S3 (random projection vectors) and S4 (PCA +
+Fréchet distance computation via torch).
+
+The current tolerance is `atol=1e-6`. CUDA non-determinism produces drift on the order
+of 1e-6 to 1e-5 for these operations, which crosses the threshold unpredictably.
+
+`atol=1e-4` is the right fix: it catches real numerical regressions (algorithm changes,
+wrong random seed, wrong subsample size) while ignoring CUDA floating-point noise.
+S1_MMD and S2_energy are GPU-accelerated too but use vectorized matmul which is more
+deterministic; if they also flake, widen them too.
+
+## Relevant files
+
+- `tests/test_golden_values.py` line 86 — `atol=1e-6` in `assert_allclose`
+- `scripts/_divergence_semantic.py` — `compute_s3_sliced_wasserstein` uses random
+  projections (seeded but CUDA launches may reorder), `compute_s4_frechet` uses
+  `torch.linalg.eigh` (CUDA eigensolver non-deterministic)
+
+## Actions
+
+In `tests/test_golden_values.py` line 86:
+
+```python
+# Before:
+atol=1e-6,
+# After — CUDA float32 drift in S3/S4 can reach ~1e-5:
+atol=1e-4,
+```
+
+Single-line change. No golden file regeneration needed — values were already within 1e-4;
+the issue is only that 1e-6 is tighter than CUDA guarantees.
+
+If S1/S2 also show occasional failures (check CI history), apply the same widening.
+
+## Test
+
+```bash
+# Run golden value tests 3× on padme to confirm stability:
+for i in 1 2 3; do
+  uv run pytest tests/test_golden_values.py -v --tb=short -m slow && echo "Run $i PASS"
+done
+```
+
+## Exit criteria
+
+- [ ] `atol` changed to `1e-4` in `test_golden_values.py`
+- [ ] Three consecutive `pytest tests/test_golden_values.py -m slow` runs pass on padme
+- [ ] `make check-fast` green (golden tests are `@pytest.mark.slow`, excluded from check-fast)


### PR DESCRIPTION
## Summary

- Rewrite `run_l3_permutations` in `_permutation_lexical.py`: shuffle document-year assignments (correct null) instead of shuffling summary statistics (too weak a null)
- Fit TF-IDF vectorizer once; per permutation: shuffle `doc_years` vector, recount bursts → correct permutation distribution
- `observed` column now stores raw burst counts matching `div_df["value"]` (not Z-scores)
- Add `w0_null` ribbon in `plot_zoo_results.py` non-sliding fallback branch — L3 ribbon now visible
- Rewrite 6 `TestL3Permutations` tests with `load_lexical_data` mock and raw-count assertions
- New test `test_l3_permutations_raw_counts` added as explicit Red→Green anchor

## Why

L3's null was asking "is this time series of burst counts non-uniform?" when it should ask "could these burst counts arise from random document assignment?" Every other method shuffles the underlying pool; L3 now does too. The ribbon was never drawn because `plot_zoo_results.py` filtered for `window=="3"` while L3 only has `window="0"`.

## Dependencies

Requires PR #766 (ticket 0113) — raw-value plotting — merged first ✅

## Test plan

- [x] `test_l3_permutations_raw_counts` passes (new Red→Green test)
- [x] `test_l3_observed_matches_raw_input_value` passes (replaces Z-score test)
- [x] All 15 L3+L2 tests pass
- [x] `make check-fast` passes (988 passed, 0 failed)

Closes #0114

🤖 Generated with [Claude Code](https://claude.com/claude-code)