### PR TITLE
state: Charles Gide paper submitted 2026-06-29

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -11,7 +11,7 @@ implementation** (tracker 0156) — the prose pass applying the decisions, then 
 ### Roadmap
 - **v2.0.5** (0156): prose pass 0134 (define-by-negation) + 0135 (hybrid economists framing), em-dash 0162, content 0137/0138/0139/0141/0143, response letter 0152, resubmit 0153.
 - Parallel (not R&R): method paper **0026** — `multilayer-detection.qmd`.
-- Parallel (done): Charles Gide conference paper `manuscript-Gide.qmd` — fact-checked (Türkiye/WB case), French captions + crossref, voice-matched, on main. Follow-up: bib accuracy validation **0164**.
+- Parallel (**submitted 2026-06-29**): Charles Gide conference paper `manuscript-Gide.qmd` — sent to RHPE reviewer + uploaded to colloque website. Tag `gide-submitted-2026-06-29` (commit 4ac6e3a); record in `papiers/sent/2026-06-29 Charles Gide/`. Follow-up: bib accuracy validation **0164**.
 
 ## Status
 <!-- generated 2026-06-28T22:52Z -->


### PR DESCRIPTION
Records the Charles Gide conference-paper submission milestone in STATE.md.

- `manuscript-Gide.qmd` sent to the RHPE reviewer and uploaded to the 21e colloque Charles Gide (Vannes, 2–4 July 2026) website on 2026-06-29.
- Provenance: local tag `gide-submitted-2026-06-29` (commit `4ac6e3a`), submission record under `papiers/sent/2026-06-29 Charles Gide/`.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)