### PR TITLE
manuscript(gide): bold Bibliographie heading

### DIFF
--- a/content/manuscript-Gide.qmd
+++ b/content/manuscript-Gide.qmd
@@ -17,7 +17,6 @@ lang: fr
 metadata-files: [manuscript-vars.yml]
 bibliography: bibliography/main.bib
 csl: bibliography/oeconomia.csl
-reference-section-title: Bibliographie
 number-sections: true
 crossref:
   fig-title: Figure
@@ -223,3 +222,8 @@ La troisième question demande si la polarisation d'après Paris se voit dans le
 {{< include tables/tab_venues_fr.md >}}
 
 **Reproductibilité, données et code.** Les opérations résumées ci-dessus reposent sur des méthodes statistiques standard : les représentations vectorielles (« embeddings ») sont produites par le modèle multilingue `BAAI/bge-m3`. Le regroupement des textes par leur sens utilise l'algorithme k-means à six groupes sur les embeddings. La détection des ruptures combine la divergence de Jensen--Shannon et la distance cosinus, sur les répartitions thématiques. Les communautés de co-citations sont examinées par la méthode de Louvain. Les scripts et la chaîne de reproduction complète sont archivés sur Zenodo (DOI : [10.5281/zenodo.19097045](https://doi.org/10.5281/zenodo.19097045)) et développés en science ouverte à l'adresse <https://github.com/MinhHaDuong/climate-finance-het>.
+
+## Bibliographie {.unnumbered}
+
+::: {#refs}
+:::


### PR DESCRIPTION
The **Bibliographie** title rendered as plain (non-bold) body text instead of a section heading.

## Cause
`reference-section-title: Bibliographie` is inserted one heading level *above* the document's sections. Under Quarto's heading-level shift (this paper's sections are already top-level), it collapsed to level 0 and pandoc emitted it as a plain paragraph — `Bibliographie` with no `\section*`, hence no bold and no TOC entry.

## Fix
Drop the auto-title and place the bibliography explicitly:

```
## Bibliographie {.unnumbered}

::: {#refs}
:::
```

Verified in the generated LaTeX: the heading now emits as `\section*{Bibliographie}\label{bibliographie}` + `\addcontentsline{toc}{section}{Bibliographie}`. PDF rebuilds cleanly.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)