### PR TITLE
chore(0145): close — main .venv rotated to shared-env symlink

### DIFF
--- a/tickets/closed/0145-rotate-existing-venv-to-shared-symlink.erg
+++ b/tickets/closed/0145-rotate-existing-venv-to-shared-symlink.erg
@@ -2,10 +2,12 @@
 Title: Rotate existing real .venv directories into symlinks to the shared /data env
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: Main checkout .venv rotated to a symlink to the shared /data env (~2 GB reclaimed); script approach scrapped as single-use per user
 
 --- log ---
 2026-06-18T00:00Z HDMX-coding-agent created
 
+2026-06-18T10:11Z HDMX-coding-agent closed — Main checkout .venv rotated to a symlink to the shared /data env (~2 GB reclaimed); script approach scrapped as single-use per user
 --- body ---
 ## Context
 PR #797 made the post-checkout hook symlink each new worktree's `.venv` to a


### PR DESCRIPTION
Closes ticket 0145. The main checkout's 2 GB real .venv was rotated to a symlink to /data/envs/venv/oeconomia by hand (single-use op; reusable-script approach scrapped per user). erg check PASS.

**Ticket:** tickets/0145-rotate-existing-venv-to-shared-symlink.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)