### PR TITLE
feat: C2ST analytical null overlay on zoo figures (ticket 0115)

### DIFF
--- a/scripts/compute_analytical_null.py
+++ b/scripts/compute_analytical_null.py
@@ -26,6 +26,7 @@ observed, z_score, p_value are NaN (analytical null only supplies the
 null distribution parameters, not the observed statistic).
 """
 
+import argparse
 import math
 import sys
 
@@ -128,8 +129,6 @@ def _iter_window_counts(cfg):
 
 def main() -> None:
     io_args, extra = parse_io_args()
-
-    import argparse
 
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(

--- a/scripts/compute_analytical_null.py
+++ b/scripts/compute_analytical_null.py
@@ -31,6 +31,8 @@ import math
 import sys
 
 import pandas as pd
+from _divergence_io import get_min_papers
+from _divergence_lexical import load_lexical_data
 from pipeline_loaders import load_analysis_config, load_analysis_corpus
 from schemas import NullModelSchema
 from script_io_args import parse_io_args, validate_io
@@ -73,15 +75,33 @@ def c2st_analytical_null(n_before: int, n_after: int) -> tuple[float, float]:
 # ---------------------------------------------------------------------------
 
 
-def _iter_window_counts(cfg):
+def _load_corpus_for_method(method: str) -> pd.DataFrame:
+    """Load the appropriate corpus DataFrame for the given C2ST method.
+
+    C2ST_lexical uses load_lexical_data() (dropna on abstract + year) to match
+    the actual rows seen by iter_lexical_windows.  C2ST_embedding uses
+    load_analysis_corpus() (no abstract filter) to match iter_semantic_windows.
+    """
+    if method == "C2ST_lexical":
+        return load_lexical_data(None)
+    # C2ST_embedding
+    df, _ = load_analysis_corpus(with_embeddings=False)
+    return df
+
+
+def _iter_window_counts(method: str, cfg: dict):
     """Yield (year, window, n_before, n_after) for each valid (year, window) pair.
 
-    Loads the corpus metadata (no embeddings), applies the same year-range and
-    gap logic as iter_semantic_windows / iter_lexical_windows, counts papers in
-    each before/after window, and skips pairs that fall below min_papers.
+    Loads the corpus for the given method (no embeddings), applies the same
+    year-range and gap logic as iter_semantic_windows / iter_lexical_windows,
+    counts papers in each before/after window, and skips pairs that fall below
+    min_papers.
 
     Parameters
     ----------
+    method : str
+        One of SUPPORTED_METHODS.  Determines which corpus loader is used so
+        that n_before / n_after match the counts seen during MC null computation.
     cfg : dict
         Analysis config from load_analysis_config().
 
@@ -94,11 +114,9 @@ def _iter_window_counts(cfg):
     windows = div_cfg["windows"]
     gap = div_cfg.get("gap", 1)
     equal_n = div_cfg.get("equal_n", False)
-    # C2ST-specific min_papers
-    min_papers = div_cfg["c2st"].get("min_papers", div_cfg["min_papers"])
+    min_papers = get_min_papers(method=method, cfg=cfg)
 
-    # Load metadata only — no embeddings needed for counting
-    df, _ = load_analysis_corpus(with_embeddings=False)
+    df = _load_corpus_for_method(method)
     year_min = int(df["year"].min())
     year_max = int(df["year"].max())
 
@@ -113,11 +131,9 @@ def _iter_window_counts(cfg):
                 continue
 
             if equal_n:
-                n_eq = min(n_b, n_a)
-                if n_eq < min_papers:
+                n_b = n_a = min(n_b, n_a)
+                if n_b < min_papers:
                     continue
-                n_b = n_eq
-                n_a = n_eq
 
             yield y, w, n_b, n_a
 
@@ -147,7 +163,7 @@ def main() -> None:
     log.info("Computing analytical null for method=%s", method)
 
     rows = []
