### PR TITLE
ticket(0171): note loss-and-damage de-dup owed to conclusion rebuild

### DIFF
--- a/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
+++ b/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
@@ -28,6 +28,12 @@ this ticket).
    costs → NCQG) as a result of the paper, not a recap.
 3. Use loss & damage / insurance logic as the falsifiable test of the thesis
    (coordinate with 0138).
+   NOTE (2026-07-08): Act III (0179/#880) already carries a forward-looking
+   loss-and-damage bifurcation that duplicates the current conclusion's
+   payoff nearly point-for-point (flagged by the #880 adversarial referee).
+   §3's version was left in place deliberately; when rebuilding the
+   conclusion, own that bifurcation HERE and trim §3 to merely set up the
+   test, so the payoff lands once.
 4. Arm the anti-commonplace defense head-on (author decision 2026-07-08,
    brief `boundary-object-conceded-then-displaced`): name Star & Griesemer
    1989, concede that climate finance qualifies in the canonical weak


### PR DESCRIPTION
Records coordination the #880 review surfaced: Act III's loss-and-damage bifurcation duplicates the conclusion payoff; the conclusion rebuild (0171) de-duplicates. §3's version stays for now.

Ticket-ref: tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)