### PR TITLE
manuscript(gide): French crossref prefixes (Tableau/Figure)

### DIFF
--- a/content/manuscript-Gide.qmd
+++ b/content/manuscript-Gide.qmd
@@ -19,6 +19,9 @@ bibliography: bibliography/main.bib
 csl: bibliography/oeconomia.csl
 reference-section-title: Bibliographie
 number-sections: true
+crossref:
+  fig-title: Figure
+  tbl-title: Tableau
 format:
   pdf:
     pdf-engine: xelatex


### PR DESCRIPTION
Malgré `lang: fr`, les légendes de tableaux sortaient avec le préfixe anglais « Table » (repéré à la vérif visuelle du PDF). Ajoute un bloc `crossref:` dans l'en-tête du papier Gide pour forcer « **Tableau** N » et « **Figure** N » (Figure étant identique en FR).

Vérifié au rendu : « TABLEAU 1 – Trois traditions… », etc. Aucun cross-ref `@tbl-/@fig-` inline dans le document, donc seuls les préfixes de légende sont concernés.

Gide uniquement — le manuscrit EN garde ses préfixes anglais.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)