### PR TITLE
Vannes debrief: notes, decisions (0165 base text, aggregate-birth title), tickets 0165/0166

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -38,6 +38,27 @@ letter.
 
 **Status:** active
 
+## title-frames-aggregate-birth
+
+**Decision:** The resubmission's title and abstract lead with the birth of
+a new economic aggregate — how climate finance was made into an aggregate
+(conventional perimeter, no single ledger, governing by measurement), in
+the lineage of histories of GDP and the monetary aggregates. "Strategic
+ambiguity" is the mechanism inside the story, not the headline.
+
+**Rationale:** Author decision 2026-07-07. The Vannes audience named the
+question ("comment un nouvel agrégat est né") and the author's own margin
+notes twice equate agrégat ≈ masse monétaire. "Ambiguity as resource" is
+an STS commonplace (boundary objects) and exposed as a headline; the
+aggregate-birth claim is the fresh, HET-native contribution and gives the
+conclusion its landing (conditions of aggregate birth: a political number
+fixed before the object, a pre-existing statistical infrastructure,
+economists under constraint).
+
+**Ticket:** 0165 (base decision); `docs/notes-vannes-2026-07.md` §1, §4.
+
+**Status:** active
+
 ## construction-not-discovery
 
 **Decision:** Prose frames climate finance as a constructed economic object —

--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -17,6 +17,27 @@ realign, summary verdicts) must clear the four reduction guards in
 `scripts/qa_llm_judge_guards.py` — output no longer than input, zero em dashes,
 no invented number, no LLMism introduced — before their output is trusted.
 
+## resubmission-base-is-translated-vf
+
+**Decision:** The v2.0.5 resubmission manuscript is rebuilt from the
+translated VF (`manuscript-Gide.qmd`) — its framing (économistes sous
+contrainte), thesis-titled sections, and conclusion-that-lands are the
+spine. VEn material (corpus-evidence sections, appendix A.1–A.6, §2
+concretizations) enters only by active reimport, gated row-by-row against
+the 0152 traceability table. Translation is treated as writing: the prose
+brief and ratchet apply to the translated text, not assumed from the French.
+
+**Rationale:** Effort is symmetric with revising the VEn in place, but
+failure modes are not: dropped reviewer-required content has a mechanical
+detector (traceability table); residual pre-decision prose does not, and
+prose (E1) was the editor's most-emphasized issue. The VF voice was
+field-tested at Vannes. HAL preprint overlap is disclosed in the cover
+letter.
+
+**Ticket:** 0165 (decision); 0156 (v2.0.5 tracker); 0152 (traceability).
+
+**Status:** active
+
 ## construction-not-discovery
 
 **Decision:** Prose frames climate finance as a constructed economic object —

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -43,8 +43,8 @@ Corps de page :
 > — Géopol : « combien ça vaut » — décomposition des 100 M[illiards] par
 >   pays → lecture géopolitique des négociations. → Reci [Belém ?], 1,3 T
 >
-> — [Corfee-]Morlot inspirée de Roelis & Oliveira [?] ; Green et des
->   Norvégiens surtout. Hans Kojo Sike [?] '93 : indicateurs négociés
+> — [Corfee-]Morlot inspirée de Martins [?] et Oliveira [?] ; Green et des
+>   Norvégiens surtout. Hans Vigo Soke [?] '93 : indicateurs négociés
 >   avec les Samis
 
 ### Slide 5 — « Économistes sous contrainte, au pied de la lettre » (stylo vert)
@@ -113,17 +113,40 @@ Bas de page (raturé) :
      (conclusion VF) ; ajouter des références à la conclusion.
    - Lecture géopolitique : décomposer les 100 Md par pays ; prolonger vers
      la feuille de route de Bakou à Belém (1 300 Md$) [?].
-5. **Pistes archivistiques** : les inspirations de Corfee-Morlot (« Green et
-   des Norvégiens surtout », indicateurs négociés avec les Samis, '93) —
-   piste pour l'histoire fine des marqueurs ; noms à confirmer.
+5. **Pistes archivistiques** (identifications 2026-07-07, à confirmer) :
+   - **« Green » + « Martins et Oliveira » = le modèle GREEN de l'OCDE** :
+     Burniaux, Martin, Nicoletti & **Oliveira Martins**, *GREEN — A
+     Multi-Sector, Multi-Region General Equilibrium Model for Quantifying
+     the Costs of Curbing CO2 Emissions: A Technical Manual*, OECD
+     Economics Department WP 116, 1992. La remarque de la salle suggère une
+     **continuité interne à l'OCDE** entre l'ère modélisation (GREEN,
+     département Économie, 1991-92) et l'ère mesure (Corfee-Morlot,
+     direction Environnement) — nuance le récit « la finance climat naît
+     hors de la modélisation » : à vérifier (liens de citation ou de
+     collaboration Corfee-Morlot ↔ équipe GREEN). Alimente 0135/0141.
+   - **« Hans Vigo Soke '93 » = Hans Viggo Sæbø** (Statistics Norway) :
+     Alfsen & Sæbø, « Environmental quality indicators: Background,
+     principles and examples from Norway », *Environmental and Resource
+     Economics* 3(5), 1993, 415-435 (aussi Statistics Norway DP 71).
+     La filiation nordique des indicateurs environnementaux (comptabilité
+     des ressources norvégienne → indicateurs OCDE), avec l'épisode des
+     indicateurs négociés avec les Samis comme cas de quantification
+     négociée avec les parties prenantes — piste pour l'histoire fine des
+     marqueurs.
 
 ## Lectures incertaines à trancher par l'auteur
 
