### PR TITLE
chore(0159): close reorg tracking ticket

### DIFF
--- a/tickets/0160-submission-workflow-docs-to-papiers-convention.erg
+++ b/tickets/0160-submission-workflow-docs-to-papiers-convention.erg
@@ -2,12 +2,12 @@
 Title: Rewrite submission-workflow docs/skills for the papiers/<state>/<track> convention
 Created: 2026-06-19
 Author: HDMX-coding-agent
-Blocked-by: 0159
 
 --- log ---
 2026-06-19T08:18Z HDMX-coding-agent created
 2026-06-19T08:18Z HDMX-coding-agent note Split out of 0159 Phase 1. The extraction PR moved engine tooling and submission records but left submission-PROCESS docs pointing at the now-gone release/ dir. Author ratified deferring these to a follow-up (they encode a workflow that the reorg changes, not just stale paths).
 
+2026-06-19T11:07Z HDMX-coding-agent note blocker 0159 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0159-reorg-monorepo-into-projets-papiers-tracks.erg
+++ b/tickets/closed/0159-reorg-monorepo-into-projets-papiers-tracks.erg
@@ -2,11 +2,13 @@
 Title: Reorg — relocate engine to projets/actifs/climate-finance-het, split submission records to papiers/<track>
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: reorg complete — Phases 1-4 landed (PRs #818/#819/#820 + GitHub rename to climate-finance-het); all exit criteria + blast-radius rows verified at e6cdbb4
 
 --- log ---
 2026-06-18T13:08Z HDMX-coding-agent created
 2026-06-18T13:08Z HDMX-coding-agent note Plan ratified interactively 2026-06-18 (monorepo + rename climate-finance-het; engine->projets, records->papiers). Blast radius VERIFIED against live filesystem (see body). Author executes from ~2026-06-19, by hand. Every step is reversible.
 
+2026-06-19T11:07Z HDMX-coding-agent closed — reorg complete — Phases 1-4 landed (PRs #818/#819/#820 + GitHub rename to climate-finance-het); all exit criteria + blast-radius rows verified at e6cdbb4
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Close the 0159 reorg tracking ticket

All four phases of the monorepo → `projets/`/`papiers/` reorg have landed and
been verified (integration review = the 12-point exit-criteria/blast-radius
check, all green at `e6cdbb4`):

| Phase | State |
|-------|-------|
| 1 — records → papiers, tooling → build/+docs/ | #818 merged |
| 2 — tree → projets/actifs/climate-finance-het, harness paths | #819 merged |
| 3 — GitHub rename + remote set-url | done |
| 4 — identity scrub | #820 merged |

`erg close 0159` set the `Closed:` header, archived the ticket to
`tickets/closed/`, and removed the `Blocked-by: 0159` line from **0160**
(submission-workflow-docs follow-up) — which is now ready to pick up. `erg check`
passes (156 tickets).

0159 is closed in this branch (Ticket-ref, not an auto-close claim — avoids a
double-close on merge).

Ticket-ref: tickets/closed/0159-reorg-monorepo-into-projets-papiers-tracks.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
