### PR TITLE
fix(0185): add missing --- log --- separator

### DIFF
--- a/tickets/0185-migrate-plot-fig-traditions-loader.erg
+++ b/tickets/0185-migrate-plot-fig-traditions-loader.erg
@@ -3,6 +3,8 @@ Title: Migrate plot_fig_traditions.py works read to the loader (arch rule 9)
 Created: 2026-07-08
 Author: HDMX-coding-agent
 
+--- log ---
+2026-07-08T12:41Z HDMX-coding-agent created
 --- body ---
 ## Context
 Raised twice on PR #876 (review red team + adherence nit): the pre-2007


### PR DESCRIPTION
Ticket 0185 was filed (PR #879) without a --- log --- section, breaking `erg check` on the store. Adds it.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)