### PR TITLE
Register pytest 'adherence' marker; mark TestNoHalfFinishedWork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
 markers = [
     "slow: marks tests that require network access or external data (deselect with '-m \"not slow\"')",
     "integration: marks tests that spawn subprocesses or use sleep-based timing (deselect with '-m \"not integration\"')",
+    "adherence: project rule enforcement (hygiene/discipline/contracts)",
 ]
 
 [tool.uv]

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1218,6 +1218,7 @@ class TestNoValuesCallOnSeries:
         )
 
 
+@pytest.mark.adherence
 class TestNoHalfFinishedWork:
     """Ratchet: stubs (NotImplementedError), skip-marked tests
     (pytest.skip, @pytest.mark.skip), and TODO comments are signals


### PR DESCRIPTION
Adds the `adherence` marker to pyproject.toml and applies `@pytest.mark.adherence` to the `TestNoHalfFinishedWork` class. Contract item for `/verify-adherence` Phase 1.

Conservative scope: only the new class is marked. The other 16 classes in `test_script_hygiene.py` are also adherence tests by intent, but their migration is left as a separate ticket.