### PR TITLE
fix(0144): co-locate uv env with cache on /data (stop 1.8 GB per-worktree copy)

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -3,9 +3,26 @@
 #
 # .env and .dvc/config.local are handled by .worktreeinclude (auto-copied
 # into worktrees created by EnterWorktree / `claude --worktree`).
-# This hook handles DVC data population only.
+#
+# This hook (a) points the worktree's uv environment at a shared env that lives
+# on the same filesystem as the uv cache, then (b) populates DVC-managed data.
 
-# Populate DVC-managed data from local cache.
+# (a) Co-locate the uv project environment with the uv cache on /data.
+# uv hardlinks wheels from its cache into the environment, but only when both
+# share a filesystem; across filesystems it falls back to copying the whole
+# torch closure (~1.8 GB) into every worktree, which is slow enough to exceed
+# the worktree tool's timeout and make worktree creation fail outright. The uv
+# cache already lives on /data, so we put the environment there too and point
+# this worktree's default `.venv` location at it via a symlink. A dangling
+# symlink makes `uv run` error, so the shared env is created first. Skipped
+# where /data is absent (the default local .venv is then used).
+SHARED_ENV=/data/envs/venv/oeconomia
+if [ -d /data/envs ] && [ ! -e .venv ]; then
+    [ -d "$SHARED_ENV" ] || uv venv "$SHARED_ENV" >/dev/null 2>&1 || true
+    [ -d "$SHARED_ENV" ] && ln -s "$SHARED_ENV" .venv
+fi
+
+# (b) Populate DVC-managed data from local cache.
 # DVC is in the "corpus" dependency group and needs a torch extra.
 if [ -f dvc.lock ]; then
     case "$(hostname)" in

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -17,9 +17,21 @@
 # symlink makes `uv run` error, so the shared env is created first. Skipped
 # where /data is absent (the default local .venv is then used).
 SHARED_ENV=/data/envs/venv/oeconomia
-if [ -d /data/envs ] && [ ! -e .venv ]; then
-    [ -d "$SHARED_ENV" ] || uv venv "$SHARED_ENV" >/dev/null 2>&1 || true
-    [ -d "$SHARED_ENV" ] && ln -s "$SHARED_ENV" .venv
+if [ -d /data/envs ]; then
+    # Create the shared env once. flock serializes the first-ever creation so
+    # concurrent worktree checkouts (parallel raids) don't race to build the
+    # same path; it is best-effort — without flock the env is still created.
+    {
+        flock 9 2>/dev/null || true
+        [ -d "$SHARED_ENV" ] || uv venv "$SHARED_ENV" >/dev/null 2>&1 || true
+    } 9>/data/envs/.oeconomia-env.lock
+    # Point .venv at the shared env when it is absent or a (possibly stale)
+    # symlink; leave a real local .venv directory untouched. ln -sfn is
+    # idempotent and replaces a dangling link, and may lose the race with a
+    # concurrent checkout harmlessly — the link ends up present either way.
+    if [ -d "$SHARED_ENV" ] && { [ ! -e .venv ] || [ -L .venv ]; }; then
+        ln -sfn "$SHARED_ENV" .venv 2>/dev/null || true
+    fi
 fi
 
 # (b) Populate DVC-managed data from local cache.

--- a/tests/test_post_checkout_hook.py
+++ b/tests/test_post_checkout_hook.py
@@ -32,3 +32,28 @@ def test_hook_runs_dvc_checkout():
 def test_hook_is_executable():
     """post-checkout must be executable."""
     assert HOOK.stat().st_mode & 0o111, "post-checkout hook is not executable"
