### PR TITLE
bib(0143): add Escobar (2) + Mitchell (2) + Popp Berman, verified on sources

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1511,3 +1511,23 @@
   year      = {1988},
   doi       = {10.1525/can.1988.3.4.02a00060}
 }
+
+@book{mitchell2002,
+  author    = {Timothy Mitchell},
+  title     = {Rule of Experts: Egypt, Techno-Politics, and Modernity},
+  publisher = {University of California Press},
+  year      = {2002},
+  address   = {Berkeley, CA},
+  isbn      = {0-520-23262-3}
+}
+
+@article{mitchell1998,
+  author    = {Timothy Mitchell},
+  title     = {Fixing the Economy},
+  journal   = {Cultural Studies},
+  volume    = {12},
+  number    = {1},
+  pages     = {82--101},
+  year      = {1998},
+  doi       = {10.1080/095023898335627}
+}

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1531,3 +1531,12 @@
   year      = {1998},
   doi       = {10.1080/095023898335627}
 }
+
+@book{poppberman2022,
+  author    = {Elizabeth Popp Berman},
+  title     = {Thinking Like an Economist: How Efficiency Replaced Equality in {U.S.} Public Policy},
+  publisher = {Princeton University Press},
+  year      = {2022},
+  address   = {Princeton, NJ},
+  isbn      = {978-0-691-16738-1}
+}

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1490,3 +1490,24 @@
   pages     = {1666--1670},
   doi       = {10.1109/ISIT.2008.4595271}
 }
+
+@book{escobar1995,
+  author    = {Arturo Escobar},
+  title     = {Encountering Development: The Making and Unmaking of the Third World},
+  publisher = {Princeton University Press},
+  year      = {1995},
+  address   = {Princeton, NJ},
+  series    = {Princeton Studies in Culture/Power/History},
+  isbn      = {0-691-00102-2}
+}
+
+@article{escobar1988,
+  author    = {Arturo Escobar},
+  title     = {Power and Visibility: Development and the Invention and Management of the {Third World}},
+  journal   = {Cultural Anthropology},
+  volume    = {3},
+  number    = {4},
+  pages     = {428--443},
+  year      = {1988},
+  doi       = {10.1525/can.1988.3.4.02a00060}
+}

--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -11,6 +11,7 @@ Author: HDMX-coding-agent
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
 2026-07-07T20:55Z HDMX-coding-agent note Vannes candidates appended (Popp Berman, Desrosières-lineage, scientization set); author picks before adding
 2026-07-08T08:10Z HDMX-coding-agent note author directive: this ticket carries the Escobar/Mitchell discussion entirely and exclusively — discussion section added (remark text, manuscript anchor, candidate works, disambiguation); do not open that discussion in any other ticket or session context
+2026-07-08T13:21Z HDMX-coding-agent note author picked the Escobar works (both, verified on the PDFs): escobar1995 (Encountering Development, Princeton UP, ISBN 0-691-00102-2) + escobar1988 (Power and Visibility, Cultural Anthropology 3(4):428-443, doi 10.1525/can.1988.3.4.02a00060); entries added to main.bib, PDFs in docs/. Still pending: the Mitchell work(s), and the replace-vs-complement call for the DAC passage.
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;
@@ -19,7 +20,7 @@ every entry (DOI/venue) before adding — do not fabricate metadata.
 
 ## Actions — add to bibliography/main.bib (verified)
 1. Golka (2024), "Epistemic Gerrymandering: ESG, Impact Investing, and the Financial Governance of Sustainability," Review of International Political Economy, 31:6, 1894–1918. (R1 §1)
