### PR TITLE
docs(0160): route submission workflow to papiers/<state>/<track>

### DIFF
--- a/.agent/guidelines/coding-guidelines.md
+++ b/.agent/guidelines/coding-guidelines.md
@@ -84,7 +84,7 @@ Quarto multi-document project (`_quarto.yml`). Four outputs share reusable fragm
 - Build with `make` (calls `quarto render` under the hood)
 - Shared fragments live in `content/_includes/` — edit there, all documents update
 - Bibliography: `content/bibliography/main.bib`, author-date style
-- Version control: old versions in `attic/`, submissions in `release/`
+- Version control: old versions in `attic/`; submission records in `papiers/<state>/<track>/` (outside the repo; engine build tooling in `build/`)
 
 ## Pipeline phases
 

--- a/.agent/runbooks/submission-branch.md
+++ b/.agent/runbooks/submission-branch.md
@@ -10,6 +10,15 @@ freezes the submitted state and accumulates revision history. Main
 continues to evolve; the submission branch cherry-picks only what's
 relevant to the paper under review.
 
+**Source vs records.** The branch freezes the manuscript *source* (qmd, pinned
+vars, reference data) and its revision history — that is git's job. Submission
+*records* (cover/decision letters, frozen PDFs, deposit archives, reviewer
+reports, response letters) live **outside the repo**, untracked, in
+`papiers/<state>/<track>/` — `<state>` ∈ {actif, sent, published}, `<track>` the
+venue-named record dir (e.g. `papiers/actif/Oeconomia_Inventing_Climate_Finance/`).
+A lifecycle transition is a plain `mv` between `papiers/{actif,sent,published}/`.
+The release journal stays in the repo at `docs/release-journal.md`.
+
 ## Branch naming
 
 `submission/{journal}-{document}` — e.g., `submission/oeconomia-manuscript`,
@@ -35,18 +44,20 @@ Tag the submission point:
 git tag v{N}.0-{journal}-submitted
 ```
 
-Add submission artifacts to `release/`:
+Place submission records in `papiers/<state>/<track>/` (outside the repo — not git-tracked):
 
 - Cover letter
 - AI disclosure statement
 - Any journal-specific files (anonymized PDF, figures, metadata)
-- Record in `release/release-journal.md`
 
-Commit and push:
+Record the submission in `docs/release-journal.md` (tracked).
+
+Commit the source freeze on the branch and push (records are not committed —
+they live in untracked `papiers/`):
 
 ```bash
-git add release/
-git commit -m "release: submit {document} to {journal}"
+git add content/{document}-vars.yml config/ docs/release-journal.md
+git commit -m "submit {document} to {journal} (source freeze)"
 git push -u origin submission/{journal}-{document}
 ```
 
@@ -84,7 +95,7 @@ git checkout submission/{journal}-{document}
 git commit -m "errata: {description}"
 ```
 
-Add errata materials to `release/YYYY-MM-DD {journal} errata/`.
+Add errata materials to `papiers/<state>/<track>/YYYY-MM-DD {journal} errata/`.
 Contact the journal editor if needed.
 
 ### 4. Revision
@@ -95,8 +106,8 @@ When reviewer reports arrive:
 git checkout submission/{journal}-{document}
 ```
 
-1. Add reviewer reports to `release/YYYY-MM-DD {journal} revision/`
-2. Create a response document (`release/.../response-to-reviewers.md`)
+1. Add reviewer reports to `papiers/<state>/<track>/YYYY-MM-DD {journal} revision/`
+2. Create a response document (`papiers/<state>/<track>/.../response-to-reviewers.md`)
 3. Make changes on the submission branch, one commit per reviewer point
 4. Tag the revision: `git tag v{N}.1-{journal}-revised`
 5. If main has relevant improvements, cherry-pick them:
@@ -112,7 +123,7 @@ After addressing all reviewer points:
 
 1. Rebuild the paper (e.g., `make output/content/manuscript.pdf`)
 2. Prepare a diff/track-changes document if required
-3. Add resubmission artifacts to `release/`
+3. Add resubmission artifacts to `papiers/<state>/<track>/`
 4. Commit: `release: resubmit {document} to {journal} (revision 1)`
 5. Push the branch
 
@@ -121,7 +132,7 @@ After addressing all reviewer points:
 When the paper is accepted:
 
 1. Tag: `git tag v{N}.{final}-{journal}-accepted`
-2. Add acceptance letter to `release/`
+2. Add acceptance letter to `papiers/published/<track>/` (and `mv` the track dir from `papiers/sent/` → `papiers/published/`)
 3. Merge the submission branch back to main:
    ```bash
    git checkout main