-    for y, w, n_before, n_after in _iter_window_counts(cfg):
+    for y, w, n_before, n_after in _iter_window_counts(method, cfg):
         null_mean, null_std = c2st_analytical_null(n_before, n_after)
         rows.append(
             {

--- a/scripts/compute_analytical_null.py
+++ b/scripts/compute_analytical_null.py
@@ -1,0 +1,192 @@
+"""Compute the analytical null distribution for C2ST methods (ticket 0115).
+
+For C2ST_embedding and C2ST_lexical, the null distribution under H0 (AUC = 0.5)
+follows a closed-form Hanley-McNeil approximation:
+
+    null_mean = 0.5
+    null_std  = sqrt((n_before + n_after + 1) / (12 * n_before * n_after))
+
+This is O(1) per (year, window) once sample counts are known — no permutations
+or corpus loading of embeddings/texts needed.
+
+Usage::
+
+    uv run python scripts/compute_analytical_null.py \\
+        --method C2ST_embedding \\
+        --output content/tables/tab_analytical_null_C2ST_embedding.csv
+
+    uv run python scripts/compute_analytical_null.py \\
+        --method C2ST_lexical \\
+        --output content/tables/tab_analytical_null_C2ST_lexical.csv
+
+Output CSV matches NullModelSchema (schemas.py):
+    year, window, observed, null_mean, null_std, z_score, p_value
+
+observed, z_score, p_value are NaN (analytical null only supplies the
+null distribution parameters, not the observed statistic).
+"""
+
+import math
+import sys
+
+import pandas as pd
+from pipeline_loaders import load_analysis_config, load_analysis_corpus
+from schemas import NullModelSchema
+from script_io_args import parse_io_args, validate_io
+from utils import get_logger
+
+log = get_logger("compute_analytical_null")
+
+SUPPORTED_METHODS = ("C2ST_embedding", "C2ST_lexical")
+
+
+# ---------------------------------------------------------------------------
+# Hanley-McNeil formula
+# ---------------------------------------------------------------------------
+
+
+def c2st_analytical_null(n_before: int, n_after: int) -> tuple[float, float]:
+    """Return (null_mean, null_std) for C2ST AUC under H0 (Hanley-McNeil 1982).
+
+    Parameters
+    ----------
+    n_before : int
+        Number of documents in the before-window.
+    n_after : int
+        Number of documents in the after-window.
+
+    Returns
+    -------
+    (null_mean, null_std) : (float, float)
+        null_mean = 0.5
+        null_std  = sqrt((n_before + n_after + 1) / (12 * n_before * n_after))
+
+    """
+    null_mean = 0.5
+    null_std = math.sqrt((n_before + n_after + 1) / (12 * n_before * n_after))
+    return null_mean, null_std
+
+
+# ---------------------------------------------------------------------------
+# Window count iteration (metadata-only — no embeddings, no texts)
+# ---------------------------------------------------------------------------
+
+
+def _iter_window_counts(cfg):
+    """Yield (year, window, n_before, n_after) for each valid (year, window) pair.
+
+    Loads the corpus metadata (no embeddings), applies the same year-range and
+    gap logic as iter_semantic_windows / iter_lexical_windows, counts papers in
+    each before/after window, and skips pairs that fall below min_papers.
+
+    Parameters
+    ----------
+    cfg : dict
+        Analysis config from load_analysis_config().
+
+    Yields
+    ------
+    (y, w, n_before, n_after) : (int, int, int, int)
+
+    """
+    div_cfg = cfg["divergence"]
+    windows = div_cfg["windows"]
+    gap = div_cfg.get("gap", 1)
+    equal_n = div_cfg.get("equal_n", False)
+    # C2ST-specific min_papers
+    min_papers = div_cfg["c2st"].get("min_papers", div_cfg["min_papers"])
+
+    # Load metadata only — no embeddings needed for counting
+    df, _ = load_analysis_corpus(with_embeddings=False)
+    year_min = int(df["year"].min())
+    year_max = int(df["year"].max())
+
+    for w in windows:
+        for y in range(year_min + w, year_max - w):
+            mask_before = (df["year"] >= y - w) & (df["year"] <= y - gap)
+            mask_after = (df["year"] >= y + gap) & (df["year"] <= y + w)
+            n_b = int(mask_before.sum())
+            n_a = int(mask_after.sum())
+
+            if n_b < min_papers or n_a < min_papers:
+                continue
+
+            if equal_n:
+                n_eq = min(n_b, n_a)
+                if n_eq < min_papers:
+                    continue
+                n_b = n_eq
+                n_a = n_eq
+
+            yield y, w, n_b, n_a
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    io_args, extra = parse_io_args()
+
+    import argparse
+
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument(
+        "--method",
+        required=True,
+        choices=list(SUPPORTED_METHODS),
+        help="Method name: C2ST_embedding or C2ST_lexical",
+    )
+    args = parser.parse_args(extra)
+    method = args.method
+
+    validate_io(output=io_args.output)
+
+    cfg = load_analysis_config()
+
+    log.info("Computing analytical null for method=%s", method)
+
+    rows = []
+    for y, w, n_before, n_after in _iter_window_counts(cfg):
+        null_mean, null_std = c2st_analytical_null(n_before, n_after)
+        rows.append(
+            {
+                "year": y,
+                "window": str(w),
+                "observed": float("nan"),
+                "null_mean": null_mean,
+                "null_std": null_std,
+                "z_score": float("nan"),
+                "p_value": float("nan"),
+            }
+        )
+
+    if not rows:
+        log.warning(
+            "No valid (year, window) pairs found — writing empty output to %s",
+            io_args.output,
+        )
+
+    out_df = pd.DataFrame(
+        rows,
+        columns=[
+            "year",
+            "window",
+            "observed",
+            "null_mean",
+            "null_std",
+            "z_score",
+            "p_value",
+        ],
+    )
+
+    # Validate against schema before writing (strict=True, coerce=True)
+    NullModelSchema.validate(out_df)
+
+    out_df.to_csv(io_args.output, index=False)
+    log.info("Wrote %d rows to %s", len(out_df), io_args.output)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -17,6 +17,12 @@ Usage::
         --method S2_energy \\
         --output content/figures/fig_zoo_S2_energy.png \\
         --null-ci content/tables/tab_null_S2_energy.csv
+
+    # With analytical null overlay (C2ST only, ticket 0115):
+    uv run python scripts/plot_zoo_results.py \\
+        --method C2ST_embedding \\
+        --output content/figures/fig_zoo_C2ST_embedding.png \\
+        --analytical-null content/tables/tab_analytical_null_C2ST_embedding.csv
 """
 
 import argparse
@@ -66,6 +72,12 @@ def _build_method_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional: tab_null_{method}.csv for CI band overlay",
     )
+    parser.add_argument(
+        "--analytical-null",
+        metavar="PATH",
+        default=None,
+        help="Optional: tab_analytical_null_{method}.csv for analytical null overlay",
+    )
     return parser
 
 
@@ -100,6 +112,18 @@ def _load_null_df(null_ci_path: str | None) -> pd.DataFrame | None:
     return null_df
 
 
+def _load_analytical_null(path: str | None) -> pd.DataFrame | None:
+    """Load analytical null CSV if path provided and file exists. Returns None otherwise."""
+    if path is None:
+        return None
+    if not Path(path).exists():
+        log.warning("Analytical null file not found: %s — skipping overlay", path)
+        return None
+    an_df = pd.read_csv(path)
+    an_df["window"] = an_df["window"].astype(str)
+    return an_df
+
+
 def _compute_null_z_threshold(df: pd.DataFrame, null_df: pd.DataFrame) -> pd.DataFrame:
     """Add z_threshold_upper / z_threshold_lower columns to null_df.
 
@@ -129,6 +153,7 @@ def _plot(
     method: str,
     output_stem: str,
     null_df: pd.DataFrame | None = None,
+    analytical_null_df: pd.DataFrame | None = None,
 ) -> None:
     """Render the Z-score panel and save to output_stem.png."""
     fig, ax = plt.subplots(figsize=(6, 4))
@@ -172,6 +197,24 @@ def _plot(
                 linewidth=0.6,
                 linestyle="--",
                 zorder=1,
+            )
+
+    # Analytical null ribbon (w=3): null_mean ± 1.96 * null_std in native units.
+    # Orange fill so it remains visually distinct from the MC ribbon (blue/FILL).
+    # Where the two ribbons overlap, combined alpha makes coincidence visible.
+    if analytical_null_df is not None:
+        w3_an = analytical_null_df[analytical_null_df["window"] == "3"].sort_values(
+            "year"
+        )
+        if not w3_an.empty and w3_an["null_mean"].notna().any():
+            ax.fill_between(
+                w3_an["year"],
+                w3_an["null_mean"] - 1.96 * w3_an["null_std"],
+                w3_an["null_mean"] + 1.96 * w3_an["null_std"],
+                color="tab:orange",
+                alpha=0.20,
+                zorder=0,
+                label=None,
             )
 
     # Period boundary verticals — shorten by 1 ex so year labels clear the title.
@@ -271,6 +314,16 @@ def _plot(
         handles.append(mpatches.Patch(color=FILL, alpha=0.15, label="null ±2σ"))
         labels.append("null ±2σ")
 
+    if analytical_null_df is not None:
+        w3_an_check = analytical_null_df[analytical_null_df["window"] == "3"]
+        if not w3_an_check.empty and w3_an_check["null_mean"].notna().any():
+            handles.append(
+                mpatches.Patch(
+                    color="tab:orange", alpha=0.20, label="analytical null 95% (w=3)"
+                )
+            )
+            labels.append("analytical null 95% (w=3)")
+
     ax.legend(
         handles=handles, labels=labels, loc="upper left", frameon=False, fontsize=7
     )
@@ -317,7 +370,11 @@ def main() -> None:
     if null_df is not None:
         null_df = _compute_null_z_threshold(df, null_df)
 
-    _plot(df, method, output_stem, null_df=null_df)
+    analytical_null_df = _load_analytical_null(args.analytical_null)
+
+    _plot(
+        df, method, output_stem, null_df=null_df, analytical_null_df=analytical_null_df
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -323,15 +323,13 @@ def _plot(
         handles.append(mpatches.Patch(color=FILL, alpha=0.15, label="null ±2σ"))
         labels.append("null ±2σ")
 
-    if analytical_null_df is not None:
-        w3_an_check = analytical_null_df[analytical_null_df["window"] == "3"]
-        if not w3_an_check.empty and w3_an_check["null_mean"].notna().any():
-            handles.append(
-                mpatches.Patch(
-                    color="tab:orange", alpha=0.20, label="analytical null 95% (w=3)"
-                )
+    if has_an_ribbon:
+        handles.append(
+            mpatches.Patch(
+                color="tab:orange", alpha=0.20, label="analytical null 95% (w=3)"
             )
-            labels.append("analytical null 95% (w=3)")
+        )
+        labels.append("analytical null 95% (w=3)")
 
     ax.legend(
         handles=handles, labels=labels, loc="upper left", frameon=False, fontsize=7

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -100,28 +100,35 @@ def _empty_figure(output_stem: str, method: str) -> None:
     plt.close(fig)
 
 
-def _load_null_df(null_ci_path: str | None) -> pd.DataFrame | None:
-    """Load null model CSV if path provided and file exists. Returns None otherwise."""
-    if null_ci_path is None:
-        return None
-    if not Path(null_ci_path).exists():
-        log.warning("Null CI file not found: %s — skipping CI band", null_ci_path)
-        return None
-    null_df = pd.read_csv(null_ci_path)
-    null_df["window"] = null_df["window"].astype(str)
-    return null_df
+def _load_null_csv(path: str | None, label: str = "null") -> pd.DataFrame | None:
+    """Load a null model CSV if path is given and file exists; return None otherwise.
 
+    Parameters
+    ----------
+    path : str | None
+        File path, or None to skip.
+    label : str
+        Short label for the warning message (e.g. "CI band", "analytical null").
 
-def _load_analytical_null(path: str | None) -> pd.DataFrame | None:
-    """Load analytical null CSV if path provided and file exists. Returns None otherwise."""
+    """
     if path is None:
         return None
     if not Path(path).exists():
-        log.warning("Analytical null file not found: %s — skipping overlay", path)
+        log.warning("%s file not found: %s — skipping", label, path)
         return None
-    an_df = pd.read_csv(path)
-    an_df["window"] = an_df["window"].astype(str)
-    return an_df
+    df = pd.read_csv(path)
+    df["window"] = df["window"].astype(str)
+    return df
+
+
+def _load_null_df(null_ci_path: str | None) -> pd.DataFrame | None:
+    """Load MC null model CSV. Thin wrapper around _load_null_csv."""
+    return _load_null_csv(null_ci_path, label="Null CI")
+
+
+def _load_analytical_null(path: str | None) -> pd.DataFrame | None:
+    """Load analytical null CSV. Thin wrapper around _load_null_csv."""
+    return _load_null_csv(path, label="Analytical null")
 
 
 def _compute_null_z_threshold(df: pd.DataFrame, null_df: pd.DataFrame) -> pd.DataFrame:
@@ -202,11 +209,13 @@ def _plot(
     # Analytical null ribbon (w=3): null_mean ± 1.96 * null_std in native units.
     # Orange fill so it remains visually distinct from the MC ribbon (blue/FILL).
     # Where the two ribbons overlap, combined alpha makes coincidence visible.
+    has_an_ribbon = False
     if analytical_null_df is not None:
         w3_an = analytical_null_df[analytical_null_df["window"] == "3"].sort_values(
             "year"
         )
         if not w3_an.empty and w3_an["null_mean"].notna().any():
+            has_an_ribbon = True
             ax.fill_between(
                 w3_an["year"],
                 w3_an["null_mean"] - 1.96 * w3_an["null_std"],

--- a/tests/test_analytical_null.py
+++ b/tests/test_analytical_null.py
@@ -100,3 +100,35 @@ def test_load_analytical_null_returns_none_when_path_is_none():
     import plot_zoo_results
 
     assert plot_zoo_results._load_analytical_null(None) is None
+
+
+def test_c2st_analytical_agrees_with_mc():
+    """Analytical null_std matches permutation-based MC std within 3 SE.
+
+    Fixture: n_b=n_a=150, n_perm=300.  Random uniform scores under H0.
+    Validates the Hanley-McNeil formula against an empirical permutation
+    distribution (the core of the overlay's visual agreement claim).
+    """
+    import numpy as np
+    from compute_analytical_null import c2st_analytical_null
+    from sklearn.metrics import roc_auc_score
+
+    rng = np.random.RandomState(42)
+    n_b, n_a = 150, 150
+    n_perm = 300
+
+    scores = rng.uniform(0, 1, n_b + n_a)
+    labels = np.array([1] * n_b + [0] * n_a)
+
+    auc_vals = [roc_auc_score(rng.permutation(labels), scores) for _ in range(n_perm)]
+    mc_mean = float(np.mean(auc_vals))
+    mc_std = float(np.std(auc_vals))
+
+    _, an_std = c2st_analytical_null(n_b, n_a)
+
+    assert abs(mc_mean - 0.5) < 0.03, f"MC mean {mc_mean:.4f} not near 0.5"
+    se = an_std / (2 * n_perm) ** 0.5
+    assert abs(mc_std - an_std) < 3 * se, (
+        f"MC std {mc_std:.5f} differs from analytical {an_std:.5f} by "
+        f"{abs(mc_std - an_std):.5f} > 3 SE ({3 * se:.5f})"
+    )

--- a/tests/test_analytical_null.py
+++ b/tests/test_analytical_null.py
@@ -1,0 +1,102 @@
+"""Tests for compute_analytical_null.py — C2ST analytical null (ticket 0115).
+
+Red test: c2st_analytical_null formula (Hanley-McNeil).
+"""
+
+import os
+import sys
+
+import pandas as pd
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+
+def test_c2st_analytical_null_formula():
+    """C2ST analytical null: Hanley-McNeil formula."""
+    from compute_analytical_null import c2st_analytical_null
+
+    n_b, n_a = 200, 200
+    mean, std = c2st_analytical_null(n_b, n_a)
+    assert abs(mean - 0.5) < 1e-9
+    expected_std = ((n_b + n_a + 1) / (12 * n_b * n_a)) ** 0.5
+    assert abs(std - expected_std) < 1e-12
+
+
+def test_c2st_analytical_null_asymmetric():
+    """Hanley-McNeil formula works for unequal group sizes."""
+    from compute_analytical_null import c2st_analytical_null
+
+    n_b, n_a = 100, 300
+    mean, std = c2st_analytical_null(n_b, n_a)
+    assert abs(mean - 0.5) < 1e-9
+    expected_std = ((n_b + n_a + 1) / (12 * n_b * n_a)) ** 0.5
+    assert abs(std - expected_std) < 1e-12
+
+
+def test_c2st_analytical_null_std_decreases_with_n():
+    """Larger samples give tighter null distribution."""
+    from compute_analytical_null import c2st_analytical_null
+
+    _, std_small = c2st_analytical_null(50, 50)
+    _, std_large = c2st_analytical_null(500, 500)
+    assert std_small > std_large
+
+
+def test_analytical_null_flag_no_crash(tmp_path):
+    """--analytical-null flag in plot_zoo_results must not crash with valid CSV."""
+    import plot_zoo_results
+
+    # Build a minimal analytical null CSV
+    an_df = pd.DataFrame(
+        {
+            "year": [2000, 2001, 2002, 2003],
+            "window": ["3", "3", "3", "3"],
+            "observed": [0.0, 0.0, 0.0, 0.0],
+            "null_mean": [0.5, 0.5, 0.5, 0.5],
+            "null_std": [0.025, 0.025, 0.025, 0.025],
+            "z_score": [float("nan")] * 4,
+            "p_value": [float("nan")] * 4,
+        }
+    )
+    an_path = tmp_path / "tab_analytical_null_C2ST_embedding.csv"
+    an_df.to_csv(an_path, index=False)
+
+    # Build a minimal crossyear CSV
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2001, 2002, 2003],
+            "window": ["3", "3", "3", "3"],
+            "value": [0.52, 0.55, 0.61, 0.58],
+            "z_score": [0.3, 0.8, 1.5, 1.1],
+        }
+    )
+    output_png = tmp_path / "fig_zoo_C2ST_embedding.png"
+    output_stem = str(output_png.with_suffix(""))
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    # Must not raise
+    an_loaded = plot_zoo_results._load_analytical_null(str(an_path))
+    assert an_loaded is not None
+    plot_zoo_results._plot(
+        df, "C2ST_embedding", output_stem, analytical_null_df=an_loaded
+    )
+
+
+def test_load_analytical_null_returns_none_for_missing_file():
+    """_load_analytical_null with a non-existent path returns None (graceful)."""
+    import plot_zoo_results
+
+    assert (
+        plot_zoo_results._load_analytical_null("/nonexistent/path/tab_an.csv") is None
+    )
+
+
+def test_load_analytical_null_returns_none_when_path_is_none():
+    """_load_analytical_null(None) must return None without raising."""
+    import plot_zoo_results
+
+    assert plot_zoo_results._load_analytical_null(None) is None

--- a/zoo.mk
+++ b/zoo.mk
@@ -84,10 +84,30 @@ NULL_METHODS_ALL := S1_MMD S2_energy S3_sliced_wasserstein S4_frechet \
 $(foreach m,$(NULL_METHODS_ALL),$(eval \
   $(ZOO_FIGS)/fig_zoo_$(m).png: $(ZOO_TABLES)/tab_null_$(m).csv))
 
-# Pattern rule for all methods: passes --null-ci when tab_null_*.csv exists.
+# ── Analytical null tables (C2ST only, ticket 0115) ──────────────────────────
+#
+# Closed-form Hanley-McNeil null for C2ST AUC. O(1) per (year, window) —
+# no corpus embeddings or permutations needed, just year-grouped counts.
+
+ANALYTICAL_NULL_METHODS := C2ST_embedding C2ST_lexical
+
+$(ZOO_TABLES)/tab_analytical_null_C2ST_%.csv: scripts/compute_analytical_null.py $(REFINED) $(DIV_CFG)
+	$(UV_RUN) python scripts/compute_analytical_null.py \
+		--method C2ST_$* --output $@
+
+.PHONY: analytical-null-tables
+analytical-null-tables: $(foreach m,$(ANALYTICAL_NULL_METHODS),$(ZOO_TABLES)/tab_analytical_null_$(m).csv)
+
+# Extra dep: C2ST figures rebuild when analytical null CSV changes.
+$(foreach m,$(ANALYTICAL_NULL_METHODS),$(eval \
+  $(ZOO_FIGS)/fig_zoo_$(m).png: $(ZOO_TABLES)/tab_analytical_null_$(m).csv))
+
+# Pattern rule for all methods: passes --null-ci when tab_null_*.csv exists,
+# and --analytical-null when tab_analytical_null_*.csv exists.
 $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_results.py
 	$(UV_RUN) python scripts/plot_zoo_results.py --method $* --output $@ \
-		$(if $(wildcard $(ZOO_TABLES)/tab_null_$*.csv),--null-ci $(ZOO_TABLES)/tab_null_$*.csv,)
+		$(if $(wildcard $(ZOO_TABLES)/tab_null_$*.csv),--null-ci $(ZOO_TABLES)/tab_null_$*.csv,) \
+		$(if $(wildcard $(ZOO_TABLES)/tab_analytical_null_$*.csv),--analytical-null $(ZOO_TABLES)/tab_analytical_null_$*.csv,)
 
 # ── Bias comparison tables (equal_n=false) ───────────────────────────────────
 #


### PR DESCRIPTION
## Summary

- Implement `c2st_analytical_null(n_before, n_after)` using Hanley-McNeil closed form: `mean=0.5`, `std=sqrt((n+m+1)/(12nm))`
- New script `scripts/compute_analytical_null.py` (C2ST_embedding, C2ST_lexical): iterates semantic/lexical windows to get per-(year,window) counts, writes `tab_analytical_null_{method}.csv` matching `NullModelSchema`
- `plot_zoo_results.py`: new `--analytical-null <path>` flag draws a second semi-transparent orange ribbon over the MC ribbon
- `zoo.mk`: pattern rules for `tab_analytical_null_C2ST_%.csv` and extended zoo figure targets

L1, S1, S2 analytical nulls are follow-up PRs (increasing formula complexity).

## Test plan

- [x] `test_c2st_analytical_null_formula` — exact Hanley-McNeil formula verified
- [x] `test_c2st_analytical_null_asymmetric` — n_before ≠ n_after
- [x] `test_c2st_analytical_null_std_decreases_with_n` — monotone sanity check
- [x] `test_analytical_null_flag_no_crash` — `--analytical-null` with valid CSV
- [x] `test_load_analytical_null_returns_none_for_missing_file` — graceful absent file
- [x] `make check-fast` passes (985 passed, 11 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)