### PR TITLE
tickets: venv rotation (0145) + dvc-checkout worktree cost (0146)

### DIFF
--- a/tickets/0145-rotate-existing-venv-to-shared-symlink.erg
+++ b/tickets/0145-rotate-existing-venv-to-shared-symlink.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: Rotate existing real .venv directories into symlinks to the shared /data env
+Created: 2026-06-18
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-18T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #797 made the post-checkout hook symlink each new worktree's `.venv` to a
+shared env on `/data` (`/data/envs/venv/oeconomia`), so new worktrees no longer
+copy the ~1.8 GB torch closure. But pre-existing real `.venv` directories were
+not touched: the main checkout still carries a ~2 GB `.venv` on `/home`, and
+stale worktrees may too. They waste `/home` space and don't share the env.
+
+Rotate them into symlinks to the shared env — same end state the hook now
+produces for fresh worktrees.
+
+## Relevant files
+- `scripts/` — a small idempotent rotation script (new), e.g. `rotate-venv-to-shared.sh`.
+- The main checkout `.venv` (~2 GB) and any worktree `.venv` that is a real directory.
+
+## Actions
+1. Add an idempotent script that, for a given checkout (default: cwd) and when
+   `/data/envs/venv/oeconomia` exists: if `.venv` is a real directory (not a
+   symlink), remove it and `ln -sfn` the shared env in its place. Skip if `.venv`
+   is already a symlink or absent. Refuse if a process is using the venv (best
+   effort: check `lsof` / skip the running session's worktree).
+2. Run it once on doudou for the main checkout to reclaim the ~2 GB.
+
+## Test
+- `tests/` source-inspection or dry-run: running the script twice is a no-op the
+  second time (idempotent); a real `.venv` dir becomes a symlink; an existing
+  symlink is left intact.
+
+## Verification
+- [ ] Main checkout `.venv` is a symlink to `/data/envs/venv/oeconomia`.
+- [ ] `/home` space reclaimed (~2 GB).
+- [ ] Re-running the script changes nothing.
+
+## Invariants
+- Never delete a `.venv` that a running process holds open.
+- Per-machine: on padme, confirm `/data` disk speed first (it may be a slower
+  disk than the repo's; see PR #797 discussion).
+
+## Exit criteria
+- Existing real `.venv` directories on doudou are symlinks to the shared env;
+  the rotation script is idempotent and tested.

--- a/tickets/0146-post-checkout-dvc-checkout-blocks-worktree-creation.erg
+++ b/tickets/0146-post-checkout-dvc-checkout-blocks-worktree-creation.erg
@@ -1,0 +1,58 @@
+%erg 0.1
+Title: post-checkout dvc checkout copies 1.7 GB into every worktree, timing out creation
+Created: 2026-06-18
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-18T00:00Z HDMX-coding-agent created
+2026-06-18T00:00Z HDMX-coding-agent note unmasked by #797 (venv copy fixed; dvc checkout now the bottleneck)
+
+--- body ---
+## Context
+After PR #797 fixed the per-worktree venv copy, EnterWorktree still fails
+(times out). The remaining cost is the post-checkout hook's
+`uv run ... dvc checkout`, which populates ~1.7 GB of DVC-managed data into
+**every** worktree. Before #797 this step failed silently (`2>/dev/null || true`)
+because no working venv existed; now that the venv resolves, it actually runs.
+
+Two compounding issues:
+1. **Eager population.** Most worktrees (prose, tickets, code) never touch the
+   corpus data, yet the hook checks it out unconditionally on every creation.
+2. **Copy, not link.** The DVC cache is on the same filesystem as the repo
+   (`/home`, device 52), but DVC's default link type (`reflink,copy`) falls back
+   to copying on ext4 (no reflink). So checkout copies 1.7 GB instead of linking.
+
+This is the same anti-pattern #797 removed for the venv, now for data.
+
+## Relevant files
+- `hooks/post-checkout` — the unconditional `dvc checkout` block.
+- `.dvc/config`, `.dvc/config.local` — cache dir and (absent) `cache.type`.
+
+## Actions
+1. Make `dvc checkout` opt-in in the hook: skip by default, run only when the
+   worktree needs data (e.g. `WORKTREE_NEEDS_DATA=1`, or a marker file). New
+   worktrees then create instantly.
+2. Set DVC `cache.type = symlink` (or `hardlink` with `cache.protected = true`)
+   so that when checkout does run, it links from the same-filesystem cache
+   instead of copying. Verify read-only corpus access still works through the
+   loaders.
+
+## Test
+- Hook source-inspection: `dvc checkout` is guarded, not unconditional.
+- Integration: creating a worktree without the data flag performs no 1.7 GB
+  copy (data dir stays empty / linked, creation is fast).
+
+## Verification
+- [ ] EnterWorktree completes in seconds without the data flag.
+- [ ] With the flag (or on demand), data is populated via links, not copies.
+- [ ] `make` analysis targets still read the corpus correctly.
+
+## Invariants
+- Phase separation: a writing-side build must still work from handoff artifacts
+  alone; this change must not make analysis silently run on missing data —
+  fail loud if data is required but absent.
+- Per-machine: padme uses an ssh DVC remote; confirm link type there too.
+
+## Exit criteria
+- Worktree creation no longer blocks on a 1.7 GB dvc checkout; data is populated
+  on demand and via links rather than copies.


### PR DESCRIPTION
Two follow-up tickets from PR #797 (uv env on /data).

- **0145** — rotate pre-existing real `.venv` directories (the ~2 GB main-checkout `.venv` on `/home`, stale worktrees) into symlinks to the shared `/data/envs/venv/oeconomia`. Same end state #797 gives fresh worktrees; reclaims `/home` space.
- **0146** — the venv fix unmasked the real remaining bottleneck: `hooks/post-checkout` runs `dvc checkout`, copying ~1.7 GB of DVC data into **every** worktree (DVC cache is same-fs but default link type copies on ext4). This is why EnterWorktree still times out. Make it opt-in and link-not-copy.

Filing only; no code change. `erg check` PASS.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)