@@ -129,14 +140,14 @@ When the paper is accepted:
        submission/{journal}-{document}
    ```
    This brings revision improvements back to main.
-4. Update `release/release-journal.md` with acceptance record
+4. Update `docs/release-journal.md` with acceptance record
 5. Update Zenodo deposit if needed (new version)
 
 ### 7. Rejection
 
 If rejected:
 
-1. Record the decision in `release/release-journal.md`
+1. Record the decision in `docs/release-journal.md`
 2. Decide: resubmit elsewhere (sprout a new submission branch from the
    current one) or abandon (leave the branch as historical record)
 3. Cherry-pick any improvements worth keeping back to main

--- a/.agent/runbooks/submission-readiness.md
+++ b/.agent/runbooks/submission-readiness.md
@@ -25,10 +25,10 @@ Every item must pass. If one fails, fix it before sprouting.
 
 ## Submission artifacts
 
-- [ ] Cover letter in `release/`
-- [ ] AI disclosure statement in `release/`
+- [ ] Cover letter in `papiers/<state>/<track>/`
+- [ ] AI disclosure statement in `papiers/<state>/<track>/`
 - [ ] Journal-specific files prepared (anonymized PDF, figures at required resolution, metadata)
-- [ ] `release/release-journal.md` entry drafted
+- [ ] `docs/release-journal.md` entry drafted
 
 ## Prior art
 
@@ -36,4 +36,4 @@ The v1.0 Oeconomia submission established this pattern:
 - Frozen `config/v1_cluster_labels.json`, `config/v1_tab_alluvial.csv`, `config/v1_identifiers.txt.gz`
 - Pinned `content/manuscript-vars.yml`
 - Zenodo tarballs (analysis 56 MB + manuscript 683 KB), tested on two independent machines
-- `release/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF
+- `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF

--- a/.claude/skills/submission-branch/SKILL.md
+++ b/.claude/skills/submission-branch/SKILL.md
@@ -14,6 +14,8 @@ Manages a long-running branch tracking a manuscript through submission, review, 
 
 Create when a paper is ready to submit. The branch freezes the submitted state and accumulates revision history. Main continues to evolve; the submission branch cherry-picks only what's relevant.
 
+**Source vs records.** The branch freezes the manuscript *source* (qmd, pinned vars, reference data) and its revision history — git's job. Submission *records* (cover/decision letters, frozen PDFs, deposit archives, reviewer reports, response letters) live outside the repo in `papiers/<state>/<track>/`, where `<state>` ∈ {actif, sent, published} and `<track>` is the venue-named record dir (e.g. `papiers/actif/Oeconomia_Inventing_Climate_Finance/`). State transitions are a plain `mv` between `papiers/{actif,sent,published}/`. Records are not git-tracked.
+
 ## Branch naming
 
 `submission/{journal}-{document}` — e.g., `submission/oeconomia-manuscript`.
@@ -28,7 +30,7 @@ git checkout -b submission/$0-$1 main
 git tag v{N}.0-$0-submitted
 ```
 
-Add to `release/`: cover letter, AI disclosure, journal-specific files. Commit and push. Enable branch protection.
+Place records (cover letter, AI disclosure, journal-specific files) in `papiers/<state>/<track>/` (outside the repo — not git-tracked). On the branch, commit only the source freeze (pinned vars, reference data) and push. Enable branch protection.
 
 ## 2. Freeze
 
@@ -40,12 +42,12 @@ No changes except errata, reviewer responses, and revision commits.
 
 ## 3. Errata
 
-Fix errors post-submission. Add to `release/YYYY-MM-DD {journal} errata/`. Contact editor if needed.
+Fix errors post-submission. Add errata materials to `papiers/<state>/<track>/YYYY-MM-DD {journal} errata/`. Contact editor if needed.
 
 ## 4. Revision
 
 When reviewer reports arrive:
