### PR TITLE
manuscript(gide): French caption for the venues table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ content/figures/*
 !content/figures/fig_breaks.png
 content/tables/*
 !content/tables/tab_venues.md
+!content/tables/tab_venues_fr.md
+!content/tables/tab_venues_fr_caption.md
 content/*-vars.yml
 !content/manuscript-vars.yml
 

--- a/content/manuscript-Gide.qmd
+++ b/content/manuscript-Gide.qmd
@@ -216,6 +216,6 @@ La troisième question demande si la polarisation d'après Paris se voit dans le
 
 La même tension se retrouve dans l'écologie des revues. Les travaux proches du pôle efficacité apparaissent davantage dans les revues de finance, d'énergie et de risque climatique. Les travaux proches du pôle redevabilité se concentrent plus souvent dans les revues de gouvernance environnementale, de politique climatique et d'économie politique. Quelques lieux, notamment *Climate Policy*, servent d'espace commun. Le tableau détaillé des lieux de publication est conservé comme élément de vérification, non comme cœur de l'argument.
 
-{{< include tables/tab_venues.md >}}
+{{< include tables/tab_venues_fr.md >}}
 
 **Reproductibilité, données et code.** Les opérations résumées ci-dessus reposent sur des méthodes standard, nommées ici pour le lecteur spécialiste. La détection des ruptures combine la divergence de Jensen--Shannon, sur les répartitions thématiques, et la distance cosinus, sur les représentations vectorielles -- les « embeddings » -- produites par le modèle multilingue `BAAI/bge-m3`. Le regroupement des textes par le sens utilise l'algorithme k-means à six groupes ; celui des co-citations, la méthode de Louvain. Le corpus, les scripts et la chaîne de reproduction complète sont archivés sur Zenodo (DOI : [10.5281/zenodo.19097045](https://doi.org/10.5281/zenodo.19097045)) et développés à l'adresse <https://github.com/MinhHaDuong/climate-finance-het>.

--- a/content/tables/tab_venues_fr.md
+++ b/content/tables/tab_venues_fr.md
@@ -1,0 +1,20 @@
+| Lean | Journal | Eff. | Acc. | Total |
+|:-----|:--------|-----:|-----:|------:|
+| Efficiency | Energy Economics | 16 | 2 | 18 |
+| Efficiency | Journal of Cleaner Production | 30 | 10 | 40 |
+| Efficiency | Renewable and Sustainable Energy Reviews | 30 | 11 | 41 |
+| Efficiency | Energy Policy | 48 | 21 | 69 |
+| Efficiency | Sustainability | 73 | 35 | 108 |
+| Efficiency | Energies | 27 | 16 | 43 |
+| Shared | Center for International Forestry Research (CIFOR) eBooks | 12 | 12 | 24 |
+| Shared | Ecology and Society | 16 | 18 | 34 |
+| Accountability | Nature Climate Change | 12 | 18 | 30 |
+| Accountability | Nature Communications | 13 | 22 | 35 |
+| Accountability | Climatic Change | 15 | 28 | 43 |
+| Accountability | Climate Policy | 20 | 38 | 58 |
+| Accountability | PLoS ONE | 11 | 22 | 33 |
+| Accountability | International Environmental Agreements Politics Law and Economics | 7 | 16 | 23 |
+| Accountability | Wiley Interdisciplinary Reviews Climate Change | 7 | 28 | 35 |
+| Accountability | Global Environmental Politics | 2 | 13 | 15 |
+
+: Revues de publication des travaux les plus cités (cités $\geq$ 50 fois), par pôle d'affectation. Chaque travail est rattaché au pôle efficacité ou redevabilité selon sa position sur l'axe sémantique (cf. note méthodologique en annexe). La colonne « Lean » indique l'orientation dominante de la revue : le pôle où se range la majorité de ses articles. {#tbl-venues}

--- a/content/tables/tab_venues_fr_caption.md
+++ b/content/tables/tab_venues_fr_caption.md
@@ -1,0 +1,1 @@
+: Revues de publication des travaux les plus cités (cités $\geq$ 50 fois), par pôle d'affectation. Chaque travail est rattaché au pôle efficacité ou redevabilité selon sa position sur l'axe sémantique (cf. note méthodologique en annexe). La colonne « Lean » indique l'orientation dominante de la revue : le pôle où se range la majorité de ses articles. {#tbl-venues}

--- a/manuscript.mk
+++ b/manuscript.mk
@@ -57,16 +57,24 @@ output/content/manuscript.docx: $(MANUSCRIPT_INPUTS)
 # sibling docs (including manuscript.qmd) so a bare render builds only the Gide
 # paper. No data, no uv — Quarto + LaTeX only.
 #
-# NOTE: content/manuscript-Gide.qmd is the author's working draft and is
-# deliberately NOT git-tracked yet, so `make gide` builds only where that file
-# is present (the author's checkout), not in a clean-room checkout. Track it
-# later to make this workpackage fully reproducible (cf. the manuscript slice of
-# ticket 0131).
-GIDE_SRC     := content/manuscript-Gide.qmd
-GIDE_PROFILE := _quarto-manuscript-Gide.yml
+# content/manuscript-Gide.qmd is git-tracked. The figures and tables it consumes
+# are tracked handoff artifacts too; regenerating them from data is the analysis
+# workpackage's job, so render this paper with those artifacts already present
+# (a full data-less clean-room rebuild is tracked in ticket 0131).
+GIDE_SRC        := content/manuscript-Gide.qmd
+GIDE_PROFILE    := _quarto-manuscript-Gide.yml
+# French-caption variant of the shared venues table: identical English table body
+# (headers, journal names, counts) with a French caption. Derived from the
+# git-tracked tab_venues.md, so it stays in sync when that table is regenerated.
+# Writing-side only: a plain-text transform, no uv and no data.
+GIDE_VENUES_FR  := content/tables/tab_venues_fr.md
+
+$(GIDE_VENUES_FR): content/tables/tab_venues.md content/tables/tab_venues_fr_caption.md
+	{ grep -v '^: ' $< ; cat content/tables/tab_venues_fr_caption.md ; } > $@
 
 GIDE_INPUTS := $(GIDE_SRC) $(MANUSCRIPT_BIB) $(MANUSCRIPT_CSL) \
-               $(MANUSCRIPT_VARS) $(GIDE_PROFILE) $(MANUSCRIPT_DELIVERABLES)
+               $(MANUSCRIPT_VARS) $(GIDE_PROFILE) \
+               $(MANUSCRIPT_DELIVERABLES) $(GIDE_VENUES_FR)
 
 output/content/manuscript-Gide.pdf: export QUARTO_PROFILE := manuscript-Gide
 


### PR DESCRIPTION
Le tableau des revues (`content/tables/tab_venues.md`) est **généré** et **partagé** entre `manuscript.qmd` (EN) et `manuscript-Gide.qmd` (FR) — sa légende anglaise ne peut donc pas être traduite en place sans affecter le papier EN.

## Solution : variante à légende FR
- **Contenu du tableau inchangé** (en-têtes `Lean/Journal/Eff./Acc./Total`, étiquettes de pôle, noms de revues) — en anglais, comme demandé.
- **Légende en français**, dans `content/tables/tab_venues_fr_caption.md`.
- `content/tables/tab_venues_fr.md` est **dérivé** de `tab_venues.md` (corps) + la légende FR, via une **règle Makefile côté écriture** (transformation texte, sans `uv` ni données) → reste en phase avec le tableau EN s'il est régénéré.
- Le papier **Gide pointe sur `tab_venues_fr.md`** ; le **papier EN est intact**.

## Corrige aussi
- Un **renvoi erroné** : la légende partagée pointait vers « (§3.4) », section inexistante dans le Gide (la méthode est dans l'annexe non numérotée). La légende FR renvoie à « la note méthodologique en annexe ».
- Un **commentaire périmé** de `manuscript.mk` (le qmd Gide est désormais tracké).
- `.gitignore` : négations pour les deux nouveaux artefacts trackés.

## Vérifié
PDF régénéré (`quarto render`, profil `manuscript-Gide`) — page 19 : corps EN + légende FR, ≥ et « Lean » rendus correctement.

Note séparée (non incluse, doc-wide) : les préfixes « Table »/« Figure » restent en anglais malgré `lang: fr` — réglage crossref Quarto global, à traiter à part si souhaité.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)