### PR TITLE
fix(0126): add --env-file .env to all uv invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ export PYTHONHASHSEED := 0
 export SOURCE_DATE_EPOCH := 0
 
 # ── Toolchain ─────────────────────────────────────────────
+# Env policy: secrets sourced from project .env via uv --env-file;
+# never via export KEY := $(shell ...) or command-line KEY=value.
+#
 # Named tool variables so invocations stay overridable and self-documenting.
 # PATH export covers non-interactive shells (ssh, cron, systemd) where
 # ~/.bashrc isn't sourced — uv lives in ~/.local/bin by default.

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,5 +1,8 @@
 # DVC pipeline — Phase 1: Corpus Building
 #
+# Env policy: secrets sourced from project .env via uv --env-file;
+# never via export KEY := $(shell ...) or command-line KEY=value.
+#
 # Mirrors Makefile Phase 1a–1f. Run with:
 #   dvc repro              (full pipeline)
 #   dvc repro discover     (single stage)
@@ -12,7 +15,7 @@ stages:
   # Hand-exported from bib.cnrs.fr (CNRS credentials required); conversion is
   # deterministic so it lives in the pipeline rather than as a pre-placed artifact.
   catalog_bibcnrs:
-    cmd: uv run python scripts/catalog_bibcnrs.py
+    cmd: uv run --env-file .env python scripts/catalog_bibcnrs.py
     deps:
       - scripts/catalog_bibcnrs.py
       - scripts/utils.py
@@ -29,7 +32,7 @@ stages:
   # DVC runs independent stages in parallel and skips unchanged ones.
 
   catalog_istex:
-    cmd: uv run python scripts/catalog_istex.py --api
+    cmd: uv run --env-file .env python scripts/catalog_istex.py --api
     deps:
       - scripts/catalog_istex.py
       - scripts/utils.py
@@ -44,7 +47,7 @@ stages:
       - data/catalogs/istex_refs.csv
 
   catalog_openalex:
-    cmd: uv run python scripts/catalog_openalex.py --resume
+    cmd: uv run --env-file .env python scripts/catalog_openalex.py --resume
     deps:
       - scripts/catalog_openalex.py
       - scripts/utils.py
@@ -65,7 +68,7 @@ stages:
   # citation-graph-based harvest. See ticket for redesign.
 
   catalog_grey:
-    cmd: uv run python scripts/catalog_grey.py
+    cmd: uv run --env-file .env python scripts/catalog_grey.py
     deps:
       - scripts/catalog_grey.py
       - scripts/utils.py
@@ -80,8 +83,8 @@ stages:
 
   catalog_teaching:
     cmd: >-
-      uv run python scripts/build_teaching_yaml.py &&
-      uv run python scripts/build_teaching_canon.py
+      uv run --env-file .env python scripts/build_teaching_yaml.py &&
+      uv run --env-file .env python scripts/build_teaching_canon.py
     deps:
       - scripts/build_teaching_yaml.py
       - scripts/build_teaching_canon.py
@@ -96,7 +99,7 @@ stages:
 
   # Merge all per-source CSVs → unified_works.csv
   catalog_merge:
-    cmd: uv run python scripts/catalog_merge.py
+    cmd: uv run --env-file .env python scripts/catalog_merge.py
     deps:
       - scripts/catalog_merge.py
       - scripts/utils.py
@@ -134,7 +137,7 @@ stages:
 
   enrich_dois:
     cmd: >-
-      uv run python scripts/enrich_dois.py --works-input data/catalogs/unified_works.csv
+      uv run --env-file .env python scripts/enrich_dois.py --works-input data/catalogs/unified_works.csv
       --output data/catalogs/enrich_cache/.dois.stamp
     deps:
       - scripts/enrich_dois.py
@@ -148,7 +151,7 @@ stages:
 
   enrich_abstracts:
     cmd: >-
