### PR TITLE
chore: set manuscript date to 2026-06-18 for conference re-upload

### DIFF
--- a/content/manuscript.qmd
+++ b/content/manuscript.qmd
@@ -12,7 +12,7 @@ jel:
   - Q54
   - F35
   - Q56
-date: "2026-03-04"
+date: "2026-06-18"
 date-format: "MMMM D, YYYY"
 metadata-files: [manuscript-vars.yml]
 bibliography: bibliography/main.bib


### PR DESCRIPTION
Sets the title-page date in `content/manuscript.qmd` to today (2026-06-18) so the conference re-upload carries the release date rather than the frozen 2026-03-04 submission stamp.

One-line change; renders as "June 18, 2026" via the existing `date-format: MMMM D, YYYY`.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)