### PR TITLE
feat(0105): replication ribbon for zoo figures

### DIFF
--- a/content/_includes/techrep-zoo.md
+++ b/content/_includes/techrep-zoo.md
@@ -14,6 +14,12 @@ with a shared vocabulary and shared concerns.
 The fifth entry, C2ST (embedding), recasts the same two-sample question as a supervised learning task
 and serves as a reference-layer sanity check rather than a convergence detector.
 
+For the six stochastic methods (S1–S4, C2ST_embedding, C2ST_lexical), each panel
+also shows a faint **replication ribbon** around the line: the trimmed range of
+$R$ subsampling replicates expressed in the same Z-score units (μ, σ shared with
+the point estimate). The band brackets variability under resampling — a visual
+proxy for sampling uncertainty rather than a formal confidence interval.
+
 ---
 
 {{< include _includes/zoo/S1_mmd.md >}}

--- a/divergence.mk
+++ b/divergence.mk
@@ -281,10 +281,12 @@ bootstrap-tables: $(BOOT_CSV)
 # Output: tab_subsample_{method}.csv
 
 SUBSAMP_DISPATCH := scripts/compute_divergence_subsampled.py
-SUBSAMP_METHODS_SEM := S2_energy
+SUBSAMP_METHODS_SEM := S1_MMD S2_energy S3_sliced_wasserstein S4_frechet
 SUBSAMP_METHODS_LEX := L1
 SUBSAMP_METHODS_CIT := G9_community G2_spectral
