### PR TITLE
build: make recipe for the Charles Gide conference paper

### DIFF
--- a/_quarto-manuscript-Gide.yml
+++ b/_quarto-manuscript-Gide.yml
@@ -1,0 +1,9 @@
+project:
+  render:
+    - content/manuscript-Gide.qmd
+    - "!content/manuscript.qmd"
+    - "!content/corpus-report.qmd"
+    - "!content/technical-report.qmd"
+    - "!content/breakpoint-detect-method-zoo.qmd"
+    - "!content/data-paper.qmd"
+    - "!content/multilayer-detection.qmd"

--- a/manuscript.mk
+++ b/manuscript.mk
@@ -49,3 +49,29 @@ output/content/manuscript.pdf: $(MANUSCRIPT_INPUTS)
 
 output/content/manuscript.docx: $(MANUSCRIPT_INPUTS)
 	quarto render $(MANUSCRIPT_SRC) --to docx
+
+# ── Charles Gide conference variant ─────────────────────────────────────────
+# Short French paper (manuscript-Gide.qmd) presented at the 21e colloque Charles
+# Gide. Same writing workpackage: shares the manuscript's git-tracked figures +
+# tab_venues.md and manuscript-vars.yml. Its own Quarto profile excludes ALL
+# sibling docs (including manuscript.qmd) so a bare render builds only the Gide
+# paper. No data, no uv — Quarto + LaTeX only.
+#
+# NOTE: content/manuscript-Gide.qmd is the author's working draft and is
+# deliberately NOT git-tracked yet, so `make gide` builds only where that file
+# is present (the author's checkout), not in a clean-room checkout. Track it
+# later to make this workpackage fully reproducible (cf. the manuscript slice of
+# ticket 0131).
+GIDE_SRC     := content/manuscript-Gide.qmd
+GIDE_PROFILE := _quarto-manuscript-Gide.yml
+
+GIDE_INPUTS := $(GIDE_SRC) $(MANUSCRIPT_BIB) $(MANUSCRIPT_CSL) \
+               $(MANUSCRIPT_VARS) $(GIDE_PROFILE) $(MANUSCRIPT_DELIVERABLES)
+
+output/content/manuscript-Gide.pdf: export QUARTO_PROFILE := manuscript-Gide
+
+output/content/manuscript-Gide.pdf: $(GIDE_INPUTS)
+	quarto render $(GIDE_SRC) --to pdf
+
+.PHONY: gide
+gide: output/content/manuscript-Gide.pdf


### PR DESCRIPTION
Adds a `make gide` target (`output/content/manuscript-Gide.pdf`) and its
`_quarto-manuscript-Gide.yml` isolation profile, mirroring the manuscript
workpackage (ticket 0131): shares the git-tracked figures + `tab_venues.md` +
`manuscript-vars.yml`, renders Quarto-only — no data, no `uv`. The profile
excludes every sibling doc (including `manuscript.qmd`) so a bare render builds
the Gide paper alone.

Verified: `make -f manuscript.mk gide` builds the PDF (494 KB) in a data-less
worktree; recipe is `quarto render` only, no Phase-1 leak.

`content/manuscript-Gide.qmd` is left as the author's untracked working draft per
request — the recipe builds from it where present. A clean-room checkout won't
build it until the source is tracked (noted in the recipe comment).

Recipe only; the Gide source is untouched.

`tests/test_makefile_contract.py` + `tests/test_build_phase_separation.py`: 28 passed.

Ticket-ref: tickets/0163-split-build-remaining-writing-workpackag.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)