### PR TITLE
test(prose): fix test_substrate_smoke after section auto-numbering

### DIFF
--- a/tests/test_manuscript_prose.py
+++ b/tests/test_manuscript_prose.py
@@ -271,7 +271,7 @@ def test_substrate_smoke():
     assert len(body()) > 1000
     assert len(paragraphs()) > 20
     assert abstract().startswith("**Abstract.**")
-    assert "Copenhagen" in section("2. Crystallization")
+    assert "Copenhagen" in section("Crystallization")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Regression fix. PR #832 (auto-numbered sections) renamed the act headings, so
`test_substrate_smoke` — which sliced `section("2. Crystallization")` — went red
on main. Match the act by its stable name `section("Crystallization")` instead.

Per the CI test-polarity rule (ticket 0148), a section number is volatile
positive content and must not be pinned; the act name is lexically stable.

`tests/test_manuscript_prose.py` — 26 passed.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)