### PR TITLE
fix: modernize legacy typing in compute_crossyear_zscore (unblock CI)

### DIFF
--- a/scripts/compute_crossyear_zscore.py
+++ b/scripts/compute_crossyear_zscore.py
@@ -21,7 +21,6 @@ Usage::
 import argparse
 import re
 import sys
-from typing import Optional
 
 import pandas as pd
 from pipeline_io import save_csv
@@ -64,7 +63,7 @@ def _subsample_percentiles(
 def compute_crossyear_zscores(
     df: pd.DataFrame,
     method: str,
-    subsample_df: Optional[pd.DataFrame] = None,
+    subsample_df: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
     """Compute cross-year Z-scores for all windows in df.
 


### PR DESCRIPTION
## What

`scripts/compute_crossyear_zscore.py` used `Optional[pd.DataFrame]` (legacy typing). `tests/test_script_hygiene.py::TestRuffModernPython::test_no_legacy_typing` (ruff UP035/UP045) caught it, failing `make check-fast` on `main` and blocking CI for **every** open PR.

## Fix

- `Optional[pd.DataFrame]` → `pd.DataFrame | None`
- drop the now-unused `from typing import Optional`

One-line behaviour-preserving change. `tests/test_script_hygiene.py` green (61 passed).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)