### PR TITLE
fix(bib): correct author name Büchner -> Buchner

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -334,7 +334,7 @@
 }
 
 @book{buchner2011,
-  author    = {Barbara Büchner and Jessica Brown and Jan Corfee-Morlot},
+  author    = {Barbara Buchner and Jessica Brown and Jan Corfee-Morlot},
   title     = {Monitoring and Tracking Long-Term Finance to Support Climate Action},
   publisher = {OECD},
   year      = {2011},
@@ -343,7 +343,7 @@
 }
 
 @book{buchner2013,
-  author    = {Barbara Büchner and Martin Stadelmann and Jessica Wilkinson and Federico Mazza and Anja Rosenberg and Dario Abramskiehn},
+  author    = {Barbara Buchner and Martin Stadelmann and Jessica Wilkinson and Federico Mazza and Anja Rosenberg and Dario Abramskiehn},
   title     = {The Global Landscape of Climate Finance 2013},
   publisher = {Climate Policy Initiative},
   year      = {2013},


### PR DESCRIPTION
`buchner2011` et `buchner2013` orthographiaient le nom de **Barbara Buchner** (directrice de la Climate Policy Initiative) avec un tréma (« Büchner »). Corrigé en « Buchner » (sans tréma) dans les deux entrées.

Repéré à la vérification visuelle du PDF Gide (« Büchner et al., 2011, 2013 »). Les deux clés sont citées par `manuscript.qmd` et `manuscript-Gide.qmd` → la correction du bib partagé répare les deux papiers.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)