### PR TITLE
docs(gide): author's own French prose as style references

### DIFF
--- a/content/style-references/1998-faut-il-moderer.txt
+++ b/content/style-references/1998-faut-il-moderer.txt
@@ -1,0 +1,571 @@
+Faut-il modérer le changement climatique?
+Minh Ha Duong 
+9 octobre 1998
+
+Résumé
+Ce texte commence par une présentation du changement climatique:
+pourquoi est-ce un problème social majeur et comment les gouvernements
+y répondent ils ? La section suivante est consacrée à l’analyse économique
+de cette réponse, autour notament des accords signés à Kyoto. Elle aborde
+les thèmes de l’actualisation, de l’inertie des systèmes énergétiques et du
+progrès technique. Enfin, la conclusion discute une caractéristique fondamentale pour l’analyse économique de ce type de problème d’environnement:
+l’incertitude. La thèse sous jacente à cet article [3] est que l’irréversibilité est
+une raison justifiant une action de précaution, c’est à dire une réduction sensible à court terme des émissions atmosphériques de dioxyde de carbone
+d’origine humaine.
+
+1 Introduction
+La composition chimique de l’atmosphère a connu des changements importants depuis la révolution industrielle. La quantité de méthane dans l’air
+a augmenté de 145% et celle de dioxyde de carbone de 30%. Il est connu
+depuis plusieurs siècles que ces gaz, comme la vapeur d’eau, contribuent à
+l’effet de serre en captant l’énergie rayonnée depuis la surface de la planète.
+Ces phénomènes sont à la base du changement climatique, un dossier qui
+ne cesse de prendre de l’importance depuis quelques années. La diminution
+des émissions polluantes de gaz à effet de serre contribue déja à l’orientation
+des politiques énergétiques nationales. Ce texte explique pourquoi, dans un
+avenir proche, elle devrait concerner tous les citoyens dans leurs choix quand
+à la façon de consommer, de se déplacer et de se loger.
+ Chargé de Recherches au CNRS, Centre International de Recherche sur l’Environnement et
+
+le Développement. CIRED, Jardin Tropical - 45 bis avenue de la Belle Gabrielle, 94732 Nogent
+sur Marne CEDEX. haduong@centre-cired.fr.
+
+1
+
+La section 2 qui suit s’attache à montrer la nature du problème constaté et
+les solutions mises en oeuvre. Elle procède d’une plus approche transversale
+des enjeux sociaux du problème. Suivant ces fondements généraux, la partie
+3 et la conclusion, axées sur un débat scientifique concernant le timing des
+efforts de réduction de la pollution (faut-il agir et quand?), se rapportent plus
+spécifiquement aux problèmes d’analyse économique liés à l’évaluation de
+la politique climatique.
+
+2 Du phénomène physique au problème politique
+Comme nous l’avons vu en introduction, la composition chimique de
+l’atmosphère a récemment évolué dans un sens susceptible de conduire à un
+réchauffement global. Mais les effets de la perturbation sur la température,
+les précipitations ou le niveau de la mer s’inscrivent sur le fond d’une variabilité naturelle importante. Par exemple, selon les climatologues, depuis la
+fin du XIXe siècle la température moyenne globale semble bien avoir augmenté de 0,3 C à 0,6 C environ, alors que sa plage de variabilité ‘naturelle’
+pendant les derniers dix mille ans serait de l’ordre de 1 C.
+
+2.1 Réalité du problème
+On peut donc soulever avec inquiétude la question de l’attribution de
+la responsabilité anthropique aux changements climatiques observés. Aujourd’hui un faisceau d’indices scientifiques convergent vers une confirmation statistique de cette responsabilité[7]. On ne peut guère s’en étonner,
+compte tenu de l’accroissement des moyens de calculs informatiques, mais
+aussi par l’amélioration des modèles ainsi que de la qualité et de la quantité des données qu’ils utilisent: le signal devient de plus en plus important
+chaque année. Cependant, même si la quête de la certitude mathématique
+avec toujours plus de décimales exactes est importante pour mieux prédire
+le changement climatique, la fraction d’incertitude résiduelle ne doit pas être
+exagérée.
+La figure 1 montre, à droite, différents hypothèses de réchauffement T
+global correspondant, à gauche, à différents scénarios d’évolution de la concentration atmosphérique de CO2 definies dans [6]. Le profil S350, par
+exemple, suppose que la concentration va cesser d’augmenter avant le milieu de XXIe siècle, pour revenir vers 2150 à peu près au niveau de l’année
+1988 soit 350 parties par million. La barre d’erreur horizontale correspondante à droite montrent que le réchauffement global à long terme dans ce
+cas est évalué entre un peu moins de +1 C et +2.5 C, avec une estimation
+de l’ordre de 1.5 C. Toutefois, ce scénario serait économiquement très diffi-
+
+
+
+2
+
+F IG . 1 – A gauche, scénarios de stabilisation de la concentration de CO2 dans
+l’atmosphère. A droite, réchauffement global correspondant, en valeur centrale
+(points) et plage d’incertitude (segment horizontaux). La ligne verticale pointillée
+a dénote la variabilité naturelle, la verticale pointillée b dénote le seuil reconnu comme dangereux par le Stockolm Environmental Institute. D’après Azar
+et Rodhe, Science, 1997.
+
+3
+
+cile à réaliser. Il impliquerait en pratique une diminution immédiate et drastique de la consommation mondiale de combustibles fossiles, difficilement
+conciliable avec les tendances lourdes de la démographie et de l’économie.
+A terme, un réchauffement global non négligeable devant la variabilité naturelle est donc l’hypothèse la plus réaliste.
+Faut-il pour autant s’alarmer d’un tel réchauffement ? Comme on peut
+le lire ça et là, après tout, la plupart d’entre nous préfèrent avoir chaud que
+froid ! Réfléchir ainsi à court terme sous- estimerait considérablement l’ampleur du problème. En l’absence de régulation forte des marchés, on ne
+voit pas ce qui empêcherait la consommation d’énergie fossile de continuer à augmenter au siècle prochain, tirée par la croissance démographique
+et économique. Les réserves cumulées de pétrole, gaz et surtout de charbon semblent aujourd’hui largement suffisantes pour suivre ou dépasser le
+scénario S1000. Le réchauffement global, pouvant atteindre 6.4 C à l’horizon 2100 et bien au delà ensuite [7], risque de dépasser largement tout ‘optimum climatique’.
+A ce stade, il semble important de souligner la différence entre la cause,
+le réchauffement global et une conséquence, le changement climatique.
+– La moyenne annuelle de la température pour toute la surface du globe
+est un indicateur qui a le mérite d’être synthétique et clair. Mais un
+chiffre moyen pouvant sembler faible peut très bien masquer des variations locales et intra-annuelles importantes.
+– De plus, on ne doit pas perdre de vue que les climats ne se limitent pas
+à la température: pour l’agriculture, la répartition des apports d’eau
+dans l’année, le nombre de jours de soleil ou la date de la dernière
+gelée sont tout aussi importants.
+– Enfin, il existe d’autres conséquences du réchauffement global, comme
+la hausse du niveau des mers consécutif à la dilatation thermique des
+océans. Le niveau a monté de 10 à 25 cm au siècle passé, et on peut
+s’attendre à quelques dm supplémentaires d’ici à 2100.
+La complexité de toutes ces conséquences permettent de comprendre
+pourquoi les modèles intégrés actuels sont insuffisament précis pour évaluer
+les risques à l’échelle locale. On sait par exemple que le courant marin dans
+l’Atlantique Nord qui assure la douceur hivernale en Europe occidentale, le
+Gulf Stream, peut être considérablement affaibli dans une configuration climatique plus chaude. C’est d’ailleurs pourquoi certains scientifiques qualifient la circulation thermohaline Nord-Atlantique de ‘talon d’Achille’ du
+climat. Mais on ne sait pas prédire quand cet affaiblissement se produirait.
+Il est également difficile de relier le changement de régime du phénomène
+El-Niño depuis quelques années à l’augmentation de la concentration de gaz
+à effet de serre.
+L’humanité s’est développée et adaptée à des conditions climatiques
+
+4
+
+relativement stables. Cette adaptation s’est traduite, par exemple, par une
+répartition du peuplement mondial, par l’édification de villes, de ports et
+autres infrastructures, par la structuration de sociétés autour de techniques
+agricoles, et aussi par l’accoutumance aux insectes, parasites et pathologies
+diverses qui accompagnent les conditions climatiques. Il existe un risque
+réel que les conditions bifurquent rapidement. En ce cas l’adaptation ne sera
+pas nécessairement un exercice gratuit et facile. Celui-ci peut au contraire
+s’avérer coûteux et tragique, tant que ces conditions ne seront pas stabilisées.
+
+2.2 Le traitement international
+Le débat précédent n’est peut être pas encore bien connu du grand public,
+comme en témoingnent de façon réccurente les colonnes Débats du journal
+Le Monde. Au niveau gouvernemental toutefois, les questions de l’attribution et d’existence du risque que nous venons d’examiner plus haut ne se
+posent plus vraiment depuis qu’en 1992 à Rio, la plupart des pays ont reconnu explicitement le risque à long terme de la pollution d’origine humaine
+par les gaz à effet de serre.
+Conscients de l’importance du problème, les États mettent en oeuvre
+des politiques de deux ordres pour y répondre. D’une part, des mesures
+d’adaptation visent à atténuer les effets des perturbations d’ores et déjà
+inévitables. D’autre part, pour la sécurité du climat, il est nécessaire de
+réduire les niveaux d’émissions mondiales de gaz à effet de serre nettement en dessous des niveaux actuels. C’est l’objectif ultime des mesures de
+modération du changement climatique et du processus mis en place à Rio de
+Janeiro en 1992 avec la signature de la Convention Cadre des Nations Unies
+sur le Changement Climatique, appelée aussi la Convention Climat. Outre
+sa valeur symbolique, la Convention a organisé la réflexion internationale
+sur les plans diplomatique et scientifique.
+L’action diplomatique est d’une envergure supérieure à celle des accords
+de Montréal sur la limitation des Substances Appauvrissant la Couche d’Ozone. Son étendue la rapprocherait davantage de l’exemple des discussions
+sur le commerce international, commencées dès 1948 et n’ayant aboutit à
+l’OMC qu’en 1996. Au stade actuel, les pays développés tentent d’élaborer
+entre eux une règle du jeu acceptable. Tous les pays n’attendent pas l’émergence
+éventuelle d’un système de permis d’émissions échangeables pour agir. La
+Suède, par exemple, a introduit dès 1991 une taxe sur les émissions de
+dioxyde de carbone.
+Les aspects scientifiques du dossier sont suivis par le Groupe d’experts
+Intergouvernemental sur l’Evolution du Climat. Le GIEC, aussi appelé IPCC
+en anglais, est une institution originale placée sous la double égide de l’Organisation Météorologique Mondiale et du Programme des Nations Unies
+pour l’Environnement. Sa fonction est de traiter de l’état général des con-
+
+5
+
+www.unfccc.de
+
+www.ipcc.ch
+
+Année de base
+1990
+
+Estimation
+1995
+
+Projection
+2010
+
+Union Européenne
+OCDE moins UE
+Pays en transition
+
+949
+2086
+1311
+
+936 -1%
+2254 +8%
+925 -29%
+
+873 -8%
+1961 -6%
+1298 -1%
+
+Total Annexe I
+Hors-Annexe I
+
+4346
+1774
+
+4115 -5%
+2225 +25%
+
+4132 -5%
+4007 +126%
+
+Total Monde
+
+6120
+
+6340 +4%
+
+8139 +33%
+
+TAB . 1 – Emissions de CO2 d’origine fossile par grandes régions, en Mt de carbone par an. Variations par rapport à l’année de base 1990. Les projections pour
+l’Annexe I correspondent au Protocole de Kyoto, pour les pays en développement
+on suppose un taux de croissance annuel des émissions de 4%.
+
+naissances scientifiques et techniques se rapportant au changement climatique. Ses travaux visent donc à représenter l’ensemble des opinions publiées
+dans des revues scientifiques. Pour cela, plus de deux mille experts de par
+le monde participent à la rédaction et à l’analyse de ses textes, et un effort
+particulier est fait pour inclure les pays en développement. Des gouvernements représentant l’ensemble de la planète approuvent et ratifient les documents du point de vue scientifique et technique. C’est pourquoi ses rapports
+bénéficient d’une autorité légitime et peuvent avoir un rôle de support objectif dans les débats internationaux.
+
+2.3 Le Protocole de Kyoto
+Même si les engagements pris reflètent d’abord l’aboutissement de rapport de forces politiques et diplomatiques entre les nombreuses parties prenantes
+aux négociations, l’argument scientifique ne saurait être totalement absent
+de l’orientation des débats. Les travaux les plus récents du GIEC mettent en
+évidence la détection statistique de la responsabilité humaine dans la perturbation du climat. Ce point confirme la nécessité de réduire à long terme les
+émissions polluantes bien en dessous du niveau actuel. Toutefois, la question
+de l’action à court terme reste moins consensuelle.
+Des divergences à ce sujet sont apparues à l’occasion de la Conférence
+de Kyoto en 1997, d’autant plus clairement que le débat s’était focalisé sur
+un paramètre simple : un objectif de réduction et de limitation d’émission
+quantifié. Ce paramètre signifie que si les émissions polluantes constatées en
+
+6
+
+%
+
+1990 étaient de 100 et l’objectif est x , alors les émissions permises en 2010
+sont de
+ , x ). Sous ce rapport, les observateurs ont pu apprécier
+la différence entre la proposition américaine de stabilisation des émissions,
+soit x
+, et la proposition européenne d’un ambitieux x
+. Ils
+ont aussi pu remarquer le remarquable sens arithmétique des négociateurs,
+puisque l’accord s’est conclut exactement au milieu du gué (x
+pour
+les américains et x
+pour l’europe, voir la table 1 d’après [1]).
+Concernant les pays développés, dit aussi “cités à l’Annexe I de la Convention Climat”, le Protocole de Kyoto peut être vu comme une invitation
+à échanger des unités de réduction, entre l’OCDE et les Pays en transition.
+Pour l’Annexe I dans son ensemble, le Protocole ne stipule pas de réduction
+au delà du -5% existant en 1995. La table 1 montre clairement que le monde
+reste dans une logique de croissance des émissions de gaz à effet de serre.
+Or c’est une décroissance durable qui serait nécessaire à la stabilisation des
+concentrations. A plus long terme, on peut montrer que si les pays de l’Annexe I ne parviennent pas à coopérer avec les pays Hors Annexe I pour la
+période 2010-2020, alors l’objectif de stabilisation à 450 ppmv de la concentration atmosphérique de CO2 deviendra très difficile à atteindre.
+Au delà de ces deux aspects relativement transparents, la critique du
+Protocole de Kyoto appelle aussi de nombreuses questions plus difficiles.
+
+100 (1
+= 0%
+
+)
+
+= 15%
+= 7%
+
+= 8%
+
+3 Comment évaluer la politique climatique?
+Comment évaluer, maintenant d’un point de vue économique, ces engagements chiffrés qui orientent la politique climatique globale ? La figure
+1 montrait les conséquences possibles des scénarios S550 et au dessus en
+ce qui concerne le réchauffement global. Mais pour répondre à la question
+précédente, il est nécessaire de d’intéresser plutôt aux effets du changement
+climatique sur les sociétés humaines, et non sur la température. Le problème
+de l’incertitude prend alors une importance supérieure pour l’évaluation
+des politiques de court terme. Nous y reviendrons, mais dans cette partie
+commençons par examiner une question plus précise: Avec quel objectif climatique à long terme Kyoto est-il cohérent?
+Bien que l’incertitude reste le problème fondamental, une analyse économique
+grossière des coûts et des avantages reste toujours possible, et nécessaire.
+Comme dit plus haut, il semble clair que viser un objectif de 350 ppmv
+demanderait des efforts très importants, disproportionnés par rapport aux
+bénéfices attendus. La concentration actuelle est de l’ordre de 360 ppmv, il
+faudrait revenir en arrière. Il semble plus simple de tolérer un changement
+climatique léger et de s’y adapter. Mais d’un autre côté, il n’est pas possible
+courir le risque associé à S1000, avec un réchauffement potentiel supérieur
+à 9 C. Dans tous les pays, le secteur énergétique est fortement régulé, et les
+possibilités techniques à long terme sont immenses.
+
+7
+
+Afin de mieux comprendre ce qui pourrait amener à préférer, dans cet interalle très large ouvert entre 350 et 1000 ppmv, un objectif environnemental
+plutôt qu’un autre, nous explorerons trois aspects critiques que sont l’actualisation, la flexibilité et le progrès technique.
+
+3.1 L’actualisation
+La courbe de la population mondiale a récemment connu un point d’inflexion: sa croissance est appelée à se ralentir davantage dans le futur. De
+même, il peut être possible de s’attendre à une baisse tendancielle du taux
+d’enrichissement par habitant au cours de siècle prochain. Mais compte tenu
+du développement économique observé sur les deux derniers siècles, dans
+l’ensemble, les décideurs peuvent s’attendre à ce que nos descendants soient
+plusieurs fois plus riches que nous. Comment, dans ces conditions, évaluer
+des mesures qui mettent en jeu simultanément les intérêts de générations
+existantes et futures?
+L’actualisation (ou escompte) est le principal outil analytique dont se servent les économistes pour comparer les effets se produisants à des périodes
+différentes. Son principe est celui des intérêts composés: au taux r , 1 unité
+de compte aujourd’hui équivaut à seulement =
+r unités à la période
+suivante. Le choix du taux d’actualisation a une grande importance technique pour l’analyse de la politique en matière de changement climatique,
+car l’horizon temporel est extrêmement long et le coût de l’atténuation a tendance à être ressenti bien plus tôt que les bénéfices des dégâts évités. Plus
+ce taux est élevé, plus les futurs bénéfices sont négligeables et plus les coûts
+actuels prennent d’importance dans l’analyse.
+Une théorie du taux d’actualisation est d’autant plus nécessaire qu’il
+serait invraisemblable de reprendre pour l’environnement global une valeur
+aussi élevée que les 8% utilisés pour le calcul économique courant des investissements de l’État en France. Cette théorie a aussi un intérêt en elle
+même, car elle relie directement aux interrogations les plus profondes de la
+pensée économique, notamment celles relatives à la croissance et l’accumulation du capital.
+Pour déterminer un taux d’actualisation, on reconnaı̂t aujourd’hui deux
+approches:
+
+1 (1 + )
+
+– La première approche, dite descriptive, met en parallèle les mesures
+de protection du climat et les autres investissements de la société. De
+même que l’éducation contribue à accumuler du capital humain, et la
+croissance du capital industriel, il s’agit de reproduire et de transmettre
+un patrimoine.
+La théorie de l’efficacité économique suggère alors d’égaliser le taux
+d’actualisation avec le taux de rentabilité des autres investissements
+
+8
+
+publics à long terme ne comprenant aucun risque. Les études empiriques concernant ce dernier conduisent à suggérer un taux situé entre 3% et 6% à prix constant.
+– La seconde approche, dite normative, considère l’actualisation comme
+un paramètre fondé sur l’éthique des choix collectifs. On actualise
+alors la consommation des diverses générations au moyen d’un “taux
+de préférence collective pour le présent”, défini comme la somme de
+deux termes:
+Le taux de préférence pure pour le présent renvoie à l’idée d’impatience et mesure en quelque sorte la distance à laquelle nous
+situons les intérêts des générations futures par rapport à ceux de
+la génération présente. Il est usuellement pris entre
+et
+.
+L’effet richesse provient du fait que nous pensons que les conditions
+de vie des générations futures seront meilleures que les notres, et
+nous pensons que la valeur supplémentaire d’une unité de biens
+sera moindre dans les sociétés plus riches du futur. Cet effet peut
+être contesté compte tenu de la nature particulière des biens environnementaux et des ressources naturelles. Cependant, il peut
+s’illustrer de façon assez convaincante par l’exemple suivant: La
+satisfaction qu’un consommateur moderne tire d’un kilo de farine
+de blé est certainement inférieure à ce que son ancêtre du XIXe
+siècle en tirait.
+
+0% 1%
+
+Au total, cette approche normative conduit à considérer des taux en
+général inférieurs à
+.
+
+3%
+
+Le choix du taux d’actualisation est un problème parce que c’est un
+paramètre critique pour l’évaluation des politiques climatiques, et que les
+diverses méthodes disponibles donnent des résultats sensiblement différents.
+Ce problème ne peut pas être contourné en raisonnant selon une approche
+coût-efficacité, c’est à dire en examinant seulement comment atteindre à
+moindre coût un objectif climatique donné par ailleurs. Certes, cela dispense
+d’évaluer formellement les bénéfices de la modération du changement climatique. Mais l’analyse suggère toujours de reporter d’autant plus les efforts
+sur les générations futures que le taux d’actualisation utilisé est élevé.
+A ce stade, diverses réponses sont possibles. La plus pragmatique consisterait à regarder ce paramètre comme un instrument subjectif, les points
+de vues différents étant également valides dans la mesure où ils sont clairs
+et correctement argumentés. La plus radicale consiste à rejeter l’idée de la
+recherche d’un optimum économique, pour se concentrer sur l’analyse des
+trajectoire faisables ou possibles. Entre ces attitudes, s’élabore actuellement
+un volume de travaux important sur le choix collectif et le développement
+durable, dont on peut espérer un jour des outils formels et numériques plus
+satisfaisants
+
+9
+
+3.2 La flexibilité et l’inertie
+Le second point clé qu’il est nécessaire de discuter pour évaluer les politiques climatiques décrit la possibilité de changer plus ou moins rapidement
+avec des coûts d’ajustement plus ou moins élevés. La flexibilité a deux effets
+opposés sur la désirabilité d’un effort de réduction à court terme.
+– D’un côté, l’inertie liée au capital en place impose le changement
+dans la continuité, en interdisant toute déviation rapide des trajectoires
+actuelles.
+– De l’autre, cette même inertie implique qu’il est d’autant plus urgent
+de débuter les réformes tôt que celles ci seront longues réaliser.
+Métaphoriquement, on retrouve ici le schéma d’opposition entre le lièvre
+et la tortue. Celle-ci doit soutenir un effort constant tout au long de la course,
+et en particulier dès le départ. Le premier peut se permettre de démarrer fort,
+mais compte surtout être en mesure de compléter rapidement le trajet sur la
+fin, et à cause de sa préférence pour le présent (l’actualisation !), il y trouve
+intérêt.
+Nous parlons ici de la transition vers des sociétés moins émettrices de
+carbone, ce qui exigera le remplacement de la base matérielle de l’économie.
+La vitesse à laquelle ce renouvellement du capital en place peut s’effectuer
+sans entrainer de coûts d’ajustement trop élevés correspond au rythme d’amortissement naturel des équipements Il est plus pratique de considérer, plutôt
+que ce rythme de dépréciation, la durée de vie D des systèmes énergétiques
+comme mesure de la flexibilité.
+Cela permet d’apprécier, en première approximation, l’urgence de faire
+démarrer les politiques de modération de l’effet de serre, en comparant cette
+durée de réforme du système socio-économique D avec le temps restant T
+avant que le climat franchisse un seuil de danger. Si l’actualisation incite à
+repousser les efforts dans le futur, l’inertie fixe la durée totale de ces efforts
+et impose de commencer à temps pour ne pas encourir de coûts d’ajustement
+trop élevés
+L’histoire énergétique des deux derniers siècles montre une succession
+de formes d’énergie primaire dominante de moins en moins polluantes, la
+biomasse, le charbon, le pétrole, et peut être demain le gaz. Chaque transition a pris environ un demi siècle. Ce chiffre, pour D , pourrait sembler
+élevé devant la durée de vie d’une centrale thermique ou des équipements
+ménagers. Ce serait oublier que les systèmes énergétiques sont aussi déterminés
+par un ensemble de facteurs interdépendants plus large, tant pour l’offre que
+pour la demande. La production, le transport et la distribution font appel à
+des infrastructures lourdes, souvent à l’échelle nationale comme des ports ou
+des pipe-lines. La structure de l’habitat, la qualité du bâti et les schémas de
+transports dépendent de considérations sociales encore plus générales, tout
+ceci évoluant lentement à l’échelle de la génération.
+
+10
+
+Pour se faire une idée sur T , on peut considérer que la concentration
+de dioxide de carbone dans l’atmosphère, qui était de l’ordre de 280 ppm
+avant la révolution industrielle, atteind aujourd’hui environ 365 ppm et augmentate environ de 15 ppm par décennie. Certains ont pu fixer un seuil de
+danger climatique à 2 C de réchauffement global, ce qui serait très probablement atteint après que la concentration s’élève à 450 parties par million
+(ppm) et très probablement dépassé si elle atteignait 550 ppm.
+Cette évaluation permet de justifier l’urgence de l’action si l’on souhaite
+respecter ce seuil de danger. En l’absence de mesures, la concentration de
+CO2 pourrait atteindre 450 ppm avant le milieu du siècle prochain, T  .
+C’est en tout cas le point de vue transparaissant dans le Protocole de la
+Convention Climat, qui ne laisse pas de délai pour débuter une redirection
+de la production et de la consommation d’énergie mondiale.
+
+50
+
+3.3 Le progrès technique
+Le jeu combiné de l’inertie (D ) et de l’actualisation permet, étant donné
+un objectif environnemental (T ), une approche empirique approximative
+concernant la question de la répartition temporelle des efforts de réduction,
+évoqués notamment dans [11]. Peut- on préciser davantage?
+A court terme, il semble que les technologies aujourd’hui disponibles
+ouvriraient de nombreuses potentalités de réduction d’émissions. Mieux même,
+on estime souvent que plus de 10% de réduction serait accessible à coût
+négatif ou nul, à l’aide d’options ‘sans regrets’.
+Mais lorsque l’on cherche à projeter l’analyse au-delà de 20 ans, pour
+une évaluation quantitative plus fine du coût de la limitation des émissions,
+et de la stabilisation de la concentration de CO2 à tel ou tel niveau, alors la
+question du progrès technique à long terme dans différents secteurs se pose
+[9, 2].
+L’objectif final pour résoudre le problème du changement climatique
+est de développer des nouveaux moyens de production et de consommation
+d’énergie. L’état actuel des connaissances sur l’évolution des conditions de
+production économique ne permet pas une approche prédictive. La question
+centrale de savoir ce qui crée le progrès technique, et au fond la richesse de
+nos sociétés, n’est toujours pas résolue.
+A ce propos, nous allons montrer maintenant comment la vue que l’on
+peut avoir à propos du lien entre réduction d’émissions et progrès technique
+a des conséquences directes sur le contenu des actions à engager.
+– Si on suppose que l’essentiel du progrès technique est produit par l’accumulation des connaissances et des dépenses publiques de RechercheDéveloppement, on pourrait en principe développer de nouvelles technologies, sans pour cela diminuer simultanément les émissions.
+
+11
+
+Dans une ‘première phase’, les Etats pourraient consacrer l’essentiel des ressources contre le changement climatique à la recherche et
+au développement des solutions énergétiques alternatives. Il s’agirait
+de développer des prototypes et des pilotes, en vue d’une ‘deuxième
+phase’ de la résolution du problème, au cours de laquelle se ferait
+l’essentiel de la réduction des émissions. Une telle approche permettrait de gagner quelques décennies avant d’agir, puisque on pourrait
+polluer tant qu’on accumule une réserve de progrès technique suffisant.
+– Toutefois, plusieurs arguments s’opposent à cette politique ‘Attendre
+et dépenser, puis courir’. Développer des technologies sans base installée est difficile, car l’histoire montre que le progrès favorise nettement les technologies existantes. De plus, faire pénétrer rapidement
+une vague de nouvelles technologies moins polluantes dans le secteur
+de l’énergie semble difficile cause du couplage des technologies.
+En effet, les différentes composantes des systèmes techniques dépendent
+les unes des autres et ne peuvent pas être remplacées indépendamment
+de façon modulaire. Ces deux rétroactions positives induisent des verrouillages technologiques (lock-in) qui font que le passage du temps
+ne correspond pas nécessairement à l’augmentation du nombre des options possibles.
+C’est pourquoi on peut penser que l’essentiel du progrès technique
+dans un domaine est induit par les changements dans les conditions du
+marché correspondant, et non par une accumulation de connaissances
+scientifiques globales ou par la dépense publique de R&D. Tenter
+d’accélérer le progrès technique sans vouloir restreindre les émissions
+polluantes pourrait être une politique peu cohérente et inefficace.
+
+Le Protocole de Kyoto peut sembler se situer dans la seconde perspective. Force est de reconnaitre qu’actuellement, une bonne part de la R&D
+privée vise à l’amélioration des technologies à base de combustibles fossiles.
+Des politiques contraignantes en matière d’émissions de CO2 tendraient à
+créer des incitations appropriées sur les marchés de l’énergie pour réallouer
+une part de cette R&D sur les technologies peu ou pas émettrices.
+Cependant, le bilan des implications de l’accord de Kyoto sur le progrès
+technique nous semble plutôt mitigé. En effet, le dispositif mis en place
+n’offre pas encore le cadre stable à long terme nécessaire pour justifier des
+investissements industriels importants dans les nouvelles technologies. De
+plus, alors qu’une responsabilité anthropique dans le changement climatique
+le justifierait, le Protocole ne va pas au delà du ‘sans regret’.
+
+12
+
+4 Conclusion: Le principe de précaution
+Nous pouvons maintenant revenir au problème fondamental de l’incertitude. Certes, l’accord de Kyoto est compatible avec un objectif plus proche
+de 450ppmv que 550ppmv, mais la souveraineté des États demeure quant à
+l’orientation effective des politiques énergétiques. Compte tenu du blocage
+du Sénat américain, on est loin d’être assuré, par exemple, que ce Protocole,
+sera un jour juridiquement valable.
+On ne peut pas exclure aujourd’hui que l’objectif final s’élève, par exemple, à une concentration de 650 ppm de CO2 dans l’atmosphère. Or pour ce
+niveau ou au-dessus, les analyses que nous venons d’exposer laissent penser
+que les objectifs fixés à Kyoto sont économiquement inefficaces. Est-ce à
+dire qu’il est peut être plus urgent d’attendre?
+Non, car il ne s’agit pas de décider une fois pour toutes de la politique
+climatique à suivre dans les 100 ans a venir, mais de choisir une stratégie
+prudente qui sera ajustée au fil du temps avec l’arrivée de nouvelles informations. En introduisant l’incertitude, le débat sur le timing gagne de nouvelles
+dimensions:
+– La plus immédiate est l’aversion au risque, ou tout simplement la prudence. On admet généralement qu’un bon père de famille ne devrait
+pas jouer de grosses sommes, même si l’espérance de gain nette est
+positive. De même, on peut penser assez légitimement que les sociétés
+devraient accorder une attention particulière aux risques globaux majeurs, mêmes si ceux si sont de probabilité inconnue ou faible.
+– La seconde dimension est le lien entre l’action et l’arrivée d’information. Par exemple, les réductions d’émissions de gaz à effet de serre
+diminuent le changement climatique. Cela tend à atténuer l’émergence
+du signal d’alarme observé par rapport au bruit de fond que représente
+la variabilité naturelle. Bien que mis en avant dans certains travaux, ce
+effet nous semble négligeable. Mettre en oeuvre le protocole de Kyoto, par exemple, ne ferait gagner que 1.5 ppm de dioxyde de carbone
+dans l’atmosphère sur une concentration de l’ordre de 400 ppm. En revanche, l’argument identique concernant les coûts de réduction semble
+beaucoup plus fort. La mise en place des marchés pour les technologies moins polluantes est susceptible de conduire à une meilleure connaissance de ces technologies, ce qui permettrait éventuellement de
+bénéficier d’une baisse significative de leurs coûts.
+– Enfin, le dernier et peut être le plus important effet justifiant le principe
+de précaution tient peut être à l’irréversibilité. D’un côté, l’action peut
+entraı̂ner des coûts économiques importants et irrécupérables qui risquent
+de s’avérer inutiles a posteriori. Mais de l’autre, retarder davantage
+l’action et laisser poursuivre la tendance croissante des émissions pol-
+
+13
+
+luantes conduit à une accumulation de gaz à effet de serre, qui risque
+d’impliquer des conséquences irréversibles et inattendues.
+Il ne nous est pas donné d’exposer ici davantage la théorie micro-économique
+relative à la prise de décision sous incertitude. Le lecteur intéressé par les
+liens entre notion de quasi-valeur d’option et de valeur espérée de l’information pourra se reporter à des articles plus spécialisés comme [4, 10, 8].
+Le changement climatique est symptomatique d’une classe de dossiers
+d’environnement où se pose le problème de la connaissance des bénéfices de
+l’action. On ignore comment s’évaluent les dommages économiques consécutifs
+au changement climatique en cours, donc il est impossible de quantifier
+précisément aujourd’hui les avantages des politiques de précaution. Pourtant les objectifs négociés à Kyoto correspondent à la mise en oeuvre sans
+délai de politiques et de programmes de restriction des émissions de gaz à
+effet de serre.
+La conjonction des effets de l’inertie et de l’incertitude, précédement
+sous estimés dans une part importante de la littérature [5], permet de donner
+une explication rationelle au principe de précaution: il s’agit de gagner du
+temps pour que les certitudes scientifiques arrivent avant les bifurcations du
+système climatique.
+
+Références
+[1] Bert Bolin. The Kyoto negotiations on climate change: A science perspective. Science, 279(5349):330–331, January 16 1998.
+[2] Michael J. Grubb. Technologies, energy systems and the timing of co2
+emissions abatement. Energy Policy, 25(2):159–172, 1997.
+[3] Minh Ha-Duong. Comment tenir compte de l’irréversibilité dans
+l’évaluation intégrée du changement climatique ? PhD thesis, École
+des hautes Études en Sciences Sociales, Paris, april 1998.
+[4] Minh Ha-Duong. Quasi-option value and climate policy choices. Energy Economics, pages 1–23, 1998. Forthcoming, Energy Economics.
+[5] Minh Ha-Duong, Michael J. Grubb, and Jean-Charles Hourcade. Influence of socioeconomic inertia and uncertainty on optimal CO2 emission abatement. Nature, 390:270–274, 1997.
+[6] T.M.L. Wigley I.G. Enting and M. Heimann. Future Emissions
+and Concentrations of Carbon Dioxide: Key Ocean/Atmosphere/Land
+Analyses. Number 31 in Division of Atmospheric Research Technical
+Paper. CSIRO, Australia, 1994.
+[7] IPCC. Second Assessment Synthesis of Scientific-Technical Information Relevant to Interpreting Article 2 of the UN Framework Convention on Climate Change. UNEP/WMO, 1995.
+
+14
+
+[8] Urvashi Narain and Anthony C. Fisher. Irreversibility and catastrophic
+global warming. In World Congress of Environmental and Resource
+Economists, Venice, Italy, June 25-27 1998. Deposited electronically
+at the GNEE archive.
+[9] Stephen H. Schneider and Lawrence H. Goulder. Achieving low-cost
+emissions targets. Nature, 389:13–14, 1997.
+[10] Alistair Ulph and David Ulph. Global warming, irreversibility and
+learning. The Economic Journal, 107(442):636–650, 1997.
+[11] T. M. L. Wigley, Richard Richels, and Jae A. Edmonds. Economic and
+environmental choices in the stabilization of atmospheric CO2 concentrations. Nature, 379(6562):240–243, 1996.
+
+15
+
+