-1. Add reports to `release/YYYY-MM-DD {journal} revision/`
+1. Add reports to `papiers/<state>/<track>/YYYY-MM-DD {journal} revision/`
 2. Create response document
 3. One commit per reviewer point
 4. Tag: `v{N}.1-{journal}-revised`
@@ -53,11 +55,11 @@ When reviewer reports arrive:
 
 ## 5. Resubmission
 
-Rebuild, prepare diff/track-changes, add to `release/`, commit, push.
+Rebuild, prepare diff/track-changes, add records to `papiers/<state>/<track>/`; commit the source changes on the branch and push.
 
 ## 6. Acceptance
 
-Tag `v{N}.{final}-{journal}-accepted`. Add acceptance letter. Merge submission branch back to main. Update Zenodo.
+Tag `v{N}.{final}-{journal}-accepted`. Add the acceptance letter to the track record and `mv` the track dir `papiers/sent/<track>/` → `papiers/published/<track>/`. Merge submission branch back to main. Update Zenodo.
 
 ## 7. Rejection
 

--- a/.claude/skills/submission-readiness/SKILL.md
+++ b/.claude/skills/submission-readiness/SKILL.md
@@ -32,10 +32,10 @@ Run before creating a submission branch (`/submission-branch`). Every item must 
 
 ## Submission artifacts
 
-- [ ] Cover letter in `release/`
-- [ ] AI disclosure statement in `release/`
+- [ ] Cover letter in `papiers/<state>/<track>/`
+- [ ] AI disclosure statement in `papiers/<state>/<track>/`
 - [ ] Journal-specific files prepared (anonymized PDF, figures at required resolution, metadata)
-- [ ] `release/release-journal.md` entry drafted
+- [ ] `docs/release-journal.md` entry drafted
 
 ## Prior art
 
@@ -43,4 +43,4 @@ The v1.0 Oeconomia submission established this pattern:
 - Frozen `config/v1_cluster_labels.json`, `config/v1_tab_alluvial.csv`, `config/v1_identifiers.txt.gz`
 - Pinned `content/manuscript-vars.yml`
 - Zenodo tarballs (analysis 56 MB + manuscript 683 KB), tested on two machines
