### PR TITLE
fix(0146): stop eager dvc checkout in worktree hook; add 'make data'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-fast smoke benchmark determinism-check regression regression-update check-corpus check-manuscript-data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
+.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-fast smoke benchmark determinism-check regression regression-update check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
 
 .DEFAULT_GOAL := manuscript
 
@@ -255,6 +255,13 @@ corpus-sync:
 	@[ "$$(hostname)" != "padme" ] || { echo "error: use 'make corpus' on padme, not corpus-sync."; exit 1; }
 	git pull
 	$(UV_RUN) dvc pull --force
+
+# Populate this worktree's DVC data from the local cache (no network).
+# Worktree creation no longer does this eagerly (it timed out copying ~1.7 GB);
+# run this on demand when a worktree actually needs the corpus data. Use
+# corpus-sync instead to also fetch from the padme remote.
+data:
+	$(UV_RUN) dvc checkout
 
 # Individual stage aliases.
 corpus-discover:

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -4,10 +4,12 @@
 # .env and .dvc/config.local are handled by .worktreeinclude (auto-copied
 # into worktrees created by EnterWorktree / `claude --worktree`).
 #
-# This hook (a) points the worktree's uv environment at a shared env that lives
-# on the same filesystem as the uv cache, then (b) populates DVC-managed data.
+# This hook only co-locates the worktree's uv environment with the uv cache so
+# worktree creation stays fast. It does NOT populate DVC data: doing that eagerly
+# copied ~1.7 GB into every worktree and timed out creation. Data is now fetched
+# on demand with `make data` (see the Makefile).
 
-# (a) Co-locate the uv project environment with the uv cache on /data.
+# Co-locate the uv project environment with the uv cache on /data.
 # uv hardlinks wheels from its cache into the environment, but only when both
 # share a filesystem; across filesystems it falls back to copying the whole
 # torch closure (~1.8 GB) into every worktree, which is slow enough to exceed
@@ -32,15 +34,4 @@ if [ -d /data/envs ]; then
     if [ -d "$SHARED_ENV" ] && { [ ! -e .venv ] || [ -L .venv ]; }; then
         ln -sfn "$SHARED_ENV" .venv 2>/dev/null || true
     fi
-fi
-
-# (b) Populate DVC-managed data from local cache.
-# DVC is in the "corpus" dependency group and needs a torch extra.
-if [ -f dvc.lock ]; then
-    case "$(hostname)" in
-        padme) extra=cu130 ;;
-        *)     extra=cpu ;;
-    esac
-    envflag=""; [ -f .env ] && envflag="--env-file .env"
-    uv run $envflag --group corpus --extra "$extra" dvc checkout 2>/dev/null || true
 fi

--- a/tests/test_post_checkout_hook.py
+++ b/tests/test_post_checkout_hook.py
@@ -1,7 +1,9 @@
 """Tests for worktree setup: post-checkout hook and .worktreeinclude.
 
 .worktreeinclude auto-copies .env and .dvc/config.local into worktrees
-created by EnterWorktree. The post-checkout hook handles DVC data only.
+created by EnterWorktree. The post-checkout hook only co-locates the uv
+environment; DVC data is populated on demand via `make data`, never
+eagerly at checkout time.
 """
 
 from pathlib import Path
@@ -9,6 +11,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 HOOK = REPO / "hooks" / "post-checkout"
 WORKTREEINCLUDE = REPO / ".worktreeinclude"
+MAKEFILE = REPO / "Makefile"
 
 
 def test_worktreeinclude_copies_env():
@@ -23,10 +26,21 @@ def test_worktreeinclude_copies_dvc_config():
     assert ".dvc/config.local" in contents
 
 
-def test_hook_runs_dvc_checkout():
-    """post-checkout hook must run dvc checkout for data population."""
+def test_hook_does_not_eagerly_checkout_data():
+    """The hook must NOT run dvc checkout: that copied ~1.7 GB of DVC data into
+    every worktree, timing out creation. Data population moved to `make data`."""
     source = HOOK.read_text()
-    assert "dvc checkout" in source
+    assert "dvc checkout" not in source
+
+
+def test_makefile_data_target_checks_out_dvc():
+    """Data is populated on demand: `make data` runs dvc checkout from the local
+    cache (no network), so a worktree fetches data only when it actually needs it."""
+    source = MAKEFILE.read_text()
+    assert "\ndata:" in source
+    # the data target's recipe runs dvc checkout
+    recipe = source.split("\ndata:", 1)[1].split("\n\n", 1)[0]
+    assert "dvc checkout" in recipe
 
 
 def test_hook_is_executable():

--- a/tickets/0146-post-checkout-dvc-checkout-blocks-worktree-creation.erg
+++ b/tickets/0146-post-checkout-dvc-checkout-blocks-worktree-creation.erg
@@ -2,11 +2,13 @@
 Title: post-checkout dvc checkout copies 1.7 GB into every worktree, timing out creation
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: Hook no longer eager-checkouts DVC; 'make data' on demand; cache.type=symlink on doudou
 
 --- log ---
 2026-06-18T00:00Z HDMX-coding-agent created
 2026-06-18T00:00Z HDMX-coding-agent note unmasked by #797 (venv copy fixed; dvc checkout now the bottleneck)
 
+2026-06-18T09:02Z HDMX-coding-agent closed — Hook no longer eager-checkouts DVC; 'make data' on demand; cache.type=symlink on doudou
 --- body ---
 ## Context
 After PR #797 fixed the per-worktree venv copy, EnterWorktree still fails


### PR DESCRIPTION
## What

Completes the worktree-creation fix. #797 made `.venv` a symlink; this removes the *other* per-worktree cost: `hooks/post-checkout` ran `dvc checkout` on every creation, copying ~1.7 GB of DVC data in. That is what still timed out EnterWorktree after #797.

- **Hook**: drop the `dvc checkout` block. Worktree creation now only symlinks the shared uv env — fast, data-free.
- **Makefile**: `make data` → `$(UV_RUN) dvc checkout`, to populate this worktree's data from the local cache on demand (no network). Added to `.PHONY` (a `data/` directory exists, which would otherwise shadow the target). `corpus-sync` still does the full remote pull.
- **Tests**: the hook must NOT run dvc checkout; `make data` must.

## Per-machine companion (not in this diff)

`.dvc/config.local` is gitignored. On doudou I set `cache.type = symlink` + `cache.protected = true` so `make data` links instead of copies. Deliberately **not** tracked: it is safe on doudou (read-only consumer) but unsafe on padme (the Phase-1 data producer, which rewrites DVC outs).

## Verification

- TDD red→green; `make check-fast`: **1001 passed**. ruff + shellcheck clean. `make -n data` parses. DVC `cache.type=symlink` confirmed on a scratch repo (checkout produces a symlink into the cache, file readable).

**Ticket:** tickets/0146-post-checkout-dvc-checkout-blocks-worktree-creation.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)