### PR TITLE
chore(0159): Phase 2 — settings.json paths follow the repo move

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
       "Bash(*quarto *)",
       "Edit(/.claude/**)",
       "WebSearch",
-      "Bash(ls \"/home/haduong/CNRS/papiers/actif/Oeconomia - Climate finance/tickets/\"*.erg)",
+      "Bash(ls \"/home/haduong/CNRS/projets/actifs/climate-finance-het/tickets/\"*.erg)",
       "Edit(*/.git/hooks/*)"
     ],
     "deny": [
@@ -20,7 +20,7 @@
     ],
     "additionalDirectories": [
       "/home/haduong/CNRS/html/src",
-      "/home/haduong/CNRS/papiers/actif/Oeconomia - Climate finance/.claude/hooks",
+      "/home/haduong/CNRS/projets/actifs/climate-finance-het/.claude/hooks",
       "/home/haduong/.claude/docs"
     ]
   },


### PR DESCRIPTION
## Phase 2 residue: settings.json absolute paths

Phase 2 of the 0159 reorg moved the working tree
`papiers/actif/Oeconomia - Climate finance` → `projets/actifs/climate-finance-het`
(atomic same-filesystem `mv`). `.claude/settings.json` is the **only git-tracked
file** the move required changing — it carries two absolute repo paths:

- L9 — the `tickets/…*.erg` ls-allowlist entry
- L23 — the project hooks dir

Both now point at the new location. Everything else in the Phase 2 repair is
local/untracked (`.env` `CLAUDE_MEMORY_DIR`, the relocated 27 MB Claude cache
dir, `git worktree repair`) and verified working: `make check-fast` green from
the new path (1009 passed), `.venv`/hooks resolve, `git status` clean.

0159 is a multi-phase tracking ticket — stays open (Phase 3 GitHub rename and
Phase 4 README scrub still pending). This PR closes nothing.

Ticket-ref: tickets/0159-reorg-monorepo-into-projets-papiers-tracks.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
