### PR TITLE
chore: archive RDJ4HSS "sent for review" notification

### DIFF
--- a/release/2026-03-26 RDJ4HSS/20260504102816_Your submission has been sent for review.txt
+++ b/release/2026-03-26 RDJ4HSS/20260504102816_Your submission has been sent for review.txt
@@ -1,0 +1,28 @@
+Your submission has been sent for review
+
+    From: Cédric Chambru via Openjournals <info@openjournals.nl>
+       To: Minh Ha-Duong <minh.ha-duong@cnrs.fr>
+Reply-To: Cédric Chambru <cedric.chambru@ens-lyon.fr>
+    Date: Mon, 04 May 2026 10:28:16 +0200
+
+
+Dear Minh Ha-Duong,
+
+I am pleased to inform you that an editor has reviewed your submission, A Curated Corpus of
+Climate Finance Literature, 1990–2024: Six Sources, Multilingual Retrieval, and Grey Literature, and
+has decided to send it for peer review. An editor will identify qualified reviewers who will provide
+feedback on your submission.
+
+This journal conducts double-anonymous peer review. The reviewers will not see any identifying
+information about you or your co-authors. Similarly, you will not know who reviewed your
+submission, and you will not hear from the reviewers directly. You will hear from us with feedback
+from the reviewers and information about the next steps.
+
+Please note that sending the submission to peer review does not guarantee that it will be
+published. We will consider the reviewers' recommendations before deciding to accept the
+submission for publication. You may be asked to make revisions and respond to the reviewers'
+comments before a final decision is made.
+
+If you have any questions, please contact me from your submission dashboard.
+
+Cédric Chambru


### PR DESCRIPTION
Archives the 04 May 2026 RDJ4HSS notice that the data-paper submission cleared editorial screening and went to double-anonymous peer review.

Stored as `.txt` (verbatim from the PDF email export) to match the existing sibling in `release/2026-03-26 RDJ4HSS/` — the 2026-03-26 acknowledgement is also `.txt` — and to stay under the 500KB pre-commit large-file guard (the source PDF was 763KB).

The file was sitting untracked in the working tree; `release/` is the append-only archive where it belongs.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)