-      uv run python scripts/enrich_abstracts.py --works-input data/catalogs/unified_works.csv
+      uv run --env-file .env python scripts/enrich_abstracts.py --works-input data/catalogs/unified_works.csv
       --output data/catalogs/enrich_cache/.abstracts.stamp
     deps:
       - scripts/enrich_abstracts.py
@@ -163,7 +166,7 @@ stages:
 
   enrich_language:
     cmd: >-
-      uv run python scripts/enrich_language.py --works-input data/catalogs/unified_works.csv
+      uv run --env-file .env python scripts/enrich_language.py --works-input data/catalogs/unified_works.csv
       --output data/catalogs/enrich_cache/.language.stamp
     deps:
       - scripts/enrich_language.py
@@ -177,7 +180,7 @@ stages:
 
   summarize_abstracts:
     cmd: >-
-      uv run python scripts/summarize_abstracts.py --works-input data/catalogs/unified_works.csv &&
+      uv run --env-file .env python scripts/summarize_abstracts.py --works-input data/catalogs/unified_works.csv &&
       date -Iseconds > data/catalogs/enrich_cache/.summaries.stamp
     deps:
       - scripts/summarize_abstracts.py
@@ -194,7 +197,7 @@ stages:
   # `dvc repro join_enrichments` reads whatever caches exist on disk.
   # Use `make corpus-enrich` to run all enrichment stages first.
   join_enrichments:
-    cmd: uv run python scripts/enrich_join.py
+    cmd: uv run --env-file .env python scripts/enrich_join.py
     deps:
       - scripts/enrich_join.py
       - scripts/utils.py
@@ -214,10 +217,10 @@ stages:
   # citations.csv is produced downstream by the ref_match stage (#539).
   enrich_citations:
     cmd: >-
-      uv run python scripts/enrich_citations_batch.py --works-input data/catalogs/enriched_works.csv & p1=$!;
-      uv run python scripts/enrich_citations_openalex.py --works-input data/catalogs/enriched_works.csv & p2=$!;
+      uv run --env-file .env python scripts/enrich_citations_batch.py --works-input data/catalogs/enriched_works.csv & p1=$!;
+      uv run --env-file .env python scripts/enrich_citations_openalex.py --works-input data/catalogs/enriched_works.csv & p2=$!;
       wait $p1 && wait $p2 &&
-      uv run python scripts/corpus_parse_citations_grobid.py
+      uv run --env-file .env python scripts/corpus_parse_citations_grobid.py
     deps:
       - scripts/enrich_citations_batch.py
       - scripts/enrich_citations_openalex.py
@@ -231,7 +234,7 @@ stages:
 
   # Phase 1b.4: Citation QC — verify against Crossref ground truth
   qa_citations:
-    cmd: uv run python scripts/qa_citations.py --works-input data/catalogs/enriched_works.csv
+    cmd: uv run --env-file .env python scripts/qa_citations.py --works-input data/catalogs/enriched_works.csv
     deps:
       - scripts/qa_citations.py
       - scripts/utils.py
@@ -245,7 +248,7 @@ stages:
   # Phase 1b.5: Sentence embeddings (encoding only — no UMAP/clustering)
   # Requires uv sync --group corpus --extra cpu (or --extra cu130 on GPU)
   enrich_embeddings:
-    cmd: uv run python scripts/enrich_embeddings.py --works-input data/catalogs/enriched_works.csv --output data/catalogs/embeddings.npz
+    cmd: uv run --env-file .env python scripts/enrich_embeddings.py --works-input data/catalogs/enriched_works.csv --output data/catalogs/embeddings.npz
     deps:
       - scripts/enrich_embeddings.py
       - scripts/utils.py
@@ -262,7 +265,7 @@ stages:
   # corpus_filter.py loads config/corpus_filter.yaml via filter_flags.py.
   extend:
     cmd: >-