-- [ ] « Lucas Ward (Nancy) » — qui ? et le contenu exact de la note en marge.
+- [ ] « Lucas [?] Ward [?] (Nancy) » — HET travaillant sur les flux d'idées
+      entre économistes opérationnels en banque centrale et économistes
+      académiques (thème « scientization of central banks » : littérature
+      Goutsmedt/Acosta/Cherrier/Sergi). Nom exact à retrouver dans le
+      programme papier du colloque (sciencesconf inaccessible depuis ici).
 - [ ] « n[iveau]x de vie : −5 %/an pdt 48 ans Nord ; ×2 Sud » — sens et source.
 - [ ] « les acquis de Kyoto *sombrent* » ou « *comblent* » ?
 - [ ] « Ambiguïté = bateau » — lecture et sens.
 - [ ] « Charlieu = livre » — quel livre / auteur ?
-- [ ] « → Reci, 1,3 T » — Belém ? (feuille de route Bakou→Belém, 1 300 Md$)
-- [ ] « Morlot inspirée de Roelis & Oliveira » — noms exacts.
-- [ ] « Hans Kojo Sike '93 » — nom exact (indicateurs négociés avec les Samis).
+- [ ] « → Reci, 1,3 T » — lu comme la feuille de route « Baku to Belém »
+      vers 1 300 Md$/an (décision NCQG, COP29) ; à confirmer.
+- [x] « Martins et Oliveira, Green » — équipe du modèle GREEN, OCDE 1992
+      (Burniaux, Martin, Nicoletti, Oliveira Martins) ; voir §5.
+- [x] « Hans Vigo Soke '93 » — Hans Viggo Sæbø (Alfsen & Sæbø 1993) ; voir §5.

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -35,7 +35,7 @@ Corps de page :
 >   Pas plus que d'habitude. Ambiguïté = bateau [STS].
 >   Ajouter + de références à la conclusion.
 >
-> ✱ Charlieu [?] = livre
+> ✱ Chantier = livre
 
 ### Page blanche face à « 1 — Introduction »
 
@@ -233,7 +233,8 @@ Bas de page (raturé) :
 - [x] « n[iveau]x de vie… » — retiré (notes personnelles sur un autre papier).
 - [x] « les acquis de Kyoto *sombrent* » — confirmé (fiasco du CDM, Dosquet).
 - [x] « Ambiguïté = bateau » — bateau *STS* : risque de lieu commun ; voir §4.
-- [ ] « Charlieu = livre » — quel livre / auteur ? (lié au projet livre ?)
+- [x] « Chantier = livre » (mal lu « Charlieu ») — les chantiers de la
+      conclusion sont le programme du livre en cours ; voir §4.
 - [ ] « → Reci, 1,3 T » — lu comme la feuille de route « Baku to Belém »
       vers 1 300 Md$/an (décision NCQG, COP29) ; à confirmer.
 - [x] « Martins et Oliveira, Green » — équipe du modèle GREEN, OCDE 1992

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -103,8 +103,9 @@ Bas de page (raturé) :
    mobilisée), l'agrégat est défini par convention de périmètre, il sert
    d'instrument de gouvernement, et son ciblage a une histoire (monétarisme)
    faite d'abandons et de redéfinitions. Alimente 0137 (fil commensuration),
-   l'intro et la conclusion ; candidat pour le titre ou la première phrase
-   de l'abstract.
+   l'intro et la conclusion. **Décidé (auteur, 2026-07-07)** : le
+   titre/abstract de la resoumission mène avec la naissance de l'agrégat —
+   voir `docs/editorial-brief.md` → `title-frames-aggregate-birth`.
 2. **Étiquetage des slides Türkiye par controverse** — Additionnalité (16),
    Valeur + Crédibilité (17), Attribution (18) : rendre explicite dans le
    texte la correspondance biunivoque cas ↔ quatre controverses.

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -39,6 +39,9 @@ Corps de page :
 
 ### Page blanche face à « 1 — Introduction »
 
