### PR TITLE
decision update(0172): machine translation, style-anchored on the author's pre-AI prose

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -24,7 +24,9 @@ translated VF (`manuscript-Gide.qmd`) — its framing (économistes sous
 contrainte), thesis-titled sections, and conclusion-that-lands are the
 spine. VEn material (corpus-evidence sections, appendix A.1–A.6, §2
 concretizations) enters only by active reimport, gated row-by-row against
-the 0152 traceability table. Translation is treated as writing: the prose
+the 0152 traceability table. The translation is machine-performed,
+style-anchored on the author's pre-AI-era English prose (method updated
+2026-07-07, superseding the earlier "act of writing" wording); the prose
 brief and ratchet apply to the translated text, not assumed from the French.
 
 **Rationale:** Effort is symmetric with revising the VEn in place, but

--- a/tickets/0172-v2-0-5-base-rebuild-translate-the-vf-and.erg
+++ b/tickets/0172-v2-0-5-base-rebuild-translate-the-vf-and.erg
@@ -2,21 +2,26 @@
 Title: v2.0.5 base rebuild — translate the VF and reimport the VEn evidence blocks
 Created: 2026-07-07
 Author: HDMX-coding-agent
-Label: needs-human
 
 --- log ---
 2026-07-07T20:49Z HDMX-coding-agent created
 
 2026-07-07T20:49Z HDMX-coding-agent label needs-human
+2026-07-07T20:52Z HDMX-coding-agent unlabel needs-human
+2026-07-07T20:52Z author update: translation is machine-performed, style-anchored on the author's pre-AI-era English prose; needs-human dropped — agent-runnable, HITL stays at PR review and 0152 sign-off
 --- body ---
 ## Context
 Decision 0165 (editorial brief `resubmission-base-is-translated-vf`): the
 v2.0.5 manuscript is rebuilt from the VF (`content/manuscript-Gide.qmd`,
-Vannes-validated), translated into English **as an act of writing, not
-machine-passed** — hence needs-human. VEn material enters only by active
-reimport. This ticket owns Step 1 of the plan, which 0165 described but no
-0156 child executed; the content tickets (0135/0137/0138/0139/0141/0171)
-apply to the base this ticket produces and are blocked by it.
+Vannes-validated), translated into English. Method updated by the author
+(2026-07-07, supersedes the "act of writing" wording in 0165): the
+translation is **machine-performed, style-anchored on the author's
+pre-AI-era English prose** (published articles, see `~/CNRS/html/src/
+Ha-Duong.bib` for the list); the editorial brief and prose ratchet apply
+to the output. VEn material enters only by active reimport. This ticket
+owns Step 1 of the plan, which 0165 described but no 0156 child executed;
+the content tickets (0135/0137/0138/0139/0141/0171) apply to the base
+this ticket produces and are blocked by it.
 
 ## Relevant files
 - `content/manuscript-Gide.qmd` — VF source (frozen: HAL/tag `gide-submitted-2026-06-29`)
@@ -25,9 +30,11 @@ apply to the base this ticket produces and are blocked by it.
 - `tickets/0152-…` — traceability table gating the reimports
 
 ## Actions
-1. Translate the VF section by section into `content/manuscript.qmd`
-   (author-led writing; the brief and prose ratchet apply to the
-   translation, not assumed from the French).
+1. Assemble the style reference: a sample of the author's pre-AI-era
+   English prose (own published articles). Then machine-translate the VF
+   section by section into `content/manuscript.qmd`, prompting with that
+   style anchor; the brief and prose ratchet apply to the translation,
+   not assumed from the French.
 2. Build the reimport inventory of VEn evidence blocks (corpus-evidence
    sections, appendix A.1–A.6, §3.1 worked transaction, §2
    concretizations) — agent-preparable.


### PR DESCRIPTION
The author updated the 0165 method: the VF→English translation is machine-performed, using the author's pre-AI-era published English prose as style reference. The editorial brief entry and ticket 0172 now carry the updated method; `needs-human` is dropped so the autonomous stream can run the base rebuild, with human control at PR review and 0152 row sign-off.

Ticket: none
Ticket-ref: tickets/0172-v2-0-5-base-rebuild-translate-the-vf-and.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)