### PR TITLE
state: prune settled/ambient content (honest headroom, not compression)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -11,7 +11,7 @@ implementation** (tracker 0156) — the prose pass applying the decisions, then 
 ### Roadmap
 - **v2.0.5** (0156): base rebuild **0172 DONE** (VF translated + reimports + honest pre-2007 retreat in Appendix A.5; pre-2007 separation is NOT a corpus result — DEMOTE + scout NO-SIGNAL, reported as a negative result). **Next: content pass** → 0135/0137/0138/0139/0141 → conclusion **0171** (aggregate-birth landing + Star/Griesemer concede-then-displace) → title **0181** → prose 0134 → em-dash 0162. Parallel: bib 0143, letter 0152, audits 0161/0164. Resubmit 0153.
 - Parallel (not R&R): method paper **0026** — `multilayer-detection.qmd`.
-- Parallel: Charles Gide conference paper `manuscript-Gide.qmd` — uploaded to colloque website 2026-06-29, sent to A. Missemer and Y. Dosquet, **presented at Vannes 2026-07-02/04**. No RHPE submission: no special-issue call exists, so there is no decision to take (moot, 2026-07-07). Tag `gide-submitted-2026-06-29` (commit 4ac6e3a); record in `papiers/sent/2026-06-29 Charles Gide/`. Follow-up: bib accuracy validation **0164**.
+- Gide paper: presented at Vannes, settled (see git + `papiers/`); only live follow-up is bib validation **0164**.
 
 ## Status
 <!-- generated 2026-07-08T13:51Z -->
@@ -37,4 +37,4 @@ Test failures: none (prose-ratchet 41 + 33 adherence). Blockers: none.
 
 - **Base rebuild complete (2026-07-08)** — 0172/0175 closed; content children unblocked. Start the **content pass**: 0135 economists · 0137 commensuration · 0138 loss&damage (R1.4) · 0139 finance-dev · 0141 concretize → **0171** conclusion → 0181 title → 0134 prose → 0162 em-dash → 0153 resubmit.
 - **Needs author (HITL):** 0143 — Escobar (2), Mitchell (2), Popp Berman imported to docs/articles/ + bib (#890); remaining author calls: which to cite where + replace-vs-complement Desrosières/Porter (0141), plus Golka/King-Levine/Aghion-Bolton; rest of the 0152 letter rows.
-- Base-independent, ready now: **0161** stats · **0164** bib audit · **0166** lead-lag · **0185** loader. Background: null-model ribbon 15/18, bias audit 0071–0078.
+- Base-independent, ready now: **0161** stats provenance · **0164** main.bib audit · **0166** lead-lag · **0185** loader arch-rule-9.

--- a/STATE.md
+++ b/STATE.md
@@ -11,7 +11,6 @@ implementation** (tracker 0156) — the prose pass applying the decisions, then 
 ### Roadmap
 - **v2.0.5** (0156): base rebuild **0172 DONE** (VF translated + reimports + honest pre-2007 retreat in Appendix A.5; pre-2007 separation is NOT a corpus result — DEMOTE + scout NO-SIGNAL, reported as a negative result). **Next: content pass** → 0135/0137/0138/0139/0141 → conclusion **0171** (aggregate-birth landing + Star/Griesemer concede-then-displace) → title **0181** → prose 0134 → em-dash 0162. Parallel: bib 0143, letter 0152, audits 0161/0164. Resubmit 0153.
 - Parallel (not R&R): method paper **0026** — `multilayer-detection.qmd`.
-- Gide paper: presented at Vannes, settled (see git + `papiers/`); only live follow-up is bib validation **0164**.
 
 ## Status
 <!-- generated 2026-07-08T13:51Z -->


### PR DESCRIPTION
Honest pruning, not compression (the earlier 41→40 was a cram, correctly called out): dropped the ambient null-model/bias-audit background line and the settled Gide conference line entirely. Gide's only live follow-up (0164) is already tracked in the roadmap and the base-independent list; the rest lives in git + papiers/. STATE is now 39 lines — genuine headroom, each line one thing.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)