-      uv run python scripts/corpus_filter.py --extend --works-input data/catalogs/enriched_works.csv --works-output data/catalogs/extended_works.csv
+      uv run --env-file .env python scripts/corpus_filter.py --extend --works-input data/catalogs/enriched_works.csv --works-output data/catalogs/extended_works.csv
     deps:
       - scripts/corpus_filter.py
       - scripts/filter_flags.py
@@ -282,7 +285,7 @@ stages:
   # Also loads config/corpus_filter.yaml for retention policy parameters.
   filter:
     cmd: >-
-      uv run python scripts/corpus_filter.py --filter --works-input data/catalogs/extended_works.csv --works-output data/catalogs/refined_works.csv
+      uv run --env-file .env python scripts/corpus_filter.py --filter --works-input data/catalogs/extended_works.csv --works-output data/catalogs/refined_works.csv
     deps:
       - scripts/corpus_filter.py
       - scripts/filter_flags.py
@@ -305,7 +308,7 @@ stages:
   # Writes enrich_cache/ref_matches.csv, then merges all citation caches
   # (crossref + openalex + grobid + ref_matches) into citations.csv.
   ref_match:
-    cmd: uv run python scripts/corpus_ref_match.py && uv run python scripts/corpus_merge_citations.py
+    cmd: uv run --env-file .env python scripts/corpus_ref_match.py && uv run --env-file .env python scripts/corpus_merge_citations.py
     deps:
       - scripts/corpus_ref_match.py
       - scripts/corpus_merge_citations.py
@@ -321,7 +324,7 @@ stages:
   #   refined_embeddings.npz[vectors][i] ↔ refined_works.csv row i
   #   refined_citations.csv edges restricted to refined DOIs
   align:
-    cmd: uv run python scripts/corpus_align.py
+    cmd: uv run --env-file .env python scripts/corpus_align.py
     deps:
       - scripts/corpus_align.py
       - scripts/utils.py

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -12,5 +12,6 @@ if [ -f dvc.lock ]; then
         padme) extra=cu130 ;;
         *)     extra=cpu ;;
     esac
-    uv run --group corpus --extra "$extra" dvc checkout 2>/dev/null || true
+    envflag=""; [ -f .env ] && envflag="--env-file .env"
+    uv run $envflag --group corpus --extra "$extra" dvc checkout 2>/dev/null || true
 fi

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -35,14 +35,14 @@ COMP_DEPS_CORE := \
 $(COMP_FIGS)/fig_companion_zseries.png: \
     scripts/plot_companion_zseries.py $(COMP_UTILS) $(COMP_STYLE) \
     $(COMP_CFG) $(COMP_DEPS_CORE)
-	uv run python scripts/plot_companion_zseries.py --output $@
+	$(UV_RUN) python scripts/plot_companion_zseries.py --output $@
 
 # ── Figure 2: Transition zone heatmap ────────────────────────────────────
 
 $(COMP_FIGS)/fig_companion_heatmap.png: \
     scripts/plot_companion_heatmap.py $(COMP_UTILS) $(COMP_STYLE) \
     $(COMP_CFG) $(COMP_DEPS_CORE)
-	uv run python scripts/plot_companion_heatmap.py --output $@
+	$(UV_RUN) python scripts/plot_companion_heatmap.py --output $@
 
 # ── Figure 3: Discriminative terms ───────────────────────────────────────
 # No hard dependency on tab_discrim_terms*.csv: the script degrades to a
@@ -50,14 +50,14 @@ $(COMP_FIGS)/fig_companion_heatmap.png: \
 
 $(COMP_FIGS)/fig_companion_terms.png: \
     scripts/plot_companion_terms.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
-	uv run python scripts/plot_companion_terms.py --output $@
+	$(UV_RUN) python scripts/plot_companion_terms.py --output $@
 
 # ── Figure 4: Community shifts ───────────────────────────────────────────
 # Same stub-fallback rationale as Figure 3.
 
 $(COMP_FIGS)/fig_companion_community.png: \
     scripts/plot_companion_community.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