-- `release/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF
+- `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/` with cover letter, AI disclosure, anonymized PDF

--- a/docs/rdj-submission-checklist.md
+++ b/docs/rdj-submission-checklist.md
@@ -18,9 +18,9 @@
 - [x] Pipeline source code on GitHub (MIT license)
 
 ## Cover letter
-- [x] Cover letter sent: `release/2026-03-26 RDJ4HSS/CoverLetter.txt`
+- [x] Cover letter sent: `papiers/sent/RDJ4HSS_Curated_Corpus_Climate_Finance/2026-03-26 RDJ4HSS/CoverLetter.txt`
 - [x] Citation count in as-sent letter: 929,014 (v1.0 number; actual v1.1 is 968,871)
-- [x] As-sent copy: `release/2026-03-26 RDJ4HSS/CoverLetter.txt`
+- [x] As-sent copy: `papiers/sent/RDJ4HSS_Curated_Corpus_Climate_Finance/2026-03-26 RDJ4HSS/CoverLetter.txt`
 
 ## Reproducibility
 - [x] Analysis archive builds: `make archive-analysis`
@@ -38,5 +38,5 @@
 
 ## Done
 - [x] DMP updated with v1.1 numbers (`docs/data-management-plan.md`)
-- [x] release/release-journal.md entry for RDJ4HSS
+- [x] docs/release-journal.md entry for RDJ4HSS
 - [x] ESHET-HES slides outline (`docs/eshet-hes-slides-outline.md`)

--- a/docs/release-journal.md
+++ b/docs/release-journal.md
@@ -78,8 +78,8 @@ GROBID-parsed refs matched against refined_works.csv using rapidfuzz token_sort_
 
 **Status**: Under review (peer reviewers + data specialists).
 
-**Cover letter**: `release/2026-03-26 RDJ4HSS/CoverLetter.txt`
-**Checklist**: `release/rdj-submission-checklist.md`
+**Cover letter**: `papiers/sent/RDJ4HSS_Curated_Corpus_Climate_Finance/2026-03-26 RDJ4HSS/CoverLetter.txt`
+**Checklist**: `docs/rdj-submission-checklist.md`
 **Submission branch**: `submission/rdj-data-paper`
 **Git tag**: `v1.1-rdj-submitted`
 
@@ -100,8 +100,8 @@ GROBID-parsed refs matched against refined_works.csv using rapidfuzz token_sort_
 **Uploaded**:
 - Anonymized manuscript PDF (shows [Anonymous], [repository URL removed for review])
 - fig_bars.png and fig_composition.png (separate files, >=1500px, 300 dpi)
-- Cover letter (see `release/2026-03-18 Oeconomia/cover letter.txt`)
-- AI disclosure statement (see `release/2026-03-18 Oeconomia/Use of AI statement.txt`)
+- Cover letter (see `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/cover letter.txt`)
+- AI disclosure statement (see `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/Use of AI statement.txt`)
 - Metadata: English + French abstracts, English + French keywords, JEL codes B20/Q54/F35/Q56
 
 **Zenodo deposit**: https://doi.org/10.5281/zenodo.19097045
@@ -126,7 +126,7 @@ GROBID-parsed refs matched against refined_works.csv using rapidfuzz token_sort_
 
 Francesco Sergi (managing editor) replied: paper not selected for the special issue "History of Climate Economics" (~50 submissions received), but encouraged to submit as Varia contribution "at your earliest convenience."
 
-Full decision letter: `release/2026-01-14 Special Issue on Climate Economics/20260216 decision.txt`
+Full decision letter: `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-01-14 Special Issue on Climate Economics/20260216 decision.txt`
 
 Key quote: "considering the quality of your proposal [...] and its relevance with respect to the general scope of Oeconomia, we encourage you to consider submitting your paper to our journal, independently from the special issue, as a 'Varia' contribution."
 
@@ -136,7 +136,7 @@ Key quote: "considering the quality of your proposal [...] and its relevance wit
 
 Submitted extended abstract "History of climate finance as an economic object: accounting categories, controversies, and economists as policy experts" to Oeconomia's special issue "History of Climate Economics."
 
-Full text: `release/2026-01-14 Special Issue on Climate Economics/extended abstract.md`
+Full text: `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-01-14 Special Issue on Climate Economics/extended abstract.md`
 
 ---
 
@@ -144,7 +144,7 @@ Full text: `release/2026-01-14 Special Issue on Climate Economics/extended abstr
 
 Initial guidance from editor on special issue scope and requirements.
 
-See: `release/2026-01-14 Special Issue on Climate Economics/2025-11-26 email guidance editor.txt`
+See: `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-01-14 Special Issue on Climate Economics/2025-11-26 email guidance editor.txt`
 
 ---
 
@@ -153,7 +153,7 @@ See: `release/2026-01-14 Special Issue on Climate Economics/2025-11-26 email gui
 The special issue call "History of Climate Economics" was the initial target. After the abstract was not selected for the special issue but received encouragement from the managing editor, the strategy shifted to submitting the full manuscript as a Varia contribution. The ESHET-HES conference (Nice, May 2026) where the abstract was accepted provides a parallel venue.
 
 **Cover letter** (as sent):
-See `release/2026-03-18 Oeconomia/cover letter.txt`
+See `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/cover letter.txt`
 
 **AI disclosure** (as sent):
-See `release/2026-03-18 Oeconomia/Use of AI statement.txt`
+See `papiers/actif/Oeconomia_Inventing_Climate_Finance/2026-03-18 Oeconomia/Use of AI statement.txt`

--- a/docs/revision-runbook.md
+++ b/docs/revision-runbook.md
@@ -133,7 +133,7 @@ For the response letter, compare v1 and v2 figures:
 ```bash
 # Manual comparison (ImageMagick):
 montage v1_fig_bars.png v2_fig_bars.png -tile 2x1 -geometry +10+10 \
