### PR TITLE
Vannes → workplan: propagate notes into v2.0.5 tickets, open 0171 conclusion rebuild

### DIFF
--- a/docs/notes-vannes-2026-07.md
+++ b/docs/notes-vannes-2026-07.md
@@ -127,7 +127,13 @@ Bas de page (raturé) :
      finance à l'échelle (krach EUA/CER phase 1 en 2006-07) crée la demande
      d'une comptabilité directe des flux. Pont causal à renforcer en §2.
    - **Les deux pôles et la littérature sur le crédit** : « entrer dans la
-     bataille : si » = l'auteur veut en faire **un livre**. Scoping : dans
+     bataille : si » = l'auteur veut en faire **un livre**. Décodage validé
+     (auteur, 2026-07-07) : les deux pôles sont la logique de solidarité
+     (don, burden-sharing, public) et la logique de crédit/investissement
+     (prêt, levier, privé mobilisé) — la tension qui produit la controverse
+     valeur faciale / équivalent-don ; « la littérature sur le crédit » est
+     le nexus finance-développement (King & Levine, Aghion & Bolton) et son
+     versant critique (de-risking, blended finance). Scoping : dans
      l'article, faire le minimum que R1.5 demande (situer blended
      finance/de-risking dans le nexus finance-développement, 0139) ; la
      bataille complète va au projet livre (`docs/projet livre - pitch.md`,

--- a/tickets/0134-r-r-prose-pass-eliminate-define-by-negat.erg
+++ b/tickets/0134-r-r-prose-pass-eliminate-define-by-negat.erg
@@ -2,6 +2,7 @@
 Title: R&R prose pass — eliminate define-by-negation, empty declaratives, formulaic closers
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0171
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 
 2026-06-23T07:45Z HDMX-coding-agent note blocker 0147 closed — Blocked-by removed.
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Blocked-by 0171 added: the final prose pass runs after the conclusion rebuild, per the run-last rule in 0156
 --- body ---
 ## Context
 Editor E1 + Reviewer 2, the most-emphasized issue: prose "defines concepts by

--- a/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
+++ b/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-06-18T08:25Z HDMX-coding-agent note Framing decision (old action 1) extracted to 0150 (needs-human, v2.0.4). This ticket is execution only: propagate the chosen framing once 0150 lands. v2.0.5 (Blocked-by 0155).
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes input appended to body (OECD GREEN-team continuity lead)
 --- body ---
 ## Context
 Reviewer 1 §1 + editor E2. The paper attributes climate-finance construction to
@@ -25,6 +26,16 @@ practice, or supply evidence of individual economists' intellectual role.
 
 ## Test
 - Manuscript asserts the chosen framing consistently; grep for "economists" attributions cross-checked against the framing.
+
+## Input from Vannes (2026-07-07)
+`docs/notes-vannes-2026-07.md` §5 (Ariane Dupont): possible **internal OECD
+continuity** between the modelling era (GREEN model — Burniaux, Martin,
+Nicoletti, Oliveira Martins, OECD Economics Dept WP 116, 1992) and the
+measurement era (Corfee-Morlot, Environment directorate). Verify citation or
+collaboration links Corfee-Morlot ↔ GREEN team before using. If real, it
+nuances « climate finance was born outside modelling » and strengthens the
+rationality-diffusion framing: the carriers moved inside the same
+institution. Shared lead with 0141.
 
 ## Exit criteria
 - [ ] Central claim reframed and internally consistent

--- a/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
+++ b/tickets/0135-r-r-reframe-the-economists-claim-economi.erg
@@ -2,6 +2,7 @@
 Title: R&R reframe the economists claim — economic rationality vs individual economists
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0137-r-r-make-commensuration-economisation-th.erg
+++ b/tickets/0137-r-r-make-commensuration-economisation-th.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-18T06:33Z HDMX-coding-agent created
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes input appended to body (aggregate ≈ monetary aggregate analogy)
 --- body ---
 ## Context
 Reviewer 1 §3: the commensuration (Espeland & Stevens 1998) / economisation
@@ -16,6 +17,17 @@ contribution but appears once in §2 then is dropped.
 ## Actions
 1. Promote the distinction to a structuring thread: at each stage show how a commensuration move (e.g. Rio markers as tracking tools) became an economisation move (their use to compute leverage ratios / claim $100bn compliance).
 2. Add explicit commensuration→economisation transitions in §1, §2, and the post-2015 section.
+
+## Input from Vannes (2026-07-07)
+`docs/notes-vannes-2026-07.md` § Interprétation 1: the audience named the
+analogy **aggregate ≈ monetary aggregate** (written twice on the handout,
+slides 5 and 20). It is richer than the GDP analogy: several competing
+perimeters coexist legitimately (M1/M2/M3 ↔ face value / grant-equivalent /
+mobilised), the aggregate is defined by perimeter convention, serves as an
+instrument of government, and its targeting has a history of abandonments
+and redefinitions (monetarism). Use it to carry the commensuration→
+economisation thread into the intro and conclusion (coordinate with 0171);
+title/abstract framing is decided in the brief (`title-frames-aggregate-birth`).
 
 ## Exit criteria
 - [ ] The distinction recurs as an analytic device in each act, not just §2

--- a/tickets/0137-r-r-make-commensuration-economisation-th.erg
+++ b/tickets/0137-r-r-make-commensuration-economisation-th.erg
@@ -2,6 +2,7 @@
 Title: R&R make commensuration economisation the structuring thread
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0138-r-r-add-loss-and-damage-insurance-logic.erg
+++ b/tickets/0138-r-r-add-loss-and-damage-insurance-logic.erg
@@ -2,6 +2,7 @@
 Title: R&R add loss and damage insurance logic as challenge to the thesis
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
+++ b/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
@@ -2,6 +2,7 @@
 Title: R&R situate climate finance in the finance-development nexus
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
+++ b/tickets/0139-r-r-situate-climate-finance-in-the-finan.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-18T06:33Z HDMX-coding-agent created
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes scoping confirmed (notes §4, deux pôles): this ticket does the R1.5 minimum only; the normative battle on the credit literature goes to the book project
 --- body ---
 ## Context
 Reviewer 1 additional question: the finance-development nexus (King & Levine

--- a/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
+++ b/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-06-18T14:55Z HDMX-coding-agent note New §3.1 "What climate finance is, concretely" (branch t140-define-terms) is a concrete worked transaction answering R2.g2/R2.34: named actors/sites/instruments (World Bank IBRD + Clean Technology Fund; Türkiye TPTS project P508354; OECD DAC grant-equivalent rules; Joint MDB methodology vs OECD Rio markers), real rates and dates. Adds the additionality + specificity critique ("electrons have no colour"; the WB financed grids long before Rio) and the donor-vs-recipient/MDB-vs-DAC measurement-regime contrast. Partially serves the Rio-markers-functioning and competing-measurement-regimes actions here. Track-changed (blue) pending author sign-off.
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes input appended to body (Baku 1.3T/0.3T gap, geopolitical reading, Türkiye↔controversies mapping)
 --- body ---
 ## Context
 Reviewer 2 (general + linear) + Reviewer 1 other comments: replace abstract /
@@ -31,6 +32,24 @@ consequences.
 - Performativity argument: make explanatory not declarative; unpack apparatus/methodologies/consequences (p12).
 - p16 UN Advisory Group composition (finance ministers, economists, central bankers, no climate scientists) — reflect on whether it matters.
 - Connect the Desrosières quote (p7) to the empirical case.
+
+## Input from Vannes (2026-07-07)
+`docs/notes-vannes-2026-07.md` §4–5:
+- **Baku gap, missing from both VF and VEn**: developing countries asked
+  **$1,300bn/yr**; the NCQG core target is $300bn (the 1.3T survives only as
+  the aspirational « Baku to Belém Roadmap », outside the obligation). The
+  1.3T/0.3T gap is the distributive controversy made visible by the
+  aggregate itself — muscle the Baku paragraph with it.
+- **Geopolitical reading (Ariane Dupont)**: Southern countries read the
+  aggregate by decomposing it — « combien je vaux » in the $100bn. This is
+  the recipient-side use of the aggregate (a device for *valuing countries*
+  as much as verifying donors); it completes the asymmetric-arenas point
+  with a concrete Southern perspective.
+- **Türkiye cases ↔ four controversies**: make the one-to-one mapping
+  explicit in the text — additionality (is it a climate project?), value +
+  credibility (how much finance in this project?), attribution (the
+  OECD/Oxfam duel).
+- **OECD GREEN-team continuity lead** (verify first) — see 0135.
 
 ## Exit criteria
 - [ ] Each flagged passage revised with concrete actors/dates/mechanisms; tracked in the cover-letter traceability table

--- a/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
+++ b/tickets/0141-r-r-concretize-actors-sites-and-mechanis.erg
@@ -2,6 +2,7 @@
 Title: R&R concretize actors sites and mechanisms across flagged passages
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created

--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -9,6 +9,7 @@ Author: HDMX-coding-agent
 2026-06-18T14:55Z HDMX-coding-agent note New §3.1 (branch t140-define-terms) introduces primary/grey sources currently cited as inline/footnote text, needing verified bib entries: World Bank TPTS press release (2025) + project page (P508354); OECD DAC 2023 grant-equivalent methodology (DCD/DAC/STAT(2023)25); CIF/CTF financial terms & conditions; Joint MDB Methodology for tracking climate finance; Türkiye 2025 USD sovereign bond data; three-month Euribor 2025 levels. Add as action 6 when the §3.1 set-piece is accepted.
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes candidates appended (Popp Berman, Desrosières-lineage, scientization set); author picks before adding
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;
@@ -21,6 +22,17 @@ every entry (DOI/venue) before adding — do not fabricate metadata.
 3. Mitchell, Timothy — on development/economy as object. (R2)
 4. King & Levine (1993) — finance-development nexus. (R1 add'l)
 5. Aghion & Bolton — finance-development. (R1 add'l)
+
+## Candidates from Vannes (2026-07-07) — author picks, same verification rule
+`docs/notes-vannes-2026-07.md` §4 and §6. For the conclusion rebuild (0171):
+- Popp Berman, *Thinking Like an Economist* (2022) — **Œconomia published a
+  symposium on it**, a direct editorial link.
+- Desrosières already cited (p7); add a history-of-monetary-aggregates
+  reference for the aggregate-birth analogy.
+Scientization set (supports 0166 framing if kept):
+- Claveau & Dion 2018 (*J. of Economic Methodology*); Hirschman & Popp
+  Berman 2014 (*Socio-Economic Review*); Acosta, Cherrier, Claveau, Fontan,
+  Goutsmedt, Sergi 2024 (*HOPE*); Goutsmedt & Sergi 2025 (*Finance & Society*).
 
 ## Test
 - `related-work-note-validate`-style DOI re-resolution on each new entry.

--- a/tickets/0152-response-to-reviewers-letter-per-remark.erg
+++ b/tickets/0152-response-to-reviewers-letter-per-remark.erg
@@ -9,6 +9,7 @@ Author: HDMX-coding-agent
 2026-06-19T08:18Z HDMX-coding-agent note 0159 Phase 1: folded the 60-row traceability table into this ticket body (it is active R&R working state, not a frozen record). Deleted the standalone release/2026-03-18 Oeconomia/response-traceability.md; its home is now this ticket. referee-reports.md (frozen) archived under papiers/actif/Oeconomia_Inventing_Climate_Finance/.
 
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-07T20:55Z HDMX-coding-agent note Vannes Q&A material appended (1990 boundary, 2007 causal bridge) for letter drafting
 --- body ---
 ## Context
 v2.0.5. The binding deliverable of the resubmission: a letter answering every
@@ -32,6 +33,18 @@ the 0159 reorg, since it is active R&R working state, not a frozen record.
 ## Exit criteria
 - [ ] Every remark in the traceability table has a response AND author Sign-off
 - [ ] Letter saved under `papiers/actif/Oeconomia_Inventing_Climate_Finance/YYYY-MM-DD Oeconomia revision/`
+
+## Letter material from Vannes (2026-07-07)
+`docs/notes-vannes-2026-07.md` §4 (Dosquet Q&A) — strengthens the letter
+prose on already-routed rows, without reopening signed-off rows:
+- **Why 1990** (rows E3a/R1.o3, Appendix A.2): the 1990 boundary is an
+  observation window, not an origin thesis — science has intellectual
+  autonomy and may produce ideas before the Convention; archives are
+  lacunary before 2000.
+- **Why 2007** (row E3b; §2 content via 0141/R2.18): stronger causal bridge
+  than the post-2012 CDM collapse — by 2007 the perception that Kyoto market
+  mechanisms would not deliver finance at scale (EUA/CER phase-1 crash
+  2006-07) creates the demand for direct accounting of flows.
 
 ## Traceability table
 

--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -12,6 +12,7 @@ Blocked-by: 0143
 Blocked-by: 0152
 Blocked-by: 0153
 Blocked-by: 0162
+Blocked-by: 0171
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
@@ -19,6 +20,7 @@ Blocked-by: 0162
 2026-06-19T15:09Z HDMX-coding-agent note blocker 0136 closed — Blocked-by removed.
 
 2026-06-23T08:50Z HDMX-coding-agent note added child 0162 (em-dash density) from 0149 inventory
+2026-07-07T20:55Z HDMX-coding-agent note added child 0171 (conclusion rebuild, from Vannes diagnosis); Vannes inputs propagated into 0135/0137/0141/0143/0152
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →
@@ -28,7 +30,8 @@ verification → resubmission). Blocked by v2.0.4 (0155).
 - [ ] 0135 reframe economists · 0136 quant integration + methods · 0137 commensuration thread
 - [ ] 0138 loss & damage · 0139 finance-development nexus · 0141 concretize actors
 - [ ] 0143 bibliography additions
-- [ ] 0134 human-led prose rewrite (ratchet-guarded; run last)
+- [ ] 0171 conclusion rebuild — land on the birth of an aggregate (Vannes; before 0134)
+- [ ] 0134 human-led prose rewrite (ratchet-guarded; run last, blocked by 0171)
 - [ ] 0162 reduce em-dash density toward 2/paragraph (ratchet finding from 0149)
 - [ ] 0152 response-to-reviewers letter · 0153 resubmission + deposit
 

--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -13,6 +13,7 @@ Blocked-by: 0152
 Blocked-by: 0153
 Blocked-by: 0162
 Blocked-by: 0171
+Blocked-by: 0172
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
@@ -21,12 +22,14 @@ Blocked-by: 0171
 
 2026-06-23T08:50Z HDMX-coding-agent note added child 0162 (em-dash density) from 0149 inventory
 2026-07-07T20:55Z HDMX-coding-agent note added child 0171 (conclusion rebuild, from Vannes diagnosis); Vannes inputs propagated into 0135/0137/0141/0143/0152
+2026-07-07T20:50Z added child 0172 (base rebuild, needs-human): translation + reimport had no owner; manuscript children 0135/0137/0138/0139/0141/0171 now blocked by 0172
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →
 verification → resubmission). Blocked by v2.0.4 (0155).
 
 ## Children
+- [ ] 0172 base rebuild — translate the VF, reimport VEn evidence (needs-human; gates all manuscript children)
 - [ ] 0135 reframe economists · 0136 quant integration + methods · 0137 commensuration thread
 - [ ] 0138 loss & damage · 0139 finance-development nexus · 0141 concretize actors
 - [ ] 0143 bibliography additions

--- a/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
+++ b/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
@@ -2,6 +2,7 @@
 Title: v2.0.5 conclusion rebuild — land on the birth of an aggregate
 Created: 2026-07-07
 Author: HDMX-coding-agent
+Blocked-by: 0172
 
 --- log ---
 2026-07-07T20:44Z HDMX-coding-agent created

--- a/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
+++ b/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: v2.0.5 conclusion rebuild — land on the birth of an aggregate
+Created: 2026-07-07
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-07T20:44Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Vannes diagnosis (`docs/notes-vannes-2026-07.md` §4, « plus de terreau en
+conclusion »): the VF conclusion is the weakest part of the validated base —
+it evacuates into « chantiers » (the book programme, not article material),
+its bibliographic anchoring is thin (Gieryn alone), and it is where the
+« ambiguity as resource is an STS commonplace » objection would land. The
+conclusion is the priority worksite of the revision. Runs on the translated
+VF base (decision 0165), before the final prose pass (0134 is blocked on
+this ticket).
+
+## Actions
+1. Land the conclusion on the thesis: the birth of a new economic aggregate,
+   with its general conditions — a political number fixed before the object,
+   a pre-existing statistical infrastructure, economists under constraint —
+   and the monetary-aggregates analogy (brief entry
+   `title-frames-aggregate-birth`).
+2. Present the abandonment-of-precision trajectory (art. 4.3 incremental
+   costs → NCQG) as a result of the paper, not a recap.
+3. Use loss & damage / insurance logic as the falsifiable test of the thesis
+   (coordinate with 0138).
+4. Arm the anti-commonplace defense explicitly: the novelty is not
+   « ambiguity is productive » (boundary objects, Star & Griesemer) but
+   (a) a precise definition existed (art. 4.3) and was abandoned, (b) the
+   ambiguity lives in the accounting conventions of an aggregate, (c)
+   economists produced it.
+5. Adopt the Vannes prose corrections: « assez ambiguës pour *servir* des
+   intérêts contradictoires » (not « agréger ») ; candidate closing line:
+   « on a inventé une façon plus économique de se disputer ».
+6. Migrate the « chantiers » to the book project (`docs/projet livre -
+   pitch.md`), keeping at most one limits line.
+7. Anchor bibliographically: Popp Berman 2022, Desrosières, history of
+   monetary aggregates (entries via 0143).
+
+## Test
+- `/review-pr-prose` brief auditor passes the new conclusion against
+  `title-frames-aggregate-birth` and `het-register-not-motivational`;
+  prose ratchet does not regress.
+
+## Invariants
+- No « endogenous periodization » claim; computation stays confirmatory
+  (brief `periodization-corroborated-not-endogenous`).
+
+## Exit criteria
+- [ ] Conclusion lands on the aggregate-birth thesis with the three
+      conditions stated; no « chantiers » list remains
+- [ ] STS-commonplace defense present
+- [ ] At least two of the three anchor references cited in the conclusion

--- a/tickets/0172-v2-0-5-base-rebuild-translate-the-vf-and.erg
+++ b/tickets/0172-v2-0-5-base-rebuild-translate-the-vf-and.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: v2.0.5 base rebuild — translate the VF and reimport the VEn evidence blocks
+Created: 2026-07-07
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-07T20:49Z HDMX-coding-agent created
+
+2026-07-07T20:49Z HDMX-coding-agent label needs-human
+--- body ---
+## Context
+Decision 0165 (editorial brief `resubmission-base-is-translated-vf`): the
+v2.0.5 manuscript is rebuilt from the VF (`content/manuscript-Gide.qmd`,
+Vannes-validated), translated into English **as an act of writing, not
+machine-passed** — hence needs-human. VEn material enters only by active
+reimport. This ticket owns Step 1 of the plan, which 0165 described but no
+0156 child executed; the content tickets (0135/0137/0138/0139/0141/0171)
+apply to the base this ticket produces and are blocked by it.
+
+## Relevant files
+- `content/manuscript-Gide.qmd` — VF source (frozen: HAL/tag `gide-submitted-2026-06-29`)
+- `content/manuscript.qmd` — VEn; target file, and source of the evidence blocks
+- `docs/editorial-brief.md` — standing decisions the translation must satisfy
+- `tickets/0152-…` — traceability table gating the reimports
+
+## Actions
+1. Translate the VF section by section into `content/manuscript.qmd`
+   (author-led writing; the brief and prose ratchet apply to the
+   translation, not assumed from the French).
+2. Build the reimport inventory of VEn evidence blocks (corpus-evidence
+   sections, appendix A.1–A.6, §3.1 worked transaction, §2
+   concretizations) — agent-preparable.
+3. Reimport block by block: nothing enters without an explicit import
+   decision, each checked against the 0152 table rows it serves.
+4. Align the two Türkiye factual discrepancies on primary sources (1.7 vs
+   15 GW; grant element half vs three-quarters) — VF/HAL stays frozen, the
+   English text gets the corrected figures (scope shared with 0161/0164).
+
+## Verification
+- [ ] Row-by-row coverage check against the 0152 table + reimport inventory
+- [ ] Prose ratchet and adherence tests pass on the rebuilt manuscript
+
+## Invariants
+- `manuscript-Gide.qmd` unchanged (frozen submission record)
+- No signed-off 0152 row loses its supporting content
+
+## Exit criteria
+- [ ] `manuscript.qmd` is the translated VF with all decided reimports in place
+- [ ] Reimport inventory archived (list of blocks kept/dropped, with reasons)


### PR DESCRIPTION
Integrates the Vannes notes into the workplan so no insight stays stranded in `docs/notes-vannes-2026-07.md`:

- **0137** — aggregate ≈ monetary aggregate analogy (M1/M2/M3 ↔ face value / grant-equivalent / mobilised) for the commensuration thread.
- **0135** — OECD GREEN-team continuity lead (verify before use).
- **0141** — Baku 1,300 vs 300 bn gap (absent from VF and VEn), Ariane Dupont's geopolitical reading, explicit Türkiye ↔ four-controversies mapping.
- **0143** — Vannes bibliography candidates (Popp Berman + Œconomia symposium, monetary-aggregates history, scientization set); author picks.
- **0152** — Dosquet Q&A material for the letter (1990 observation window / E3a; 2007 causal bridge via the Kyoto-mechanisms fiasco / E3b).
- **0139** — deux-pôles scoping confirmed in the log (R1.5 minimum here, battle → book).
- **New ticket 0171** — conclusion rebuild (land on aggregate birth, abandonment-of-precision as result, L&D falsifiable test, STS-commonplace defense, Vannes prose corrections). 0134 now blocked by it; tracker 0156 updated.
- Also records the author-validated reading of the deux-pôles margin note in the Vannes notes (first commit).

Ticket: none
Ticket-ref: tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
Ticket-ref: tickets/0156-v2-0-5-implementation-version-tracker.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)