### PR TITLE
fix: revert golden ATOL 1e-4 → 1e-6 (padme deterministic; CPU↔GPU needs 1e-3+)

### DIFF
--- a/tests/test_golden_values.py
+++ b/tests/test_golden_values.py
@@ -2,7 +2,7 @@
 
 Compares fresh runs of all 15 divergence methods against committed golden
 CSVs in tests/fixtures/smoke/golden/. Any change in output values (beyond
-ATOL=1e-4) is a regression.
+ATOL=1e-6) is a regression.
 
 These tests catch silent changes in:
   - Numeric libraries (scipy, dcor, ot, numpy)
@@ -26,11 +26,11 @@ from compute_divergence import METHODS
 
 ALL_METHODS = sorted(METHODS.keys())
 
-# Tolerance for value regression check. 1e-4 accommodates environmental drift
-# (golden files regenerated on padme may differ from other environments by ~1e-3).
-# Catches real regressions (algorithm change, wrong seed) while ignoring
-# cross-environment float32 noise. See test_gpu_backend.py for per-backend tolerances.
-ATOL = 1e-4
+# Tolerance for value regression check. Golden files are padme (GPU) outputs.
+# Padme S3 is deterministic run-to-run (diff = 0.0); 1e-6 is sufficient.
+# CPU environments deviate by ~1e-3 from GPU goldens — these tests are
+# intentionally padme-only (@pytest.mark.slow). See ticket 0123 for investigation.
+ATOL = 1e-6
 
 from conftest import run_compute as _run_compute
 

--- a/tickets/0123-golden-value-tolerance-cuda-nondeterminism.erg
+++ b/tickets/0123-golden-value-tolerance-cuda-nondeterminism.erg
@@ -5,6 +5,19 @@ Created: 2026-04-25
 Author: claude
 
 --- log ---
+2026-04-26T09:10Z claude post-merge investigation (review consider: points):
+  Hypothesis A: padme S3 is deterministic → atol=1e-6 sufficient after regen.
+  Hypothesis B: atol=1e-4 is forward insurance for S1/S2 CUDA drift.
+  Hypothesis C (user): CPU vs GPU numeric libs — float32 non-associativity in GPU parallel
+    reductions (different summation order, CUDA FMA) produces per-element rounding differences
+    that compound across projections/years. Mechanistic explanation for the 1.80e-3 CPU↔GPU
+    gap: not a code-path difference but unavoidable float32 non-associativity in parallel ops.
+    Implication: cross-env tolerance would need ~1e-2 to be reliable; golden tests should
+    always run on padme (same GPU + same driver).
+  Test: CPU compute vs GPU-regenerated golden — max diff=1.80e-3, mean=3.52e-4; 74/96 > 1e-4.
+  Conclusion: atol=1e-4 is neither necessary (padme diff=0 → 1e-6 exact) nor sufficient for
+  cross-env (Hypothesis C). Golden tests are padme-only by design (@slow).
+  Action: reverted atol 1e-4 → 1e-6; comment updated to document padme-only intent. PR #771.
 2026-04-26T04:20Z claude diagnostic — S3 run-to-run diff = 0.0 (deterministic). Golden mismatch is environmental drift (golden generated elsewhere). Fix: regenerate S3 golden on padme. S4 SchemaError (missing 'year' column) is separate upstream bug → new ticket.
 2026-04-26T04:15Z claude tolerance 1e-6→1e-4 landed (eb0fc93). S3 drift up to 1.8e-3 vs golden — not CUDA noise, stale golden file.
 2026-04-26T01:00Z claude execute — tolerance changed (eb0fc93); make check-fast green (1 pre-existing flaky).


### PR DESCRIPTION
## Summary

Reverts the `ATOL=1e-4` widening from PR #770. Post-merge investigation shows:

- **Padme (GPU) is deterministic**: S3 run-to-run diff = 0.0 → `atol=1e-6` is exact
- **`atol=1e-4` is not enough for cross-environment**: CPU vs GPU-regenerated golden deviates by up to **1.80e-3** (mean 3.52e-4); 74/96 values exceed 1e-4
- **The actual fix in PR #770 was the golden regen on padme** — the tolerance widening was unnecessary and gives false confidence

Golden tests are padme-only by design (`@pytest.mark.slow`). Comment updated to document this intent. Ticket 0123 log updated with investigation hypotheses and results.

## Investigation

```
n=96  max=1.80e-03  mean=3.52e-04
  > 1e-6: 96   > 1e-5: 95   > 1e-4: 74   > 1e-3: 7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)