+
+
+def test_hook_points_venv_at_shared_env_on_data():
+    """The hook must symlink .venv to a shared env that lives beside the uv
+    cache on /data, so uv hardlinks wheels instead of copying ~1.8 GB per
+    worktree (a cross-filesystem copy that makes worktree creation time out)."""
+    source = HOOK.read_text()
+    assert "/data/envs" in source
+    assert "ln -s" in source and ".venv" in source
+
+
+def test_hook_precreates_shared_env_before_symlinking():
+    """A dangling .venv symlink makes `uv run` error, so the shared env must be
+    created (uv venv) before the symlink is made."""
+    source = HOOK.read_text()
+    assert "uv venv" in source
+    # uv venv must appear before the symlink in the source order.
+    assert source.index("uv venv") < source.index("ln -s")
+
+
+def test_hook_skips_shared_env_without_data_filesystem():
+    """The shared-env step must be guarded so the default local .venv is used
+    where /data is absent (portability to machines without the data disk)."""
+    source = HOOK.read_text()
+    assert "[ -d /data/envs ]" in source

--- a/tests/test_post_checkout_hook.py
+++ b/tests/test_post_checkout_hook.py
@@ -57,3 +57,19 @@ def test_hook_skips_shared_env_without_data_filesystem():
     where /data is absent (portability to machines without the data disk)."""
     source = HOOK.read_text()
     assert "[ -d /data/envs ]" in source
+
+
+def test_hook_replaces_stale_venv_symlink():
+    """A dangling .venv symlink (target deleted) must not wedge the hook: use
+    ln -sfn so the link is replaced idempotently rather than erroring on a
+    pre-existing symlink, and only when .venv is absent or itself a symlink."""
+    source = HOOK.read_text()
+    assert "ln -sfn" in source
+    assert "[ -L .venv ]" in source
+
+
+def test_hook_serializes_concurrent_env_creation():
+    """Concurrent worktree checkouts (parallel raids) must not race to build the
+    shared env; the first-ever creation is serialized with flock."""
+    source = HOOK.read_text()
+    assert "flock" in source

--- a/tickets/0144-uv-env-on-data-filesystem.erg
+++ b/tickets/0144-uv-env-on-data-filesystem.erg
@@ -1,0 +1,69 @@
+%erg 0.1
+Title: Co-locate uv env with cache on /data so worktree creation stops copying 1.8 GB
+Created: 2026-06-18
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-18T00:00Z HDMX-coding-agent created
+2026-06-18T00:00Z HDMX-coding-agent note root cause + fix validated empirically on doudou
+
+--- body ---
+## Context
+Creating a worktree was painfully slow and now fails outright (EnterWorktree
+times out, leaving an orphan branch). Root cause: the uv cache lives on `/data`
+(`/data/cache/uv`, a separate filesystem) while the repos live on
+`/home/haduong`. uv hardlinks wheels from its cache into each project env, but
+only when cache and env share a filesystem. Across filesystems it falls back to
+**copying** the full torch closure (~1.8 GB, ~39 000 files) into every
+worktree's `.venv`. That copy is the "temps fou", and it now exceeds the
+worktree tool's timeout — turning a slow operation into a hard failure.
+
+The separate-filesystem placement of the cache is deliberate hygiene ("big
+regenerable things go on a separate disk"). The bug is that the principle was
+applied to the cache but not the env: the `.venv` is equally big, automatic and
+regenerable, yet it landed on `/home`. Fix = apply the principle consistently —
+put the env on `/data` too, beside the cache, so hardlinks work again.
+
+Mechanism chosen: symlink `.venv -> /data/envs/venv/oeconomia` (the house
+`/data/envs` convention). Filesystem-determined, so it works for every `uv run`
+regardless of which `.env`/secrets file is loaded — important now that secrets
+are being unified under `~/.config/keys`. A shared single env per project (all
+worktrees symlink to it) is simplest; the only trade-off is concurrent dep
+changes during a raid, negligible for a stable-deps paper repo (uv serializes
+env access anyway).
+
+Validated on doudou: a package installed into an env on `/data` is hardlinked
+to `/data/cache` (nlink=2, same device); a second worktree only creates a
+25-byte symlink instead of a 1.8 GB copy.
+
+## Relevant files
+- `hooks/post-checkout` — pre-create the shared env, symlink `.venv` to it,
+  then run the existing dvc checkout.
+- `tests/test_post_checkout_hook.py` — source-inspection tests for the new logic.
+
+## Actions
+1. In `hooks/post-checkout`, before the dvc-checkout block: if `/data/envs`
+   exists and `.venv` is absent, `uv venv` the shared env if missing (a dangling
+   symlink makes `uv run` error), then `ln -s` it to `.venv`. Guard on
+   `/data/envs` so machines without the data disk fall back to a local `.venv`.
+2. Add tests asserting the shared-env path, the symlink, the pre-create order,
+   and the `/data/envs` guard.
+
+## Test
+- `tests/test_post_checkout_hook.py::test_hook_points_venv_at_shared_env_on_data`
+  (red before the hook edit, green after).
+
+## Verification
+- [ ] `.venv` in a fresh worktree is a symlink to `/data/envs/venv/oeconomia`,
+      not a 1.8 GB directory.
+- [ ] A second worktree creation does no copy (env already populated).
+- [ ] `make check-fast` passes.
+
+## Invariants
+- Behaviour on a machine without `/data` is unchanged (local `.venv`).
+- The dvc checkout step is unchanged.
+- No dependency on any `.env`/secrets file for env location.
+
+## Exit criteria
+- Worktree creation no longer copies the torch closure; `.venv` is a symlink to
+  the shared `/data` env. Tests cover the logic. `make check-fast` green.

--- a/tickets/0144-uv-env-on-data-filesystem.erg
+++ b/tickets/0144-uv-env-on-data-filesystem.erg
@@ -2,11 +2,13 @@
 Title: Co-locate uv env with cache on /data so worktree creation stops copying 1.8 GB
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: Implemented: shared uv env on /data via symlinked .venv; PR #797
 
 --- log ---
 2026-06-18T00:00Z HDMX-coding-agent created
 2026-06-18T00:00Z HDMX-coding-agent note root cause + fix validated empirically on doudou
 
+2026-06-18T08:18Z HDMX-coding-agent closed — Implemented: shared uv env on /data via symlinked .venv; PR #797
 --- body ---
 ## Context
 Creating a worktree was painfully slow and now fails outright (EnterWorktree


### PR DESCRIPTION
## What

Worktree creation copied the full torch closure (~1.8 GB, ~39 000 files) into every worktree's `.venv`, and recently started **failing outright** (EnterWorktree times out, leaving an orphan branch).

**Root cause:** the uv cache lives on `/data` (`/data/cache/uv`, a separate filesystem) while repos live on `/home/haduong`. uv hardlinks wheels from cache into each env *only* when both share a filesystem; across filesystems it copies the whole closure. The cross-fs copy is the slowness, and it now exceeds the worktree tool's timeout.

**Fix:** apply the cache's own hygiene principle (big regenerable things on `/data`) to the env too. `hooks/post-checkout` now pre-creates a shared env at `/data/envs/venv/oeconomia` (beside the cache → uv hardlinks) and symlinks the worktree's `.venv` at it. A dangling symlink makes `uv run` error, hence the pre-create. Guarded on `/data/envs` so machines without the data disk keep a local `.venv`. Filesystem-determined — no `.env` dependency, consistent with unifying secrets under `~/.config/keys`.

## Evidence (doudou)

- torch `.so` in the shared env is hardlinked to `/data/cache` (`nlink=2`, same device).
- A second worktree creates only a **25-byte symlink** instead of a 1.8 GB copy.
- 7 hook tests green, ruff green on the diff.

## Heads-up: pre-existing red CI on main

`make check-fast` currently fails on `origin/main` (unrelated to this PR): `scripts/compute_crossyear_zscore.py:67` uses `Optional[pd.DataFrame]` (legacy typing, caught by `test_no_legacy_typing`). This one-liner blocks **all** PRs' CI until fixed; it is not in this diff. Suggest a separate tiny fix.

**Ticket:** tickets/0144-uv-env-on-data-filesystem.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)