### PR TITLE
fix(make): run pytest via `python -m`, add $(PYTHON) macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ content/*-vars.yml
 !content/manuscript-vars.yml
 
 # Python / uv
-.venv/
+.venv
 __pycache__/
 *.pyc
 .mypy_cache/

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/data/envs/venv/oeconomia

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/data/envs/venv/oeconomia

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ export SOURCE_DATE_EPOCH := 0
 # ~/.bashrc isn't sourced — uv lives in ~/.local/bin by default.
 UV      ?= uv
 UV_RUN  ?= $(UV) run $(if $(wildcard .env),--env-file .env,)
+# Run Python through uv (via `python -m`, never the generated console scripts —
+# their shebangs point at the building worktree and break when it is removed).
+PYTHON  ?= $(UV_RUN) python
 export PATH := $(HOME)/.local/bin:$(PATH)
 
 # ── Modular Makefile includes ────────────────────────────
@@ -289,7 +292,7 @@ deploy-corpus:
 # ── Corpus diagnostics (Phase 1 — reads enrichment caches) ──
 content/tables/qa_citations_report.json: scripts/qa_citations.py scripts/utils.py \
 		$(DATA_DIR)/citations.csv
-	$(UV_RUN) python $<
+	$(PYTHON) $<
 
 # ═══════════════════════════════════════════════════════════
 # PHASE 2 — Analysis & Figures (fast, deterministic, run often)
@@ -304,10 +307,10 @@ content/tables/qa_citations_report.json: scripts/qa_citations.py scripts/utils.p
 # Embeddings stay as .npz (already binary). One conversion pass (~5s) replaces
 # ~48s of repeated CSV parsing across 25 Phase 2 script invocations.
 $(REFINED_FTH): $(REFINED)
-	$(UV_RUN) python -c "import pandas as pd; pd.read_csv('$<').to_feather('$@')"
+	$(PYTHON) -c "import pandas as pd; pd.read_csv('$<').to_feather('$@')"
 
 $(REFINED_CIT_FTH): $(REFINED_CIT)
-	$(UV_RUN) python -c "import pandas as pd; pd.read_csv('$<', low_memory=False).to_feather('$@')"
+	$(PYTHON) -c "import pandas as pd; pd.read_csv('$<', low_memory=False).to_feather('$@')"
 
 corpus-handoff: check-corpus $(REFINED_FTH) $(REFINED_CIT_FTH)
 
@@ -327,20 +330,20 @@ check-manuscript-data:
 	$$ok || { echo "Run '$(UV_RUN) dvc pull' to sync data, or 'make corpus' to rebuild."; exit 1; }
 
 corpus-validate: $(REFINED)
-	$(UV_RUN) python -m pytest tests/test_corpus_acceptance.py -v -s --tb=long
+	$(PYTHON) -m pytest tests/test_corpus_acceptance.py -v -s --tb=long
 
 # ── Corpus reporting (Phase 2 — reads only refined data) ──
 content/tables/tab_citation_coverage.md: scripts/export_citation_coverage.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/tables/tab_venues.md: scripts/export_tab_venues.py scripts/utils.py $(REFINED) content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/tables/tab_corpus_sources.csv content/tables/tab_corpus_sources.md &: scripts/export_corpus_table.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/tables/tab_languages.md: scripts/export_language_table.py scripts/utils.py $(ENRICHED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 corpus-tables: content/tables/tab_corpus_sources.csv content/tables/tab_corpus_sources.md \
                content/tables/tab_citation_coverage.md \
@@ -362,7 +365,7 @@ $(COMPUTED_STATS) &: scripts/compute_vars.py scripts/utils.py $(REFINED) \
 		$(wildcard $(DATA_DIR)/citations.csv) \
 		$(wildcard $(REFINED_CIT)) \
 		$(wildcard content/tables/qa_citations_report.json)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 stats: $(COMPUTED_STATS)
 
@@ -370,57 +373,57 @@ stats: $(COMPUTED_STATS)
 
 # Core subset → venues table
 $(MOSTCITED): scripts/build_het_core.py scripts/utils.py $(REFINED) $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/tables/tab_core_venues_top10.md: scripts/export_core_venues_markdown.py scripts/summarize_core_venues.py scripts/utils.py $(MOSTCITED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # ── Figures ──────────────────────────────────────────────
 
 # -- Manuscript (Oeconomia article) --
 # Fig 1 (bars): corpus growth per year
 content/figures/fig_bars.png: scripts/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Fig 1 v1 variant: restricted to submission corpus for manuscript stability
 content/figures/fig_bars_v1.png: scripts/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --v1-only
+	$(PYTHON) $< --output $@ --v1-only
 
 # Fig 2 (composition): frozen v1 archive data + corrected labels
 content/figures/fig_composition.png: scripts/plot_fig2_composition.py scripts/plot_style.py scripts/utils.py $(CONFIG) \
 		config/v1_tab_alluvial.csv config/v1_cluster_labels.json
-	$(UV_RUN) python $< --output $@ --input config/v1_tab_alluvial.csv --labels config/v1_cluster_labels.json
+	$(PYTHON) $< --output $@ --input config/v1_tab_alluvial.csv --labels config/v1_cluster_labels.json
 
 # -- Data paper --
 # Semantic clusters (computation only — no figures)
 SEMANTIC_CLUSTERS := $(DATA_DIR)/semantic_clusters.csv
 
 $(SEMANTIC_CLUSTERS): scripts/analyze_embeddings.py scripts/utils.py $(CONFIG) $(ENRICHED) $(DATA_DIR)/embeddings.npz
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Semantic UMAP maps (one parameterized plot script, 3 invocations)
 content/figures/fig_semantic.png: scripts/plot_semantic.py scripts/utils.py $(SEMANTIC_CLUSTERS)
-	$(UV_RUN) python $< --color-by cluster --output $@
+	$(PYTHON) $< --color-by cluster --output $@
 
 content/figures/fig_semantic_lang.png: scripts/plot_semantic.py scripts/utils.py $(SEMANTIC_CLUSTERS)
-	$(UV_RUN) python $< --color-by language --output $@
+	$(PYTHON) $< --color-by language --output $@
 
 content/figures/fig_semantic_period.png: scripts/plot_semantic.py scripts/utils.py $(SEMANTIC_CLUSTERS)
-	$(UV_RUN) python $< --color-by period --output $@
+	$(PYTHON) $< --color-by period --output $@
 
 # -- Companion paper (quantitative) --
 # Structural break tables (independent of clustering)
 content/tables/tab_breakpoints.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/tables/tab_breakpoint_robustness.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --robustness
+	$(PYTHON) $< --output $@ --robustness
 
 # Clustering + alluvial flow tables — full corpus (companion paper, tech report)
 content/tables/tab_alluvial.csv content/tables/cluster_labels.json \
 content/tables/tab_core_shares.csv &: \
 		scripts/compute_clusters.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output content/tables/tab_alluvial.csv
+	$(PYTHON) $< --output content/tables/tab_alluvial.csv
 
 # Clustering — v1 frozen from reproducibility archive (not re-clustered).
 # KMeans is unstable to small corpus perturbations; re-clustering the v1
@@ -433,164 +436,164 @@ content/figures/fig_breakpoints.png: \
 		scripts/plot_fig_breakpoints.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_breakpoints.csv content/tables/tab_breakpoint_robustness.csv \
 		content/tables/tab_alluvial.csv
-	$(UV_RUN) python $< --output $@ --input content/tables/tab_breakpoints.csv content/tables/tab_breakpoint_robustness.csv content/tables/tab_alluvial.csv
+	$(PYTHON) $< --output $@ --input content/tables/tab_breakpoints.csv content/tables/tab_breakpoint_robustness.csv content/tables/tab_alluvial.csv
 
 # Alluvial figure (static PNG)
 content/figures/fig_alluvial.png: \
 		scripts/plot_fig_alluvial.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_alluvial.csv content/tables/cluster_labels.json
-	$(UV_RUN) python $< --output $@ --input content/tables/tab_alluvial.csv
+	$(PYTHON) $< --output $@ --input content/tables/tab_alluvial.csv
 
 # Alluvial figure (interactive HTML)
 content/figures/fig_alluvial.html: \
 		scripts/plot_alluvial_html.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_alluvial.csv content/tables/cluster_labels.json
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Period divergence curves
 content/figures/fig_breaks.png: scripts/plot_fig2_breaks.py scripts/plot_style.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_breakpoints.csv
-	$(UV_RUN) python $< --output $@ --input content/tables/tab_breakpoints.csv
+	$(PYTHON) $< --output $@ --input content/tables/tab_breakpoints.csv
 
 # Bimodality tables (computation only — figures are separate targets below)
 content/tables/tab_bimodality.csv content/tables/tab_axis_detection.csv \
 content/tables/tab_pole_papers.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output content/tables/tab_bimodality.csv
+	$(PYTHON) $< --output content/tables/tab_bimodality.csv
 
 # Bimodality figures (each reads tab_pole_papers.csv)
 content/figures/fig_bimodality.png: scripts/plot_bimodality.py scripts/utils.py \
 		content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/figures/fig_bimodality_lexical.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
 		content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/figures/fig_bimodality_keywords.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
 		content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Seed-axis violin (core, manuscript figure)
 content/figures/fig_seed_axis_core.png: scripts/plot_fig_seed_axis.py scripts/plot_style.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # PCA scatter (unsupervised)
 content/figures/fig_pca_scatter.png: scripts/plot_fig45_pca_scatter.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Citation genealogy: model (lineage table) then renderers
 content/tables/tab_lineages.csv: scripts/analyze_genealogy.py scripts/utils.py $(CONFIG) \
 		$(REFINED) $(REFINED_CIT) content/tables/tab_pole_papers.csv $(SEMANTIC_CLUSTERS)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/figures/fig_genealogy.png: scripts/plot_genealogy.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_lineages.csv $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 content/figures/fig_genealogy.html: scripts/plot_genealogy_html.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_lineages.csv $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # -- Technical report (robustness, variants, supplementary) --
 # Core-only: structural break tables
 content/tables/tab_breakpoints_core.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --core-only
+	$(PYTHON) $< --output $@ --core-only
 
 content/tables/tab_breakpoint_robustness_core.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --robustness --core-only
+	$(PYTHON) $< --output $@ --robustness --core-only
 
 # Core-only: clustering + alluvial flow tables
 content/tables/tab_alluvial_core.csv content/tables/cluster_labels_core.json &: \
 		scripts/compute_clusters.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output content/tables/tab_alluvial_core.csv --core-only
+	$(PYTHON) $< --output content/tables/tab_alluvial_core.csv --core-only
 
 # Core-only figures
 content/figures/fig_breakpoints_core.png: \
 		scripts/plot_fig_breakpoints.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_breakpoints_core.csv content/tables/tab_breakpoint_robustness_core.csv \
 		content/tables/tab_alluvial_core.csv
-	$(UV_RUN) python $< --output $@ --core-only --input content/tables/tab_breakpoints_core.csv content/tables/tab_breakpoint_robustness_core.csv content/tables/tab_alluvial_core.csv
+	$(PYTHON) $< --output $@ --core-only --input content/tables/tab_breakpoints_core.csv content/tables/tab_breakpoint_robustness_core.csv content/tables/tab_alluvial_core.csv
 
 content/figures/fig_alluvial_core.png: \
 		scripts/plot_fig_alluvial.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_alluvial_core.csv content/tables/cluster_labels_core.json
-	$(UV_RUN) python $< --output $@ --core-only --input content/tables/tab_alluvial_core.csv
+	$(PYTHON) $< --output $@ --core-only --input content/tables/tab_alluvial_core.csv
 
 # Bimodality core variant tables
 content/tables/tab_bimodality_core.csv content/tables/tab_axis_detection_core.csv \
 content/tables/tab_pole_papers_core.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output content/tables/tab_bimodality_core.csv --core-only
+	$(PYTHON) $< --output content/tables/tab_bimodality_core.csv --core-only
 
 # Bimodality core variant figures
 content/figures/fig_bimodality_core.png: scripts/plot_bimodality.py scripts/utils.py \
 		content/tables/tab_pole_papers_core.csv
-	$(UV_RUN) python $< --core-only --output $@
+	$(PYTHON) $< --core-only --output $@
 
 content/figures/fig_bimodality_lexical_core.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
 		content/tables/tab_pole_papers_core.csv
-	$(UV_RUN) python $< --core-only --output $@
+	$(PYTHON) $< --core-only --output $@
 
 content/figures/fig_bimodality_keywords_core.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
 		content/tables/tab_pole_papers_core.csv
-	$(UV_RUN) python $< --core-only --output $@
+	$(PYTHON) $< --core-only --output $@
 
 # Pre-2007 co-citation traditions network
 content/figures/fig_traditions.png: scripts/plot_fig_traditions.py scripts/plot_style.py scripts/utils.py $(CONFIG) $(REFINED) $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Co-citation communities (compute: community assignments + summary table)
 COMMUNITIES := data/catalogs/communities.csv
 $(COMMUNITIES): scripts/analyze_cocitation.py scripts/utils.py $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Co-citation communities (plot: network figure)
 content/figures/fig_communities.png: scripts/plot_cocitation.py scripts/utils.py $(COMMUNITIES) $(REFINED_CIT)
-	$(UV_RUN) python $< --output $@ --input $(COMMUNITIES)
+	$(PYTHON) $< --output $@ --input $(COMMUNITIES)
 
 # KDE supplementary
 content/figures/fig_kde.png: scripts/plot_figS_kde.py scripts/plot_style.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Lexical TF-IDF table (diagnostic, not in manuscript)
 content/tables/tab_lexical_tfidf.csv: scripts/compute_lexical.py scripts/utils.py $(REFINED) \
 		content/tables/tab_breakpoint_robustness.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Multilingual epistemic structure (exploratory JSON report)
 content/tables/multilingual_report.json: scripts/analyze_multilingual.py scripts/utils.py \
 		scripts/build_het_core.py $(REFINED) $(REFINED_EMB) $(REFINED_CIT) $(SEMANTIC_CLUSTERS)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # K-sensitivity table
 content/tables/tab_k_sensitivity.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --k-sensitivity
+	$(PYTHON) $< --output $@ --k-sensitivity
 
 # K-sensitivity figure
 content/figures/fig_k_sensitivity.png: scripts/plot_fig_k_sensitivity.py $(CONFIG) \
 		content/tables/tab_k_sensitivity.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # Lexical TF-IDF figures (one per detected break year; output filenames are
 # dynamic, so we use a sentinel file to track freshness).
 .lexical_tfidf.stamp: scripts/plot_fig_lexical_tfidf.py scripts/plot_style.py $(CONFIG) \
 		content/tables/tab_lexical_tfidf.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # DVC pipeline DAG (data paper)
 content/figures/fig_dag.png: scripts/plot_fig_dag.py scripts/plot_style.py $(CONFIG) dvc.yaml
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # -- NCC Analysis (Nature Climate Change) --
 
 # Censor-gap k=2 breakpoint tables (intermediate for NCC figure a)
 content/tables/tab_breakpoints_censor2.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --censor-gap 2
+	$(PYTHON) $< --output $@ --censor-gap 2
 
 content/tables/tab_breakpoint_robustness_censor2.csv: scripts/compute_breakpoints.py scripts/utils.py $(CONFIG) $(REFINED)
-	$(UV_RUN) python $< --output $@ --robustness --censor-gap 2
+	$(PYTHON) $< --output $@ --robustness --censor-gap 2
 
 # NCC Figure (a): Divergence with 2009 peak (baseline vs censor-gap k=2)
 content/figures/fig_ncc_divergence.png: \
@@ -598,7 +601,7 @@ content/figures/fig_ncc_divergence.png: \
 		content/tables/tab_breakpoints.csv \
 		content/tables/tab_breakpoints_censor2.csv \
 		content/tables/tab_breakpoint_robustness_censor2.csv
-	$(UV_RUN) python $< --output $@ --input content/tables/tab_breakpoints.csv content/tables/tab_breakpoints_censor2.csv content/tables/tab_breakpoint_robustness_censor2.csv
+	$(PYTHON) $< --output $@ --input content/tables/tab_breakpoints.csv content/tables/tab_breakpoints_censor2.csv content/tables/tab_breakpoint_robustness_censor2.csv
 
 # NCC Figure (b): Core vs full corpus comparison panel
 content/figures/fig_ncc_core_comparison.png: \
@@ -607,19 +610,19 @@ content/figures/fig_ncc_core_comparison.png: \
 		content/tables/tab_alluvial.csv \
 		content/tables/tab_breakpoints_core.csv content/tables/tab_breakpoint_robustness_core.csv \
 		content/tables/tab_alluvial_core.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # NCC Figure (c): Bimodality KDE with period decomposition
 content/figures/fig_ncc_bimodality.png: \
 		scripts/plot_ncc_bimodality.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_pole_papers.csv
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # NCC Figure (d): Alluvial diagram (NCC format)
 content/figures/fig_ncc_alluvial.png: \
 		scripts/plot_ncc_alluvial.py scripts/utils.py $(CONFIG) \
 		content/tables/tab_alluvial.csv content/tables/cluster_labels.json
-	$(UV_RUN) python $< --output $@ --input content/tables/tab_alluvial.csv
+	$(PYTHON) $< --output $@ --input content/tables/tab_alluvial.csv
 
 figures-manuscript: corpus-handoff $(MANUSCRIPT_FIGS)
 figures-datapaper:  corpus-handoff $(DATAPAPER_FIGS)
@@ -701,31 +704,31 @@ archive-datapaper: check-corpus corpus-tables figures-datapaper
 
 # ── All checks (tests) ───────────────────────────────────
 check:
-	$(UV_RUN) python -m pytest tests/ -v --tb=short -n 4
+	$(PYTHON) -m pytest tests/ -v --tb=short -n 4
 
 # Fast subset: unit tests only (no Python subprocess spawning, no sleeps, < 10s).
 check-fast:
-	$(UV_RUN) python -m pytest tests/ -v --tb=short -m "not slow and not integration" -n 4
+	$(PYTHON) -m pytest tests/ -v --tb=short -m "not slow and not integration" -n 4
 
 # Smoke pipeline: run Phase 2 on a 100-row fixture (no DVC pull needed, <30s).
 # Exercises: compute_breakpoints, compute_clusters, plot_fig1_bars.
 smoke:
-	$(UV_RUN) python -m pytest tests/test_smoke_pipeline.py -v --tb=short
+	$(PYTHON) -m pytest tests/test_smoke_pipeline.py -v --tb=short
 
 # Determinism check: run figure scripts twice on smoke data, diff outputs.
 # Catches unseeded randomness, leaking timestamps, floating-point non-determinism.
 determinism-check:
-	$(UV_RUN) python -m pytest tests/test_determinism.py -v --tb=short
+	$(PYTHON) -m pytest tests/test_determinism.py -v --tb=short
 
 # Regression hashes: compare Phase 2 output hashes against golden baseline.
 # Runs as pytest (one test per script, module-scoped fixture = scripts run once).
 #   make regression          — check against golden baseline
 #   make regression-update   — regenerate golden baseline (after intentional change)
 regression:
-	$(UV_RUN) python -m pytest tests/test_regression.py -v --tb=short -m integration -k "test_regression_"
+	$(PYTHON) -m pytest tests/test_regression.py -v --tb=short -m integration -k "test_regression_"
 
 regression-update:
-	$(UV_RUN) python scripts/compute_regression_hashes.py --update-golden
+	$(PYTHON) scripts/compute_regression_hashes.py --update-golden
 
 # ── Benchmarking ─────────────────────────────────────────
 # Record wall time + peak RSS per Phase 2 target.
@@ -735,10 +738,10 @@ BENCH_OUT := benchmarks/timings.jsonl
 
 benchmark: check-corpus
 	@mkdir -p benchmarks
-	$(BENCH) compute_breakpoints $(BENCH_OUT) $(UV_RUN) python scripts/compute_breakpoints.py --output content/tables/tab_breakpoints.csv
-	$(BENCH) compute_clusters $(BENCH_OUT) $(UV_RUN) python scripts/compute_clusters.py --output content/tables/tab_alluvial.csv
-	$(BENCH) analyze_bimodality $(BENCH_OUT) $(UV_RUN) python scripts/analyze_bimodality.py --output content/tables/tab_bimodality.csv
-	$(BENCH) plot_fig1_bars $(BENCH_OUT) $(UV_RUN) python scripts/plot_fig1_bars.py
+	$(BENCH) compute_breakpoints $(BENCH_OUT) $(PYTHON) scripts/compute_breakpoints.py --output content/tables/tab_breakpoints.csv
+	$(BENCH) compute_clusters $(BENCH_OUT) $(PYTHON) scripts/compute_clusters.py --output content/tables/tab_alluvial.csv
+	$(BENCH) analyze_bimodality $(BENCH_OUT) $(PYTHON) scripts/analyze_bimodality.py --output content/tables/tab_bimodality.csv
+	$(BENCH) plot_fig1_bars $(BENCH_OUT) $(PYTHON) scripts/plot_fig1_bars.py
 	@echo "Benchmark results: $(BENCH_OUT)"
 
 # ── Setup (run once after cloning) ───────────────────────

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ check-manuscript-data:
 	$$ok || { echo "Run '$(UV_RUN) dvc pull' to sync data, or 'make corpus' to rebuild."; exit 1; }
 
 corpus-validate: $(REFINED)
-	$(UV_RUN) pytest tests/test_corpus_acceptance.py -v -s --tb=long
+	$(UV_RUN) python -m pytest tests/test_corpus_acceptance.py -v -s --tb=long
 
 # ── Corpus reporting (Phase 2 — reads only refined data) ──
 content/tables/tab_citation_coverage.md: scripts/export_citation_coverage.py scripts/utils.py $(REFINED)
@@ -701,7 +701,7 @@ archive-datapaper: check-corpus corpus-tables figures-datapaper
 
 # ── All checks (tests) ───────────────────────────────────
 check:
-	$(UV_RUN) pytest tests/ -v --tb=short -n 4
+	$(UV_RUN) python -m pytest tests/ -v --tb=short -n 4
 
 # Fast subset: unit tests only (no Python subprocess spawning, no sleeps, < 10s).
 check-fast:
@@ -710,19 +710,19 @@ check-fast:
 # Smoke pipeline: run Phase 2 on a 100-row fixture (no DVC pull needed, <30s).
 # Exercises: compute_breakpoints, compute_clusters, plot_fig1_bars.
 smoke:
-	$(UV_RUN) pytest tests/test_smoke_pipeline.py -v --tb=short
+	$(UV_RUN) python -m pytest tests/test_smoke_pipeline.py -v --tb=short
 
 # Determinism check: run figure scripts twice on smoke data, diff outputs.
 # Catches unseeded randomness, leaking timestamps, floating-point non-determinism.
 determinism-check:
-	$(UV_RUN) pytest tests/test_determinism.py -v --tb=short
+	$(UV_RUN) python -m pytest tests/test_determinism.py -v --tb=short
 
 # Regression hashes: compare Phase 2 output hashes against golden baseline.
 # Runs as pytest (one test per script, module-scoped fixture = scripts run once).
 #   make regression          — check against golden baseline
 #   make regression-update   — regenerate golden baseline (after intentional change)
 regression:
-	$(UV_RUN) pytest tests/test_regression.py -v --tb=short -m integration -k "test_regression_"
+	$(UV_RUN) python -m pytest tests/test_regression.py -v --tb=short -m integration -k "test_regression_"
 
 regression-update:
 	$(UV_RUN) python scripts/compute_regression_hashes.py --update-golden

--- a/divergence.mk
+++ b/divergence.mk
@@ -49,29 +49,29 @@ DIV_CSV_ALL := $(DIV_CSV_SEM) $(DIV_CSV_LEX) $(DIV_CSV_CIT) $(DIV_CSV_C2ST)
 
 $(foreach m,$(DIV_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(DIV_DISPATCH) --method $(m) --output $$@))
+	$(PYTHON) $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Lexical methods (depend on REFINED only) ─────────────────────────────
 
 $(foreach m,$(DIV_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(DIV_DISPATCH) --method $(m) --output $$@))
+	$(PYTHON) $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Citation methods (depend on REFINED + REFINED_CIT) ───────────────────
 
 $(foreach m,$(DIV_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_citation.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	$(UV_RUN) python $(DIV_DISPATCH) --method $(m) --output $$@))
+	$(PYTHON) $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── C2ST methods (embedding variant depends on embeddings, lexical on REFINED) ─
 
 $(foreach m,$(DIV_METHODS_C2ST_SEM),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_c2st.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(DIV_DISPATCH) --method $(m) --output $$@))
+	$(PYTHON) $(DIV_DISPATCH) --method $(m) --output $$@))
 
 $(foreach m,$(DIV_METHODS_C2ST_LEX),$(eval \
 $(DIV_TABLES)/tab_div_$(m).csv: $(DIV_DISPATCH) scripts/_divergence_c2st.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(DIV_DISPATCH) --method $(m) --output $$@))
+	$(PYTHON) $(DIV_DISPATCH) --method $(m) --output $$@))
 
 # ── Convenience targets ──────────────────────────────────────────────────
 
@@ -95,7 +95,7 @@ divergence-tables: $(DIV_CSV_ALL)
 DIV_FIG_STAMP := $(DIV_FIGS)/.divergence_figs.stamp
 
 $(DIV_FIG_STAMP): scripts/plot_divergence.py $(DIV_CSV_ALL)
-	$(UV_RUN) python scripts/plot_divergence.py \
+	$(PYTHON) scripts/plot_divergence.py \
 		--output $(DIV_FIGS)/fig_divergence.png \
 		--input $(DIV_CSV_ALL)
 	touch $@
@@ -119,11 +119,11 @@ SENS_CSV_ALL := $(SENS_CSV_PCA) $(SENS_CSV_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_pca_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
+	$(PYTHON) $(SENS_SCRIPT) --method $(m) --projection pca --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_TABLES)/tab_sens_jl_$(m).csv: $(SENS_SCRIPT) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
+	$(PYTHON) $(SENS_SCRIPT) --method $(m) --projection jl --output $$@))
 
 # Figures: one PNG per (method, projection) pair — 1 invocation = 1 figure
 SENS_FIG_PCA := $(foreach m,$(SENS_METHODS),$(DIV_FIGS)/fig_sensitivity_pca_$(m).png)
@@ -132,11 +132,11 @@ SENS_FIG_ALL := $(SENS_FIG_PCA) $(SENS_FIG_JL)
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_pca_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_pca_$(m).csv ; \
-	$(UV_RUN) python $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
+	$(PYTHON) $(SENS_PLOT) --palette gradient --input $(DIV_TABLES)/tab_sens_pca_$(m).csv --output $$@))
 
 $(foreach m,$(SENS_METHODS),$(eval \
 $(DIV_FIGS)/fig_sensitivity_jl_$(m).png: $(SENS_PLOT) $(DIV_TABLES)/tab_sens_jl_$(m).csv ; \
-	$(UV_RUN) python $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
+	$(PYTHON) $(SENS_PLOT) --aggregate ribbon --input $(DIV_TABLES)/tab_sens_jl_$(m).csv --output $$@))
 
 .PHONY: sensitivity-tables
 sensitivity-tables: $(SENS_CSV_ALL)
@@ -162,13 +162,13 @@ CV_TABLE   := $(DIV_TABLES)/tab_convergence.csv
 CP_FIG     := $(DIV_FIGS)/fig_convergence.png
 
 $(CP_TABLE): $(CP_SCRIPT) $(DIV_CSV_ALL) $(DIV_CFG)
-	$(UV_RUN) python $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
+	$(PYTHON) $(CP_SCRIPT) --output $@ --input $(DIV_CSV_ALL)
 
 $(CV_TABLE): $(CV_SCRIPT) $(CP_TABLE)
-	$(UV_RUN) python $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
+	$(PYTHON) $(CV_SCRIPT) --output $@ --input $(CP_TABLE)
 
 $(CP_FIG): $(CP_PLOT) $(CP_TABLE) $(CV_TABLE)
-	$(UV_RUN) python $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
+	$(PYTHON) $(CP_PLOT) --output $@ --input $(CP_TABLE) $(CV_TABLE)
 
 .PHONY: changepoints-tables
 changepoints-tables: $(CP_TABLE) $(CV_TABLE)
@@ -209,33 +209,33 @@ NULL_CSV := $(foreach m,$(NULL_METHODS),$(DIV_TABLES)/tab_null_$(m).csv)
 # Semantic null models (depend on embeddings + divergence CSV)
 $(foreach m,$(NULL_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_semantic.py scripts/_permutation_accel.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
 
 # Lexical null models — L1: JS divergence (depend on REFINED + divergence CSV)
 $(foreach m,$(NULL_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py scripts/_permutation_accel.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
 
 # Lexical null models — L2/L3: use _permutation_lexical.py instead of _permutation_accel.py
 $(foreach m,$(NULL_METHODS_LEX_L2L3),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py scripts/_permutation_lexical.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
 
 # Citation null models (depend on REFINED + REFINED_CIT + divergence CSV)
 # _permutation_citation.py is the extracted G1/G5/G6/G8 helper module.
 $(foreach m,$(NULL_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_citation.py scripts/_divergence_community.py scripts/_citation_methods.py scripts/_permutation_citation.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --n-jobs $(NJOBS) --output $$@))
 
 # C2ST null models — embedding variant (depends on embeddings; no --n-jobs)
 $(foreach m,$(NULL_METHODS_C2ST_SEM),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 # C2ST null models — lexical variant (depends on REFINED + divergence CSV; no --n-jobs)
 $(foreach m,$(NULL_METHODS_C2ST_LEX),$(eval \
 $(DIV_TABLES)/tab_null_$(m).csv: $(NULL_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(NULL_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 .PHONY: null-model
 null-model: $(NULL_CSV)
@@ -259,17 +259,17 @@ BOOT_CSV := $(foreach m,$(BOOT_METHODS),$(DIV_TABLES)/tab_boot_$(m).csv)
 # Semantic bootstrap (depends on embeddings + divergence CSV)
 $(foreach m,$(BOOT_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_boot_$(m).csv: $(BOOT_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 # Lexical bootstrap (depends on REFINED + divergence CSV)
 $(foreach m,$(BOOT_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_boot_$(m).csv: $(BOOT_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 # Citation bootstrap (depends on REFINED + REFINED_CIT + divergence CSV)
 $(foreach m,$(BOOT_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_boot_$(m).csv: $(BOOT_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_citation.py scripts/_divergence_community.py scripts/_citation_methods.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	$(UV_RUN) python $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(BOOT_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 .PHONY: bootstrap-tables
 bootstrap-tables: $(BOOT_CSV)
@@ -291,23 +291,23 @@ SUBSAMP_CSV := $(foreach m,$(SUBSAMP_METHODS),$(DIV_TABLES)/tab_subsample_$(m).c
 
 $(foreach m,$(SUBSAMP_METHODS_SEM),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 $(foreach m,$(SUBSAMP_METHODS_LEX),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 $(foreach m,$(SUBSAMP_METHODS_CIT),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_citation.py scripts/_divergence_community.py scripts/_citation_methods.py $(REFINED) $(REFINED_CIT) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 $(foreach m,$(SUBSAMP_METHODS_C2ST_SEM),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py $(REFINED) $(REFINED_EMB) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 $(foreach m,$(SUBSAMP_METHODS_C2ST_LEX),$(eval \
 $(DIV_TABLES)/tab_subsample_$(m).csv: $(SUBSAMP_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv scripts/_divergence_c2st.py $(REFINED) $(DIV_CFG) ; \
-	$(UV_RUN) python $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
+	$(PYTHON) $(SUBSAMP_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --output $$@))
 
 .PHONY: subsample-tables
 subsample-tables: $(SUBSAMP_CSV)
@@ -323,7 +323,7 @@ SUMM_CSV := $(foreach m,$(BOOT_METHODS),$(DIV_TABLES)/tab_summary_$(m).csv)
 # Summary with ribbon (all four lead methods — S2, L1, G9, G2)
 $(foreach m,$(SUBSAMP_METHODS),$(eval \
 $(DIV_TABLES)/tab_summary_$(m).csv: $(SUMM_DISPATCH) $(DIV_TABLES)/tab_div_$(m).csv $(DIV_TABLES)/tab_boot_$(m).csv $(DIV_TABLES)/tab_null_$(m).csv $(DIV_TABLES)/tab_subsample_$(m).csv ; \
-	$(UV_RUN) python $(SUMM_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --boot-csv $(DIV_TABLES)/tab_boot_$(m).csv --null-csv $(DIV_TABLES)/tab_null_$(m).csv --subsample-csv $(DIV_TABLES)/tab_subsample_$(m).csv --output $$@))
+	$(PYTHON) $(SUMM_DISPATCH) --method $(m) --div-csv $(DIV_TABLES)/tab_div_$(m).csv --boot-csv $(DIV_TABLES)/tab_boot_$(m).csv --null-csv $(DIV_TABLES)/tab_null_$(m).csv --subsample-csv $(DIV_TABLES)/tab_subsample_$(m).csv --output $$@))
 
 .PHONY: divergence-summary
 divergence-summary: $(SUMM_CSV)

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -35,14 +35,14 @@ COMP_DEPS_CORE := \
 $(COMP_FIGS)/fig_companion_zseries.png: \
     scripts/plot_companion_zseries.py $(COMP_UTILS) $(COMP_STYLE) \
     $(COMP_CFG) $(COMP_DEPS_CORE)
-	$(UV_RUN) python scripts/plot_companion_zseries.py --output $@
+	$(PYTHON) scripts/plot_companion_zseries.py --output $@
 
 # ── Figure 2: Transition zone heatmap ────────────────────────────────────
 
 $(COMP_FIGS)/fig_companion_heatmap.png: \
     scripts/plot_companion_heatmap.py $(COMP_UTILS) $(COMP_STYLE) \
     $(COMP_CFG) $(COMP_DEPS_CORE)
-	$(UV_RUN) python scripts/plot_companion_heatmap.py --output $@
+	$(PYTHON) scripts/plot_companion_heatmap.py --output $@
 
 # ── Figure 3: Discriminative terms ───────────────────────────────────────
 # No hard dependency on tab_discrim_terms*.csv: the script degrades to a
@@ -50,14 +50,14 @@ $(COMP_FIGS)/fig_companion_heatmap.png: \
 
 $(COMP_FIGS)/fig_companion_terms.png: \
     scripts/plot_companion_terms.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
-	$(UV_RUN) python scripts/plot_companion_terms.py --output $@
+	$(PYTHON) scripts/plot_companion_terms.py --output $@
 
 # ── Figure 4: Community shifts ───────────────────────────────────────────
 # Same stub-fallback rationale as Figure 3.
 
 $(COMP_FIGS)/fig_companion_community.png: \
     scripts/plot_companion_community.py $(COMP_UTILS) $(COMP_STYLE) $(COMP_CFG)
-	$(UV_RUN) python scripts/plot_companion_community.py --output $@
+	$(PYTHON) scripts/plot_companion_community.py --output $@
 
 .PHONY: companion-figures
 companion-figures: \
@@ -69,12 +69,12 @@ companion-figures: \
 # ── Sensitivity grid (ticket 0083) ──────────────────────────────────────
 $(COMP_TABLES)/tab_sensitivity_grid.csv: \
     scripts/compute_sensitivity_grid.py $(COMP_CFG)
-	$(UV_RUN) python scripts/compute_sensitivity_grid.py --output $@
+	$(PYTHON) scripts/compute_sensitivity_grid.py --output $@
 
 $(COMP_FIGS)/fig_companion_sensitivity.png: \
     scripts/plot_companion_sensitivity.py $(COMP_CFG) \
     $(COMP_TABLES)/tab_sensitivity_grid.csv
-	$(UV_RUN) python scripts/plot_companion_sensitivity.py \
+	$(PYTHON) scripts/plot_companion_sensitivity.py \
 	    --input $(COMP_TABLES)/tab_sensitivity_grid.csv --output $@
 
 .PHONY: companion-sensitivity

--- a/venues.mk
+++ b/venues.mk
@@ -24,10 +24,10 @@ venue-concentration-figure: $(VENUE_FIG)
 
 $(VENUE_TABLE): scripts/compute_venue_concentration.py scripts/summarize_core_venues.py \
 		scripts/schemas.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # ── Figure ────────────────────────────────────────────────────────────────
 
 $(VENUE_FIG): scripts/plot_venue_concentration.py scripts/plot_style.py scripts/utils.py \
 		$(VENUE_TABLE) content/tables/tab_breakpoints.csv
-	$(UV_RUN) python $< --output $@ --input $(VENUE_TABLE) content/tables/tab_breakpoints.csv
+	$(PYTHON) $< --output $@ --input $(VENUE_TABLE) content/tables/tab_breakpoints.csv

--- a/zoo.mk
+++ b/zoo.mk
@@ -49,7 +49,7 @@ zoo-figures: $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 # real embeddings when available and fall back to synthetic data otherwise.
 
 $(ZOO_FIGS)/schematic_%.png: scripts/plot_schematic_%.py scripts/script_io_args.py
-	$(UV_RUN) python $< --output $@
+	$(PYTHON) $< --output $@
 
 # ── Cross-year Z-score tables ─────────────────────────────────────────────
 #
@@ -62,16 +62,16 @@ crossyear-tables: $(addprefix $(ZOO_TABLES)/tab_crossyear_,$(addsuffix .csv,$(CR
 
 # L2: filter to resonance-only before Z-scoring to align with run_l2_permutations (ticket 0112).
 $(ZOO_TABLES)/tab_crossyear_L2.csv: $(ZOO_TABLES)/tab_div_L2.csv scripts/compute_crossyear_zscore.py
-	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method L2 --metric resonance --output $@
+	$(PYTHON) scripts/compute_crossyear_zscore.py --method L2 --metric resonance --output $@
 
 # Stochastic methods: pass --subsample-csv for replication ribbon (ticket 0105).
 RIBBON_METHODS := S1_MMD S2_energy S3_sliced_wasserstein S4_frechet C2ST_embedding C2ST_lexical
 $(foreach m,$(RIBBON_METHODS),$(eval \
 $(ZOO_TABLES)/tab_crossyear_$(m).csv: $(ZOO_TABLES)/tab_div_$(m).csv $(ZOO_TABLES)/tab_subsample_$(m).csv scripts/compute_crossyear_zscore.py ; \
-	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method $(m) --subsample-csv $(ZOO_TABLES)/tab_subsample_$(m).csv --output $$@))
+	$(PYTHON) scripts/compute_crossyear_zscore.py --method $(m) --subsample-csv $(ZOO_TABLES)/tab_subsample_$(m).csv --output $$@))
 
 $(ZOO_TABLES)/tab_crossyear_%.csv: $(ZOO_TABLES)/tab_div_%.csv scripts/compute_crossyear_zscore.py
-	$(UV_RUN) python scripts/compute_crossyear_zscore.py --method $* --output $@
+	$(PYTHON) scripts/compute_crossyear_zscore.py --method $* --output $@
 
 # ── Zoo result panel recipes (pattern rule) ───────────────────────────────
 #
@@ -98,7 +98,7 @@ $(foreach m,$(NULL_METHODS_ALL),$(eval \
 ANALYTICAL_NULL_METHODS := C2ST_embedding C2ST_lexical
 
 $(ZOO_TABLES)/tab_analytical_null_C2ST_%.csv: scripts/compute_analytical_null.py $(REFINED) $(DIV_CFG)
-	$(UV_RUN) python scripts/compute_analytical_null.py \
+	$(PYTHON) scripts/compute_analytical_null.py \
 		--method C2ST_$* --output $@
 
 .PHONY: analytical-null-tables
@@ -111,7 +111,7 @@ $(foreach m,$(ANALYTICAL_NULL_METHODS),$(eval \
 # Pattern rule for all methods: passes --null-ci when tab_null_*.csv exists,
 # and --analytical-null when tab_analytical_null_*.csv exists.
 $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_results.py
-	$(UV_RUN) python scripts/plot_zoo_results.py --method $* --output $@ \
+	$(PYTHON) scripts/plot_zoo_results.py --method $* --output $@ \
 		$(if $(wildcard $(ZOO_TABLES)/tab_null_$*.csv),--null-ci $(ZOO_TABLES)/tab_null_$*.csv,) \
 		$(if $(wildcard $(ZOO_TABLES)/tab_analytical_null_$*.csv),--analytical-null $(ZOO_TABLES)/tab_analytical_null_$*.csv,)
 
@@ -123,22 +123,22 @@ $(ZOO_FIGS)/fig_zoo_%.png: $(ZOO_TABLES)/tab_crossyear_%.csv scripts/plot_zoo_re
 BIAS_METHODS := S1_MMD S2_energy L1 C2ST_embedding
 
 $(ZOO_TABLES)/tab_div_biased_S1_MMD.csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
-	$(UV_RUN) python $(DIV_DISPATCH) --method S1_MMD --no-equal-n --output $@
+	$(PYTHON) $(DIV_DISPATCH) --method S1_MMD --no-equal-n --output $@
 
 $(ZOO_TABLES)/tab_div_biased_S2_energy.csv: $(DIV_DISPATCH) scripts/_divergence_semantic.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
-	$(UV_RUN) python $(DIV_DISPATCH) --method S2_energy --no-equal-n --output $@
+	$(PYTHON) $(DIV_DISPATCH) --method S2_energy --no-equal-n --output $@
 
 $(ZOO_TABLES)/tab_div_biased_L1.csv: $(DIV_DISPATCH) scripts/_divergence_lexical.py $(REFINED) $(DIV_CFG)
-	$(UV_RUN) python $(DIV_DISPATCH) --method L1 --no-equal-n --output $@
+	$(PYTHON) $(DIV_DISPATCH) --method L1 --no-equal-n --output $@
 
 $(ZOO_TABLES)/tab_div_biased_C2ST_embedding.csv: $(DIV_DISPATCH) scripts/_divergence_c2st.py $(REFINED) $(REFINED_EMB) $(DIV_CFG)
-	$(UV_RUN) python $(DIV_DISPATCH) --method C2ST_embedding --no-equal-n --output $@
+	$(PYTHON) $(DIV_DISPATCH) --method C2ST_embedding --no-equal-n --output $@
 
 BIAS_FIGS := $(foreach m,$(BIAS_METHODS),$(ZOO_FIGS)/fig_zoo_bias_$(m).png)
 
 $(ZOO_FIGS)/fig_zoo_bias_%.png: scripts/plot_zoo_bias_comparison.py \
     $(ZOO_TABLES)/tab_div_%.csv $(ZOO_TABLES)/tab_div_biased_%.csv
-	$(UV_RUN) python scripts/plot_zoo_bias_comparison.py --method $* \
+	$(PYTHON) scripts/plot_zoo_bias_comparison.py --method $* \
 	    --input $(ZOO_TABLES)/tab_div_$*.csv \
 	    --biased-csv $(ZOO_TABLES)/tab_div_biased_$*.csv \
 	    --output $@


### PR DESCRIPTION
Two commits.

## 1. Fix `make check` (`pytest: error: unrecognized arguments: -n`)

`pytest-xdist` is **not** missing — it is installed in the shared `/data` venv. The generated `bin/pytest` console script carried a **dangling shebang**:

```
#!/home/haduong/.claude/jobs/fddacf5c/tmp/wt-nohook/.venv/bin/python3   ← deleted worktree
```

`.venv` symlinks to the shared `/data/envs/venv/oeconomia` (one env across all worktrees, per the torch-hardlink constraint). A prior background-job worktree ran `uv sync` and uv stamped **all 52** console scripts with *that worktree's* local `.venv` path. When the worktree was removed the interpreter vanished, so `uv run pytest` fell through to the **system** pytest — which cannot import the venv's xdist.

`$(UV_RUN) python -m pytest` bypasses the generated console script, immune to stale-shebang drift no matter which worktree last synced. Matches what `check-fast` already did; the 5 remaining `$(UV_RUN) pytest` sites are aligned to it.

## 2. Add `$(PYTHON)` macro (DRY)

`$(UV_RUN) python` appeared 116 times across `Makefile` + the four included `.mk` files. Introduce `PYTHON ?= $(UV_RUN) python` and use `$(PYTHON)` everywhere. Semantically identical — expands to `uv run --env-file .env python` — but the "run Python through uv, never the console script" intent now lives in one named, overridable place. `UV_RUN` stays for the 11 `dvc` calls (no `python -m` entry point).

## Verification

- `make -n check` → `uv run --env-file .env python -m pytest tests/ -v --tb=short -n 4`.
- `$(PYTHON)` resolves to `uv run --env-file .env python`, including across the `.mk` includes (shared namespace).
- Test slices pass under `-n 4` (`test_script_hygiene` 60 passed, `test_io_discipline` 17 passed); full collection: 1227 tests.

## Out of scope (follow-up)

The 52 stale console scripts (`pytest`, `ruff`, `mypy`, `dvc`, …) still want regeneration via `uv sync` for interactive and `dvc` use — `dvc` has no `python -m` entry. Worth a ticket to pin shared-venv shebangs to the canonical `/data` interpreter so this can't recur.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)