### PR TITLE
docs(0169): document het_* companion pipeline in architecture.md

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -65,6 +65,21 @@ The Makefile knob is `NJOBS` (in `divergence.mk`). Default `-1` uses all cores �
 Submission *records* (cover/decision letters, frozen PDFs, deposit archives) are
 not engine — they live outside the repo under `papiers/<state>/<track>/` (0159).
 
+## Companion pipelines (out of phase contract)
+
+`scripts/het_build_corpus.py`, `het_embed.py`, `het_plot_overlap.py`, and
+`data/het/` are not part of this paper's own build. They generate a citation-
+overlap figure for a different paper, "Un théorème, sept costumes", which
+lives in the sibling repo `polycentric_activity` (its tickets 0011/0027).
+The scripts live here — not there — because this repo already has the
+OpenAlex-crawl and embedding conventions they reuse (`retry_get`,
+`reconstruct_abstract`, `build_text`); duplicating that machinery in the
+other repo was rejected as the worse option (ticket 0167). They read/write
+only `data/het/` (only `seeds.csv` committed, the rest regenerable) and
+never touch `enrich_cache/` or the Phase 1/2 contract files. The figure and
+its methodology note are committed in `polycentric_activity/conception/`,
+not here.
+
 ## Data location
 
 Data lives **outside the repo**, at `CLIMATE_FINANCE_DATA` in `.env`.

--- a/tickets/0169-document-het-companion-pipeline-in-archi.erg
+++ b/tickets/0169-document-het-companion-pipeline-in-archi.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: document het_* companion pipeline in architecture.md
+Created: 2026-07-07
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-07T20:28Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #860 (ticket 0167) added `scripts/het_*.py` and `data/het/` — a
+standalone companion pipeline unrelated to this paper's own build, reusing
+this repo's OpenAlex/embedding conventions to generate a citation-overlap
+figure for a different paper in the sibling repo `polycentric_activity`
+(tickets 0011/0027 there). Author confirmed (post-hoc, this session) that
+keeping the machinery here rather than duplicating it in the other repo was
+the deliberate call, matching what `polycentric_activity` ticket 0027
+already records. `architecture.md` had no mention of this, so a future
+reader scanning `scripts/` had no signal these three files sit outside the
+Phase 1-4 taxonomy.
+
+## Relevant files
+- `.claude/rules/architecture.md` — added a "Companion pipelines" section
+
+## Exit criteria
+- [x] architecture.md documents the het_* companion pipeline and why it
+      lives here instead of in `polycentric_activity`
+

--- a/tickets/closed/0169-document-het-companion-pipeline-in-archi.erg
+++ b/tickets/closed/0169-document-het-companion-pipeline-in-archi.erg
@@ -2,10 +2,12 @@
 Title: document het_* companion pipeline in architecture.md
 Created: 2026-07-07
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #864
 
 --- log ---
 2026-07-07T20:28Z HDMX-coding-agent created
 
+2026-07-07T20:29Z HDMX-coding-agent closed — autoclosed — PR #864
 --- body ---
 ## Context
 PR #860 (ticket 0167) added `scripts/het_*.py` and `data/het/` — a


### PR DESCRIPTION
## Summary
- `architecture.md` had no mention of the `het_*.py` / `data/het/` companion
  pipeline added in PR #860 (ticket 0167) — a citation-overlap figure
  generator for a different paper ("Un théorème, sept costumes") in the
  sibling repo `polycentric_activity`.
- Adds a short "Companion pipelines" section explaining why the machinery
  lives here (reuses this repo's OpenAlex/embedding conventions) rather
  than in the paper's own repo, matching the deliberate call already
  recorded in `polycentric_activity` ticket 0027.

**Ticket:** tickets/0169-document-het-companion-pipeline-in-archi.erg

## Test plan
- [x] Docs-only change; no code affected.