-2. Escobar — see discussion section below (author picks the works).
+2. Escobar — DONE: escobar1995 + escobar1988 added (both picked, verified on PDFs).
 3. Mitchell, Timothy — see discussion section below (author picks the works).
 4. King & Levine (1993) — finance-development nexus. (R1 add'l)
 5. Aghion & Bolton — finance-development. (R1 add'l)

--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -13,6 +13,7 @@ Author: HDMX-coding-agent
 2026-07-08T08:10Z HDMX-coding-agent note author directive: this ticket carries the Escobar/Mitchell discussion entirely and exclusively — discussion section added (remark text, manuscript anchor, candidate works, disambiguation); do not open that discussion in any other ticket or session context
 2026-07-08T13:21Z HDMX-coding-agent note author picked the Escobar works (both, verified on the PDFs): escobar1995 (Encountering Development, Princeton UP, ISBN 0-691-00102-2) + escobar1988 (Power and Visibility, Cultural Anthropology 3(4):428-443, doi 10.1525/can.1988.3.4.02a00060); entries added to main.bib, PDFs in docs/. Still pending: the Mitchell work(s), and the replace-vs-complement call for the DAC passage.
 2026-07-08T13:23Z HDMX-coding-agent note Mitchell works added (both, verified on PDFs): mitchell2002 (Rule of Experts, UC Press, ISBN 0-520-23262-3) + mitchell1998 (Fixing the Economy, Cultural Studies 12(1):82-101, doi 10.1080/095023898335627); Timothy not Ian. All 4 Escobar/Mitchell works now in bib + docs/. Remaining: which to cite where, and replace-vs-complement Desrosieres/Porter at the DAC passage (0141).
+2026-07-08T13:28Z HDMX-coding-agent note poppberman2022 added (Thinking Like an Economist, Princeton UP 2022, ISBN 978-0-691-16738-1; verified from EPUB OPF metadata; epub in docs/). For the conclusion 0171 (Œconomia symposium link).
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;

--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -12,6 +12,7 @@ Author: HDMX-coding-agent
 2026-07-07T20:55Z HDMX-coding-agent note Vannes candidates appended (Popp Berman, Desrosières-lineage, scientization set); author picks before adding
 2026-07-08T08:10Z HDMX-coding-agent note author directive: this ticket carries the Escobar/Mitchell discussion entirely and exclusively — discussion section added (remark text, manuscript anchor, candidate works, disambiguation); do not open that discussion in any other ticket or session context
 2026-07-08T13:21Z HDMX-coding-agent note author picked the Escobar works (both, verified on the PDFs): escobar1995 (Encountering Development, Princeton UP, ISBN 0-691-00102-2) + escobar1988 (Power and Visibility, Cultural Anthropology 3(4):428-443, doi 10.1525/can.1988.3.4.02a00060); entries added to main.bib, PDFs in docs/. Still pending: the Mitchell work(s), and the replace-vs-complement call for the DAC passage.
+2026-07-08T13:23Z HDMX-coding-agent note Mitchell works added (both, verified on PDFs): mitchell2002 (Rule of Experts, UC Press, ISBN 0-520-23262-3) + mitchell1998 (Fixing the Economy, Cultural Studies 12(1):82-101, doi 10.1080/095023898335627); Timothy not Ian. All 4 Escobar/Mitchell works now in bib + docs/. Remaining: which to cite where, and replace-vs-complement Desrosieres/Porter at the DAC passage (0141).
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;
@@ -21,7 +22,7 @@ every entry (DOI/venue) before adding — do not fabricate metadata.
 ## Actions — add to bibliography/main.bib (verified)
 1. Golka (2024), "Epistemic Gerrymandering: ESG, Impact Investing, and the Financial Governance of Sustainability," Review of International Political Economy, 31:6, 1894–1918. (R1 §1)
 2. Escobar — DONE: escobar1995 + escobar1988 added (both picked, verified on PDFs).
-3. Mitchell, Timothy — see discussion section below (author picks the works).
+3. Mitchell, Timothy — DONE: mitchell2002 + mitchell1998 added (both picked, verified on PDFs).
 4. King & Levine (1993) — finance-development nexus. (R1 add'l)
 5. Aghion & Bolton — finance-development. (R1 add'l)
 6. Star & Griesemer (1989), "Institutional Ecology, 'Translations' and


### PR DESCRIPTION
Author-picked bibliography additions for R&R remark R2.30 (Escobar/Mitchell) plus the conclusion (Popp Berman). Metadata verified sur pièce against the downloaded sources (imported to docs/, gitignored):

- **escobar1995** — Encountering Development (Princeton UP 1995, ISBN 0-691-00102-2)
- **escobar1988** — Power and Visibility (Cultural Anthropology 3(4):428-443, doi 10.1525/can.1988.3.4.02a00060)
- **mitchell2002** — Rule of Experts (UC Press 2002, ISBN 0-520-23262-3)
- **mitchell1998** — Fixing the Economy (Cultural Studies 12(1):82-101, doi 10.1080/095023898335627)
- **poppberman2022** — Thinking Like an Economist (Princeton UP 2022, ISBN 978-0-691-16738-1) — for the conclusion 0171

0143 stays open — which works to cite where, and replace-vs-complement Desrosières/Porter at the DAC passage (0141), remain the author's call.

Ticket-ref: tickets/0143-r-r-bibliography-additions-golka-escobar.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)