### PR TITLE
fix: empty-results guard for citation, community, lexical, C2ST modules (ticket 0120)

### DIFF
--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -22,6 +22,7 @@ from _divergence_citation import (
     _get_years,
     _iter_sliding_pairs,
 )
+from _divergence_io import empty_divergence_df
 from scipy.optimize import curve_fit
 from scipy.sparse.linalg import eigsh
 from scipy.spatial.distance import jensenshannon
@@ -222,6 +223,8 @@ def compute_g1_pagerank(works, citations, internal_edges, cfg):
             }
         )
 
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 
@@ -251,6 +254,8 @@ def _sliding_abs_diff(works, internal_edges, cfg, metric_fn, label):
         results.append(
             {"year": year, "window": str(w), "hyperparams": "", "value": value}
         )
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 

--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -239,4 +239,18 @@ def compute_c2st_lexical(df, cfg):
         )
 
     log.info("  C2ST_lexical: %d data points", len(results))
+    if not results:
+        return pd.DataFrame(
+            columns=[
+                "year",
+                "window",
+                "hyperparams",
+                "value",
+                "auc_std",
+                "auc_q025",
+                "auc_q975",
+                "n_folds",
+                "p_value_vs_chance",
+            ]
+        )
     return pd.DataFrame(results)

--- a/scripts/_divergence_c2st.py
+++ b/scripts/_divergence_c2st.py
@@ -22,6 +22,18 @@ from utils import get_logger
 
 log = get_logger("_divergence_c2st")
 
+_C2ST_COLUMNS = [
+    "year",
+    "window",
+    "hyperparams",
+    "value",
+    "auc_std",
+    "auc_q025",
+    "auc_q975",
+    "n_folds",
+    "p_value_vs_chance",
+]
+
 
 # ── Core classifier ──────────────────────────────────────────────────────
 
@@ -130,19 +142,7 @@ def compute_c2st_embedding(df, emb, cfg):
         df, emb, cfg, method="c2st"
     )
     if not any(years_by_window.values()):
-        return pd.DataFrame(
-            columns=[
-                "year",
-                "window",
-                "hyperparams",
-                "value",
-                "auc_std",
-                "auc_q025",
-                "auc_q975",
-                "n_folds",
-                "p_value_vs_chance",
-            ]
-        )
+        return pd.DataFrame(columns=_C2ST_COLUMNS)
 
     gap = div_cfg.get("gap", 1)
     results = []
@@ -186,6 +186,8 @@ def compute_c2st_embedding(df, emb, cfg):
 
     if last_w is not None:
         log.info("C2ST_embedding window=%d done", last_w)
+    if not results:
+        return pd.DataFrame(columns=_C2ST_COLUMNS)
     return pd.DataFrame(results)
 
 
@@ -240,17 +242,5 @@ def compute_c2st_lexical(df, cfg):
 
     log.info("  C2ST_lexical: %d data points", len(results))
     if not results:
-        return pd.DataFrame(
-            columns=[
-                "year",
-                "window",
-                "hyperparams",
-                "value",
-                "auc_std",
-                "auc_q025",
-                "auc_q975",
-                "n_folds",
-                "p_value_vs_chance",
-            ]
-        )
+        return pd.DataFrame(columns=_C2ST_COLUMNS)
     return pd.DataFrame(results)

--- a/scripts/_divergence_community.py
+++ b/scripts/_divergence_community.py
@@ -17,6 +17,7 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 from _divergence_citation import _iter_sliding_pairs
+from _divergence_io import empty_divergence_df
 from scipy.spatial.distance import jensenshannon
 from utils import get_logger
 
@@ -47,6 +48,8 @@ def compute_community_divergence(works, citations, internal_edges, cfg):
             }
         )
 
+    if not results:
+        return empty_divergence_df()
     return pd.DataFrame(results)
 
 

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -68,8 +68,12 @@ def _smooth_distribution(v, eps=1e-10):
     return v
 
 
+from _divergence_io import (
+    empty_divergence_df,
+    per_window_year_ranges,
+    subsample_equal_n,
+)
 from _divergence_io import get_min_papers as _get_min_papers
-from _divergence_io import per_window_year_ranges, subsample_equal_n
 
 
 def _iter_lexical_window_pairs(df, cfg):
@@ -180,6 +184,8 @@ def compute_l1_js(df, cfg):
         )
 
     log.info("  L1: %d data points", len(rows))
+    if not rows:
+        return empty_divergence_df()
     return pd.DataFrame(rows)
 
 
@@ -278,6 +284,8 @@ def compute_l2_novelty(df, cfg):
                 )
 
     log.info("  L2: %d data points", len(rows))
+    if not rows:
+        return empty_divergence_df()
     return pd.DataFrame(rows)
 
 
@@ -351,4 +359,6 @@ def compute_l3_bursts(df, cfg):
         )
 
     log.info("  L3: %d data points", len(rows))
+    if not rows:
+        return empty_divergence_df()
     return pd.DataFrame(rows)

--- a/scripts/_divergence_lexical.py
+++ b/scripts/_divergence_lexical.py
@@ -73,7 +73,9 @@ from _divergence_io import (
     per_window_year_ranges,
     subsample_equal_n,
 )
-from _divergence_io import get_min_papers as _get_min_papers
+from _divergence_io import (
+    get_min_papers as _get_min_papers,
+)
 
 
 def _iter_lexical_window_pairs(df, cfg):


### PR DESCRIPTION
## Summary

- Adds `if not results: return empty_divergence_df()` guard before every unguarded `return pd.DataFrame(results/rows)` in `_citation_methods.py`, `_divergence_community.py`, `_divergence_lexical.py`
- Adds matching 9-column empty-frame guard in `_divergence_c2st.compute_c2st_lexical` (mirrors the existing pattern in `compute_c2st_embedding`)

Defensive fix: prevents a 0-column DataFrame when the window iterator yields nothing (too-small corpus or extreme config). The dispatcher's `result["channel"] = channel` would then produce a 1-column frame that fails `DivergenceSchema.validate` — same root cause as ticket 0118 / PR #764.

**Out of scope noted:** `_divergence_semantic.py` calls `empty_divergence_df()` in four guards (from PR #764) but does not import it. Latent `NameError` that never fires in smoke fixtures. Tracked as a follow-up.

## Files changed

| File | Sites guarded |
|------|--------------|
| `_citation_methods.py` | `compute_g1_pagerank`, `_sliding_abs_diff` (G2/G5/G6/G8) |
| `_divergence_community.py` | `compute_community_divergence` (G9) |
| `_divergence_lexical.py` | `compute_l1_js`, `compute_l2_novelty`, `compute_l3_bursts` |
| `_divergence_c2st.py` | `compute_c2st_lexical` |

## Test plan

- [x] `make check-fast` passes (989 passed, 0 failed)
- [x] No new warnings introduced

Closes ticket 0120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)