### PR TITLE
Merge v2.0.1 Vannes variant to main (de-anonymized)

### DIFF
--- a/content/manuscript.qmd
+++ b/content/manuscript.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Inventing Climate Finance. From Incremental Costs to Strategic Ambiguity"
 subtitle: "*Inventer la finance climat. Des coûts incrémentaux à l'ambiguïté stratégique*"
-author: "[Anonymous]"
+author: "Dr. Minh Ha-Duong"
 keywords:
   - climate finance
   - quantification
@@ -26,13 +26,13 @@ format:
           \usepackage{fancyhdr}
           \fancypagestyle{plain}{
             \fancyhf{}
-            \fancyhead[C]{\small\itshape Submitted to Œconomia --- Errata 1}
+            \fancyhead[C]{\small\itshape Présentation au 21e colloque international de l'association Charles Gide, à Vannes, 2-4 juillet 2026, sous le titre "Économistes sous contrainte : controverses et construction de la finance climat comme objet économique (1990 à 2025)"}
             \fancyfoot[C]{\thepage}
             \renewcommand{\headrulewidth}{0pt}
           }
           \usepackage{etoolbox}
           \renewcommand{\CSLBlock}[1]{\newline\noindent #1}
-      # - file: author-footnote.tex  # uncomment after review
+      - file: author-footnote.tex
 ---
 
 <!-- Phase 2→3 contract: this manuscript consumes
@@ -255,6 +255,6 @@ The economists who built the measurement infrastructure did not simply fail to d
 
 Several limitations point to further research. Our multilingual corpus remains dominated by English; the intellectual history of climate finance as seen from recipient countries is largely unwritten---and the developed/developing binary itself, frozen in 1992 and never updated despite dramatic shifts in the global economy, remains one of the most consequential yet least examined constructions in climate finance governance. Our account of economists as institutional architects rests on published outputs rather than archival records or interviews; claims about individual motivations remain conjectural until primary-source research is undertaken. Our corpus covers academic and institutional publications; the role of professional financial media (*The Economist*, *Financial Times*, Bloomberg) in popularising and framing climate finance categories falls outside its scope. The trajectory from Article 4.3 to the NCQG itself deserves a dedicated legal-institutional history drawing on negotiation records and committee minutes. Whether the next generation of economists will return to the precision that Article 4.3 offered, or whether the productive ambiguity will prove durable, remains the open question of climate finance governance.
 
-**Data and code availability.** The corpus, analysis scripts, and reproducible pipeline used in this study are available at [repository URL removed for review].
+**Data and code availability.** The corpus, analysis scripts, and reproducible pipeline used in this study are archived on Zenodo (DOI: [10.5281/zenodo.19097045](https://doi.org/10.5281/zenodo.19097045)) and developed at <https://github.com/MinhHaDuong/Oeconomia-Climate-finance>.
 
 

--- a/tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg
+++ b/tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg
@@ -9,6 +9,7 @@ Blocked-by: 0156
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
 2026-06-18T07:05Z HDMX-coding-agent note skeptical completeness audit (sonnet agent) vs decision PDF found 7 gaps where remarks sat only in this inventory, not in a child action step. Closed: R2a→0136 action 0 (indeterminacy thesis as analytic spine); R2p, R2w-substantive, R2x, R2y, R2z, R2ad→added as explicit 0141 action bullets. R2p was missing from this inventory entirely — now added below.
+2026-06-18T12:30Z HDMX-coding-agent note v2.0.1 (vannes) merged into main; single working branch from here, the "separate branch / not destined for main" framing was stale. Main now un-blinded — re-anonymize before resubmission (0153 action 0).
 
 --- body ---
 ## Context
@@ -25,7 +26,7 @@ every referee point (addressed or declined-with-reason).
 ## Version ladder (gating)
 Execution is sequenced as shippable version increments, each gated by a version
 tracker (closing a tracker unlocks the next version's work via Blocked-by):
-- **v2.0.1** ✅ Vannes communication (de-anon + render; uploaded). Separate branch.
+- **v2.0.1** ✅ Vannes communication (de-anon + render; uploaded). Merged to main 2026-06-18 (was a separate branch) at author request → **main is now un-blinded**; re-anonymization before the double-blind resubmission is tracked as action 0 of 0153.
 - **v2.0.2** light & easy fixes (0140 safe subset; DAC/GNI/GEF done, PR #796).
 - **v2.0.3** prose ratchet → tracker **0154** (0147 harness, 0148 brief+polarity, 0149 initialize+triage).
 - **v2.0.4** orientation & decisions → tracker **0155** (0142 structure, 0150 economists framing, 0151 indeterminacy thesis; all needs-human, I draft options).

--- a/tickets/0153-resubmission-rebuild-verify-version-bump.erg
+++ b/tickets/0153-resubmission-rebuild-verify-version-bump.erg
@@ -6,12 +6,23 @@ Blocked-by: 0155
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
+2026-06-18T12:30Z HDMX-coding-agent note v2.0.1 (vannes) de-anon merged to main per author request; main now carries author name + Gide header. MUST re-anonymize before the resubmission build (action 0 below).
 
 --- body ---
 ## Context
 v2.0.5 final step. Package and deposit the revised manuscript.
 
+**⚠️ Re-anonymize first.** The v2.0.1 Vannes variant (author name, Gide running
+header, real Zenodo/GitHub data-availability line, uncommented `author-footnote.tex`)
+was merged to main on 2026-06-18 at the author's request. Œconomia resubmission is
+double-blind, so `content/manuscript.qmd` on main is currently **un-blinded**. The
+inverse of the v2.0.1 diff must be applied before the build below. See ticket 0133
+(v2.0.1 entry) for the exact lines.
+
 ## Actions
+0. **Re-anonymize `content/manuscript.qmd`**: `author: "[Anonymous]"`, restore the
+   blind running header, re-comment `author-footnote.tex`, and restore the
+   `[repository URL removed for review]` data-availability placeholder.
 1. `make manuscript` + `make check`; `@adherence` prose ratchet green; `/review-pr-prose` clean.
 2. Version bump (manuscript-vars / config snapshot only if numbers changed — most edits are prose).
 3. Zenodo new-version (not new record) + HAL; update STATE.md links.


### PR DESCRIPTION
Merges the v2.0.1 Charles Gide conference variant into main, per author
request: **one working branch from here**; the original commit's
"separate branch / not destined for main / stays double-blind" note was
stale.

## What lands on main
- `content/manuscript.qmd` de-anonymized: real author name, Gide running
  header, `author-footnote.tex` enabled, real Zenodo DOI + GitHub
  data-availability line (replacing the blind-review placeholders).
- Rebased onto current origin/main — clean, no conflicts (the 4 de-anon
  lines don't overlap main's only manuscript churn, the DAC/GNI/GEF
  acronym expansions).

## Consequence (tracked, not forgotten)
Main is now **un-blinded**. The Œconomia resubmission is double-blind, so
the manuscript must be re-anonymized before that build. Recorded in:
- 0133 (resubmission tracker): v2.0.1 entry updated + log note.
- 0153 (resubmission rebuild): new **action 0 — re-anonymize** + ⚠️ context note.

Closes nothing; both tickets stay open.

Ticket: none
Ticket-ref: tickets/0133-oeconomia-r-r-resubmission-tracking-tick.erg
Ticket-ref: tickets/0153-resubmission-rebuild-verify-version-bump.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)