-    release/revision-diff/fig_bars_comparison.png
+    "papiers/<state>/<track>/revision-diff/fig_bars_comparison.png"
 
 # Or: open both in an image viewer
 ```

--- a/tests/test_submission_docs_papiers.py
+++ b/tests/test_submission_docs_papiers.py
@@ -1,0 +1,41 @@
+"""Ticket 0160: submission-workflow docs must use the papiers/<state>/<track>
+convention, not the `release/` directory removed in the 0159 reorg.
+
+The submission-branch mechanism is kept (it freezes the manuscript *source* and
+its revision history); only the artifact-carrying role moved out of the repo to
+untracked `papiers/<state>/<track>/`. Process docs that still send new submission
+artifacts to `release/` are stale and would misdirect the next submission.
+
+Dated historical snapshots (braindumps) intentionally describe the pre-0159
+layout — the 0160 invariant says preserve historical events, rewrite only
+forward-looking process docs — so they are allowlisted.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCOPE = [".agent", ".claude/skills", "docs"]
+ALLOWLIST = {
+    "docs/braindump-2026-03-18.md",
+    "docs/braindump-2026-03-28.md",
+}
+
+
+def _scoped_md_files():
+    for top in SCOPE:
+        yield from (REPO / top).rglob("*.md")
+
+
+def test_no_release_dir_refs_in_process_docs():
+    offenders = []
+    for path in _scoped_md_files():
+        rel = path.relative_to(REPO).as_posix()
+        if rel in ALLOWLIST:
+            continue
+        if "release/" in path.read_text(encoding="utf-8"):
+            offenders.append(rel)
+    assert not offenders, (
+        "These docs still reference the removed release/ directory; route "
+        "submission records to papiers/<state>/<track>/ and the release journal "
+        "to docs/ (ticket 0160):\n  " + "\n  ".join(sorted(offenders))
+    )

--- a/tickets/closed/0160-submission-workflow-docs-to-papiers-convention.erg
+++ b/tickets/closed/0160-submission-workflow-docs-to-papiers-convention.erg
@@ -2,12 +2,14 @@
 Title: Rewrite submission-workflow docs/skills for the papiers/<state>/<track> convention
 Created: 2026-06-19
 Author: HDMX-coding-agent
+Closed: implemented — submission-workflow docs rewritten to papiers/<state>/<track> convention; submission-branch kept for source freeze (records → papiers), release journal at docs/; grep-ratchet test added
 
 --- log ---
 2026-06-19T08:18Z HDMX-coding-agent created
 2026-06-19T08:18Z HDMX-coding-agent note Split out of 0159 Phase 1. The extraction PR moved engine tooling and submission records but left submission-PROCESS docs pointing at the now-gone release/ dir. Author ratified deferring these to a follow-up (they encode a workflow that the reorg changes, not just stale paths).
 
 2026-06-19T11:07Z HDMX-coding-agent note blocker 0159 closed — Blocked-by removed.
+2026-06-19T11:25Z HDMX-coding-agent closed — implemented — submission-workflow docs rewritten to papiers/<state>/<track> convention; submission-branch kept for source freeze (records → papiers), release journal at docs/; grep-ratchet test added
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Route the submission workflow to papiers/<state>/<track> (ticket 0160)

Follow-up to the 0159 reorg, which removed `release/` from the repo. Several
process docs still sent new submission artifacts to `release/`; this fixes them.

**Open question resolved (author decision):** *keep* the submission-branch
mechanism. It freezes the manuscript **source** + revision history (git's job);
submission **records** route to untracked `papiers/<state>/<track>/`. This split
is now documented in the submission-branch skill + runbook.

### Changes
- **submission-branch** skill + runbook — "Source vs records" note; sprout places
  records in papiers and commits only the source freeze (no `git add release/`);
  errata / revision / resubmission / acceptance point at papiers; release-journal
  refs → `docs/`; acceptance does the `papiers/sent → papiers/published` mv.
- **submission-readiness** skill + runbook — artifact checklist + prior-art example.
- **coding-guidelines** — "submissions in release/" → records in `papiers/`.
- **docs/** historical pointers (`release-journal.md`, `rdj-submission-checklist.md`,
  `revision-runbook.md` example) — paths updated to papiers track paths / `docs/`;
  **events preserved** (0160 invariant: pointers only, no rewritten history).

### Test (TDD)
`tests/test_submission_docs_papiers.py` — grep-ratchet: no `release/` in
`.agent` / `.claude/skills` / `docs` (dated braindumps allowlisted as historical
snapshots). Red before the rewrite, green after.

Mechanical adherence covered by `make check-fast` (1002 passed, incl. ruff +
the new ratchet). Self-reviewed for prose + path correctness.

Ticket-ref: tickets/closed/0160-submission-workflow-docs-to-papiers-convention.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
