### PR TITLE
fix(0127): import empty_divergence_df in _divergence_semantic

### DIFF
--- a/scripts/_divergence_semantic.py
+++ b/scripts/_divergence_semantic.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 import pandas as pd
 from _divergence_io import (
+    empty_divergence_df,
     get_min_papers,
     per_window_year_ranges,
     subsample_equal_n,

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -997,3 +997,77 @@ class TestCommunityDivergence:
         assert channel == "citation"
         assert needs_emb is False
         assert needs_cit is True
+
+
+# ---------------------------------------------------------------------------
+# Empty-results guard for semantic S1-S4 (ticket 0127)
+# ---------------------------------------------------------------------------
+
+
+def _tiny_semantic_data():
+    """Minimal semantic data: 2 works over 2 years.
+
+    With window=5, per_window_year_ranges returns empty ranges, so the
+    empty-results guard fires at the top of each compute_s* function.
+    """
+    df = pd.DataFrame({"year": [2010, 2011], "cited_by_count": [0, 0]})
+    emb = np.random.RandomState(42).randn(2, 16).astype(np.float32)
+    return df, emb
+
+
+def _empty_guard_cfg():
+    """Config that forces the empty-results guard to fire.
+
+    window=5 with only 2 years (2010-2011) means per_window_year_ranges
+    returns an empty list → not any(years_by_window.values()) is True.
+    min_papers=100 and min_papers_smoke=100 are belt-and-suspenders.
+    """
+    cfg = _smoke_cfg(seed=42)
+    cfg["divergence"]["windows"] = [5]
+    cfg["divergence"]["min_papers"] = 100
+    cfg["divergence"]["min_papers_smoke"] = 100
+    return cfg
+
+
+class TestEmptyResultsGuard:
+    """Semantic compute_* functions return empty DataFrame on sparse corpus."""
+
+    def test_semantic_s1_empty_results_guard(self):
+        from _divergence_semantic import compute_s1_mmd
+
+        df, emb = _tiny_semantic_data()
+        cfg = _empty_guard_cfg()
+        result = compute_s1_mmd(df, emb, cfg)
+        assert isinstance(result, pd.DataFrame)
+        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
+        assert len(result) == 0
+
+    def test_semantic_s2_empty_results_guard(self):
+        from _divergence_semantic import compute_s2_energy
+
+        df, emb = _tiny_semantic_data()
+        cfg = _empty_guard_cfg()
+        result = compute_s2_energy(df, emb, cfg)
+        assert isinstance(result, pd.DataFrame)
+        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
+        assert len(result) == 0
+
+    def test_semantic_s3_empty_results_guard(self):
+        from _divergence_semantic import compute_s3_wasserstein
+
+        df, emb = _tiny_semantic_data()
+        cfg = _empty_guard_cfg()
+        result = compute_s3_wasserstein(df, emb, cfg)
+        assert isinstance(result, pd.DataFrame)
+        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
+        assert len(result) == 0
+
+    def test_semantic_s4_empty_results_guard(self):
+        from _divergence_semantic import compute_s4_frechet
+
+        df, emb = _tiny_semantic_data()
+        cfg = _empty_guard_cfg()
+        result = compute_s4_frechet(df, emb, cfg)
+        assert isinstance(result, pd.DataFrame)
+        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
+        assert len(result) == 0

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -1032,42 +1032,23 @@ def _empty_guard_cfg():
 class TestEmptyResultsGuard:
     """Semantic compute_* functions return empty DataFrame on sparse corpus."""
 
-    def test_semantic_s1_empty_results_guard(self):
-        from _divergence_semantic import compute_s1_mmd
+    @pytest.mark.parametrize(
+        "fn_name",
+        [
+            "compute_s1_mmd",
+            "compute_s2_energy",
+            "compute_s3_wasserstein",
+            "compute_s4_frechet",
+        ],
+    )
+    def test_empty_results_guard(self, fn_name):
+        import importlib
 
+        mod = importlib.import_module("_divergence_semantic")
+        fn = getattr(mod, fn_name)
         df, emb = _tiny_semantic_data()
         cfg = _empty_guard_cfg()
-        result = compute_s1_mmd(df, emb, cfg)
-        assert isinstance(result, pd.DataFrame)
-        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
-        assert len(result) == 0
-
-    def test_semantic_s2_empty_results_guard(self):
-        from _divergence_semantic import compute_s2_energy
-
-        df, emb = _tiny_semantic_data()
-        cfg = _empty_guard_cfg()
-        result = compute_s2_energy(df, emb, cfg)
-        assert isinstance(result, pd.DataFrame)
-        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
-        assert len(result) == 0
-
-    def test_semantic_s3_empty_results_guard(self):
-        from _divergence_semantic import compute_s3_wasserstein
-
-        df, emb = _tiny_semantic_data()
-        cfg = _empty_guard_cfg()
-        result = compute_s3_wasserstein(df, emb, cfg)
-        assert isinstance(result, pd.DataFrame)
-        assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
-        assert len(result) == 0
-
-    def test_semantic_s4_empty_results_guard(self):
-        from _divergence_semantic import compute_s4_frechet
-
-        df, emb = _tiny_semantic_data()
-        cfg = _empty_guard_cfg()
-        result = compute_s4_frechet(df, emb, cfg)
+        result = fn(df, emb, cfg)
         assert isinstance(result, pd.DataFrame)
         assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
         assert len(result) == 0


### PR DESCRIPTION
## Summary

- Add `empty_divergence_df` to the import block in `scripts/_divergence_semantic.py`
- Add tests for all 4 guard sites (S1 MMD, S2 energy, S3 Wasserstein, S4 Fréchet)

The function was called at lines 226, 307, 365, 502 but not imported, causing a latent `NameError` on empty-corpus edge cases.

Closes ticket 0127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)