--- a/content/style-references/2000-perspectives-changement-climatique.txt
+++ b/content/style-references/2000-perspectives-changement-climatique.txt
@@ -1,0 +1,767 @@
+Perspectives sur le changement climatique.
+Minh Ha Duong
+10 décembre 2002
+Chargé de Recherche au CNRS, section Économie. CIRED, Campus du Jardin
+Tropical, 45bis avenue de la belle Gabrielle, 94736 Nogent sur Marne CEDEX.
+tel. 43 94 73 75, fax. 43 94 73 70, courriel haduong@centre-cired.fr.1
+Résumé :
+Des progrès importants ont été réalisés cette dernière décennie dans la compréhension
+du changement climatique et de ses remèdes. L’hypothèse centrale pour le futur
+est un réchauffement global de l’ordre de 2◦ C en 2100, avec une concentration
+de dioxide de carbone dépassant 550 ppmv. Une bifurcation catastrophiquement
+rapide dans la dynamique du climat reste possible. Les négociations internationales menées dans le cadre de la Convention Climat ont débuté sur le modèle des
+traités protégeant la couche d’ozone. Mais il s’agit d’un problème de précaution
+intergénérationnel bien plus vaste.
+Les pays industrialisés se sont donné à Kyoto en 1997 l’objectif de réduire
+leurs émissions dès l’horizon 2008-2012 à environ 5% en dessous du niveau de
+1990. Cet objectif est ambitieux devant l’inertie des systèmes énergétiques, mais
+ne suffit pas à créer une rentabilité stable à long terme pour des investissements
+industriels dans les technologies moins émettrices.
+
+1 Ces travaux trouvent leur origine dans la thèse de doctorat de l’auteur Ha-Duong (1998)
+
+soutenue publiquement le 3 avril 1998. Le texte a servi de document de cours au niveau DEA
+et grande école.
+
+1
+
+English title : Perspectives on climate change policy
+
+Summary :
+The past decade achieved significant progress in how humanity understand
+and cope with global climate change. It is increasingly known that the central
+hypothesis for the next century is that global average temperature will increase
+by about 2 degree celsius in 2100, with carbon dioxyde concentration raising over
+550 ppm. A catastrophic change of pattern in climate dynamics remains possible,
+which may be a risk more serious than gradual and anticipated warming. It’s
+more and more understood that burning the world reserves of oil, gas and coal
+is technically very feasible, but environmentally very catastrophic. International
+negociations are led within the framework of the Climate Convention. Initially,
+they followed the model of the ozone layer treaty negociations. But climate
+change is a much wider issue, comparable in scope to law-of-the-sea or to freetrade negociations, with the additional complexity of scientific ignorance and
+intergenerational aspects. Negociation must be expected to go on for several
+decades. Industrialized countries agreed in Kyoto, in 1997, to reduce the level
+of their greenhouse gases emissions as soon as 2008-2012, about 5% below their
+1990 level. This objective is ambitious considering the inertia of energy systems,
+since the current global trend is more like a 1% annual growth. But this is not
+enought to insure a stable long-term rentability for industrial investments in
+less emitting technologies.
+
+Key words : Climate Change, Global Change, economics, policy, integrated
+assessment.
+Mots clés : Changement climatique, changement global, economie, politique.
+2
+
+Introduction
+Peut-on considérer que les tempêtes de décembre 1999 sur l’Europe, et plus
+généralement l’occurrence d’évènements climatiques extrêmes sans précédents
+connus traduisent un dérèglement du climat généralisé ?
+D’un point de vue scientifique, ce serait un non-sens puisque le climat, par
+définition, renvoie à la période longue. Ses changements ne peuvent donc pas
+être reliés à un événement ponctuel mais à plusieurs décennies d’observations.
+Depuis la révolution industrielle par exemple, on observe que la composition
+chimique de l’atmosphère a connu des changements importants. La quantité
+de méthane dans l’air a augmenté de 145% et celle de dioxyde de carbone de
+30%. Il est connu depuis plusieurs siècles que ces gaz, comme la vapeur d’eau,
+contribuent à l’effet de serre en captant l’énergie rayonnée depuis la surface de
+la planète. La composition chimique de l’atmosphère évolue donc dans un sens
+susceptible de conduire à un réchauffement global.
+On observe aussi que depuis la fin du XIXe siècle, la température moyenne
+globale a augmenté de 0,3◦ C à 0,6◦ C environ. Toutefois, la plage de variabilité
+naturelle de cette moyenne pendant les derniers dix mille ans est de l’ordre de
+1◦ C. Les effets de la perturbation observée sur la température, les précipitations
+ou le niveau de la mer, s’inscrivent sur le fond d’une variabilité naturelle importante.
+C’est pourquoi les scientifiques sont prudents pour attribuer une responsabilité humaine aux changements observés. La convergence des indices climatiques
+globaux construits à cet effet vers une confirmation statistique du phénomène
+ne peut être que lente.
+Cette lenteur de l’arrivée d’information peut poser un problème par rapport à l’échelle de temps de la prise de décision politique, qui effectue plus
+souvent les changement de trajectoires à l’occasion de crises immédiatement
+compréhensibles par les gouvernés. C’est pourquoi certains militants ont pu
+déclarer que les aléas météorologiques constituaient un symptôme du changement climatique, alors que ces tempêtes sont seulement une opportunité pour
+agir. Mais faut-il agir ?
+
+Le changement climatique et ses risques : État des lieux
+Pour en comprendre la nécessité, examinons ce qui pourrait se passer au
+cours des deux prochains siècles concernant la température moyenne globale.
+La figure 1 montre, à droite, différentes hypothèses de réchauffement global
+correspondant, à gauche, à différents scénarios d’évolution de la concentration
+atmosphérique de CO2 . Il ne s’agit pas là de résultats calculés par des modèles.
+Bien au contraire, ils ont été construits en ajustant une courbe régulière entre les
+données actuelles et divers objectif de stabilisation à long terme arbitrairement
+choisis (Enting et al., 1994).
+Le profil S350, par exemple, suppose que la concentration va cesser d’augmenter avant le milieu de XXIe siècle, pour revenir vers 2150 à peu près au
+niveau de l’année 1988, soit 350 parties par million. La barre d’erreur horizontale correspondante, à droite, montre que le réchauffement à long terme dans
+ce cas est évalué environ entre +1◦ C et +2.5◦ C, avec une estimation centrale
+autour de +1.5◦ C. Toutefois, ce scénario serait économiquement très difficile à
+réaliser.
+3
+
+Fig. 1 – A gauche, scénarios de stabilisation de la concentration de CO2 dans
+l’atmosphère. A droite, réchauffement global correspondant, en valeur centrale
+(points) et plage d’incertitude (segments horizontaux). La ligne verticale pointillée a dénote la variabilité naturelle, la verticale pointillée b dénote le seuil
+reconnu comme dangereux par le Stockholm Environmental Institute. D’après
+Azar & Rodhe (1997).
+
+4
+
+En l’absence de régulation forte des marchés, on ne voit pas ce qui empêcherait
+la consommation d’énergie fossile de continuer à augmenter au siècle prochain,
+tirée par la croissance démographique et économique. Les réserves cumulées de
+pétrole, gaz et surtout de charbon semblent aujourd’hui largement suffisantes
+pour suivre ou dépasser le scénario S1000. Le réchauffement global peut atteindre 6.4◦ C à l’horizon 2100 et bien au-delà ensuite.
+Pour résumer, un réchauffement global d’une amplitude non négligeable devant la variabilité naturelle (environ 1◦ C pendant les derniers dix millénaires)
+est l’hypothèse la plus réaliste. Un réchauffement important est possible.
+Faut-il pour autant s’alarmer d’une telle situation ? Comme on peut le lire
+ça et là, après tout, la plupart d’entre nous préfèrent avoir chaud que froid !
+L’argument repose en partie sur une confusion de vocabulaire : le changement
+climatique doit être distingué de sa cause, le réchauffement global, et du principe
+physique impliqué, l’effet de serre. De plus, ce qui compte n’est pas le changement climatique en lui-même, mais ses conséquences sur les sociétés humaines.
+Se focaliser sur la température minimise l’ampleur du problème pour plusieurs
+raisons :
+– La moyenne annuelle de la température sur toute la surface du globe est
+un indicateur qui a le mérite d’être synthétique et clair. Mais ce chiffre
+moyen masque les variations locales et intra-annuelles plus importantes.
+– Les climats ne se limitent pas à la température : pour l’agriculture, la
+répartition des apports d’eau dans l’année, le nombre de jours de soleil ou
+la date de la dernière gelée sont tout aussi importants.
+– Enfin, il existe d’autres conséquences du réchauffement global, comme
+la hausse du niveau des mers consécutive à la dilatation thermique des
+océans. Le niveau a monté de 10 à 25 centimètres au siècle passé, et on
+peut s’attendre à quelques décimètres supplémentaires d’ici à 2100.
+Les modèles actuels ne permettent pas de quantifier le risque à l’échelle locale. Ce n’est qu’à l’échelle globale et continentale que les résultats prennent
+du sens. On sait par exemple que le courant marin dans l’Atlantique Nord qui
+assure la douceur hivernale en Europe occidentale, le Gulf Stream, peut être
+considérablement affaibli dans une configuration climatique plus chaude. C’est
+pourquoi Broecker (1997) qualifie la circulation thermohaline Nord-Atlantique
+de ‘talon d’Achille’ du climat. On ne sait pas prédire quand cet affaiblissement se
+produirait, mais les observations paléoclimatiques montrent qu’une telle bifurcation peut se produire sur une période de temps relativement courte, quelques
+dizaines d’années.
+Or le problème du rythme est fondamental. L’humanité s’est développée
+et adaptée à des conditions climatiques relativement stables. Cette adaptation
+s’est traduite, par exemple, par une répartition du peuplement mondial, par
+l’édification de villes, de ports et autres infrastructures, par la structuration de
+sociétés autour de techniques agricoles, et aussi par l’accoutumance aux insectes,
+parasites et pathologies diverses qui accompagnent les conditions climatiques.
+Dans la mesure où les structures sociales sont flexibles, un changement climatique graduel ne présente a priori pas un souci majeur. Mais il existe un risque
+réel que les conditions bifurquent rapidement. Si cela se produit, l’adaptation
+à une variabilité climatique augmentée ne sera pas nécessairement un exercice
+gratuit et facile. Celui-ci peut au contraire s’avérer coûteux et tragique, tant
+que ces conditions ne seront pas stabilisées.
+Pour résumer, ce n’est pas un réchauffement moyen de quelques degrés qui
+5
+
+inquiète. Le danger de la pollution d’origine humaine par les gaz à effet de
+serre, c’est d’avoir créé et d’accroı̂tre le risque d’une rupture brutale dans le
+système. En cela, les épisodes météorologiques extrêmes illustrent bien la nature du problème global, mal spécifié mais réel, reconnu explicitement par la
+communauté internationale. Pour tenter de parer à ce risque, les États mettent
+en oeuvre un programme à plusieurs volets.
+
+Le cadre de la Convention Climat
+Le processus a été mis en place à Rio de Janeiro en 1992 avec la signature de la Convention Cadre des Nations Unies sur le Changement Climatique, appelée aussi la Convention Climat2 . Celle-ci souligne la nécessité de
+mesures d’adaptation visant à atténuer les effets des perturbations d’ores et
+déjà inévitables, en plus des mesures de modération du changement climatique.
+L’objectif ultime est de stabiliser la concentration de gaz à effet de serre. Rien
+que pour cela, il est absolument nécessaire de réduire les niveaux d’émissions
+mondiales de gaz à effet de serre nettement en dessous des niveaux actuels, et
+ce dans un contexte de croissance démographique et économique.
+A ces fins, la Convention suit le modèle utilisé pour les négociations sur la
+protection de l’ozone stratosphérique. Elle met en place un réseau d’expertise
+scientifique international, parallèlement à la tenue de conférences annuelles destinées à ajouter des amendements renforçant et précisant les obligations des
+États.
+Les aspects scientifiques du dossier sont suivis par le Groupe d’experts Intergouvernemental sur l’Évolution du Climat. Le GIEC3 , acronyme IPCC en anglais, est une institution originale placée sous la double égide de l’Organisation
+Météorologique Mondiale et du Programme des Nations Unies pour l’Environnement. Sa fonction est de traiter de l’état général des connaissances scientifiques
+et techniques se rapportant au changement climatique.
+Ses travaux visent à représenter l’ensemble des opinions publiées dans des
+revues scientifiques. Pour cela, plus de deux mille experts de par le monde participent à la rédaction et à l’analyse de ces textes. Un effort particulier est fait pour
+inclure les pays en développement. Des gouvernements représentant l’ensemble
+de la planète approuvent et ratifient les documents du point de vue scientifique
+et technique. C’est pourquoi ses rapports bénéficient d’une autorité légitime et
+peuvent avoir un rôle de support objectif dans les débats internationaux.
+Les travaux les plus récents du GIEC reconnaissent qu’un faisceau d’indices
+convergents met en évidence la détection statistique de la responsabilité humaine
+dans la perturbation du climat. Ce point confirme la nécessité de réduire à long
+terme les émissions polluantes bien en dessous du niveau actuel. Toutefois, la
+question de l’action à court terme reste moins consensuelle. Même si l’argument
+scientifique ne saurait être totalement absent, les engagements pris reflètent
+d’abord l’aboutissement de rapports de forces politiques et diplomatiques entre
+les nombreuses parties prenantes aux négociations.
+Si l’action diplomatique s’inspire du déroulement des négociations sur la limitation des Substances Appauvrissant la Couche d’Ozone, avec le Protocole de
+Montréal, son envergure bien supérieure permet de la comparer aussi aux discussions sur le commerce international, commencées dès 1948 et n’ayant abouti
+2 http ://www.unfccc.de
+3 http ://www.ipcc.ch
+
+6
+
+Union Européenne
+OCDE moins UE
+Ex bloc communiste
+Reste du monde
+Total Monde
+Dont pays riches
+
+Année
+de base
+1990
+949
+2086
+1311
+1774
+6120
+4346
+
+Évolution
+récente
+1995
+936
+2254
+925
+2225
+6340
+4115
+
+Variation
+totale
+1990-95
+-1%
++8%
+-29%
++25%
++4%
+-5%
+
+Prospective
+2010
+873
+1961
+1298
+4007
+8139
+4132
+
+Variation
+totale
+1990-10
+-8%
+-6%
+-1%
++126%
++33%
+-5%
+
+Tab. 1 – Emissions de CO2 d’origine fossile par grande région du monde, en
+Mt de carbone par an, et variation calculée par rapport à l’année de base 1990.
+Données pour 1990 et 1995 d’après Bolin (1998). Pour les pays riches en 2010,
+on a utilisé l’objectif de réduction et de limitation d’émission quantifié à la
+conférence Kyoto. Pour pour les pays en développement en 2010, on a supposé
+un taux de croissance annuel des émissions de 4%.
+à l’OMC qu’en 1996. On peut s’attendre à une négociation de longue durée. Au
+stade actuel, relativement préliminaire, les pays les plus industrialisés ont reconnu le principe dit de responsabilité commune mais différenciée, qui implique
+qu’ils prennent des mesures les premiers. Pour cela, ils tentent d’élaborer une
+règle du jeu acceptable entre eux.
+L’avancée la plus concrète reste adoption à Kyoto en 1997 d’objectifs d’émission
+quantifiés et du principe d’un système de permis d’émissions échangeables. Cependant, des problèmes fondamentaux subsistent quand au fonctionnement de
+ce système. L’allocation initiale des permis, les règles d’échange, les sanctions,
+les limitations et la nature légale des acteurs pouvant intervenir sur le marché,
+ainsi que bien d’autres questions, restent ouverts à la discussion. De même, le
+Protocole de Kyoto reste muet sur ce qui se passera après 2012.
+Les conférences de Buenos Aires (1998) et de Bonn (1999) n’ont pas apporté
+de résultats significatifs. La simultanéité en novembre 2000 entre la conférence
+de La Haye (COP-6) et les élections américaines risque d’empêcher toute progression importante compte tenu du poids des USA dans le processus.
+Un des blocages actuels est que le congrès américain refuse de ratifier Kyoto
+tant que les pays en développement n’ont pas pris d’engagements, mais ceux-ci
+attendent des pays riches qu’ils agissent les premiers en application du principe
+de responsabilité commune différenciée.
+Pour l’avenir de la négociation, l’observation des tendances sur la période
+1990-1995 et des objectifs de Kyoto (tableau 1) suggère au moins deux difficultés
+majeures.
+Premièrement, même si l’on doit noter le caractère conjoncturel de la diminution des émissions de CO2 dans la Communauté Européenne entre 1990
+et 1995, il existe des différences de tendances économiques et démographiques
+importantes entre l’Europe et les États-Unis, amplifiées par des différences culturelles. A Kyoto, les observateurs ont pu apprécier la différence entre la proposition américaine de stabilisation des émissions, soit x = 0%, et la proposition
+européenne d’un ambitieux x = 15%. Ils ont aussi pu noter le remarquable
+sens arithmétique des négociateurs, puisque l’accord s’est conclut exactement
+au milieu du gué : x = 7% pour les américains et x = 8% pour l’Europe.
+
+7
+
+Deuxièmement, le système de permis échangeables peut apparaı̂tre comme
+un jeu comptable qui épargne aux pays de l’OCDE de faire des efforts réels.
+Concernant les pays riches dans leur ensemble, le tableau 1 montre que l’objectifs de Kyoto de -5% était à peu près réalisé en 1995. L’explication est bien
+entendu la récession économique des pays de l’est. Or, dans la mesure où la
+situation en Russie ne s’est pas redressée sur la période 1995-2000, cet état
+de fait peut miner la crédibilité du marché de permis d’émission spécifié dans
+le Protocole de Kyoto. Les négociateurs ont baptisé “air chaud” ces réductions
+d’émissions fictives découlant des changements structurels des pays en transition
+vers l’économie de marché .
+Même si ces deux points étaient résolus, Kyoto ne suffirait pas. Le monde
+resterait dans une logique de croissance des émissions de gaz à effet de serre,
+avec une projection de +33% sur deux décennies. Or c’est une décroissance
+durable qui serait nécessaire à la stabilisation des concentrations. Pour l’avenir,
+le point essentiel est que les pays riches parviennent à coopérer avec les autres
+dès la période 2010-2020. Sinon, l’objectif de stabilisation à 450 ppmv de la
+concentration atmosphérique de CO2 deviendrait irréaliste.
+Au total, la négociation climat progresse lentement au rythme de la mondialisation. Un regard rétrospectif sur la dernière décennie permet cependant
+de juger d’avancées sérieuses dans la socialisation du problème, mais aussi dans
+l’expérience des changements climatiques. Outre l’action internationale exposée
+ici, beaucoup d’acteurs gouvernementaux, industriels ou citoyens ont pris des
+initiatives qu’il n’est pas possible de résumer ici.
+L’objectif ultime de la Convention est de stabiliser la concentration atmosphérique de gaz à effet de serre à un niveau qui éviterait des interférences
+dangereuses avec le climat. Il s’agit d’un idéal, le niveau zéro du risque climatique. Malgré le dispositif mis en place, il est très probable que le risque
+continuera à augmenter durant le XXIe siècle.
+
+Fondements d’une action de précaution
+Le paragraphe précédent montre que l’augmentation du risque climatique est
+attendue, et que des efforts internationaux ont été lancés, suivant une procédure
+fortement marquée par les rapports de force et d’opportunité politiques. Certes
+la négociation reste le mode de décision le plus pratique pour ce genre de
+problème d’environnement global. Il n’en reste pas moins important de rechercher une approche scientifique du principe de précaution (Treich, 1997).
+Le changement climatique est symptomatique d’une classe de dossiers d’environnement où se pose le problème de la connaissance des bénéfices de l’action.
+Comment dans ces conditions définir un but collectif ? Comment calculer un
+optimum social ? La solidarité intergénérationelle et l’ignorance excessive sont
+ici deux difficultés majeures qu’il convient d’examiner.
+
+Perspective éthique intergénérationnelle
+La courbe de la population mondiale a récemment connu un point d’inflexion : sa croissance est appelée à se ralentir davantage dans le futur. De même,
+
+8
+
+il peut être possible de s’attendre à une baisse tendancielle du taux d’enrichissement par habitant au cours de siècle prochain. Malgré ces tendances, compte
+tenu du développement économique observé sur les deux derniers siècles, dans
+l’ensemble, les décideurs peuvent s’attendre à ce que nos descendants soient
+plusieurs fois plus riches que nous. Comment, dans ces conditions évaluer des
+mesures qui mettent en jeu simultanément les intérêts de générations existantes
+et futures ? L’actualisation (ou escompte) est le principal outil analytique dont
+se servent les économistes pour comparer les effets se produisant à des périodes
+différentes (Arrow, 1995).
+Son principe est celui des intérêts composés : au taux r, 1 unité de compte
+aujourd’hui équivaut à seulement 1/(1 + r) unités à la période suivante. Le
+choix du taux d’actualisation a une grande importance technique pour l’analyse
+de la politique en matière de changement climatique, car l’horizon temporel
+est extrêmement long et le coût de l’atténuation a tendance à être ressenti bien
+plus tôt que les bénéfices des dégâts évités. Plus ce taux est élevé, plus les futurs
+bénéfices sont négligeables et plus les coûts actuels prennent d’importance dans
+l’analyse.
+Il serait certes très problématique de reprendre pour l’environnement global une valeur aussi élevée que les 8 pour cent par an utilisés pour le calcul
+économique courant des investissements publics en France. A ce taux par exemple, une mesure qui coûte 1 aujourd’hui n’est jugée rentable que si ses bénéfices
+se montent à (1 + 8%)200 = 2 millions dans 200 ans.
+Or il est impossible de montrer que la rentabilité à long terme des mesures
+d’atténuation du changement climatique est de l’ordre de 2 million d’euros de
+dommages évités par euro investi aujourd’hui. Cet argument des intérêts composés peut être utilisé à l’emporte-pièce pour tenter de démontrer l’inutilité
+d’une action de précaution contre le changement climatique.
+A contrario, il peut être utilisé pour montrer le caractère inopérant de l’analyse économique. Cependant un usage raisonné de la théorie de l’actualisation
+moderne, discuté plus en détail encadré 1, suggère plutôt d’utiliser un taux situé
+dans la plage de 2% à 5% par an, ce qui diminue l’acuité du problème.
+[Encadré 1 about there]
+Ce problème ne peut pas être contourné en raisonnant selon une approche
+coût-efficacité, c’est à dire en examinant seulement comment atteindre à moindre
+coût un objectif climatique donné par ailleurs. Certes, cela dispense d’évaluer
+formellement les bénéfices de la modération du changement climatique. Mais
+l’analyse suggère toujours de reporter d’autant plus les efforts sur les générations
+futures que le taux d’actualisation utilisé est élevé.
+A ce stade, diverses réponses sont possibles. La plus pragmatique consisterait à regarder ce paramètre comme un instrument subjectif, les points de
+vues différents étant également valides dans la mesure où ils sont clairs et correctement argumentés. La plus radicale consiste à rejeter l’idée de la recherche
+d’un optimum économique, pour se concentrer sur l’analyse des trajectoire faisables ou possibles. Entre ces attitudes, s’élabore actuellement un volume de
+travaux important sur le choix collectif et le développement durable, dont on
+peut espérer un jour des outils formels et numériques plus satisfaisants.
+
+9
+
+Ignorance, décisions collectives et controverses
+A cause des incertitudes sur l’état futur de l’économie et du climat, on ignore
+comment évaluer les dommages économiques consécutifs au changement climatique en cours. Quantifier précisément aujourd’hui les avantages des politiques
+de précaution est impossible. Dans une telle situation, la théorie de la décision
+sous incertitude explicite trois points importants.
+L’aversion au risque. On admet généralement qu’un bon père de famille ne
+devrait pas jouer de fractions importantes de son patrimoine, même si l’espérance
+de gain nette est positive. De même, on peut penser assez légitimement que les
+sociétés devraient, par principe moral, accorder une attention particulière aux
+risques globaux majeurs, mêmes si ceux-ci sont de probabilité inconnue ou faible.
+L’apprentissage. Les mesures de prévention du changement climatique sont
+susceptibles d’avoir deux effets opposés sur le rythme de réduction des incertitudes. Le premier effet est théoriquement important, mais quelque peu paradoxal
+en pratique : si la pollution diminue, les conséquences de la pollution sont moins
+visibles. Par exemple, si l’usage des substances appauvrissant la couche d’ozone
+avait été banni dès 1974, alors on n’aurait jamais observé le trou au dessus de
+l’antarctique. On peut donc se demander si les réductions d’émissions de gaz à
+effet de serre pourraient tendre à atténuer l’émergence du signal d’alarme observé par rapport au bruit de fond que représente la variabilité naturelle. Cet
+effet nous semble négligeable. Par exemple réaliser le protocole de Kyoto ne
+ferait gagner que 1.5 ppmv de dioxyde de carbone dans l’atmosphère sur une
+concentration de l’ordre de 400 ppmv (Bolin, 1998) à l’horizon 2012.
+Le second effet nous semble beaucoup plus important et se situe du côté
+de l’apprentissage des coûts de réduction. La mise en place des marchés pour
+les technologies moins polluantes est susceptible de conduire à une meilleure
+connaissance de ces technologies, ce qui permettrait éventuellement de bénéficier
+d’une baisse significative de leurs coûts.
+L’irréversibilité. D’un côté, l’action peut entraı̂ner des coûts économiques
+importants et irrécupérables qui risquent de s’avérer inutiles a posteriori. Mais
+de l’autre, retarder davantage l’action et laisser poursuivre la tendance croissante
+des émissions polluantes conduit à une accumulation de gaz à effet de serre, qui
+risque d’impliquer des conséquences irréversibles et inattendues.
+L’analyse de l’incertitude suggère qu’une dimension essentielle des politiques
+de prévention du changement climatique est finalement de gagner du temps
+d’apprentissage pour que les certitudes scientifiques et le savoir-faire technique
+arrivent avant les bifurcations du système climatique.
+Un volume important de travaux sur le choix collectif et le développement
+durable vise à enrichir ou dépasser les notions exposées ci dessus. Mais il n’est
+pas possible de présenter davantage, par exemple, le courant de recherche récent
+suggérant que l’incertitude sur la croissance justifie l’utilisation d’un taux d’actualisation inférieur pour les activités à très long terme comme la modération
+du changement climatique (Portney & Weyant, 1999; Weitzman, 1998). Dans la
+suite, nous examinons plus spécifiquement les mesures adoptées à la Conférence
+de Kyoto.
+
+10
+
+Le Protocole de Kyoto
+L’objectif ultime de stabilisation
+Mettre en balance les coûts et des avantages des mesures de réduction du
+risque climatique est une tâche formidable. Relever ce défi est important non
+seulement pour la science, mais aussi pour aider les puissances publiques à
+négocier, à décider et à communiquer.
+Pour cette analyse coût-avantage, comparons en première approche les alternatives illustrées figure 1. S’il fallait traduire littéralement l’objectif ultime de
+la Convention Climat, quelle cible de concentration de CO2 dans l’atmosphère
+choisir ?
+Le niveau actuel est déjà au dessus de 360 ppmv. Il semble raisonnable
+de rejeter l’objectif de stabiliser à 350. Plus précisément un tel objectif demanderait des sacrifices très sensibles à court terme jugés disproportionnés par
+rapport à la réduction du risque obtenue. Il impliquerait en pratique une diminution immédiate et drastique de la consommation mondiale de combustibles
+fossiles, difficilement conciliable avec les tendances lourdes de la démographie
+et de l’économie.
+D’un autre côté, il ne semble pas raisonnable de courir le risque associé à
+S1000, avec un réchauffement potentiel supérieur à 9◦ C, alors que les possibilités techniques à long terme sont immenses et que la régulation du secteur
+énergétique est une action politique éprouvée de longue date.
+L’étendue des ignorances actuelles ne permet pas de choisir, dans l’intervalle
+restant entre 400 et 900 ppmv, une valeur plutôt qu’une autre. L’imprécision de
+l’analyse coûts-avantages concernant l’objectif ultime de la Convention impose
+de revenir à une certitude plus ferme : stabiliser la concentration atmosphérique
+de CO2 , à quel niveau que se soit, exige une réduction des émissions mondiales
+de carbone bien en dessous des niveaux actuels.
+
+L’objectif opérationnel justifiant Kyoto.
+Cette certitude permet de fixer un objectif opérationnel à moyen terme :
+stopper la croissance des émissions. Cet objectif de stabilisation pour les pays
+riches, explicitement mentionné dans la Convention Climat signée à Rio, n’est
+dans l’ensemble pas respecté à l’horizon 2000. Cette poursuite de la tendance
+polluante n’a surpris personne.
+On pouvait s’attendre à ce que l’inertie liée au capital en place interdise
+toute déviation rapide des trajectoires actuelles. L’aspect essentiel des politiques de prévention du changement climatique est le ré-aménagement majeur
+de l’utilisation des combustibles fossiles. Cette transition vers des sociétés moins
+émettrices de carbone exige le renouvellement de la base physique de l’économie :
+il faut changer des machines et des réseaux. C’est pourquoi, si il est certes
+matériellement possible de réformer rapidement le système énergétique mondial, le faire avant que le capital soit amorti entraı̂nerait des coûts, appelés
+coûts d’ajustement, trop élevés.
+L’importance des coûts d’ajustement introduit une nouvelle perspective dans
+l’analyse coût-avantage du problème. A la question de l’objectif ultime de concentration s’ajoute celle du rythme, de la répartition dans le temps de l’effort de
+réduction. La figure 2 illustre deux trajectoires, haute et basse, conduisant au
+
+11
+
+11.5
+
+11
+
+10.5
+
+Gigatonnes de Carbone
+
+12
+
+Tendance
+Trajectoire
+Haute
+
+10
+Trajectoire
+Adaptative
+
+9.5
+
+9
+
+Kyoto
+
+Trajectoire
+Basse
+
+8.5
+date
+2000
+
+2005
+
+2010
+
+2015
+
+2020
+
+2025
+
+Fig. 2 – Émissions mondiales de CO2 pour les prochaines décennies : comparaison des objectifs prescrits par le Protocole de Kyoto et diverses autres
+trajectoires.
+La courbe “Kyoto” montre qu’en supposant que les pays industrialisés remplissent leurs objectifs et que les pays en développement suivent leur tendance
+actuelle, les émissions mondiales seraient de l’ordre de 8,8 Gt de carbone en 2010
+(émissions fossiles plus celles provenant des changement dans l’usage des sols).
+La courbe “Tendance” montre que si le monde entier suit la tendance actuelle,
+ce chiffre serait de l’ordre de 9,8 Gt. Les deux courbes en pointillées illustrent
+l’étendue des trajectoires à court terme compatibles avec la stabilisation à long
+terme de la concentration atmosphérique au niveau 550ppmv. La “Trajectoire
+Adaptative” représente une politique de précaution optimale : c’est le résultat
+d’un calcul de minimisation des coûts en supposant qu’on choisira en 2020 un
+objectif à long terme de 450, 550 ou 650 ppmv avec équiprobabilité. D’après
+Ha-Duong et al. (1998).
+
+12
+
+même objectif de long terme : la stabilisation de la concentration de CO2 atmosphérique à 550ppmv. Les implications à court terme de ces deux trajectoires
+sont très différentes.
+L’effet d’actualisation discuté plus haut est ici important. Pour les décideurs
+d’aujourd’hui, la trajectoire haute, qui reporte les efforts de réduction dans plusieurs décennies, est comparativement moins coûteuse que la trajectoire basse.
+Or, comme on le voit sur la figure 2, les objectifs de Kyoto sont plus proches de
+la trajectoire basse.
+Ces objectifs peuvent se comprendre si l’on souhaite respecter le seuil des
+450 ppmv correspondant au seuil de danger de 2◦ C. Pour cela, il n’est plus
+temps de différer les efforts car la concentration de dioxyde de carbone dans
+l’atmosphère, qui était de l’ordre de 280 ppmv avant la révolution industrielle,
+atteint aujourd’hui environ 365 ppmv et augmente environ de 15 ppmv par
+décennie. En l’absence de mesures fortes, la concentration de CO2 atteindra
+450 ppmv avant le milieu du vingt et unième siècle.
+
+En décision séquentielle, c’est l’inertie qui compte.
+Mais compte tenu de l’ignorance quand au seuil ultime de concentration,
+il est nécessaire de pousser davantage l’explication et de raisonner en décision
+séquentielle. Il ne s’agit pas de décider une fois pour toutes de la politique
+climatique à suivre dans les 50 ans à venir, mais de choisir une stratégie prudente
+qui sera ajustée au fil du temps avec l’arrivée de nouvelles informations. La figure
+2 représente une telle trajectoire adaptative. La trajectoire représentée permet
+de bifurquer en 2020 vers l’un des trois objectifs 450, 550 ou 650 ppmv.
+Cette représentation très stylisée du processus de décision serait probablement inapplicable en pratique, mais elle permet de souligner la séquentialité
+du processus de décision. La négociation dure depuis une décennie et n’en est
+qu’à son début. Dans un contexte de révision des choix, ce qui importe est de
+comparer l’inertie du système énergétique et du système climatique (Ha-Duong
+et al., 1997).
+L’histoire énergétique des deux derniers siècles montre une succession de
+formes d’énergie primaire dominante : la biomasse, le charbon, le pétrole, et
+vraisemblablement demain le gaz. Chacun de ces combustibles est moins polluant que celui qui l’a précédé, au sens où sa combustion libère moins de carbone
+dans l’atmosphère pour un même service rendu.
+Chaque transition a pris environ un demi siècle. Ce chiffre pourrait sembler élevé devant la durée de vie d’une centrale thermique ou des équipements
+ménagers. Ce serait oublier que les systèmes énergétiques sont aussi déterminés
+par un ensemble de facteurs interdépendants plus large, tant pour l’offre que
+pour la demande. La production, le transport et la distribution font appel à
+des infrastructures lourdes, souvent à l’échelle nationale comme des ports, des
+réseaux, des oléoducs et gazoducs. La structure de l’habitat, la qualité du bâti
+et les schémas de transports dépendent de considérations sociales encore plus
+générales, tout ceci évoluant lentement à l’échelle de la génération.
+Il est préférable de respecter le rythme d’amortissement naturel des équipements
+afin d’éviter des coûts d’ajustement trop élevés. D’un autre côté, l’inertie a un effet opposé sur la nécessité d’un effort de réduction à court terme : il est d’autant
+plus urgent de débuter les réformes tôt que celles-ci seront longues à réaliser.
+
+13
+
+Or les modèles, comme les observations paléoclimatiques, montrent qu’à
+l’échelle du demi-siècle, le système climatique peut évoluer catastrophiquement
+avec une redistribution importante de la répartition de l’énergie thermique entre
+les deux hémisphères terrestres. Ne pas agir dès à présent sur le système social
+déterminant l’économie des combustibles fossiles, ce serait s’exposer à être pris
+de vitesse par le changement climatique.
+Hoffert et al. (1998) montrent bien l’ampleur de la tâche. L’énergie primaire
+produite actuellement provenant de combustibles fossiles est de l’ordre de 10
+térawatts (1 TW = 1012 W), pour 1.3 TW provenant de source sans carbone.
+Dans tous les scénarios étudiés, la croissance économique et la stabilisation de
+la concentration de dioxyde de carbone exigent une capacité supplémentaire de
+10 TW sans carbone avant 2050. Cette date est avancée à 2030 environ pour la
+cible de 550 ppmv de CO2 .
+Les auteurs remarquent que depuis la première pile atomique de Enrico
+Fermi développée en 1943 à Chicago, l’énergie nucléaire ne fournit aujourd’hui
+que quelques centièmes de la production actuelle. Une prolifération est à l’heure
+actuelle peu probable compte tenu des risques politiques, environnementaux
+et financiers. Mais comme la capacité unitaire d’une centrale nucléaire est de
+l’ordre du GW, même une croissance forte du nombre de centrales ne fournirait
+qu’une partie des 10 TW énoncés plus haut.
+Les autres énergies renouvelables seront donc nécessaires. Un potentiel hydroélectrique significatif reste à développer dans certains pays du Sud, comme
+par exemple le fameux barrage des Trois Gorges prévu pour 17 GW qui deviendra le plus grand barrage actuel, devant celui d’Itaipu au Brésil (12.6 GW). Dans
+les pays européens, les expériences de l’Allemagne et du Danemark montrent
+que l’énergie éolienne peut se développer lorsque le gouvernement garantit un
+prix minimal d’achat de l’électricité ainsi produite. Le solaire photo-voltaı̈que
+et thermique décentralisé connaı̂t un progrès technique important, et le retour
+d’un intérêt pour le solaire thermique centralisé pourrait être souhaitable. A
+partir de la situation actuelle, pour que la part de marché de ces énergies renouvelables deviennent importante il faudra qu’elle connaisse plusieurs décennies
+de croissance à deux chiffres.
+Cette analyse en terme d’inertie comparée justifie économiquement le Protocole de Kyoto, qui ne laisse pas de délai pour agir sur la production et de
+la consommation d’énergie mondiale. A court terme, les technologies aujourd’hui disponibles ouvrent de nombreuses potentialités de réduction d’émissions.
+Mieux même, on estime souvent que plus de 10% de réduction serait accessible
+à coût négatif ou nul, à l’aide d’options ‘sans regrets’ discutées encadré 2.
+[Encadré 2 about there]
+
+Conclusion.
+Sans aller au delà de la marge d’options sans regrets, le Protocole de Kyoto
+est remarquable car il pose des contraintes de réductions à court terme. Il marque
+donc un passage important du processus de négociation qui, parti de l’expression de principes généreux mais verbaux, est en chemin pour arriver à imposer
+des contraintes réelles fortes comparables à celles imposées par le Protocole de
+
+14
+
+Montréal sur la protection de la couche d’Ozone. Pour conclure, demandonsnous dans quelle mesure les obligations de Kyoto sont pertinentes pour garantir le développement des nouveaux moyens de production et de consommation
+d’énergie.
+La question centrale de savoir ce qui crée le progrès technique, moteur de la
+richesse actuelle, n’est toujours pas résolue. Toutefois, on peut identifier deux
+perspectives différentes concernant le lien entre réduction d’émissions et progrès
+technique, qui ont toutes deux des conséquences directes sur le contenu des
+actions à engager.
+Si on suppose que l’essentiel du progrès technique est produit par l’accumulation des connaissances et des dépenses publiques de Recherche-Développement,
+on pourrait en principe développer des technologies propres, dans le cadre de la
+nouvelle économie, sans pour cela diminuer simultanément les émissions.
+Dans une première phase, les États pourraient consacrer l’essentiel des ressources contre le changement climatique à la recherche et au développement des
+solutions énergétiques alternatives. Il s’agirait de développer des prototypes et
+des pilotes, en vue d’une deuxième phase de la résolution du problème, au cours
+de laquelle se ferait l’essentiel de la réduction des émissions. Une telle approche
+permettrait de gagner quelques décennies avant d’agir, puisqu’on pourrait polluer tant qu’on accumule une réserve de progrès technique suffisant.
+Toutefois, plusieurs arguments s’opposent à cette politique ‘Attendre et
+dépenser, puis courir’ : faire pénétrer rapidement une vague de nouvelles technologies moins polluantes dans le secteur de l’énergie semble difficile car les
+différentes composantes des systèmes techniques sont liées entre elles et ne
+peuvent pas être remplacées indépendamment les unes des autres. Développer
+des technologies sans base installée est difficile, car l’histoire montre que le
+progrès favorise nettement les technologies existantes. Ces deux rétroactions
+positives induisent des verrouillages technologiques qui font que le passage du
+temps ne correspond pas nécessairement à l’augmentation du nombre des options possibles.
+C’est pourquoi on peut penser que l’essentiel du progrès technique dans un
+domaine est induit par les changements dans les conditions du marché correspondant, et non par une accumulation de connaissances scientifiques globales
+ou par la dépense publique de R&D. Tenter d’accélérer le progrès technique
+sans vouloir restreindre les émissions polluantes pourrait être une politique peu
+cohérente et inefficace.
+Une bonne part de la R&D privée actuelle vise à l’amélioration des technologies liées aux combustibles fossiles. Des politiques contraignantes en matière
+d’émissions de CO2 tendraient à créer des incitations appropriées sur les marchés
+de l’énergie pour ré-allouer une part de cette R&D sur les technologies peu ou
+pas émettrices.
+A cet égard, le bilan des implications de l’accord de Kyoto sur le progrès
+technique nous semble plutôt mitigé. En effet, le dispositif mis en place n’offre
+pas encore le cadre stable à long terme nécessaire pour justifier des investissements industriels importants dans les nouvelles technologies.
+La souveraineté des États demeure quant à l’orientation effective des politiques énergétiques. Compte tenu des blocages politiques, au Sénat américain
+par exemple, on est loin d’être assuré que le Protocole de Kyoto sera un jour
+juridiquement valable. On peut s’attendre aujourd’hui à une concentration de
+550 ppmv de CO2 dans l’atmosphère.
+15
+
+Remerciements
+Je remercie Jean-Charles Hourcade pour avoir dirigé ces travaux, Michael
+Grubb, Alan Manne, Thierry Chapuis et Franck Lecocq pour nos collaboration,
+ainsi que G. Mégie et deux relecteurs anonymes pour leurs commentaires.
+
+Références
+Arrow, Kenneth J. 1995. Effet de serre et actualisation. Revue de l’énergie,
+471, 631–636.
+Azar, Christian, & Rodhe, Henning. 1997. Targets for stabilization of atmospheric CO2 . Science, 276, 1818–1819.
+Bolin, Bert. 1998. The Kyoto negociations on climate change : A science perspective. Science, 279(5349), 330–331.
+Broecker, Wallace. 1997. Thermohaline circulation, the Achille’s heel of our
+climate system : Will man-made CO2 upset the current balance. Science,
+278(5343), 1582–1588.
+Enting, I. G., Wigley, T. M. L., & Heimann, M. 1994. Future emissions
+and concentrations of carbon dioxide : Key Ocean/Atmosphere/Land analyses. Tech. rept. Technical Paper 31. CSIRO Division of Atmospheric Research, Australia. Also published on the internet, formatted as Postscript,
+on CDIAC electronic archives, http ://cdiac.esd.ornl.gov/ndps/db1009.html,
+accessed 9/7/98.
+Ha-Duong, Minh. 1998 (Apr.). Comment tenir compte de l’irréversibilité dans
+l’évaluation intégrée du changement climatique ? Thèse de doctorat, École
+des hautes Études en Sciences Sociales, Paris.
+Ha-Duong, Minh, Grubb, Michael J., & Hourcade, Jean-Charles. 1997. Influence
+of socioeconomic inertia and uncertainty on optimal CO2 -emission abatement.
+Nature, 390, 270–274.
+Ha-Duong, Minh, Hourcade, Jean-Charles, & Lecocq, Franck. 1998. Dynamic
+consistency problems behind the Kyoto protocol. International journal of
+environment and pollution, 11(4), 426–446.
+Hoffert, Martin I., Caldeira, Ken, Jain, Atul K., Haites, Erik F., Harvey, L.
+D. Danny, Potter, Seth D., Schlesinger, Michael E., Schneider, Stephen H.,
+Watts, Robert G., Wigley, Tom M. L., & Wuebbles, Donald J. 1998. Energy
+implications of future stabilization of atmospheric CO2 content. Nature, 395,
+881–884.
+Portney, Paul R., & Weyant, John P. (eds). 1999. Discounting and intergenerational equity. Washington, DC : Resources for the Future.
+Treich, Nicolas. 1997. Vers une théorie economique de la précaution ? Risques,
+32, 117–130. Repris dans Problèmes Economiques n◦ 2.572, 10 juin 1998, pp
+19-25.
+
+16
+
+Weitzman, M. 1998. Why the far-distant future should be discounted at its
+lowest possible rate ? Journal of environmental economics and management,
+36, 210–208.
+
+17
+
+Liste des encadrés
+1. Méthodes de détermination d’un taux d’actualisation
+
+19
+
+2. Notion de coût sans regrets
+
+20
+
+18
+
+Encadré 1 : Méthodes de détermination d’un taux d’actualisation
+La théorie moderne de l’actualisation pour les biens d’environnement est liée aux aspects
+fondamentaux de la pensée macro-économique, c’est à dire la croissance et l’accumulation
+du capital. Deux approches existent pour déterminer un taux d’actualisation des coûts et
+bénéfices :
+– La première approche met en parallèle les mesures de protection du climat et les autres
+investissements de la société. De même que l’éducation contribue à accumuler du capital
+humain, ou que l’industrie contribue à accumuler du capital économique, il s’agit de
+reproduire et de transmettre un capital naturel, un patrimoine. La théorie de l’efficacité
+économique suggère alors d’égaliser le taux d’actualisation avec le taux de rentabilité des
+autres investissements publics à long terme sans risque. Les études empiriques conduisent
+à suggérer un taux situé entre 3% et 6% à prix constant.
+– La seconde approche, qui suggère des taux inférieurs, considère l’actualisation comme
+un paramètre fondé sur l’éthique des choix collectifs. L’actualisation est alors la somme
+de deux effets :
+– La préférence pure pour le présent renvoie à l’idée d’impatience et mesure en quelque
+sorte la distance à laquelle nous situons les intérêts des générations futures par rapport
+à la nôtre.
+– L’effet richesse peut s’illustrer par l’exemple suivant : la satisfaction qu’un consommateur moderne tire d’un kilo de farine de blé est certainement inférieure à ce
+que son ancêtre du XIXe siècle en tirait. En général, nous pensons que la valeur
+supplémentaire d’une unité de biens est moindre dans une société plus riche. Compte
+tenu du développement économique observé sur les deux derniers siècles, dans l’ensemble, les décideurs peuvent s’attendre à ce que nos descendants dans un siècle soient
+plusieurs fois plus riches que nous.
+Il apparaı̂t dans les deux cas que le choix d’un taux d’actualisation est lié aux anticipations
+concernant le taux de croissance. Or il est légitime d’avoir des anticipations différentes pour
+le long et le très long terme, par exemple à cause des effets démographiques. En ce sens,
+le concept d’un taux unique pour tous les projets publics n’est pas défendable. La théorie
+propose plutôt un taux d’actualisation variable dans le temps et dépendant de l’horizon
+d’analyse.
+
+19
+
+Encadré 2 : Options sans regrets et coût négatifs.
+Le concept de coût négatifs présente un aspect paradoxal qu’il est possible d’éclaircir en
+distinguant l’approche technique de l’approche macro-économique.
+L’IPCC définit les mesures sans regrets comme celles dont les avantages tels que
+l’amélioration du rendement ou la réduction de la pollution au plan local ou régional (sans
+inclure les avantages apportés par l’atténuation des effets du changement climatique) sont
+supérieurs aux coûts qu’elles entraı̂nent.
+L’exemple classique est le remplacement des ampoules à incandescence par les ampoules
+fluo-compactes dans les bureaux. Le coût total des ampoules comprend au moins quatre
+composantes : a) l’achat, b) le travail nécessaire à la pose, c) la consommation directe
+d’électricité et d) les frais indirects comme l’évacuation de la chaleur produite par les
+lampes quand un système d’air conditionné est utilisé. Les lampes fluo-compactes sont
+économiquement avantageuses car leur coût d’achat supérieur est plus que compensé par
+la diminution des trois autres composantes (durée de vie accrue et consommation électrique
+moindre). Le bénéfice environnemental est une diminution de la consommation d’énergie.
+La notion de mesure sans regrets illustrée ci dessus se place au niveau technique. Il convient
+de distinguer au moins quatre niveaux sémantiques pour la notion de coût.
+Un coût Technique peut se calculer pour remplacer un type d’équipement par un autre,
+plus moderne ou plus performant, comme dans l’exemple donné ci dessus.
+Le coût Sectoriel correspond aux effets d’une politique donnée sur la rentabilité d’un
+secteur industriel donné comme l’industrie automobile ou la chimie.
+Un coût Macro-économique est le plus souvent le résultat d’un modèle d’équilibre des
+échanges de biens et services, exprimé en termes d’impact sur la production nationale
+brute.
+Le coût Social se réfère aux objectifs de bonheur d’une population, il est difficilement
+mesurable et modélisable car outre la richesse il faut considérer l’emploi, le loisir ou
+la qualité de vie.
+Diverses études montrent l’existence de tout un inventaire de mesures techniques permettant d’économiser l’énergie de manière économiquement rentable.
+La perspective macro-économique est différente. Le modèle standard suppose que les agents
+maximisent leur bien-être et donc il ne saurait exister de “coûts négatifs” à l’optimum. Dans
+un monde idéal infiniment efficace et parfaitement rationnel, s’il est possible d’économiser
+de l’argent, les agents l’ont déjà fait. D’où le caractère paradoxal du concept.
+Mais le monde réel n’est pas idéal. Dans ce cadre, les options sans regrets s’analysent
+comme des corrections par rapport à des inefficacités pré-existantes. Il s’agit par exemple de
+réduire des distorsions dans la concurrence ou de mieux informer des agents. La perspective
+technique et le point de vue macro-économique sont ainsi compatibles.
+
+20
+
+