+Source des références : **Ariane Dupont** [Dupont-Kieffer ?], en
+conversation au colloque (identifiée par l'auteur, 2026-07-07).
+
 > Copenhague
 >
 > — Géopol : « combien ça vaut » — décomposition des 100 M[illiards] par
@@ -158,7 +161,14 @@ Bas de page (raturé) :
      conclusion de la révision.
    - Lecture géopolitique : décomposer les 100 Md par pays ; prolonger vers
      la feuille de route de Bakou à Belém (1 300 Md$) [?].
-5. **Pistes archivistiques** (identifications 2026-07-07, à confirmer) :
+5. **Pistes archivistiques** (identifications 2026-07-07, à confirmer) —
+   données par **Ariane Dupont** [Dupont-Kieffer ?]. Si c'est bien Ariane
+   Dupont-Kieffer (Paris 1, historienne de l'économétrie, spécialiste de
+   Ragnar Frisch), la piste nordique est son terrain : la lignée
+   norvégienne (comptabilité nationale et des ressources, Statistics
+   Norway) est cohérente avec ses travaux — contact précieux pour
+   l'histoire fine des indicateurs, et relectrice potentielle du récit
+   « naissance d'un agrégat ».
    - **« Green » + « Martins et Oliveira » = le modèle GREEN de l'OCDE** :
      Burniaux, Martin, Nicoletti & **Oliveira Martins**, *GREEN — A
      Multi-Sector, Multi-Region General Equilibrium Model for Quantifying

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -19,19 +19,20 @@ Marge haute :
 
 Corps de page :
 
-> = n[iveau]x de vie [?] : −5 %/an pdt 48 ans Nord ; ×2 Sud
+> [ligne retirée à la demande de l'auteur : notes personnelles sur un
+> autre papier]
 >
 > élargie aux politiques concrètes
 >
 > ? pk '90 → ≠ science policy
 >
-> ? pk 2007 = les acquis de Kyoto sombrent [comblent ?] — tu l'as dit
+> ? pk 2007 = les acquis de Kyoto sombrent — tu l'as dit
 >
 > ✱ Tension entre 2 pôles ? Questionne la littérature sur le crédit ?
 >   entrer dans la bataille : si
 >
 > ✱ Q : est-ce que le Nord a choisi l'arène qui lui est favorable ?
->   Pas plus que d'habitude. Ambiguïté = bateau [?].
+>   Pas plus que d'habitude. Ambiguïté = bateau [STS].
 >   Ajouter + de références à la conclusion.
 >
 > ✱ Charlieu [?] = livre
@@ -101,16 +102,38 @@ Bas de page (raturé) :
    contradictoires » (au lieu d'« agréger ») ; la chute « on a inventé une
    façon plus économique de se disputer » (la quantification comme mode de
    dispute à moindre coût) — candidate pour la conclusion.
-4. **Questions de la salle à traiter dans la révision** :
-   - Pourquoi 1990 comme point de départ ; positionnement vis-à-vis de la
-     littérature science policy.
-   - 2007 : le rôle de l'effondrement des acquis de Kyoto (CDM) dans la
-     cristallisation — déjà dans le texte (VEn §1), à rendre plus saillant.
-   - Les deux pôles engagent-ils la littérature sur le crédit ? (« entrer
-     dans la bataille : si ») — recoupe 0139 (nexus finance-développement).
-   - Le Nord a-t-il choisi l'arène qui lui est favorable ? Réponse esquissée :
-     « pas plus que d'habitude » — recoupe le point des arènes asymétriques
-     (conclusion VF) ; ajouter des références à la conclusion.
+4. **Questions de la salle, avec les réponses de l'auteur (2026-07-07)** :
+   - **Pourquoi 1990 ? (question Dosquet)** — réponse donnée : la science a
+     son autonomie intellectuelle ; on n'exclut pas qu'elle produise des
+     idées avant la Convention. Peu de références, mais les archives sont
+     lacunaires avant 2000. → À intégrer comme justification de la borne
+     1990 dans l'annexe (répond aussi à E3, frontières du corpus) : la
+     borne est une fenêtre d'observation, pas une thèse d'origine.
+   - **Pourquoi la rupture 2007 ? (Dosquet)** — on acte le fiasco du CDM et
+     des autres mécanismes de Kyoto. La VEn a déjà l'effondrement du CDM
+     (post-2012, prix des CER) ; le point de Dosquet est plus fort : dès
+     2007, la perception que les mécanismes de marché ne livreraient pas la
+     finance à l'échelle (krach EUA/CER phase 1 en 2006-07) crée la demande
+     d'une comptabilité directe des flux. Pont causal à renforcer en §2.
+   - **Les deux pôles et la littérature sur le crédit** : « entrer dans la
+     bataille : si » = l'auteur veut en faire **un livre**. Scoping : dans
+     l'article, faire le minimum que R1.5 demande (situer blended
+     finance/de-risking dans le nexus finance-développement, 0139) ; la
+     bataille complète va au projet livre (`docs/projet livre - pitch.md`,
+     `docs/projet livre - plan détaillé.md`).
+   - **Le Nord a-t-il choisi l'arène qui lui est favorable ?** Réponse
+     esquissée : « pas plus que d'habitude » — recoupe le point des arènes
+     asymétriques (conclusion VF) ; ajouter des références à la conclusion.
+   - **« Ambiguïté = bateau [STS] »** — mise en garde (soufflée par
+     l'agent, pré-Vannes) : « l'ambiguïté comme ressource » est un lieu
+     commun STS (objets-frontières, Star & Griesemer). L'audience réduite
+     n'a pas tiqué, mais un referee STS-compétent pourrait. Défense à
+     rendre explicite : la nouveauté n'est pas « l'ambiguïté est
+     productive », c'est (a) la démonstration historique qu'une définition
+     précise existait (art. 4.3) et a été *abandonnée*, (b) l'ambiguïté
+     logée dans les conventions comptables d'un agrégat, (c) les
+     économistes comme producteurs de cette ambiguïté. À armer dans la
+     conclusion de la révision.
    - Lecture géopolitique : décomposer les 100 Md par pays ; prolonger vers
      la feuille de route de Bakou à Belém (1 300 Md$) [?].
 5. **Pistes archivistiques** (identifications 2026-07-07, à confirmer) :
@@ -175,10 +198,10 @@ Bas de page (raturé) :
       académiques (thème « scientization of central banks » : littérature
       Goutsmedt/Acosta/Cherrier/Sergi). Nom exact à retrouver dans le
       programme papier du colloque (sciencesconf inaccessible depuis ici).
-- [ ] « n[iveau]x de vie : −5 %/an pdt 48 ans Nord ; ×2 Sud » — sens et source.
-- [ ] « les acquis de Kyoto *sombrent* » ou « *comblent* » ?
-- [ ] « Ambiguïté = bateau » — lecture et sens.
-- [ ] « Charlieu = livre » — quel livre / auteur ?
+- [x] « n[iveau]x de vie… » — retiré (notes personnelles sur un autre papier).
+- [x] « les acquis de Kyoto *sombrent* » — confirmé (fiasco du CDM, Dosquet).
+- [x] « Ambiguïté = bateau » — bateau *STS* : risque de lieu commun ; voir §4.
+- [ ] « Charlieu = livre » — quel livre / auteur ? (lié au projet livre ?)
 - [ ] « → Reci, 1,3 T » — lu comme la feuille de route « Baku to Belém »
       vers 1 300 Md$/an (décision NCQG, COP29) ; à confirmer.
 - [x] « Martins et Oliveira, Green » — équipe du modèle GREEN, OCDE 1992

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -134,6 +134,40 @@ Bas de page (raturé) :
      négociée avec les parties prenantes — piste pour l'histoire fine des
      marqueurs.
 
+6. **Littérature « scientization of central banks »** (survol 2026-07-07,
+   suite à la remarque de la collègue de Nancy sur le sens de circulation
+   des idées selon leur nature) :
+   - **Claveau & Dion 2018** (*J. of Economic Methodology*) : le sens du
+     flux d'influence s'est **inversé dans le temps** — la balance des
+     citations en économie monétaire penchait vers l'académie (années
+     1970-80), elle penche désormais vers les banques centrales, devenues
+     dominantes dans leur propre champ savant.
+   - **Hirschman & Popp Berman 2014** (*Socio-Economic Review*) : le sens
+     de circulation dépend de la **forme** du savoir — les *policy devices*
+     (PIB, analyse coût-bénéfice, règles budgétaires) et le *style de
+     raisonnement économique* voyagent vers la décision publique ; le
+     conseil théorique direct voyage mal. Prolongé par Popp Berman,
+     *Thinking Like an Economist* (2022) — dont **Œconomia a publié un
+     symposium** : lien éditorial direct pour 0143.
+   - **Acosta, Cherrier, Claveau, Fontan, Goutsmedt, Sergi 2024** (*HOPE*,
+     « Six Decades of Economic Research at the Bank of England ») et
+     **Goutsmedt & Sergi 2025** (*Finance & Society*, « Redefining
+     scientization ») : la scientisation est stratégique et différenciée
+     selon la fonction (modèles de prévision vs recherche contributive) —
+     pas un transfert linéaire académie → praticiens.
+   - **Import pour le manuscrit** : l'hypothèse symétrique pour la finance
+     climat — les *instruments* (marqueurs de Rio, équivalent-don,
+     attribution de la finance mobilisée) naissent côté opérationnel et la
+     théorisation académique suit (Michaelowa 2007 analyse des marqueurs de
+     1998 ; Stadelmann 2011 des baselines de Copenhague), tandis que les
+     *cadres théoriques* (défaillances de marché, levier) circulent en sens
+     inverse. **Testable dans le corpus** : dater la première apparition de
+     chaque catégorie clé dans le segment gris vs académique. Répondrait à
+     la fois à R1.1 (absence des revues d'économie = les savoirs
+     d'instrument circulent par les canaux institutionnels d'abord) et à
+     E3 (un quantitatif qui gagne sa place). Ticket à ouvrir si l'auteur
+     valide.
+
 ## Lectures incertaines à trancher par l'auteur
 
 - [ ] « Lucas [?] Ward [?] (Nancy) » — HET travaillant sur les flux d'idées

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -1,0 +1,129 @@
+# Notes de Vannes — annotations sur le handout des slides Gide
+
+Colloque Charles Gide, Vannes, 2--4 juillet 2026. Présentation « Économistes
+sous contrainte » (dernière session, audience réduite mais engagée).
+Transcription des annotations manuscrites portées sur le handout des slides
+(`content/slides-gide.qmd`), depuis 8 photos, le 2026-07-07.
+
+Convention : `[?]` = lecture incertaine, à corriger par l'auteur.
+Les lectures incertaines sont regroupées en fin de fichier.
+
+## Transcription verbatim
+
+### Page de titre
+
+Marge haute :
+
+> Lucas Ward [?] (Nancy) — flux entre économistes académiques vs
+> opé[rationnels] en b[an]que ce[ntrale] [?]
+
+Corps de page :
+
+> = n[iveau]x de vie [?] : −5 %/an pdt 48 ans Nord ; ×2 Sud
+>
+> élargie aux politiques concrètes
+>
+> ? pk '90 → ≠ science policy
+>
+> ? pk 2007 = les acquis de Kyoto sombrent [comblent ?] — tu l'as dit
+>
+> ✱ Tension entre 2 pôles ? Questionne la littérature sur le crédit ?
+>   entrer dans la bataille : si
+>
+> ✱ Q : est-ce que le Nord a choisi l'arène qui lui est favorable ?
+>   Pas plus que d'habitude. Ambiguïté = bateau [?].
+>   Ajouter + de références à la conclusion.
+>
+> ✱ Charlieu [?] = livre
+
+### Page blanche face à « 1 — Introduction »
+
+> Copenhague
+>
+> — Géopol : « combien ça vaut » — décomposition des 100 M[illiards] par
+>   pays → lecture géopolitique des négociations. → Reci [Belém ?], 1,3 T
+>
+> — [Corfee-]Morlot inspirée de Roelis & Oliveira [?] ; Green et des
+>   Norvégiens surtout. Hans Kojo Sike [?] '93 : indicateurs négociés
+>   avec les Samis
+
+### Slide 5 — « Économistes sous contrainte, au pied de la lettre » (stylo vert)
+
+> « Agrégat » ≈ Masse Monétaire
+
+### Slide 14 — « Compter, c'est gouverner » (Accord de Paris, art. 9)
+
+> création des fonds verts…
+
+### Slide 16 — cas Türkiye, « Est-ce un projet climat ? »
+
+> Additionnalité
+
+### Slide 17 — tableau « Combien de finance climat dans ce projet ? »
+
+> Valeur
+> Crédibilité
+
+### Slide 18 — « quatre controverses » (couvertures OCDE / Oxfam Shadow Report)
+
+> Attribution
+
+### Slide 20 — conclusion, « ambiguïté : défaut ou ressource ? »
+
+> Agrégat
+
+Correction portée sur le texte du slide (« assez ambiguës pour agréger des
+intérêts contradictoires ») :
+
+> assez ambiguës pour ~~agréger~~ **servir** des intérêts contradictoires
+
+Bas de page (raturé) :
+
+> on a ~~créé~~ inventé une ~~[illisible]~~ dispute intellectuelle [?] —
+> façon plus économique [de se disputer ?]
+
+## Interprétation (à valider)
+
+1. **« Agrégat » ≈ masse monétaire** — écrit deux fois (slides 5 et 20), au
+   stylo vert sur le slide-thèse. C'est l'analogie que la salle a nommée :
+   la finance climat comme agrégat monétaire (M1/M2/M3), pas comme PIB.
+   L'analogie est plus riche que le PIB : plusieurs périmètres concurrents
+   coexistent légitimement (M1/M2/M3 ↔ valeur faciale/équivalent-don/
+   mobilisée), l'agrégat est défini par convention de périmètre, il sert
+   d'instrument de gouvernement, et son ciblage a une histoire (monétarisme)
+   faite d'abandons et de redéfinitions. Alimente 0137 (fil commensuration),
+   l'intro et la conclusion ; candidat pour le titre ou la première phrase
+   de l'abstract.
+2. **Étiquetage des slides Türkiye par controverse** — Additionnalité (16),
+   Valeur + Crédibilité (17), Attribution (18) : rendre explicite dans le
+   texte la correspondance biunivoque cas ↔ quatre controverses.
+3. **Corrections de prose à adopter** : « servir des intérêts
+   contradictoires » (au lieu d'« agréger ») ; la chute « on a inventé une
+   façon plus économique de se disputer » (la quantification comme mode de
+   dispute à moindre coût) — candidate pour la conclusion.
+4. **Questions de la salle à traiter dans la révision** :
+   - Pourquoi 1990 comme point de départ ; positionnement vis-à-vis de la
+     littérature science policy.
+   - 2007 : le rôle de l'effondrement des acquis de Kyoto (CDM) dans la
+     cristallisation — déjà dans le texte (VEn §1), à rendre plus saillant.
+   - Les deux pôles engagent-ils la littérature sur le crédit ? (« entrer
+     dans la bataille : si ») — recoupe 0139 (nexus finance-développement).
+   - Le Nord a-t-il choisi l'arène qui lui est favorable ? Réponse esquissée :
+     « pas plus que d'habitude » — recoupe le point des arènes asymétriques
+     (conclusion VF) ; ajouter des références à la conclusion.
+   - Lecture géopolitique : décomposer les 100 Md par pays ; prolonger vers
+     la feuille de route de Bakou à Belém (1 300 Md$) [?].
+5. **Pistes archivistiques** : les inspirations de Corfee-Morlot (« Green et
+   des Norvégiens surtout », indicateurs négociés avec les Samis, '93) —
+   piste pour l'histoire fine des marqueurs ; noms à confirmer.
+
+## Lectures incertaines à trancher par l'auteur
+
+- [ ] « Lucas Ward (Nancy) » — qui ? et le contenu exact de la note en marge.
+- [ ] « n[iveau]x de vie : −5 %/an pdt 48 ans Nord ; ×2 Sud » — sens et source.
+- [ ] « les acquis de Kyoto *sombrent* » ou « *comblent* » ?
+- [ ] « Ambiguïté = bateau » — lecture et sens.
+- [ ] « Charlieu = livre » — quel livre / auteur ?
+- [ ] « → Reci, 1,3 T » — Belém ? (feuille de route Bakou→Belém, 1 300 Md$)
+- [ ] « Morlot inspirée de Roelis & Oliveira » — noms exacts.
+- [ ] « Hans Kojo Sike '93 » — nom exact (indicateurs négociés avec les Samis).

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -44,12 +44,19 @@ conversation au colloque (identifiée par l'auteur, 2026-07-07).
 
 > Copenhague
 >
-> — Géopol : « combien ça vaut » — décomposition des 100 M[illiards] par
->   pays → lecture géopolitique des négociations. → Reci [Belém ?], 1,3 T
+> — Géopol : « combien je vaux » — décomposition des 100 M[illiard]s par
+>   pays → lecture géopolitique des négociations. → récl[amé], 1,3 T
 >
 > — [Corfee-]Morlot inspirée de Martins [?] et Oliveira [?] ; Green et des
 >   Norvégiens surtout. Hans Vigo Soke [?] '93 : indicateurs négociés
 >   avec les Samis
+
+Décodage (auteur, 2026-07-07) : remarque d'**Ariane Dupont** — la lecture
+géopolitique des négociations, c'est que les pays du Sud comprennent
+« combien je vaux » : ils décomposent les 100 milliards par pays. Réponse
+de l'auteur : « Merci pour la remarque, ce n'est pas une question » — et
+rappel que les pays en développement avaient demandé **1,3 trillion** de
+dollars à Bakou, pas 0,3.
 
 ### Slide 5 — « Économistes sous contrainte, au pied de la lettre » (stylo vert)
 
@@ -159,8 +166,18 @@ Bas de page (raturé) :
      logée dans les conventions comptables d'un agrégat, (c) les
      économistes comme producteurs de cette ambiguïté. À armer dans la
      conclusion de la révision.
-   - Lecture géopolitique : décomposer les 100 Md par pays ; prolonger vers
-     la feuille de route de Bakou à Belém (1 300 Md$) [?].
+   - **Lecture géopolitique (Ariane Dupont)** : les pays du Sud lisent
+     l'agrégat en le décomposant — « combien je vaux » dans les
+     100 milliards. Import pour le manuscrit : c'est l'usage récipiendaire
+     de l'agrégat — un dispositif de *valorisation des pays* autant que de
+     vérification des donneurs — qui complète le point des arènes
+     asymétriques avec une perspective Sud concrète. Et muscler le
+     paragraphe Bakou : les pays en développement demandaient
+     **1 300 Md$/an** ; l'accord fixe 300 Md$ de cible cœur (le 1,3 T
+     survit en « Baku to Belém Roadmap », aspirationnel, hors obligation).
+     L'écart 1,3 T / 0,3 T est la controverse distributive rendue visible
+     par l'agrégat lui-même — ni la VF ni la VEn ne le mentionnent
+     aujourd'hui (0141).
 5. **Pistes archivistiques** (identifications 2026-07-07, à confirmer) —
    données par **Ariane Dupont** [Dupont-Kieffer ?]. Si c'est bien Ariane
    Dupont-Kieffer (Paris 1, historienne de l'économétrie, spécialiste de
@@ -236,8 +253,8 @@ Bas de page (raturé) :
 - [x] « Ambiguïté = bateau » — bateau *STS* : risque de lieu commun ; voir §4.
 - [x] « Chantier = livre » (mal lu « Charlieu ») — les chantiers de la
       conclusion sont le programme du livre en cours ; voir §4.
-- [ ] « → Reci, 1,3 T » — lu comme la feuille de route « Baku to Belém »
-      vers 1 300 Md$/an (décision NCQG, COP29) ; à confirmer.
+- [x] « → récl[amé], 1,3 T » — les 1 300 Md$/an demandés par les pays en
+      développement à Bakou (la cible cœur adoptée étant 300 Md$) ; voir §4.
 - [x] « Martins et Oliveira, Green » — équipe du modèle GREEN, OCDE 1992
       (Burniaux, Martin, Nicoletti, Oliveira Martins) ; voir §5.
 - [x] « Hans Vigo Soke '93 » — Hans Viggo Sæbø (Alfsen & Sæbø 1993) ; voir §5.

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -138,8 +138,14 @@ Bas de page (raturé) :
      (art. 4.3 → NCQG) comme résultat, pas comme rappel ; (c) pertes et
      préjudices comme test falsifiable de la thèse ; (d) références :
      Popp Berman (style de raisonnement), Desrosières (lignée
-     statistique-État), histoire des agrégats monétaires ; les chantiers
-     réduits à un paragraphe bref.
+     statistique-État), histoire des agrégats monétaires.
+     **Précision de l'auteur (2026-07-07) : chantier = livre.** Les
+     « chantiers » de la conclusion VF sont le programme du livre en
+     cours, annoncés à l'oral pour le colloque — ils n'ont pas vocation à
+     figurer tels quels dans l'article. Pour la resoumission : la
+     conclusion atterrit sur la thèse (a-b-c ci-dessus) ; les chantiers
+     migrent vers le projet livre (`docs/projet livre - pitch.md`), sauf
+     mention d'une ligne s'il en faut une pour les limites.
    - **« Ambiguïté = bateau [STS] »** — mise en garde (soufflée par
      l'agent, pré-Vannes) : « l'ambiguïté comme ressource » est un lieu
      commun STS (objets-frontières, Star & Griesemer). L'audience réduite

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -225,11 +225,12 @@ Bas de page (raturé) :
 
 ## Lectures incertaines à trancher par l'auteur
 
-- [ ] « Lucas [?] Ward [?] (Nancy) » — HET travaillant sur les flux d'idées
+- [ ] « Lucas [?] Ward [?] » — HET travaillant sur les flux d'idées
       entre économistes opérationnels en banque centrale et économistes
       académiques (thème « scientization of central banks » : littérature
-      Goutsmedt/Acosta/Cherrier/Sergi). Nom exact à retrouver dans le
-      programme papier du colloque (sciencesconf inaccessible depuis ici).
+      Goutsmedt/Acosta/Cherrier/Sergi). **« (Nancy) » = fausse piste**
+      (auteur, 2026-07-07) — ne pas chercher l'affiliation par là. Nom
+      exact à retrouver dans le programme papier du colloque.
 - [x] « n[iveau]x de vie… » — retiré (notes personnelles sur un autre papier).
 - [x] « les acquis de Kyoto *sombrent* » — confirmé (fiasco du CDM, Dosquet).
 - [x] « Ambiguïté = bateau » — bateau *STS* : risque de lieu commun ; voir §4.

--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -123,7 +123,23 @@ Bas de page (raturé) :
      `docs/projet livre - plan détaillé.md`).
    - **Le Nord a-t-il choisi l'arène qui lui est favorable ?** Réponse
      esquissée : « pas plus que d'habitude » — recoupe le point des arènes
-     asymétriques (conclusion VF) ; ajouter des références à la conclusion.
+     asymétriques (conclusion VF).
+   - **« Plus de terreau en conclusion »** — décodage de l'auteur
+     (2026-07-07) : façon polie de dire que **la conclusion est faible**.
+     Diagnostic : la conclusion VF s'évacue en « chantiers » (travaux
+     futurs) au lieu d'atterrir ; l'ancrage bibliographique y est mince
+     (Gieryn seul) ; et c'est là que loge le risque « ambiguïté = bateau
+     STS ». Convergence des deux notes : la conclusion est le chantier
+     prioritaire de la révision. Terreau disponible : (a) atterrir sur la
+     naissance de l'agrégat comme mécanisme général — conditions : un
+     chiffre politique fixé avant l'objet, une infrastructure statistique
+     préexistante, des économistes sous contrainte — avec l'analogie des
+     agrégats monétaires ; (b) le trajet abandon-de-la-précision
+     (art. 4.3 → NCQG) comme résultat, pas comme rappel ; (c) pertes et
+     préjudices comme test falsifiable de la thèse ; (d) références :
+     Popp Berman (style de raisonnement), Desrosières (lignée
+     statistique-État), histoire des agrégats monétaires ; les chantiers
+     réduits à un paragraphe bref.
    - **« Ambiguïté = bateau [STS] »** — mise en garde (soufflée par
      l'agent, pré-Vannes) : « l'ambiguïté comme ressource » est un lieu
      commun STS (objets-frontières, Star & Griesemer). L'audience réduite

--- a/tickets/0165-decision-resubmission-base-text.erg
+++ b/tickets/0165-decision-resubmission-base-text.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: decision — resubmission base text: VEn restructured vs VF translated
+Created: 2026-07-07
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-07T14:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+The Œconomia decision is "reject in current form / resubmit (major)" — more
+than just revise. Two candidate base texts exist for the v2.0.5 rewrite:
+
+- **VEn** `content/manuscript.qmd` (~12.7k words) — the reviewed manuscript,
+  already carrying post-decision work woven in: appendix A.1–A.6 (0136),
+  definitions (0140), corpus-evidence sections, two-anchor traditions table.
+- **VF** `content/manuscript-Gide.qmd` (~6.9k words) — the Vannes conference
+  paper (HAL, tag `gide-submitted-2026-06-29`), written post-decision with
+  the "économistes sous contrainte" framing, thesis-titled sections, tighter
+  prose. Its bibliography is a strict subset of VEn's; no unique refs.
+
+Both share the three-act structure (0142 decision A holds either way).
+Analysis (session 2026-07-07): total effort is nearly symmetric — the
+difference is the *default*. Base-VEn: an old sentence survives unless
+actively reworked (risk: insufficient transformation on E1, the editor's
+most-emphasized issue; only partially netted by the prose ratchet). Base-VF:
+an old sentence enters only if actively imported (risk: dropping
+reviewer-required content; netted by the 0152 HITL traceability table and
+the reimport inventory). Seams fall inside narrative flow under base-VEn,
+between narrative and evidence blocks under base-VF.
+
+Evidence from Vannes (2026-07-02/04, `docs/notes-vannes-2026-07.md`): small
+but engaged audience; the VF framing resonated — "how a new aggregate is
+born" named as the fascinating question; "agrégat ≈ masse monétaire" analogy
+offered twice in the author's margin notes. Oral-only, small-N caveat.
+
+## Options
+- **A. Base VEn, graft VF elements** — rewrite intro/method/conclusion and
+  section titles from the VF; keep body in place; prose pass 0134 over the
+  rest. Safest for coverage; most exposed on E1 residue.
+- **B. Base VF translated, reimport evidence** — translate the VF (~7k words,
+  treated as writing, not machine passing); reinsert corpus-evidence
+  sections, appendix A.1–A.6, §2 concretizations (already in English);
+  verify coverage row-by-row against the 0152 table. Freshest voice; most
+  exposed on dropped content; larger public overlap with the HAL preprint
+  (disclose in cover letter; interacts with 0153 action 0 re-anonymization).
+
+Both options require: hybrid framing C (0150) written explicitly, the
+indeterminacy thesis (0151), the 0143 bibliography additions, and the two
+Türkiye factual discrepancies resolved first (1.7 vs 15 GW; grant element
+half vs three-quarters — VF/HAL is frozen, align VEn on primary sources;
+scope 0161/0164).
+
+## Exit criteria
+- [ ] Author selects A or B; the 1-paragraph rationale is recorded here
+- [ ] Decision propagated to `docs/editorial-brief.md` — gates 0156 sequencing

--- a/tickets/0166-term-leadlag-grey-vs-academic.erg
+++ b/tickets/0166-term-leadlag-grey-vs-academic.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: corpus test — direction of circulation: grey vs academic first use of instrument concepts
+Created: 2026-07-07
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-07T16:20Z HDMX-coding-agent created — author green light (session 2026-07-07)
+
+--- body ---
+## Context
+Hypothesis from the scientization literature (Hirschman & Popp Berman 2014:
+the direction of idea circulation depends on the nature of the knowledge —
+policy devices travel from practice, theory from academia; see
+`docs/notes-vannes-2026-07.md` §6): climate finance *instrument* concepts
+(Rio markers, grant equivalent, mobilised private finance, additionality,
+blended finance, de-risking) should appear in the grey/institutional
+segment of the corpus *before* the academic segment, while theoretical
+frames flow the other way.
+
+If confirmed, one analysis answers two referee objections at once:
+- **R1.1** — the absence of core economics journals is the signature of how
+  instrument knowledge circulates (institutional channels first), not a
+  corpus selection artifact.
+- **E3** — a quantitative element that visibly earns its footprint.
+
+Feasibility: `refined_works.csv` carries `from_grey` and per-source
+provenance booleans; term matching runs on title+abstract+keywords (same
+text contract as the embeddings). Segment definition (grey = `from_grey`;
+academic = indexed sources without grey flag) must be stated in the table
+caption and tested.
+
+## Method sketch (Execute refines)
+- Term list and match patterns (incl. spelling variants, EN minimum;
+  document the language limitation) in `config/analysis.yaml` — no
+  hardcoded lists (arch rule 6).
+- New Phase-2 script `scripts/compute_term_leadlag.py` (dispatcher not
+  needed: single method). Reads via `load_refined_works()` (arch rule 9),
+  `--output` required (script-io rule).
+- Output CSV: one row per (term, segment) with first_year, n_before_2015,
+  n_total; plus per-term lead = academic_first − grey_first. Pandera
+  schema in `scripts/schemas.py` (strict, coerce).
+- Robustness to singletons: also report the year each term reaches k≥3
+  cumulative occurrences per segment (first attestation can be an outlier).
+- Makefile: own target in an existing or new `.mk`; 1 invocation = 1 output.
+
+## First test (Red)
+`tests/test_term_leadlag.py::test_first_appearance_by_segment` — build a
+synthetic works DataFrame (6 rows: term "grant equivalent" in grey rows
+2010, 2012 and academic rows 2013, 2015; distractor rows without the term)
+monkeypatched into the loader; run the compute function with a 2-term
+config; assert first_year and k=3 attestation per (term, segment) and
+lead values match hand-computed expectations, and that the output
+validates against the new schema.
+
+## Exit criteria
+- [ ] Term list + patterns in `config/analysis.yaml`
+- [ ] `compute_term_leadlag.py` + schema + passing tests (unit + io-discipline)
+- [ ] Output table generated from the real corpus, committed under
+      `content/tables/` with segment definition in caption
+- [ ] Three-sentence findings note appended to this ticket (feeds 0136/0141
+      integration; manuscript prose is NOT in scope here)
+- [ ] `make check` passes

--- a/tickets/closed/0165-decision-resubmission-base-text.erg
+++ b/tickets/closed/0165-decision-resubmission-base-text.erg
@@ -3,9 +3,12 @@ Title: decision — resubmission base text: VEn restructured vs VF translated
 Created: 2026-07-07
 Author: HDMX-coding-agent
 Label: needs-human
+Closed: author chose B — VF translated as base, evidence reimported; propagated to editorial brief
 
 --- log ---
 2026-07-07T14:30Z HDMX-coding-agent created
+2026-07-07T16:40Z HDMX-coding-agent note author selected B (interactive session); recorded + propagated to editorial brief
+2026-07-07T16:40Z HDMX-coding-agent closed — author chose B; propagation done
 
 --- body ---
 ## Context
@@ -52,6 +55,20 @@ Türkiye factual discrepancies resolved first (1.7 vs 15 GW; grant element
 half vs three-quarters — VF/HAL is frozen, align VEn on primary sources;
 scope 0161/0164).
 
+## Decision (2026-07-07) — B. VF translated as base, evidence reimported
+The VF (`manuscript-Gide.qmd`), whose voice and framing were validated at
+Vannes, becomes the base: translated into English as an act of writing (not
+machine-passed), with the brief/ratchet applied to the translation. The VEn
+evidence blocks — corpus-evidence sections, appendix A.1–A.6, §2
+concretizations, already in English — are reimported one by one; nothing
+enters the manuscript without an active import decision. Coverage is gated
+row-by-row against the 0152 traceability table plus the reimport inventory
+(session 2026-07-05/07 analysis). Rationale: total effort is symmetric with
+option A, but the failure modes are not — dropped content has a mechanical
+detector (traceability table), residual old prose does not, and E1 prose was
+the editor's most-emphasized issue. The HAL overlap is disclosed in the
+cover letter; interacts with 0153 action 0 (re-anonymization).
+
 ## Exit criteria
-- [ ] Author selects A or B; the 1-paragraph rationale is recorded here
-- [ ] Decision propagated to `docs/editorial-brief.md` — gates 0156 sequencing
+- [x] Author selects A or B; the 1-paragraph rationale is recorded here
+- [x] Decision propagated to `docs/editorial-brief.md` — gates 0156 sequencing


### PR DESCRIPTION
Docs-and-tickets only — no engine or manuscript changes.

## Contents

**Vannes debrief** (`docs/notes-vannes-2026-07.md`, new): verbatim transcription of the 8 annotated handout pages from the Charles Gide presentation (2026-07-02/04), with author-validated decodings: the aggregate ≈ monetary-aggregate framing, the Türkiye slides tagged by controversy, audience Q&A (1990 boundary, 2007 CDM-fiasco bridge, arena asymmetry), the "plus de terreau en conclusion" weak-conclusion signal, chantiers = book programme, the 1.3T/0.3T Baku gap (Ariane Dupont), and archival leads (OECD GREEN model team 1992; Alfsen & Sæbø 1993). One open item: the "Lucas? Ward?" central-bank-scientization colleague.

**Decisions** (recorded in `docs/editorial-brief.md`):
- `resubmission-base-is-translated-vf` — ticket **0165** (closed): the Œconomia v2.0.5 resubmission is rebuilt from the translated Gide VF; VEn evidence blocks reimported under row-by-row 0152 traceability control.
- `title-frames-aggregate-birth` — title/abstract lead with the birth of an aggregate; strategic ambiguity becomes the internal mechanism.

**Tickets**:
- 0165 (decision, closed → `tickets/closed/`)
- 0166 (new): corpus lead-lag test — grey vs academic first attestation of instrument concepts; answers R1.1 + E3; first test specified.

`erg check`: PASS (162 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkK3f5Z3CyeBKjrKJmn36L

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkK3f5Z3CyeBKjrKJmn36L)_