-SUBSAMP_METHODS := $(SUBSAMP_METHODS_SEM) $(SUBSAMP_METHODS_LEX) $(SUBSAMP_METHODS_CIT)
+SUBSAMP_METHODS_C2ST_SEM := C2ST_embedding
+SUBSAMP_METHODS_C2ST_LEX := C2ST_lexical
+SUBSAMP_METHODS := $(SUBSAMP_METHODS_SEM) $(SUBSAMP_METHODS_LEX) $(SUBSAMP_METHODS_CIT) $(SUBSAMP_METHODS_C2ST_SEM) $(SUBSAMP_METHODS_C2ST_LEX)
 SUBSAMP_CSV := $(foreach m,$(SUBSAMP_METHODS),$(DIV_TABLES)/tab_subsample_$(m).csv)
 
 $(foreach m,$(SUBSAMP_METHODS_SEM),$(eval \
@@ -297,6 +299,14 @@ $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_
 
 $(foreach m,$(SUBSAMP_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_citation.py scripts/_divergence_community.py scripts/_citation_methods.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
+	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+$(foreach m,$(SUBSAMP_METHODS_C2ST_SEM),$(eval \
+$(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
+	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+
+$(foreach m,$(SUBSAMP_METHODS_C2ST_LEX),$(eval \
+$(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py $(REFINED) $(DIV_CFG) ; \
 	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 .PHONY: subsample-tables

--- a/scripts/compute_crossyear_zscore.py
+++ b/scripts/compute_crossyear_zscore.py
@@ -21,9 +21,11 @@ Usage::
 import argparse
 import re
 import sys
+from typing import Optional
 
 import pandas as pd
 from pipeline_io import save_csv
+from pipeline_loaders import load_analysis_config
 from schemas import CrossyearZscoreSchema
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger
@@ -31,7 +33,29 @@ from utils import get_logger
 log = get_logger("compute_crossyear_zscore")
 
 
-def compute_crossyear_zscores(df: pd.DataFrame, method: str) -> pd.DataFrame:
+def _subsample_percentiles(
+    subsample_df: pd.DataFrame, trim: int = 2
+) -> dict[tuple[int, str], tuple[float, float]]:
+    """Compute trimmed Q10/Q90 per (year, window) from subsample replicates.
+
+    Returns {(year, window): (value_lo, value_hi)}.
+    """
+    result: dict[tuple[int, str], tuple[float, float]] = {}
+    for (y, w), grp in subsample_df.groupby(["year", "window"]):
+        vals = grp["value"].dropna().sort_values().values
+        if len(vals) <= 2 * trim:
+            result[(int(y), str(w))] = (float(vals[0]), float(vals[-1]))
+        else:
+            trimmed = vals[trim : len(vals) - trim]
+            result[(int(y), str(w))] = (float(trimmed[0]), float(trimmed[-1]))
+    return result
+
+
+def compute_crossyear_zscores(
+    df: pd.DataFrame,
+    method: str,
+    subsample_df: Optional[pd.DataFrame] = None,
+) -> pd.DataFrame:
     """Compute cross-year Z-scores for all windows in df.
 
     Parameters
@@ -40,17 +64,32 @@ def compute_crossyear_zscores(df: pd.DataFrame, method: str) -> pd.DataFrame:
         Raw divergence data with columns year, window, value (plus any others).
     method : str
         Method name, written into the output 'method' column.
+    subsample_df : pd.DataFrame, optional
+        Subsampling replicates (from compute_divergence_subsampled.py) with
+        columns year, window, replicate, value.  When provided, derives
+        z_lo/z_hi ribbon bounds using the same μ/σ as z_score.
 
     Returns
     -------
     pd.DataFrame
-        Schema: method (str), year (int), window (str), value (float),
-        z_score (float).  z_score is NaN when std == 0 or value is NaN.
+        Schema: method, year, window, value, z_score, z_lo, z_hi.
+        z_lo/z_hi are NaN when subsample_df is absent or has no data for a cell.
 
     """
-    # Group by (window, hyperparams) so each hyperparameter setting gets its own
-    # Z-score series. Then aggregate across hyperparams per (year, window) by
-    # taking the mean, so the output has exactly one row per (year, window).
+    trim = 2
+    if subsample_df is not None:
+        try:
+            cfg = load_analysis_config()
+            trim = cfg["divergence"].get("subsample_trim", 2)
+        except Exception:
+            trim = 2
+
+    pctiles = (
+        _subsample_percentiles(subsample_df, trim=trim)
+        if subsample_df is not None
+        else {}
+    )
+
     group_keys = ["window"]
     if "hyperparams" in df.columns:
         group_keys.append("hyperparams")
@@ -63,24 +102,47 @@ def compute_crossyear_zscores(df: pd.DataFrame, method: str) -> pd.DataFrame:
         std_d = vals.std()
         if std_d == 0 or pd.isna(std_d):
             z = pd.Series([float("nan")] * len(grp), index=grp.index)
+            z_lo_series = pd.Series([float("nan")] * len(grp), index=grp.index)
+            z_hi_series = pd.Series([float("nan")] * len(grp), index=grp.index)
         else:
             z = (vals - mean_d) / std_d
+            z_lo_vals = []
+            z_hi_vals = []
+            window = keys[0] if isinstance(keys, tuple) else keys
+            for _, row in grp.iterrows():
+                key = (int(row["year"]), str(window))
+                if key in pctiles:
+                    vlo, vhi = pctiles[key]
+                    z_lo_vals.append((vlo - mean_d) / std_d)
+                    z_hi_vals.append((vhi - mean_d) / std_d)
+                else:
+                    z_lo_vals.append(float("nan"))
+                    z_hi_vals.append(float("nan"))
+            z_lo_series = pd.Series(z_lo_vals, index=grp.index)
+            z_hi_series = pd.Series(z_hi_vals, index=grp.index)
+
         window = keys[0] if isinstance(keys, tuple) else keys
         grp = grp.copy()
         grp["z_score"] = z
+        grp["z_lo"] = z_lo_series
+        grp["z_hi"] = z_hi_series
         grp["window"] = str(window)
-        per_hp.append(grp[["year", "window", "value", "z_score"]])
+        per_hp.append(grp[["year", "window", "value", "z_score", "z_lo", "z_hi"]])
 
     combined = pd.concat(per_hp, ignore_index=True)
 
-    # Average across hyperparameter settings for each (year, window).
     agg = (
         combined.groupby(["year", "window"], sort=True)
-        .agg(value=("value", "mean"), z_score=("z_score", "mean"))
+        .agg(
+            value=("value", "mean"),
+            z_score=("z_score", "mean"),
+            z_lo=("z_lo", "mean"),
+            z_hi=("z_hi", "mean"),
+        )
         .reset_index()
     )
     agg.insert(0, "method", method)
-    return agg[["method", "year", "window", "value", "z_score"]]
+    return agg[["method", "year", "window", "value", "z_score", "z_lo", "z_hi"]]
 
 
 def main() -> None:
@@ -100,6 +162,11 @@ def main() -> None:
             "Filter to rows where hyperparams contains metric=<value>. "
             "Used for L2 (resonance) to align observed statistic with null model."
         ),
+    )
+    parser.add_argument(
+        "--subsample-csv",
+        default=None,
+        help="Path to tab_subsample_{method}.csv for replication ribbon (ticket 0105).",
     )
     args = parser.parse_args(extra)
 
@@ -143,7 +210,21 @@ def main() -> None:
 
     log.info("Loaded %d rows, %d unique windows", len(raw), raw["window"].nunique())
 
-    result = compute_crossyear_zscores(raw, method)
+    subsample_df = None
+    if args.subsample_csv:
+        try:
+            subsample_df = pd.read_csv(args.subsample_csv)
+            log.info(
+                "Loaded %d subsample rows from %s",
+                len(subsample_df),
+                args.subsample_csv,
+            )
+        except FileNotFoundError:
+            log.warning(
+                "Subsample file not found: %s — ribbon will be NaN", args.subsample_csv
+            )
+
+    result = compute_crossyear_zscores(raw, method, subsample_df=subsample_df)
 
     # Validate against schema before writing.
     CrossyearZscoreSchema.validate(result)

--- a/scripts/compute_crossyear_zscore.py
+++ b/scripts/compute_crossyear_zscore.py
@@ -36,14 +36,24 @@ log = get_logger("compute_crossyear_zscore")
 def _subsample_percentiles(
     subsample_df: pd.DataFrame, trim: int = 2
 ) -> dict[tuple[int, str], tuple[float, float]]:
-    """Compute trimmed Q10/Q90 per (year, window) from subsample replicates.
+    """Compute trimmed-range bounds per (year, window) from subsample replicates.
+
+    Drops `trim` extreme replicates from each tail and returns the remaining
+    min/max — an order-statistic range, not a fixed-percentile interval. The
+    resulting percentile coverage depends on R: with R=20 trim=2 it spans
+    roughly Q10/Q90; with R=10 trim=2, ≈ Q20/Q80.
+
+    Returns (NaN, NaN) when a (year, window) group has no usable replicates,
+    and the un-trimmed min/max when R ≤ 2*trim.
 
     Returns {(year, window): (value_lo, value_hi)}.
     """
     result: dict[tuple[int, str], tuple[float, float]] = {}
     for (y, w), grp in subsample_df.groupby(["year", "window"]):
         vals = grp["value"].dropna().sort_values().values
-        if len(vals) <= 2 * trim:
+        if len(vals) == 0:
+            result[(int(y), str(w))] = (float("nan"), float("nan"))
+        elif len(vals) <= 2 * trim:
             result[(int(y), str(w))] = (float(vals[0]), float(vals[-1]))
         else:
             trimmed = vals[trim : len(vals) - trim]
@@ -81,8 +91,13 @@ def compute_crossyear_zscores(
         try:
             cfg = load_analysis_config()
             trim = cfg["divergence"].get("subsample_trim", 2)
-        except Exception:
-            trim = 2
+        except (FileNotFoundError, KeyError) as exc:
+            log.warning(
+                "Falling back to default subsample trim=%s; could not read "
+                "divergence.subsample_trim from analysis config: %s",
+                trim,
+                exc,
+            )
 
     pctiles = (
         _subsample_percentiles(subsample_df, trim=trim)

--- a/scripts/compute_divergence_subsampled.py
+++ b/scripts/compute_divergence_subsampled.py
@@ -175,8 +175,11 @@ def _run_c2st_embedding_subsampled(method_name, div_df, cfg, R):
     c2st_cfg = cfg["divergence"].get("c2st", {})
     pca_dim = c2st_cfg.get("pca_dim", 32)
     cv_folds = c2st_cfg.get("cv_folds", 5)
+    class_weight = c2st_cfg.get("class_weight", "balanced")
     seed = cfg["divergence"]["random_seed"]
 
+    # Disable equal_n so the iterator yields the full unequal-sized arrays.
+    # subsample_one_window applies equal-n R times independently.
     cfg_raw = copy.deepcopy(cfg)
     cfg_raw["divergence"]["equal_n"] = False
 
@@ -192,7 +195,7 @@ def _run_c2st_embedding_subsampled(method_name, div_df, cfg, R):
             combined_r[: len(X)],
             combined_r[len(X) :],
             cv_folds=cv_folds,
-            class_weight="balanced",
+            class_weight=class_weight,
             seed=seed,
         )["mean"]
 
@@ -209,19 +212,25 @@ def _run_c2st_embedding_subsampled(method_name, div_df, cfg, R):
 def _run_c2st_lexical_subsampled(method_name, div_df, cfg, R):
     """R subsampling replicates for C2ST_lexical."""
     from _divergence_c2st import _c2st_auc
-    from _divergence_io import iter_lexical_windows
+    from _divergence_io import fit_lexical_vectorizer, iter_lexical_windows
 
     c2st_cfg = cfg["divergence"].get("c2st", {})
     cv_folds = c2st_cfg.get("cv_folds", 5)
+    class_weight = c2st_cfg.get("class_weight", "balanced")
     seed = cfg["divergence"]["random_seed"]
+    vectorizer = fit_lexical_vectorizer(cfg)
 
+    # Disable equal_n so the iterator yields the full unequal-sized text lists.
+    # subsample_one_window applies equal-n R times independently.
     cfg_raw = copy.deepcopy(cfg)
     cfg_raw["divergence"]["equal_n"] = False
 
-    def statistic_fn(X, Y):
-        return _c2st_auc(X, Y, cv_folds=cv_folds, class_weight="balanced", seed=seed)[
-            "mean"
-        ]
+    def statistic_fn(texts_before, texts_after):
+        X = vectorizer.transform(texts_before)
+        Y = vectorizer.transform(texts_after)
+        return _c2st_auc(
+            X, Y, cv_folds=cv_folds, class_weight=class_weight, seed=seed
+        )["mean"]
 
     return _collect_subsample_rows(
         iter_lexical_windows(div_df, cfg_raw),

--- a/scripts/compute_divergence_subsampled.py
+++ b/scripts/compute_divergence_subsampled.py
@@ -167,6 +167,72 @@ def _run_lexical_subsampled(method_name, div_df, cfg, R):
     )
 
 
+def _run_c2st_embedding_subsampled(method_name, div_df, cfg, R):
+    """R subsampling replicates for C2ST_embedding."""
+    from _divergence_c2st import _c2st_auc
+    from _divergence_io import iter_semantic_windows
+
+    c2st_cfg = cfg["divergence"].get("c2st", {})
+    pca_dim = c2st_cfg.get("pca_dim", 32)
+    cv_folds = c2st_cfg.get("cv_folds", 5)
+    seed = cfg["divergence"]["random_seed"]
+
+    cfg_raw = copy.deepcopy(cfg)
+    cfg_raw["divergence"]["equal_n"] = False
+
+    def statistic_fn(X, Y):
+        from sklearn.decomposition import PCA
+
+        n_components = min(pca_dim, min(len(X), len(Y)) - 1, X.shape[1])
+        n_components = max(2, n_components)
+        pca = PCA(n_components=n_components, random_state=seed)
+        combined = np.vstack([X, Y])
+        combined_r = pca.fit_transform(combined)
+        return _c2st_auc(
+            combined_r[: len(X)],
+            combined_r[len(X) :],
+            cv_folds=cv_folds,
+            class_weight="balanced",
+            seed=seed,
+        )["mean"]
+
+    return _collect_subsample_rows(
+        iter_semantic_windows(div_df, cfg_raw),
+        method_name,
+        statistic_fn,
+        R,
+        seed,
+        log,
+    )
+
+
+def _run_c2st_lexical_subsampled(method_name, div_df, cfg, R):
+    """R subsampling replicates for C2ST_lexical."""
+    from _divergence_c2st import _c2st_auc
+    from _divergence_io import iter_lexical_windows
+
+    c2st_cfg = cfg["divergence"].get("c2st", {})
+    cv_folds = c2st_cfg.get("cv_folds", 5)
+    seed = cfg["divergence"]["random_seed"]
+
+    cfg_raw = copy.deepcopy(cfg)
+    cfg_raw["divergence"]["equal_n"] = False
+
+    def statistic_fn(X, Y):
+        return _c2st_auc(X, Y, cv_folds=cv_folds, class_weight="balanced", seed=seed)[
+            "mean"
+        ]
+
+    return _collect_subsample_rows(
+        iter_lexical_windows(div_df, cfg_raw),
+        method_name,
+        statistic_fn,
+        R,
+        seed,
+        log,
+    )
+
+
 def _run_citation_subsampled(method_name, div_df, cfg, R):
     """R equal-n subsampling replicates for citation methods (G2, G9).
 
@@ -266,7 +332,11 @@ def main():
     div_df = pd.read_csv(args.div_csv)
     log.info("Loaded %d rows from %s", len(div_df), args.div_csv)
 
-    if channel == "semantic":
+    if method_name == "C2ST_embedding":
+        result = _run_c2st_embedding_subsampled(method_name, div_df, cfg, R)
+    elif method_name == "C2ST_lexical":
+        result = _run_c2st_lexical_subsampled(method_name, div_df, cfg, R)
+    elif channel == "semantic":
         result = _run_semantic_subsampled(method_name, div_df, cfg, R)
     elif channel == "lexical":
         result = _run_lexical_subsampled(method_name, div_df, cfg, R)

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -252,6 +252,21 @@ def _plot(
         if sub.empty:
             continue
         style = _WINDOW_STYLES[w_str]
+
+        if (
+            "z_lo" in sub.columns
+            and "z_hi" in sub.columns
+            and sub["z_lo"].notna().any()
+        ):
+            ax.fill_between(
+                sub["year"],
+                sub["z_lo"],
+                sub["z_hi"],
+                alpha=0.08,
+                color=style["color"],
+                zorder=2,
+            )
+
         ax.plot(
             sub["year"],
             sub["z_score"],

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -229,6 +229,8 @@ CrossyearZscoreSchema = DataFrameSchema(
         "window": Column(str),
         "value": Column(float, nullable=True),
         "z_score": Column(float, nullable=True),
+        "z_lo": Column(float, nullable=True),
+        "z_hi": Column(float, nullable=True),
     },
     strict=True,
     coerce=True,

--- a/tests/test_replication_ribbon.py
+++ b/tests/test_replication_ribbon.py
@@ -102,3 +102,18 @@ class TestRibbonZscores:
         nonnull = result.dropna(subset=["z_lo", "z_hi"])
         widths = nonnull["z_hi"] - nonnull["z_lo"]
         assert widths.mean() > 0.01, f"ribbon too narrow: mean width = {widths.mean()}"
+
+    def test_ribbon_handles_all_nan_subsample_group(self, synthetic_div_df):
+        """All-NaN subsample groups must return (NaN, NaN), not IndexError."""
+        from compute_crossyear_zscore import _subsample_percentiles
+
+        all_nan = pd.DataFrame(
+            [
+                {"year": 2005, "window": "2", "value": float("nan")},
+                {"year": 2005, "window": "2", "value": float("nan")},
+            ]
+        )
+        result = _subsample_percentiles(all_nan, trim=2)
+        assert (2005, "2") in result
+        vlo, vhi = result[(2005, "2")]
+        assert pd.isna(vlo) and pd.isna(vhi)

--- a/tests/test_replication_ribbon.py
+++ b/tests/test_replication_ribbon.py
@@ -1,0 +1,104 @@
+"""Tests for replication ribbon (ticket 0105).
+
+Tests that compute_crossyear_zscores propagates z_lo/z_hi from subsample
+percentiles using the same μ/σ as the main z_score.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+from compute_crossyear_zscore import compute_crossyear_zscores
+
+
+class TestRibbonZscores:
+    """Unit tests for z_lo/z_hi derivation in compute_crossyear_zscores."""
+
+    @pytest.fixture()
+    def synthetic_div_df(self):
+        """Synthetic divergence data for 3 windows, 5 years each."""
+        rows = []
+        rng = np.random.RandomState(99)
+        for w in [2, 3, 4]:
+            for y in range(2005, 2010):
+                rows.append(
+                    {"year": y, "window": str(w), "value": rng.uniform(0.1, 0.9)}
+                )
+        return pd.DataFrame(rows)
+
+    @pytest.fixture()
+    def synthetic_subsample_df(self, synthetic_div_df):
+        """Synthetic subsample replicates: R=10 per (year, window)."""
+        rows = []
+        rng = np.random.RandomState(42)
+        for _, row in synthetic_div_df.iterrows():
+            y, w, center = int(row["year"]), row["window"], row["value"]
+            for r in range(10):
+                rows.append(
+                    {
+                        "method": "S2_energy",
+                        "year": y,
+                        "window": w,
+                        "hyperparams": "",
+                        "replicate": r,
+                        "value": center + rng.normal(0, 0.05),
+                    }
+                )
+        return pd.DataFrame(rows)
+
+    def test_ribbon_columns_present(self, synthetic_div_df, synthetic_subsample_df):
+        """z_lo and z_hi columns must be present when subsample_df is provided."""
+        result = compute_crossyear_zscores(
+            synthetic_div_df, "S2_energy", subsample_df=synthetic_subsample_df
+        )
+        assert "z_lo" in result.columns, "missing z_lo"
+        assert "z_hi" in result.columns, "missing z_hi"
+
+    def test_ribbon_normalization_consistent(
+        self, synthetic_div_df, synthetic_subsample_df
+    ):
+        """z_lo and z_hi must use the same μ/σ as z_score."""
+        result = compute_crossyear_zscores(
+            synthetic_div_df, "S2_energy", subsample_df=synthetic_subsample_df
+        )
+        for w, grp in result.groupby("window"):
+            mu = grp["value"].mean()
+            sigma = grp["value"].std()
+            if sigma == 0:
+                continue
+            expected_z = (grp["value"] - mu) / sigma
+            pd.testing.assert_series_equal(
+                grp["z_score"].reset_index(drop=True),
+                expected_z.reset_index(drop=True),
+                check_names=False,
+                atol=1e-6,
+            )
+            nonnull = grp.dropna(subset=["z_lo", "z_hi"])
+            assert len(nonnull) > 0, f"all z_lo/z_hi are null for window={w}"
+            for _, row in nonnull.iterrows():
+                assert row["z_lo"] <= row["z_hi"], (
+                    f"z_lo > z_hi at year={row['year']}, window={w}"
+                )
+
+    def test_ribbon_absent_without_subsample(self, synthetic_div_df):
+        """Without subsample_df, z_lo and z_hi should be NaN."""
+        result = compute_crossyear_zscores(synthetic_div_df, "S2_energy")
+        assert "z_lo" in result.columns
+        assert "z_hi" in result.columns
+        assert result["z_lo"].isna().all()
+        assert result["z_hi"].isna().all()
+
+    def test_ribbon_width_nondegenerate(self, synthetic_div_df, synthetic_subsample_df):
+        """Ribbon must have nonzero width (some spread expected from replicates)."""
+        result = compute_crossyear_zscores(
+            synthetic_div_df, "S2_energy", subsample_df=synthetic_subsample_df
+        )
+        nonnull = result.dropna(subset=["z_lo", "z_hi"])
+        widths = nonnull["z_hi"] - nonnull["z_lo"]
+        assert widths.mean() > 0.01, f"ribbon too narrow: mean width = {widths.mean()}"

--- a/tickets/0105-zoo-replication-ribbon.erg
+++ b/tickets/0105-zoo-replication-ribbon.erg
@@ -7,6 +7,7 @@ Author: claude
 --- log ---
 2026-04-24T11:45Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-05-01T09:00Z claude note raid-reimagine: Path B — reuse compute_divergence_subsampled.py (existing RNG namespacing, tested seed isolation, 1-invocation-1-output). Point estimate unchanged; ribbon is visual overlay. Extend SUBSAMP_METHODS to all 6 stochastic methods; add C2ST statistic fns; wire subsample CSV into crossyear zscore via --subsample-csv; derive z_lo/z_hi with shared mu/sigma.
 --- body ---
 ## Context
 

--- a/tickets/0105-zoo-replication-ribbon.erg
+++ b/tickets/0105-zoo-replication-ribbon.erg
@@ -8,6 +8,7 @@ Author: claude
 2026-04-24T11:45Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
 2026-05-01T09:00Z claude note raid-reimagine: Path B — reuse compute_divergence_subsampled.py (existing RNG namespacing, tested seed isolation, 1-invocation-1-output). Point estimate unchanged; ribbon is visual overlay. Extend SUBSAMP_METHODS to all 6 stochastic methods; add C2ST statistic fns; wire subsample CSV into crossyear zscore via --subsample-csv; derive z_lo/z_hi with shared mu/sigma.
+2026-05-01T17:00Z claude note /verify PR #781 APPROVED
 --- body ---
 ## Context
 

--- a/zoo.mk
+++ b/zoo.mk
@@ -64,6 +64,12 @@ crossyear-tables: $(addprefix $(ZOO_TABLES)/tab_crossyear_,$(addsuffix .csv,$(CR
 $(ZOO_TABLES)/tab_crossyear_L2.csv: $(ZOO_TABLES)/tab_div_L2.csv scripts/compute_crossyear_zscore.py
 	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method L2 --metric resonance --output $@
 
+# Stochastic methods: pass --subsample-csv for replication ribbon (ticket 0105).
+RIBBON_METHODS := S1_MMD S2_energy S3_sliced_wasserstein S4_frechet C2ST_embedding C2ST_lexical
+$(foreach m,$(RIBBON_METHODS),$(eval \
+$(ZOO_TABLES)/tab_crossyear_$(m).csv: $(ZOO_TABLES)/tab_div_$(m).csv $(ZOO_TABLES)/tab_subsample_$(m).csv scripts/compute_crossyear_zscore.py ; \
+	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method $(m) --subsample-csv $(ZOO_TABLES)/tab_subsample_$(m).csv --output $$@))
+
 $(ZOO_TABLES)/tab_crossyear_%.csv: $(ZOO_TABLES)/tab_div_%.csv scripts/compute_crossyear_zscore.py
 	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method $* --output $@
 


### PR DESCRIPTION
## Summary

- Extends `compute_divergence_subsampled.py` to all 6 stochastic methods (S1–S4, C2ST_embedding, C2ST_lexical) with C2ST-specific subsampling drivers
- Adds `z_lo`/`z_hi` columns to `CrossyearZscoreSchema` and `compute_crossyear_zscore.py` (derived from subsample percentiles using shared μ/σ)
- `plot_zoo_results.py` draws a faint `fill_between` ribbon from `z_lo`/`z_hi` per window
- Make targets wired: `divergence.mk` extends `SUBSAMP_METHODS`; `zoo.mk` passes `--subsample-csv` for ribbon methods

**Design decision (Path B):** Reuses existing `compute_divergence_subsampled.py` infrastructure (ticket 0084) instead of adding `--replicates` to the dispatcher. Point estimate is unchanged; ribbon is a visual overlay showing subsampling variability. See reimagine log in ticket.

## Test plan

- [x] Unit tests: `test_replication_ribbon.py` — z_lo/z_hi presence, normalization consistency, width, absence without subsample data
- [x] `make check-fast` passes (998 passed)
- [ ] Rebuild zoo figures for S1–S4, C2ST_embedding, C2ST_lexical and visually confirm ribbon
- [ ] `make check` full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)