### PR TITLE
fix(bib): correct corfee-morlot2009 and carty_lecomte2018 citations

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -216,12 +216,12 @@
 % -- Corfee-Morlot and OECD statistical infrastructure --
 
 @book{corfee-morlot2009,
-  author    = {Jan Corfee-Morlot and Lamia Kamal-Chaoui and Michael G. Donovan and Ian Cochran and Alexis Robert and Pierre-Jonathan Teasdale},
-  title     = {Cities, Climate Change and Multilevel Governance},
-  publisher = {OECD},
+  author    = {Jan Corfee-Morlot and Bruno Guay and Kate M. Larsen},
+  title     = {Financing Climate Change Mitigation: Towards a Framework for Measurement, Reporting and Verification},
+  publisher = {OECD/IEA},
+  address   = {Paris},
   year      = {2009},
-  doi       = {10.1787/220062444715},
-  note      = {OECD Environment Working Papers No.~14}
+  note      = {OECD/IEA Information Paper COM/ENV/EPOC/IEA/SLT(2009)6}
 }
 
 @book{corfee-morlot2012,
@@ -373,7 +373,7 @@
 }
 
 @book{carty_lecomte2018,
-  author    = {Tracey Carty and Jan {Le Comte}},
+  author    = {Tracy Carty and Armelle {Le Comte}},
   title     = {Climate Finance Shadow Report 2018: Assessing Progress towards the \$100 Billion Commitment},
   publisher = {Oxfam International},
   year      = {2018},


### PR DESCRIPTION
Deux corrections au bib partagé `content/bibliography/main.bib`, découvertes en vérifiant les clés citées par le manuscrit Gide. **Les deux clés sont aussi citées par `manuscript.qmd`** — la correction répare donc les deux papiers.

## 1. `corfee-morlot2009` — mauvais article (mis-citation)
La clé pointait vers *« Cities, Climate Change and Multilevel Governance »* (OCDE WP 14), un papier sur les **villes**. Or `manuscript.qmd` (L68, L158) et `manuscript-Gide.qmd` (L43, L111) la citent pour le rôle de Corfee-Morlot dans l'**infrastructure de mesure** de la finance climat (marqueurs de Rio, équivalent-don, cadres MRV).

→ Repointée vers le papier qui porte effectivement cette thèse : **Corfee-Morlot, Guay & Larsen (2009), *Financing Climate Change Mitigation: Towards a Framework for Measurement, Reporting and Verification*, OCDE/AIE** (doc COM/ENV/EPOC/IEA/SLT(2009)6). « Cities » n'était cité nulle part comme papier sur les villes : rien n'est perdu. Pas de DOI fiable trouvé → identifié par son n° de document OCDE, comme les autres entrées OCDE du bib.

## 2. `carty_lecomte2018` — noms d'auteurs faux
Vérifié contre le rapport Oxfam *Climate Finance Shadow Report 2018* :
- « Tracey Carty » → **Tracy Carty**
- « Jan Le Comte » → **Armelle Le Comte**

Titre, éditeur, année et DOI inchangés (corrects).

## Vérifiées et laissées intactes
`bachus_becault2017` (Bachus & Bécault, BeFinD WP 0117, Namur 2017) et `corfee-morlot2012` (Green Investment Policy Framework) : confirmées exactes.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)