--- a/content/style-references/2017-droit-a-l-energie.txt
+++ b/content/style-references/2017-droit-a-l-energie.txt
@@ -1,0 +1,820 @@
+7
+
+n ZOOM SUR...
+
+LA PRÉCARITÉ
+ÉNERGÉTIQUE
+
+Minh Ha-Duong, directeur de recherche au CNRS, nous apporte des
+éléments pour penser hors des sentiers battus le problème de l’accès
+universel à l’énergie, notamment en considérant notre réalité française et
+la réalité vietnamienne. Cette problématique à été l’objet de la conférence
+qu’il a prononcée le 26 août 2017 à Angers dans le cadre de l’université
+d’été du Parti communiste français.
+
+OCTOBRE-NOVEMBRE-DÉCEMBRE 2017
+
+Progressistes
+
+ZOOM SUR LA PRÉCARITÉ ÉNERGÉTIQUE
+
+8
+
+Le droit à l’énergie, dangereuse chimère
+ou juste exigence ?
+Survivre au froid en hiver et au chaud en été est un des besoins humains essentiels, tout
+comme manger cuit dans un air intérieur libre de fumée. L’objectif de développement
+durable d’un « accès à une énergie propre et abordable pour tous » reconnaît ainsi
+un droit à l’énergie comme une juste exigence universelle. Mais le garantir au quotidien
+pour 7 milliards de contemporains soulève des questions pratiques. Les pays en développement ont-ils le droit d’utiliser les énergies fossiles comme l’ont fait les pays riches ?
+Comment définir et repérer les ménages en situation de précarité énergétique, et
+comment les aider ? Ce texte propose quelques réponses concrètes, qui s’appuient sur
+le cas d’un pays riche, la France, et d’un pays à revenu intermédiaire, le Vietnam.
+UN OBJECTIF
+DU DÉVELOPPEMENT DURABLE
+En 2015, l’Organisation des
+Nations unies a publié l’Agenda
+2030 qui résume les aspirations
+collectives de l’humanité en dixsept objectifs de développement durable : pas de pauvreté ;
+faim « zéro » ; bonne santé et
+bien-être ; éducation de qualité… Sans être juridiquement
+contraignant, cet agenda a le
+mérite d’avoir été adopté officiellement par les 193 États
+membres de l’ONU, après une
+participation sans précédent
+de la société civile et d’autres
+
+Minh Ha-Duong
+parties prenantes, comme le
+secteur privé et les maires, au
+processus de négociation.
+Le septième objectif de développement durable est clair :
+« Garantir l’accès de tous à des
+
+services énergétiques fiables,
+durables et modernes, à un coût
+abordable. » Selon l’ONU, 3 milliards de personnes dépendent
+du bois, du charbon ou des
+déchets animaux pour la cuisson et le chauffage. Et puisque
+l’énergie est le principal facteur
+contribuant au changement climatique – elle représente environ 60 % des émissions mondiales de gaz à effet de serre –
+réduire l’intensité en carbone
+dans la production de l’énergie
+est une cible clé des objectifs
+climatiques à long terme.
+Le tableau 1 illustre la situation
+
+actuelle dans les deux pays exemples et dans le monde. En 2005,
+une personne sur cinq n’avait pas
+accès à l’électricité. Le taux d’accès s’améliore relativement rapidement, 85,3 % en 2014 dans le
+monde. Mais cela signifie qu’il reste
+1 milliard d’humains hors réseau.
+Les énergies renouvelables représentaient 18,3 % dans la consommation finale brute d’énergie
+mondiale en 2014. Il s’agit surtout de la biomasse chaleur et
+de l’hydroélectricité. La France
+est en dessous de la moyenne
+mondiale, la part des énergies
+renouvelables étant inférieure
+
+Tableau 1
+ÉNERGIE : INDICATEURS DU DÉVELOPPEMENT DURABLE
+FRANCE
+2014
+
+Variation
+sur 10 ans
+
+Source : UNStats
+
+VIETNAM
+2014
+
+Variation
+sur 10 ans
+
+MONDE
+2014
+
+Variation
+sur 9 ans
+
+Proportion de la population ayant accès
+100
+=
+99,2
++ 8,5
+85,3
++ 5,1
+à l’électricité (en %)
+Part des énergies renouvelables dans la consommation finale brute d’énergie
+13,1
++ 4,2
+36,2
+– 9,8
+18,3
++ 1,4
+(en %)
+Intensité énergétique (consommation d’énergie primaire en MJ/PIB,
+4,1
+– 0,9
+5,7
+– 0,4
+5,5
+– 1,2
+en dollars PPP1 2011)
+1. Purchasing power party, en français « parité de pouvoir d’achat » ; cette parité ne se fonde donc pas sur les taux de conversion monétaire.
+
+Progressistes OCTOBRE-NOVEMBRE-DÉCEMBRE 2017
+
+Progressistes N18-DEF_progressistes 21/12/2017 11:08 Page9
+
+9
+
+Vietnam, que le droit à l’énergie fait partie du droit au développement. Mais n’est-ce pas
+une dangereuse chimère si le
+réchauffement global doit rester sous la barre des 2 °C ? À
+Washington, en mai 2016, Jim
+Yong Kim, président de la Banque
+
+de mettre en œuvre des plans
+fondés sur le charbon, je pense
+que c’est fini »).
+La diplomatie internationale
+tente de mettre en œuvre deux
+idées pour résoudre ce problème. La première est le développement durable. On ne peut
+
+Selon l’ONU, 3 milliards de personnes dépendent
+du bois, du charbon ou des déchets animaux pour
+la cuisson et le chauffage.
+mondiale, lançait cet avertissement : « If Vietnam goes forward
+with 40GW of coal, if the entire
+region implements the coalbased plans right now, I think
+we are finished » (« Si le Vietnam
+continue de se développer avec
+40 GW produits grâce au charbon, si toute la région continue
+
+pas prédire l’avenir, mais comme
+une grande partie des trajectoires sociales peuvent être anticipées, il est utile de poser comme
+axiome qu’il est possible de
+répondre aux besoins des générations présentes sans sacrifier
+la capacité des générations
+futures à répondre aux leurs.
+
+Cela donne aux acteurs une idée
+de la direction à prendre. Le
+développement durable est une
+approche pascalienne du problème de Malthus.
+La seconde idée est le principe
+de responsabilité commune mais
+différenciée. Il dit que les pays
+développés doivent prendre la
+tête dans la lutte contre le changement climatique. Durant la
+dernière décennie, le coût de
+l’énergie éolienne et de l’énergie solaire photovoltaïque a
+beaucoup baissé, résultat des
+dépenses d’investissements
+massives dans les pays riches.
+Les petits consommateurs européens ont vu le prix de leur électricité augmenter principalement en raison de la hausse des
+coûts du soutien aux énergies
+renouvelables et des coûts des
+réseaux. Ainsi, le prix de l’élec-
+
+OCTOBRE-NOVEMBRE-DÉCEMBRE 2014
+2017
+
+Progressistes
+
+s
+
+à celle du nucléaire, des produits pétroliers et du gaz.
+L’économie française, de plus
+en plus fondée sur les services,
+est relativement peu consommatrice d’énergie. En termes
+de part d’énergies renouvelables, le Vietnam faisait mieux
+que la moyenne mondiale en
+2014, mais la consommation
+de charbon et de gaz y est en
+augmentation rapide du fait
+que les installations hydroélectriques ont atteint leur maximum. Et l’efficacité énergétique
+globale de son économie est
+plus faible que la moyenne mondiale : on ouvre des usines dans
+le pays.
+Les pays riches, comme la France,
+se sont industrialisés en brûlant des énergies fossiles.
+Personne ne conteste aux pays
+qui s’industrialisent, comme le
+
+ZOOM SUR LA PRÉCARITÉ ÉNERGÉTIQUE
+
+10
+
+s
+
+tricité pour les ménages
+Allemands a plus que doublé
+entre 2000 et 2013, passant de
+13,94 à 28,73 centimes d’euro
+
+ficulté qu’éprouve une personne dans son logement « à
+disposer de la fourniture d’énergie nécessaire à la satisfaction
+
+Depuis 2014, un chiffre circule : 1 Français sur 5 est en
+situation de précarité énergétique. Cette statistique
+effrayante provient de l’observation qu’environ 4 millions
+de foyers consacrent plus de 10 % de leurs revenus à
+leurs dépenses en énergie (incluant électricité,
+carburants, fuel, gaz).
+
+par kilowattheure. Le déploiement de l’industrie a divisé le
+prix des panneaux photo voltaïques par trois en dix ans.
+Aujourd’hui, produire de l’électricité à partir du vent et du
+rayonnement solaire peut être
+aussi économique que de la produire à partir du charbon.
+Espérons que demain le Vietnam
+en tiendra compte dans son
+prochain plan de développement énergétique.
+
+DÉFINIR LA PRÉCARITÉ
+ÉNERGÉTIQUE POUR REPÉRER
+LES MÉNAGES EN DIFFICULTÉ
+Les critères onusiens sont
+utiles, mais insuffisants pour
+éclairer les détails fins du problème de l’accès de tous à
+l’énergie. Occuper un logement raccordé au réseau électrique n’immunise pas contre
+la précarité énergétique, définie en France comme la dif-
+
+de ses besoins élémentaires en
+raison de l’inadaptation de ses
+ressources ou de ses conditions
+d’habitat » (loi Grenelle II de
+juillet 2010). Trois approches
+permettent de préciser davantage la définition : par la quantité, par le budget, par la satisfaction perçue.
+La première approche consiste
+à comparer la consommation
+d’énergie à un seuil de pauvreté énergétique, défini en
+référence à une notion de
+besoin de base. La deuxième
+conduit à examiner la facture
+énergétique payée par les
+ménages, en la divisant par le
+revenu total pour tenir compte
+des inégalités de niveaux de
+vie: le quotient est appelé « taux
+d’effort énergétique ». La troisième approche fait référence
+à la qualité des services énergétiques reçus ; elle peut s’évaluer par questionnaire.
+
+Progressistes OCTOBRE-NOVEMBRE-DÉCEMBRE 2017
+
+Approche par la quantité
+Quand peut-on dire qu’un
+ménage n’a pas assez d’énergie
+pour ses besoins de base ?
+La réponse est bien sûr à moduler en fonction du climat, du
+logement, de la taille de la
+famille et de la performance
+technique des équipements,
+mais le tableau 2 montre que
+30 kWh/mois permettent de
+satisfaire les besoins fondamentaux de communication, eau
+potable, éclairage, ventilation.
+Pour utiliser en plus un réfrigérateur, un téléviseur ou un autocuiseur, il faut dépasser les
+100 kWh/mois d’électricité.
+
+Au Vietnam, en 2014, environ
+un quart des ménages consommait moins de 50 kWh/mois, et
+la moitié moins de 100 kWh. En
+France, en 2016, la consommation moyenne par foyer était de
+390 kWh par mois. Cette comparaison suggère que ce qu’une
+société considère comme le
+niveau des besoins élémentaires
+est déterminé par son histoire
+et sa culture autant que par le
+climat.
+En France, un logement décent
+doit comporter des équipements de production d’eau
+chaude et de chauffage (en
+métropole) ; et s’il est meublé,
+des plaques de cuisson, un four,
+
+Tableau 2
+CONSOMMATION D’ÉLECTRICITÉ POUR QUELQUES SERVICES COURANTS
+Source : estimations auteur.
+
+CONSOMMATION
+MENSUELLE
+
+SERVICE RENDU
+
+1 kWh
+
+Communication : charger un téléphone
+tous les jours
+
+2 kWh
+
+Eau potable : 5 bouteilles par jour
+
+7 kWh
+
+Éclairage : 4 lampes efficaces
+quatre heures par jour
+
+17 kWh
+
+Confort thermique : ventilateur
+huit heures par jour
+
+23 kWh
+
+Autocuiseur ou téléviseur
+
+50 kWh
+
+Réfrigération
+
+60 kWh
+
+Confort thermique : air conditionné ou
+chauffage électrique, deux heures par jour
+
+11
+
+En 2005, une personne sur cinq n’avait pas accès à l’électricité. Le taux d’accès s’améliore relativement rapidement, 85,3 % en 2014 dans le monde.
+Mais cela signifie qu’il reste 1 milliard d’humains hors réseau.
+un réfrigérateur, un congélateur, des luminaires. La loi sur
+la transition énergétique prévoyait d’inclure un critère de
+
+ménages paye moins de 2,1 %
+du revenu pour l’électricité. Le
+taux d’effort pour la France correspond à peu près à la moyenne
+
+Si l’on ne considère que les ménages faisant partie des
+30 % les plus pauvres, ce n’est plus 1 Français sur 5
+mais un 1 sur 10 qui était concerné (chiffres de 2006).
+
+performance énergétique dans
+la définition du logement décent,
+et ce pour forcer les bailleurs
+de « passoires thermiques » à
+rénover. Le décret de mars 2017
+pris en application est bien
+décevant sur ce point, puisqu’il
+se borne à imposer la protection contre les infiltrations d’air
+parasites. Éliminer les vents
+coulis ne va pas suffire à sortir
+beaucoup de locataires de la
+précarité énergétique.
+
+L’approche par les difficultés
+budgétaires (l’énergie dans
+le budget du ménage)
+
+Approche par
+la satisfaction perçue
+Cette approche – dite aussi
+déclarative – concerne les
+ménages déclarant souffrir du
+
+froid en hiver ou des besoins
+insatisfaits.
+Le problème est qu’en France
+des gens meurent de froid en
+hiver. Une enquête demandant
+aux répondants s’ils souffrent
+du froid permet d’appréhender ce risque dans la population. En 2013, 6 % des ménages
+français dans les trois premiers
+déciles de revenus par unité de
+consommation ont déclaré subir
+une sensation de froid en raison d’un motif lié à la précarité énergétique (installation
+insuffisante ou en panne, raison financière, coupure du fournisseur d’énergie consécutive
+à une facture impayée et mauvaise isolation du logement).
+Ce chiffre correspond à environ 4,1 millions d’individus, et
+est en légère augmentation par
+rapport à 2006.
+Au Vietnam, l’enquête nationale sur les conditions de vie
+des ménages pose périodiquement la question « La consommation d’électricité de votre
+foyer au cours des 30 derniers
+jours a-t-elle été suffisante pour
+vos besoins? ». En 2010, un quart
+de la population était insatisfait; en 2014 ce chiffre est tombé
+à 2,7 % ! Ce progrès extraordinaire s’explique, à notre avis,
+par l’amélioration de la fiabilité de la fourniture d’électricité. L’augmentation des capacités de génération a permis
+
+OCTOBRE-NOVEMBRE-DÉCEMBRE 2014
+2017
+
+Progressistes
+
+s
+
+En termes de facture électrique,
+les 390 kWh/mois consommés
+par le ménage français moyen
+coûtent 775 €par an (65 €/mois).
+Rapporté au revenu médian de
+20 150 €par an et par ménage
+(1 679 €/mois), cela correspond
+à un taux d’effort du budget
+électricité de 3,9 % du revenu.
+Au Vietnam, nous estimons
+qu’en 2014 la moitié des
+
+mondiale, c’est au Vietnam que
+l’électricité est relativement
+peu chère.
+Depuis 2014, un chiffre circule :
+1 Français sur 5 est en situation
+de précarité énergétique. Cette
+statistique effrayante provient
+de l’observation qu’environ
+4 millions de foyers consacrent
+plus de 10 % de leurs revenus à
+leurs dépenses en énergie
+(incluant électricité, carburants,
+fuel, gaz). Pis encore, si on définit la vulnérabilité énergétique
+comme étant la situation d’un
+ménage qui dépense plus de
+8 % de ses revenus pour le chauffage ou plus de 4 ; 5 % pour ses
+déplacements, alors 5,9 millions de ménages étaient concernés en 2008.
+Mais un taux d’effort budgétaire élevé peut caractériser
+aussi bien des ménages aisés
+qui ne se soucient pas de leur
+facture que des petits retraités
+vivant dans des maisons mal
+isolées. L’approche par les dif-
+
+ficultés budgétaires doit aussi
+tenir compte du niveau absolu
+du revenu. Si l’on ne considère
+que les ménages faisant partie
+des 30 % les plus pauvres, ce
+n’est plus 1 Français sur 5 mais
+un 1 sur 10 qui était concerné
+(chiffres de 2006). D’autres définitions de « bas revenu » et de
+« dépense élevée » sont possibles, qui conduisent à des résultats pouvant varier de 6 % à 13 %
+selon l’analyse de l’Observatoire
+national de la précarité énergétique (ONPE, 2016).
+D’après nos calculs, moins de
+1 % des ménages vietnamiens
+doivent consentir un effort budgétaire élevé pour l’électricité…
+et sont officiellement pauvres.
+Pourtant, la France n’est pas
+vraiment en retard sur le Vietnam
+dans l’accès à l’énergie! La comparaison montre que l’approche
+par les difficultés budgétaires
+dépend de seuils de précarité
+choisis arbitrairement : 10 % du
+revenu, 30 % des ménages…
+L’approche a le mérite d’être
+sensible à la problématique du
+prix de l’énergie, mais le niveau
+absolu du résultat a surtout une
+valeur médiatique pour attirer
+l’attention sur le problème.
+
+ZOOM SUR LA PRÉCARITÉ ÉNERGÉTIQUE
+
+12
+
+s
+
+de sortir d’une situation de
+rationnement par des délestages quotidiens.
+L’approche déclarative est subjective, elle a aussi ses limites.
+Par exemple, en France la température de chauffe augmente
+mais la sensation de froid perçue aussi. La réponse dépend
+donc aussi beaucoup de la question. Et le niveau de satisfaction
+élevé au Vietnam, bien qu’un
+quart de ménages consomme
+moins de 50 kWh/mois, s’explique parce que la demande
+dépend pour beaucoup du taux
+
+services énergétiques essentiels. Il le fait en particulier par
+l’électrification rurale, qui est
+un vecteur de construction nationale. Les aides au raccordement
+et la péréquation tarifaire matérialisent une forme de solidarité nationale et d’égalité dans
+l’accès au service public.
+Certaines îles payent l’électricité plus cher que la métropole,
+mais les justifications techniques
+sont compréhensibles : il s’agit
+de zones non connectées au
+reste du réseau.
+Dans les deux pays encore, l’État
+
+Au Vietnam, l’enquête nationale sur les conditions
+de vie des ménages pose périodiquement la question :
+« La consommation d’électricité de votre foyer au cours
+des 30 derniers jours a-t-elle été suffisante pour vos
+besoins? ». En 2010, un quart de la population était
+insatisfait; en 2014 ce chiffre est tombé à 2,7 %!
+d’équipement. Dans l’absolu,
+la misère inacceptable des uns
+dans un pays riche est à mettre
+en regard de la pauvreté digne
+des autres. Le droit à l’énergie
+ne peut s’évaluer que dans une
+société donnée.
+En somme, ces trois approches
+de la précarité énergétique éclairent trois aspects de ce qu’il faut
+bien appeler la misère. Ces trois
+approches ciblent des ménages
+différents, autant en France
+qu’au Vietnam. D’après l’Observatoire national de la précarité
+énergétique, 6 millions de
+ménages en France (20,4 %)
+sont concernés par au moins
+l’une d’elles, soit 12 millions
+d’individus. On retrouve le ratio
+de 1 sur 5 qui fait le buzz. Mais
+le noyau de la précarité énergétique, qui regroupe les
+ménages en situation d’inconfort thermique et économique,
+concerne 1 million de ménages,
+soit 2,6 millions de mal-logés
+en France.
+
+ASSURER
+L’ACCÈS À L’ÉNERGIE
+En France comme au Vietnam,
+l’État assume un rôle d’aide aux
+plus démunis pour accéder aux
+
+met en œuvre, historiquement,
+deux instruments sociaux: subventions directes aux ménages
+et contrôle du prix de l’électricité. En France, le tarif réglementé cohabite certes avec une
+offre dérégulée à prix de marché, mais seuls 12 % des ménages
+y ont recours (fin 2016).
+Le prix de l’électricité résulte
+d’un compromis de politique
+économique et environnementale répondant à plusieurs objectifs fondamentaux.
+1. Le tarif de l’électricité est un
+des leviers de contrôle direct
+de l’inflation. Ainsi, au Vietnam
+en 2008-2010 le gouvernement
+a laissé stable le tarif de l’électricité pour les consommateurs
+de moins de 50 kWh/mois, alors
+même que la crise asiatique
+entraînait une hausse des prix
+généralisée supérieure à 8 %
+par an.
+2. Le coût pour les ménages doit
+être assez bas pour y permettre l’accès de tous. En France,
+en 2015, il y a eu pour impayés
+476000 réductions de puissance
+et résiliations à l’initiative des
+fournisseurs d’électricité, et
+101 000 coupures à l’initiative
+des fournisseurs de gaz. La struc-
+
+Progressistes OCTOBRE-NOVEMBRE-DÉCEMBRE 2017
+
+ture centralisée avec un réseau
+unique du secteur justifie que
+l’État intervienne pour éviter
+que le monopole (ou un cartel
+de producteurs) n’utilise son
+pouvoir de marché au détriment des consommateurs.
+3. Cependant, un coût trop bas
+n’incite pas les consommateurs
+à faire des économies d’énergie. Comparé aux autres pays
+européens, le prix de l’électricité en France est bas : en
+2014, le kilowattheure coûtait
+15,85 centimes d’euro, contre
+29,81 en Allemagne et 24,46 en
+Italie. On peut penser que cela
+explique le fort développement
+du chauffage électrique dans
+l’Hexagone, qui exacerbe
+aujourd’hui les problèmes de
+précarité énergétique. Le but
+ultime du droit à l’énergie n’est
+pas d’augmenter la consommation en joules, mais l’accès
+aux services énergétiques: communication, éclairage, confort
+thermique, mobilité.
+4. Le prix de vente doit être assez
+élevé pour permettre aux producteurs et aux réseaux de couvrir leurs coûts. Il s’agit non seulement des coûts proportionnels
+à la production d’électricité,
+mais aussi de la rentabilité des
+
+l’acheminement, qui sert à rémunérer les gestionnaires de réseau
+de transport et de distribution
+d’électricité. Et un tiers de taxes
+et équivalents, dont, en particulier, la contribution au service public de l’électricité,
+laquelle est en forte hausse pour
+financer la transition énergétique et la solidarité.
+Jusqu’en 2017, la solidarité contre
+la précarité énergétique se faisait par l’accès à des tarifs sociaux
+du gaz et de l’électricité pour
+les abonnés, sous condition de
+ressources, en fonction de la
+composition du ménage. À
+compter de 2018, ce dispositif
+est simplifié et remplacé par un
+chèque énergie, lequel n’est plus
+lié au contrat d’abonnement :
+il peut être utilisé quel que soit
+le moyen de chauffage, pour
+le fioul ou le bois par exemple.
+Il peut également financer une
+partie des travaux d’économies
+d’énergie dans le logement.
+Nous avons présenté plus haut
+trois approches pour identifier
+la précarité énergétique, et nous
+avons vu qu’il n’y a pas de critère idéal. En pratique, il serait
+peu pertinent de conditionner
+une aide directe à une simple
+
+Le Vietnam offre aussi des aides aux plus pauvres pour
+l’accès à l’électricité. Des programmes de raccordement
+gratuit sont mis en œuvre, certains avec l’aide
+internationale. Des subventions directes limitées à
+30 kWh/mois sont accordées aux ménages pauvres.
+investissements pour développer le système. Il faut des capitaux pour augmenter la capacité de production totale dans
+un pays comme le Vietnam. En
+France, même si la demande
+est maîtrisée, développer des
+sources d’énergie renouvelables demande aussi du financement.
+Au final, le tarif en France se
+décompose en trois parties. Un
+gros tiers pour la fourniture
+d’énergie, qui couvre les coûts
+de production et de commercialisation. Un petit tiers pour
+
+déclaration de sensation de
+froid, ou même de la fonder sur
+une estimation de consommation d’énergie de l’année précédente. C’est le critère de revenu
+qui a été retenu. Le bénéfice du
+chèque énergie est ouvert aux
+ménages dont le revenu fiscal
+de référence annuel par unité
+de consommation est inférieur
+à 7700 €, occupant un logement
+soumis à la taxe d’habitation.
+La simplification du critère d’attribution a permis de rendre
+automatique l’envoi du chèque.
+Il n’y a pas de démarche à faire,
+
+13
+
+ce qui améliore notablement la
+portée du dispositif par rapport
+aux tarifs sociaux précédents.
+Le montant de l’aide s’évalue à
+150 €en moyenne. Il va de 48 €
+pour une personne isolée au
+revenu compris entre 6 700 €et
+7 700 €par an, à 227 €pour un
+ménage de quatre ou plus au
+revenu annuel inférieur à 5500 €.
+La première ou seule personne
+du ménage constitue une unité
+de consommation; la deuxième
+personne est prise en compte
+pour 0,5 unité de consommation ; la troisième personne et
+chaque personne supplémentaire pour 0,3 unité de consommation. Le montant de 150 €
+correspond par exemple, à
+45 kWh/mois sur une facture
+d’électricité: 540 kWh dans l’année à 15 centimes, plus un abonnement annuel à 70 €. Au regard
+du tableau 2, on voit que le dispositif ne subventionne pas le
+chauffage électrique mais bien
+les services essentiels.
+Le chèque énergie ne concerne
+cependant pas toute la précarité énergétique. Pour les sanspapiers et sans domicile fixe,
+l’accès aux services énergétiques
+essentiels doit être assuré par
+d’autres dispositifs.
+Le Vietnam offre aussi des aides
+aux plus pauvres pour l’accès à
+l’électricité. Des programmes
+de raccordement gratuit sont
+mis en œuvre, certains avec
+
+l’aide internationale. Des subventions directes limitées à
+30 kWh/mois sont accordées
+aux ménages pauvres (revenu
+mensuel inférieur à 20 € par
+personne), mais les démarches
+administratives nécessaires limitent la portée du dispositif. De
+plus, le Vietnam met en œuvre
+une tarification progressive de
+l’électricité : les gros consommateurs paient plus cher que
+les petits. Pour illustrer le principe, considérons un ménage
+
+Brottes, qui prévoyait la mise
+en place d’un système de
+bonus/malus, a même été votée
+en 2013 avant d’être largement
+censurée par le Conseil constitutionnel. Cette loi avait un
+objectif double, puisque la partie « bonus » pour les petits
+consommateurs » visait à
+réduire la précarité énergétique, alors que la partie
+« malus » pour les gros consommateurs visait à inciter aux
+économies d’énergie.
+
+En France, la solidarité contre la précarité énergétique
+se faisait par l’accès à des tarifs sociaux du gaz
+et de l’électricité pour les abonnés, sous condition
+de ressources, en fonction de la composition du ménage.
+À compter de 2018, ce dispositif est simplifié et remplacé
+par un chèque énergie.
+qui consommerait 130 kWh par
+mois. Sa consommation totale
+est divisée en blocs de 50 kWh,
+dont le prix va croissant :
+1 484 dongs le kilowattheure
+pour le premier bloc ; 1533 dongs
+pour le deuxième ; 1 786 dongs
+pour le troisième… Sa facture
+totale serait donc alors de
+204 430 dongs (1 € = 26 370
+dongs), soit 1 484 × 50 + 1 533
+× 50 + 1 786 × 30.
+Le système de la tarification
+progressive est répandu dans
+le monde. En France, la loi
+
+La tarification progressive présente des avantages et des limites.
+Globalement, elle va bien dans
+le sens d’une redistribution au
+profit des ménages les plus pauvres. Au Vietnam, les 25 % des
+ménages dans le premier bloc
+payent leur électricité en dessous de son coût de production
+moyen : ils bénéficient d’un
+transfert de la part des autres
+consommateurs. Cet avantage
+est d’autant plus significatif que
+le tarif de l’électricité avec un
+abonnement fixe plus une partie variable proportionnelle à
+la consommation est régressif :
+il avantage les gros consommateurs, dans la mesure où la part
+du fixe devient proportionnellement moindre.
+Par ailleurs, la tarification progressive joue contre les familles
+nombreuses. Au Vietnam, il est
+possible sous certaines conditions de fractionner une facture
+en plusieurs abonnements. Une
+maison occupée par deux
+familles peut avoir deux compteurs, mais cela crée un effet
+pervers : quand la maison est
+ensuite louée à une seule famille,
+il y a avantage à garder les deux
+compteurs. Le système joue
+aussi contre les locataires isolés, comme les ouvriers ou les
+
+étudiants : alors même qu’il
+s’agit des populations les plus
+précaires, leur propriétaire bailleur refacture l’électricité au
+tarif le plus élevé.
+
+CONCLUSION
+Le droit à l’énergie est une juste
+exigence reconnue par tous les
+gouvernements, il participe des
+objectifs du développement
+durable.
+Les pays pauvres ont le droit
+d’augmenter leur production
+d’énergie. Cela peut aujourd’hui
+se faire à faible impact environnemental parce que le principe
+de responsabilité commune
+mais différenciée a été respecté.
+Les pays riches ont pris la tête
+dans la lutte contre le changement climatique en investissant massivement dans les énergies renouvelables, ce qui a fait
+baisser leur coût.
+Les ménages pauvres ont le
+droit d’accéder aux services
+énergétiques essentiels. Il n’y
+a pas de baguette magique pour
+éradiquer la précarité énergétique. La tarification progressive de l’électricité, mise en
+œuvre dans des dizaines de
+pays comme le Vietnam, est
+rejetée en France au profit du
+chèque énergie. Ce système
+d’aide directe et multi-énergie
+aux plus pauvres, instauré à
+compter de 2018, améliore le
+dispositif précédent de tarifs
+sociaux de l’électricité et du
+gaz. Il est plus simple, plus systématique et va concerner plus
+de ménages. Il reste à évaluer
+s’il réduit effectivement le noyau
+de 1 million de ménages français en situation d’inconfort
+thermique et économique.n
+*MINH HA-DUONG.
+POUR EN SAVOIR PLUS
+Minh Ha-Duong et Hoai Son Nguyen,
+« Is electricity affordable and reliable
+for all in Vietnam ? », in CIRED
+Working Papers, no 65, juillet 2017.
+Charles-André Bernard et Olivier
+Teissier, Analyse de la précarité
+énergétique à la lumière de l’Enquête
+nationale Logement (ENL) 2013,
+étude CSTB cofinancée par l’ADEME,
+publiée par l’Observatoire national de
+la précarité énergétique, 2016.
+
+OCTOBRE-NOVEMBRE-DÉCEMBRE 2017
+
+Progressistes
+
+

--- a/content/style-references/README.md
+++ b/content/style-references/README.md
@@ -1,0 +1,21 @@
+# Références de style — manuscript-Gide
+
+Trois textes français, signés de Minh Ha-Duong seul, en prose continue, servant
+d'ancre stylistique pour `content/manuscript-Gide.qmd` (communication au colloque
+Charles Gide 2026, registre histoire de la pensée économique). Texte brut extrait
+des PDF par `pdftotext` — les sauts de ligne sont ceux du PDF, pas la mise en page
+d'origine.
+
+| Fichier | Source | Année | Rôle de référence |
+|---|---|---|---|
+| `2000-perspectives-changement-climatique.txt` | *Natures – Sciences – Sociétés* 8(4), p. 5–14 ([HAL](https://hal.science/halshs-00007467), DOI 10.1016/S1240-1307(01)80002-9) | 2000 | Genre académique : article de revue SHS interdisciplinaire, voisinage direct d'Œconomia. |
+| `1998-faut-il-moderer.txt` | Rapport / article « Faut-il modérer le changement climatique ? » | 1998 | Charpente d'argument : thèse explicite, analyse économique conduite comme un raisonnement. |
+| `2017-droit-a-l-energie.txt` | *Progressistes* n°18, p. 7–13 ([HAL](https://hal.science/hal-01692449)) | 2017 | Rhétorique de titre-tension et nervosité de phrase ; registre un cran plus journalistique. |
+
+Ces fichiers sont des aides à la rédaction, pas des artefacts de la chaîne de
+production. Ne pas les citer ni les inclure dans le manuscrit.
+
+**Copies temporaires — à supprimer après publication.** Le texte intégral
+reproduit ici provient de publications déjà déposées sur HAL ; ces extraits ne
+servent qu'à caler le style pendant la rédaction du papier Gide. Une fois le
+manuscrit publié, supprimer ce dossier (`content/style-references/`).


### PR DESCRIPTION
Adds three sole-authored French prose texts under `content/style-references/` to anchor the writing register of `content/manuscript-Gide.qmd` (Charles Gide 2026 communication, HET register).

- **2000 — Perspectives sur le changement climatique** (*Natures – Sciences – Sociétés*): academic SHS-journal genre, Œconomia's neighborhood.
- **1998 — Faut-il modérer le changement climatique ?**: thesis-driven argumentative charpente.
- **2017 — Le droit à l'énergie**: title-tension rhetoric, sharper sentences.

Plain text extracted via `pdftotext` from PDFs already deposited on HAL. These are writing aids, not pipeline artifacts. The `README.md` marks them as **temporary copies to delete after publication**.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)