-	uv run python scripts/plot_companion_community.py --output $@
+	$(UV_RUN) python scripts/plot_companion_community.py --output $@
 
 .PHONY: companion-figures
 companion-figures: \

--- a/release/scripts/build_datapaper_archive.sh
+++ b/release/scripts/build_datapaper_archive.sh
@@ -31,7 +31,7 @@ rm -rf "$TMP/code/.dvc" "$TMP/code/attic" "$TMP/code/.claude"
 # ── Data: deposit files ──────────────────────────────────
 echo "  Preparing deposit CSV (dropping abstracts)..."
 cd "$PROJ_ROOT"
-uv run python scripts/export_deposit.py --output "$TMP/data/climate_finance_corpus.csv"
+uv run --env-file .env python scripts/export_deposit.py --output "$TMP/data/climate_finance_corpus.csv"
 
 echo "  Copying embeddings, citations, and source catalogs..."
 cp -L "$DATA_DIR/embeddings.npz" "$TMP/data/"

--- a/scripts/run_corpus_pipeline.sh
+++ b/scripts/run_corpus_pipeline.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # run_corpus_pipeline.sh — Run the full DVC corpus pipeline on padme.
 #
+# Env policy: secrets sourced from project .env via uv --env-file;
+# never via command-line KEY=value.
+#
 # Guards: hostname must be padme, dvc must be installed, branch must be main.
 # After dvc repro + push, auto-commits dvc.lock if it's the only changed file.
 # Otherwise warns the user to commit manually.
@@ -20,7 +23,7 @@ if [ "$(hostname)" != "padme" ]; then
 fi
 
 # --- Guard: dvc installed ---
-if ! uv run dvc version >/dev/null 2>&1; then
+if ! uv run --env-file .env dvc version >/dev/null 2>&1; then
     echo "error: dvc not found. Install with: uv tool install 'dvc[ssh]'"
     exit 1
 fi
@@ -34,8 +37,8 @@ fi
 
 # --- Run pipeline ---
 ret=0
-uv run dvc repro || ret=$?
-uv run dvc push
+uv run --env-file .env dvc repro || ret=$?
+uv run --env-file .env dvc push
 
 if [ "$ret" -ne 0 ]; then
     exit "$ret"

--- a/tickets/0126-uv-env-file-leak-fix.erg
+++ b/tickets/0126-uv-env-file-leak-fix.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Refactor uv invocations to use --env-file (CLAUDE_ENV_FILE leak fix)
-Status: open
+Status: doing
 Created: 2026-04-30
 Author: claude
 
 --- log ---
 2026-04-30T16:31Z claude created — see AEDIST commit 4000c21 for the model fix
 2026-05-01T00:00Z claude note Makefile UV_RUN fixed (commit 4cef9bc) — DVC pipeline and shell scripts still need audit before closing
+2026-05-03T12:00Z claude status doing — raid 0126: migrating all remaining bare uv run invocations
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- **multilayer-detection.mk**: 4 bare `uv run` → `$(UV_RUN)` macro
- **dvc.yaml**: add `--env-file .env` to all 22 stage commands (defense-in-depth for standalone `dvc repro`)
- **scripts/run_corpus_pipeline.sh**: wrap dvc calls with `--env-file`
- **release/scripts/build_datapaper_archive.sh**: add `--env-file`
- **hooks/post-checkout**: conditional `--env-file` (tolerates missing `.env` in worktrees)
- **Makefile + dvc.yaml**: document env policy in header comments

Secrets are loaded from `.env` at child-process spawn time via `uv --env-file`, never passed as `KEY=value` on the command line (the `ps -ef` leak vector from ticket 0126).

Closes #0126.

## Test plan

- [x] `make check-fast` — 1012 passed (1 pre-existing failure: `test_always_loaded_line_budget`, unrelated)
- [x] `ps -ef` spot-check: `uv run --env-file .env python ...` shows no secrets in process args
- [ ] Verify `dvc repro --dry` still parses stages correctly (padme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)