### PR TITLE
R&R revision pipeline: version ladder (v2.0.2–v2.0.5) + prose ratchet plan

### DIFF
--- a/tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg
+++ b/tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg
@@ -2,16 +2,9 @@
 Title: Oeconomia R&R — resubmission tracking ticket
 Created: 2026-06-18
 Author: HDMX-coding-agent
-Blocked-by: 0134
-Blocked-by: 0135
-Blocked-by: 0136
-Blocked-by: 0137
-Blocked-by: 0138
-Blocked-by: 0139
-Blocked-by: 0140
-Blocked-by: 0141
-Blocked-by: 0142
-Blocked-by: 0143
+Blocked-by: 0154
+Blocked-by: 0155
+Blocked-by: 0156
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -28,6 +21,18 @@ Recommendations: R1 "Resubmit for Review", R2 "Revisions Required".
 This is a **tracking ticket** — stays open until every child below is closed,
 then a final integration pass verifies the resubmission cover letter answers
 every referee point (addressed or declined-with-reason).
+
+## Version ladder (gating)
+Execution is sequenced as shippable version increments, each gated by a version
+tracker (closing a tracker unlocks the next version's work via Blocked-by):
+- **v2.0.1** ✅ Vannes communication (de-anon + render; uploaded). Separate branch.
+- **v2.0.2** light & easy fixes (0140 safe subset; DAC/GNI/GEF done, PR #796).
+- **v2.0.3** prose ratchet → tracker **0154** (0147 harness, 0148 brief+polarity, 0149 initialize+triage).
+- **v2.0.4** orientation & decisions → tracker **0155** (0142 structure, 0150 economists framing, 0151 indeterminacy thesis; all needs-human, I draft options).
+- **v2.0.5** implementation → tracker **0156** (0134–0139, 0141, 0143 content; 0152 response letter; 0153 resubmission + deposit).
+This master is now Blocked-by the three version trackers (0154/0155/0156), not the
+ten leaves directly. The original child-ticket inventory below is unchanged; the
+trackers group them by version.
 
 ## Child tickets (workstreams)
 - [ ] 0134 — prose pass: define-by-negation, empty declaratives, formulaic closers (editor E1 + R2 prose). **The single most-emphasized issue.**

--- a/tickets/0134-r-r-prose-pass-eliminate-define-by-negat.erg
+++ b/tickets/0134-r-r-prose-pass-eliminate-define-by-negat.erg
@@ -2,9 +2,12 @@
 Title: R&R prose pass — eliminate define-by-negation, empty declaratives, formulaic closers
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0147
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
+2026-06-18T08:25Z HDMX-coding-agent note v2.0.5. Re-scoped: this is now the human-led prose rewrite that drives the ratchet ceilings (0147) down; the mechanical defect-guards live in the ratchet, not here. Run last in v2.0.5, after 0141 fills the concrete content. Blocked-by 0147 (guard) + 0155 (version gate).
 
 --- body ---
 ## Context

--- a/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
+++ b/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
@@ -2,9 +2,11 @@
 Title: R&R reframe the economists claim — economic rationality vs individual economists
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
+2026-06-18T08:25Z HDMX-coding-agent note Framing decision (old action 1) extracted to 0150 (needs-human, v2.0.4). This ticket is execution only: propagate the chosen framing once 0150 lands. v2.0.5 (Blocked-by 0155).
 
 --- body ---
 ## Context

--- a/tickets/0136-r-r-integrate-quantitative-analysis-with.erg
+++ b/tickets/0136-r-r-integrate-quantitative-analysis-with.erg
@@ -2,9 +2,11 @@
 Title: R&R integrate quantitative analysis with the historical argument and justify methods
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
+2026-06-18T08:25Z HDMX-coding-agent note Indeterminacy-thesis + quant-role decision (old action 0) extracted to 0151 (needs-human, v2.0.4). This ticket keeps methods-justification, Table1/Fig2 directionality, burden-sharing divergence. v2.0.5 (Blocked-by 0155).
 
 --- body ---
 ## Context

--- a/tickets/0137-r-r-make-commensuration-economisation-th.erg
+++ b/tickets/0137-r-r-make-commensuration-economisation-th.erg
@@ -2,6 +2,7 @@
 Title: R&R make commensuration economisation the structuring thread
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0138-r-r-add-loss-and-damage-insurance-logic.erg
+++ b/tickets/0138-r-r-add-loss-and-damage-insurance-logic.erg
@@ -2,6 +2,7 @@
 Title: R&R add loss and damage insurance logic as challenge to the thesis
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
+++ b/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
@@ -2,6 +2,7 @@
 Title: R&R situate climate finance in the finance-development nexus
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0140-r-r-define-terms-at-first-use-and-reduce.erg
+++ b/tickets/0140-r-r-define-terms-at-first-use-and-reduce.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
+2026-06-18T08:25Z HDMX-coding-agent note v2.0.2. Trimmed to the safe factual define-at-first-use subset (DAC/GNI/GEF done, PR #796). Substantive definitions (Rio-markers function, Barnesian, CDM-in-practice) move to 0141 / implementation. Closeable when the v2.0.2 subset ships.
 2026-06-18T06:45Z HDMX-coding-agent note expanded acronyms at first use: DAC, GNI, GEF (safe factual edits). Substantive jargon defs (Rio markers function, concessional/grant-element/face-value, Barnesian form, CDM in practice) left for the author per editor's human-engagement mandate.
 
 --- body ---

--- a/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
+++ b/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
@@ -2,6 +2,7 @@
 Title: R&R concretize actors sites and mechanisms across flagged passages
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0142-r-r-restructure-around-institutional-rup.erg
+++ b/tickets/0142-r-r-restructure-around-institutional-rup.erg
@@ -2,6 +2,8 @@
 Title: R&R restructure around institutional ruptures vs chronology
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Label: needs-human
+Blocked-by: 0154
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -2,9 +2,11 @@
 Title: R&R bibliography additions Golka Escobar Mitchell King-Levine Aghion-Bolton
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0155
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
+2026-06-18T08:25Z HDMX-coding-agent note needs-human micro-decision: author must name the exact Escobar and Mitchell works before entries are added (derisk fabrication). v2.0.5 (Blocked-by 0155).
 
 --- body ---
 ## Context

--- a/tickets/0147-prose-ratchet-harness-manuscript-source.erg
+++ b/tickets/0147-prose-ratchet-harness-manuscript-source.erg
@@ -1,0 +1,35 @@
+%erg 0.1
+Title: prose ratchet harness — manuscript_source substrate + negative-guard tests + ceiling files
+Created: 2026-06-18
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+v2.0.3 infrastructure. Build the NEGATIVE half of the prose ratchet, ported from
+the AEDIST / Econom'IA technical report (the mature model) and the book proposal.
+Per the CI test-polarity rule (added in 0148): tests pin only negative guards +
+mechanical checks; positive voice lives in the editorial brief.
+
+## Relevant prior art
+- AEDIST: `tests/manuscript_source.py` (substrate), `tests/test_manuscript_*` (parametrized regex bans), `tests/data/emdash_ceiling.txt` (committed integer ceiling, only ratchets down).
+- This repo: `config/ai-tells.yml` (seed wordlists), `scripts/qa_word_count.py` (PDF-based checks to fold in, source-based + line-anchored).
+
+## Actions
+1. `tests/manuscript_source_qmd.py` — load `content/manuscript.qmd`; strip YAML front-matter, HTML/`%` comments, blockquotes/quoted spans, code; expose `body()`, `section(heading)`, `paragraphs()`, `abstract()`.
+2. `tests/test_manuscript_prose.py` (`pytestmark = pytest.mark.adherence`) — parametrized regex bans, seeded as the UNION of:
+   - ai-tells.yml blacklist words/phrases + conditional words (`robust`, `landscape`).
+   - reviewer/v2.0.2 defects: define-by-negation (`not X, but Y`; "not natural categories but historical constructs"), empty paragraph-closers, repeated-high-level-claim openers.
+   - AEDIST defect classes: AI-English doublets, lab-journal connectives, forward-promises, hardcoded cross-ref numbers (require `@ref`), hedging conditionals.
+3. Ceiling files `tests/data/*_ceiling.txt` for density metrics (em-dash count, `not X but Y` count) — init at current count, only ratchet down; per-paragraph local caps as constants.
+4. Register the `adherence` marker in `pyproject.toml`.
+
+## Test
+- Red first: a known-bad fixture string trips each guard. Green: the guards import the substrate and run under `pytest -m adherence`.
+
+## Exit criteria
+- [ ] `pytest -m adherence tests/test_manuscript_prose.py` runs; every defect class has a guard
+- [ ] Ceiling files committed; lowering one is the only way to pass after a reduction
+- [ ] `adherence` marker registered

--- a/tickets/0148-editorial-brief-ci-test-polarity-rule-ll.erg
+++ b/tickets/0148-editorial-brief-ci-test-polarity-rule-ll.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: editorial brief + CI test-polarity rule + LLM-judge wiring
+Created: 2026-06-18
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+v2.0.3 infrastructure. The POSITIVE half + governance. Ported from AEDIST
+`docs/editorial-brief.md` and its CI test-polarity rule.
+
+## Actions
+1. Create `docs/editorial-brief.md` (schema: **Decision** / **Rationale** / **Ticket** / **Status**). Seed from `.claude/rules/writing.md` ghost-mode + house rules (define-at-first-use, concrete actors/dates, North-South specificity) and — once 0150/0151 land — the framing + thesis decisions.
+2. Add the **CI test-polarity rule** to `.claude/rules/writing.md`: tests pin only negative guards + mechanical checks; positive authorial phrasing is never asserted in tests — it lives in the brief and is checked by `/review-pr-prose`. Keep terse — `TestAlwaysLoadedContextBudget` caps always-loaded rules at 300 lines.
+3. Wire the `/review-pr-prose` brief-auditor agent to read `docs/editorial-brief.md`.
+4. LLM-judge harness with AEDIST reduction guards: output words ≤ input, em-dash=0 in abstract, every number/claim preserved verbatim, no invented summary verdicts.
+
+## Exit criteria
+- [ ] `docs/editorial-brief.md` exists and is consumed by `/review-pr-prose`
+- [ ] writing.md carries the polarity rule; context-budget test still green
+- [ ] LLM-judge guards documented and runnable

--- a/tickets/0149-initialize-prose-ratchet-over-manuscript.erg
+++ b/tickets/0149-initialize-prose-ratchet-over-manuscript.erg
@@ -1,0 +1,25 @@
+%erg 0.1
+Title: initialize prose ratchet over manuscript and triage findings
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0147
+Blocked-by: 0148
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+v2.0.3. With the ratchet (0147) and brief (0148) in place, run it over the WHOLE
+manuscript. The point: surface defects the referees never named.
+
+## Actions
+1. Run the `@adherence` prose suite + `/review-pr-prose` over `content/manuscript.qmd`.
+2. Enumerate every current violation (this is the defect inventory beyond the referee list).
+3. Fix the trivial ones in this version (then lower the ceiling files).
+4. File each non-trivial violation (needs author prose) as an implementation finding referencing 0156.
+
+## Exit criteria
+- [ ] Full-manuscript ratchet run produces an enumerated findings list
+- [ ] Trivial violations fixed; ceilings lowered to the new counts
+- [ ] Non-trivial findings ticketed under v2.0.5

--- a/tickets/0150-decision-economists-vs-diffusion-of-econ.erg
+++ b/tickets/0150-decision-economists-vs-diffusion-of-econ.erg
@@ -1,0 +1,26 @@
+%erg 0.1
+Title: decision — economists vs diffusion of economic rationality framing
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Label: needs-human
+Blocked-by: 0154
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Author-only call (R1 §1, editor E2). The paper attributes climate-finance
+construction to "economists," but named actors are policy professionals and
+Table 2 shows no economics-journal venues. I draft the options; author decides.
+
+## Deliverable (I prepare)
+A one-page memo with 2-3 framings, tradeoffs, my recommendation, and the
+1-paragraph claim each implies:
+- A. Diffusion of economic *rationality* into institutional practice (recommended — corpus-supported).
+- B. Genuinely individual economists (requires new intellectual-resource evidence).
+- C. Hybrid: rationality-diffusion as spine, named economists as carriers.
+
+## Exit criteria
+- [ ] Author selects a framing; the 1-paragraph claim is recorded here
+- [ ] Decision propagated to the editorial brief (0148) — gates 0135, 0139

--- a/tickets/0151-decision-how-to-state-the-indeterminacy.erg
+++ b/tickets/0151-decision-how-to-state-the-indeterminacy.erg
@@ -1,0 +1,25 @@
+%erg 0.1
+Title: decision — how to state the indeterminacy thesis and the quant role
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Label: needs-human
+Blocked-by: 0154
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Author-only call (R2's headline "potentially innovative" point + editor E4). The
+central claim — categories made climate finance measurable AND contestable
+because the qualitative→quantitative translation is indeterminate — must be
+stated explicitly, and the quant's role framed (confirmatory / exploratory /
+generative).
+
+## Deliverable (I prepare)
+A memo with 2-3 ways to phrase the thesis + the role-framing options, tradeoffs,
+recommendation, and the 1-paragraph statement each implies.
+
+## Exit criteria
+- [ ] Author selects the thesis statement + quant role; recorded here
+- [ ] Propagated to the editorial brief (0148) — gates 0136, 0137, 0134

--- a/tickets/0152-response-to-reviewers-letter-per-remark.erg
+++ b/tickets/0152-response-to-reviewers-letter-per-remark.erg
@@ -1,0 +1,22 @@
+%erg 0.1
+Title: response to reviewers letter + per-remark traceability table
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0155
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+v2.0.5. The binding deliverable of the resubmission: a letter answering every
+editor/R1/R2 point. Template: `release/revision-runbook.md` §4.
+
+## Actions
+1. One numbered response per remark (addressed / declined-with-reason), quoting the referee.
+2. Traceability table: remark → manuscript §/page → diff/commit.
+3. Decline-with-reason entries where applicable (e.g., 0142 if the 3-act structure is kept).
+
+## Exit criteria
+- [ ] Every point in the 0133 inventory has a response
+- [ ] Letter saved under `release/YYYY-MM-DD Oeconomia revision/`

--- a/tickets/0153-resubmission-rebuild-verify-version-bump.erg
+++ b/tickets/0153-resubmission-rebuild-verify-version-bump.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: resubmission rebuild verify version-bump and Zenodo HAL deposit
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0155
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+v2.0.5 final step. Package and deposit the revised manuscript.
+
+## Actions
+1. `make manuscript` + `make check`; `@adherence` prose ratchet green; `/review-pr-prose` clean.
+2. Version bump (manuscript-vars / config snapshot only if numbers changed — most edits are prose).
+3. Zenodo new-version (not new record) + HAL; update STATE.md links.
+4. submission-branch Revision-stage cherry-picks to `submission/oeconomia-varia`; tag `v1.1-oeconomia-revised`.
+5. Upload revised PDF + response letter via the Œconomia platform "Revisions" form.
+
+## Exit criteria
+- [ ] Clean build + green ratchet
+- [ ] Zenodo/HAL revised; tag pushed; resubmitted on platform

--- a/tickets/0154-v2-0-3-ratchet-version-tracker.erg
+++ b/tickets/0154-v2-0-3-ratchet-version-tracker.erg
@@ -1,0 +1,24 @@
+%erg 0.1
+Title: v2.0.3 ratchet — version tracker
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0147
+Blocked-by: 0148
+Blocked-by: 0149
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Version-milestone tracker for **v2.0.3 — prose ratchet infrastructure**. Gate:
+while this ticket is open, v2.0.4 work (blocked by it) stays hidden from
+`erg ready`. Closing it = "ratchet shipped, decisions unlock."
+
+## Children
+- [ ] 0147 prose-ratchet harness (substrate + negative guards + ceilings)
+- [ ] 0148 editorial brief + CI polarity rule + LLM judge
+- [ ] 0149 initialize ratchet over manuscript + triage findings
+
+## Exit criteria
+- [ ] 0147, 0148, 0149 closed; `make check` runs the prose ratchet green

--- a/tickets/0155-v2-0-4-decisions-version-tracker.erg
+++ b/tickets/0155-v2-0-4-decisions-version-tracker.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: v2.0.4 decisions — version tracker
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0142
+Blocked-by: 0150
+Blocked-by: 0151
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Version-milestone tracker for **v2.0.4 — orientation & decisions**. Blocked by
+v2.0.3 (0154). Gate: while open, v2.0.5 implementation work stays hidden.
+
+## Children
+- [ ] 0142 structure decision (3-act vs ruptures)
+- [ ] 0150 economists-framing decision
+- [ ] 0151 indeterminacy-thesis decision
+
+## Exit criteria
+- [ ] All three decisions recorded and propagated to `docs/editorial-brief.md`

--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: v2.0.5 implementation — version tracker
+Created: 2026-06-18
+Author: HDMX-coding-agent
+Blocked-by: 0134
+Blocked-by: 0135
+Blocked-by: 0136
+Blocked-by: 0137
+Blocked-by: 0138
+Blocked-by: 0139
+Blocked-by: 0141
+Blocked-by: 0143
+Blocked-by: 0152
+Blocked-by: 0153
+
+--- log ---
+2026-06-18T08:50Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Version-milestone tracker for **v2.0.5 — implementation** (research → writing →
+verification → resubmission). Blocked by v2.0.4 (0155).
+
+## Children
+- [ ] 0135 reframe economists · 0136 quant integration + methods · 0137 commensuration thread
+- [ ] 0138 loss & damage · 0139 finance-development nexus · 0141 concretize actors
+- [ ] 0143 bibliography additions
+- [ ] 0134 human-led prose rewrite (ratchet-guarded; run last)
+- [ ] 0152 response-to-reviewers letter · 0153 resubmission + deposit
+
+## Exit criteria
+- [ ] All children closed; resubmitted to Œconomia; closes master tracker 0133

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -35,6 +35,7 @@ Rules agents must know:
 - Closed/not-closed is inferred from path conventions or a non-empty `Closed:` header
 - `Label:` is optional and repeatable; accepted values are defined in `tickets/.ergrc` (defaults: `needs-human`, `deferred`)
 - Log entries are append-only: `YYYY-MM-DDTHH:MMZ author verb detail`
+- Ticket IDs are atomic 4-digit numbers — never suffix them (`0134a`, `0134b`). To split a ticket, create new numbered tickets with descriptive slugs that cross-reference the parent in their body; on ID collision, renumber to the next free ID (`git mv` + fix cross-references).
 - Artifacts a ticket consumes or produces (reports, data, generated files, scripts) live in their natural location in the project tree and are referenced from the body by path, not embedded wholesale, and not kept as a filename-twinned `0002-slug.md` sidecar the tooling cannot track.
 
 On GitHub, `tickets/erg-github` (a separate committed helper, not an `erg` subcommand) adds a `verify` check that fails a PR referencing a still-open ticket -- so close the ticket in the same PR (`erg close`).


### PR DESCRIPTION
Restructures the Œconomia R&R execution from a flat ticket tree into **version increments**, each shippable and gated by a version-tracker ticket.

## Version ladder
- **v2.0.1** ✅ Vannes communication (uploaded; separate branch)
- **v2.0.2** light & easy fixes — 0140 safe subset (DAC/GNI/GEF done in #796)
- **v2.0.3** prose ratchet (tracker **0154**) — 0147 harness (substrate + negative guards + ceiling files, ported from AEDIST), 0148 editorial brief + CI test-polarity rule + LLM judge, 0149 initialize over the manuscript + triage findings *(catches defects beyond the referee list)*
- **v2.0.4** decisions (tracker **0155**) — 0142 structure, 0150 economists framing, 0151 indeterminacy thesis. All `needs-human`; I draft 2-3 options + recommendation, author picks.
- **v2.0.5** implementation (tracker **0156**) — 0134–0143 content, 0152 response-to-reviewers letter, 0153 resubmission + Zenodo/HAL deposit

## Gating mechanism
Each version-tracker is `Blocked-by` its children; the next version's work is `Blocked-by` the prior tracker. So `erg ready` surfaces only the current front — verified: it shows 0140, 0147, 0148 and hides everything downstream. Master **0133** is now `Blocked-by` the three trackers (two-level tree).

## Also
- Framing/thesis decisions extracted from 0135/0136 into `needs-human` 0150/0151 (no `a/b/c` suffixes — new full IDs).
- **Anti-suffix rule** added to `tickets/AGENTS.md` per request (atomic 4-digit IDs; split into new numbered tickets). Note: AGENTS.md is a vendored `erg` asset — this rule should also be upstreamed to git-erg so `erg migrate` doesn't revert it.

`erg check` PASS (150 tickets). Plan: `/home/haduong/.claude/plans/swift-dancing-conway.md`.

Ticket-ref: tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)