### PR TITLE
test(hygiene): accept het_ companion-pipeline prefix

### DIFF
--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -860,6 +860,12 @@ class TestScriptNaming:
         "export_",
         "summarize_",
         "build_",
+        # Companion-pipeline scripts for a sibling repo's paper, kept here
+        # by design (architecture.md "Companion pipelines"). Not part of
+        # this paper's Phase 2, so they carry their own het_ prefix. Left
+        # out of _PIPELINE_PREFIXES on purpose: the no-bare-print rule is
+        # for this pipeline's scripts, not the companions'.
+        "het_",
     )
     LIBRARY_MODULES = {
         "utils.py",


### PR DESCRIPTION
Stops the recurring `test_all_scripts_have_conforming_prefix` failure on `het_*` that surfaced in every adherence check this session. These are documented companion-pipeline scripts (architecture.md § Companion pipelines) for a sibling repo's paper. Added `het_` to the conforming PREFIXES only — not to `_PIPELINE_PREFIXES`, so the no-bare-print rule stays scoped to this paper's pipeline.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)