### PR TITLE
bib(articles): index docs/articles fulltext into main.bib

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -45,6 +45,7 @@
 }
 
 @article{fourcade2007,
+  file = {docs/articles/fourcade2007.pdf},
   author    = {Marion Fourcade},
   title     = {Theories of Markets and Theories of Society},
   journal   = {American Behavioral Scientist},
@@ -56,6 +57,7 @@
 }
 
 @article{caliskan_callon2009,
+  file = {docs/articles/caliskan_callon2009.pdf},
   author    = {Koray Çalışkan and Michel Callon},
   title     = {Economization, Part 1: Shifting Attention from the Economy towards Processes of Economization},
   journal   = {Economy and Society},
@@ -67,6 +69,7 @@
 }
 
 @article{caliskan_callon2010,
+  file = {docs/articles/caliskan_callon2010.pdf},
   author    = {Koray Çalışkan and Michel Callon},
   title     = {Economization, Part 2: A Research Programme for the Study of Markets},
   journal   = {Economy and Society},
@@ -78,6 +81,7 @@
 }
 
 @article{gieryn1983,
+  file = {docs/articles/gieryn1983.pdf},
   author    = {Thomas F. Gieryn},
   title     = {Boundary-Work and the Demarcation of Science from Non-Science: Strains and Interests in Professional Ideologies of Scientists},
   journal   = {American Sociological Review},
@@ -98,6 +102,7 @@
 }
 
 @inproceedings{kaul2017,
+  file = {docs/articles/kaul2017.pdf},
   author    = {Inge Kaul},
   title     = {Putting Climate Finance into Context: A Global Public Goods Perspective},
   booktitle = {The Paris Agreement on Climate Change: Analysis and Commentary},
@@ -120,6 +125,7 @@
 }
 
 @article{negishi1960,
+  file = {docs/articles/negishi1960.pdf},
   author    = {Takashi Negishi},
   title     = {Welfare Economics and Existence of an Equilibrium for a Competitive Economy},
   journal   = {Metroeconomica},
@@ -131,6 +137,7 @@
 }
 
 @article{nordhaus1992,
+  file = {docs/articles/nordhaus1992.pdf},
   author    = {William D. Nordhaus},
   title     = {An Optimal Transition Path for Controlling Greenhouse Gases},
   journal   = {Science},
@@ -142,6 +149,7 @@
 }
 
 @book{stern2007,
+  file = {docs/articles/stern2007.pdf},
   author    = {Nicholas Stern},
   title     = {The Economics of Climate Change: The Stern Review},
   publisher = {Cambridge University Press},
@@ -160,6 +168,7 @@
 }
 
 @article{weitzman2007,
+  file = {docs/articles/weitzman2007.pdf},
   author    = {Martin L. Weitzman},
   title     = {A Review of {The Stern Review on the Economics of Climate Change}},
   journal   = {Journal of Economic Literature},
@@ -171,6 +180,7 @@
 }
 
 @article{weitzman2009,
+  file = {docs/articles/weitzman2009.pdf},
   author    = {Martin L. Weitzman},
   title     = {On Modeling and Interpreting the Economics of Catastrophic Climate Change},
   journal   = {Review of Economics and Statistics},
@@ -182,6 +192,7 @@
 }
 
 @article{manne_richels1992,
+  file = {docs/articles/manne_richels1992.pdf},
   author    = {Alan S. Manne and Richard G. Richels},
   title     = {Buying Greenhouse Insurance},
   journal   = {Energy Policy},
@@ -202,6 +213,7 @@
 }
 
 @article{steckel2016,
+  file = {docs/articles/steckel2016.pdf},
   author    = {Jan Christoph Steckel and Michael Jakob and Christian Flachsland and Ulrike Kornek and Kai Lessmann and Ottmar Edenhofer},
   title     = {From Climate Finance Toward Sustainable Development Finance},
   journal   = {Wiley Interdisciplinary Reviews: Climate Change},
@@ -216,6 +228,7 @@
 % -- Corfee-Morlot and OECD statistical infrastructure --
 
 @book{corfee-morlot2009,
+  file = {docs/articles/corfee-morlot2009.pdf},
   author    = {Jan Corfee-Morlot and Bruno Guay and Kate M. Larsen},
   title     = {Financing Climate Change Mitigation: Towards a Framework for Measurement, Reporting and Verification},
   publisher = {OECD/IEA},
@@ -225,6 +238,7 @@
 }
 
 @book{corfee-morlot2012,
+  file = {docs/articles/corfee-morlot2012.pdf},
   author    = {Jan Corfee-Morlot and Virginie Marchal and Cédric Kauffmann and Christopher Kennedy and Fiona Stewart and Christopher Kaminker and Geraldine Ang},
   title     = {Towards a Green Investment Policy Framework},
   publisher = {OECD},
@@ -236,6 +250,7 @@
 % -- Michaelowa --
 
 @article{michaelowa2007,
+  file = {docs/articles/michaelowa2007.pdf},
   author    = {Axel Michaelowa and Katharina Michaelowa},
   title     = {Climate or Development: Is {ODA} Diverted from Its Original Purpose?},
   journal   = {Climatic Change},
@@ -247,6 +262,7 @@
 }
 
 @article{michaelowa2019,
+  file = {docs/articles/michaelowa2019.pdf},
   author    = {Axel Michaelowa and Sonja Butzengeiger and Madeleine Sharan and Katharina Michaelowa},
   title     = {Evolution of International Carbon Markets: Lessons for the {Paris} Agreement},
   journal   = {Wiley Interdisciplinary Reviews: Climate Change},
@@ -259,6 +275,7 @@
 % -- Weikmans and Roberts --
 
 @article{roberts_weikmans2017,
+  file = {docs/articles/roberts_weikmans2017.pdf},
   author    = {J. Timmons Roberts and Romain Weikmans},
   title     = {Postface: Fragmentation, Failing Trust and Enduring Tensions over What Counts as Climate Finance},
   journal   = {International Environmental Agreements: Politics, Law and Economics},
@@ -270,6 +287,7 @@
 }
 
 @article{roberts2021,
+  file = {docs/articles/roberts2021.pdf},
   author    = {J. Timmons Roberts and Romain Weikmans and Stacy-ann Robinson and David Ciplet and Timmon Roberts and Guy Edwards},
   title     = {Rebooting a Failed Promise of Climate Finance},
   journal   = {Nature Climate Change},
@@ -280,6 +298,7 @@
 }
 
 @article{khan_weikmans2019,
+  file = {docs/articles/khan_weikmans2019.pdf},
   author    = {Mizan R. Khan and J. Timmons Roberts and Saleemul Huq and Victoria Hoffmeister},
   title     = {Twenty-Five Years of Adaptation Finance through a Climate Justice Lens},
   journal   = {Climatic Change},
@@ -292,6 +311,7 @@
 % -- Stadelmann --
 
 @article{stadelmann2011,
+  file = {docs/articles/stadelmann2011.pdf},
   author    = {Martin Stadelmann and J. Timmons Roberts and Axel Michaelowa},
   title     = {New and Additional to What? Assessing Options for Baselines to Assess ``New and Additional'' Climate Finance},
   journal   = {Climate and Development},
@@ -303,6 +323,7 @@
 }
 
 @article{stadelmann2013,
+  file = {docs/articles/stadelmann2013.pdf},
   author    = {Martin Stadelmann and Axel Michaelowa and J. Timmons Roberts},
   title     = {Difficulties in Accounting for Private Finance in International Climate Policy},
   journal   = {Climate Policy},
@@ -316,6 +337,7 @@
 % -- OECD reports on mobilised private finance --
 
 @book{caruso_ellis2013,
+  file = {docs/articles/caruso_ellis2013.pdf},
   author    = {Roberta Caruso and Jane Ellis},
   title     = {Comparing Definitions and Methods to Estimate Mobilised Climate Finance},
   publisher = {OECD},
@@ -325,6 +347,7 @@
 }
 
 @book{jachnik2015,
+  file = {docs/articles/jachnik2015.pdf},
   author    = {Raphaël Jachnik and Roberta Caruso and Anuschka Srivastava},
   title     = {Estimating Mobilised Private Climate Finance: Methodological Approaches, Options and Trade-offs},
   publisher = {OECD},
@@ -334,6 +357,7 @@
 }
 
 @book{buchner2011,
+  file = {docs/articles/buchner2011.pdf},
   author    = {Barbara Buchner and Jessica Brown and Jan Corfee-Morlot},
   title     = {Monitoring and Tracking Long-Term Finance to Support Climate Action},
   publisher = {OECD},
@@ -343,6 +367,7 @@
 }
 
 @book{buchner2013,
+  file = {docs/articles/buchner2013.pdf},
   author    = {Barbara Buchner and Martin Stadelmann and Jessica Wilkinson and Federico Mazza and Anja Rosenberg and Dario Abramskiehn},
   title     = {The Global Landscape of Climate Finance 2013},
   publisher = {Climate Policy Initiative},
@@ -373,6 +398,7 @@
 }
 
 @book{carty_lecomte2018,
+  file = {docs/articles/carty_lecomte2018.pdf},
   author    = {Tracy Carty and Armelle {Le Comte}},
   title     = {Climate Finance Shadow Report 2018: Assessing Progress towards the \$100 Billion Commitment},
   publisher = {Oxfam International},
@@ -381,6 +407,7 @@
 }
 
 @book{zagema2023,
+  file = {docs/articles/zagema2023.pdf},
   author    = {Bertram Zagema and Jan Kowalzig and Lyndsay Walsh and Andrew Hattle and Christopher Roy and Hans Peter Dejgaard},
   title     = {Climate Finance Shadow Report 2023: Assessing the Delivery of the \$100 Billion Commitment},
   publisher = {Oxfam International},
@@ -389,6 +416,7 @@
 }
 
 @book{unfccc1992,
+  file = {docs/articles/unfccc1992.pdf},
   author    = {{United Nations}},
   title     = {United Nations Framework Convention on Climate Change},
   year      = {1992},
@@ -398,6 +426,7 @@
 }
 
 @misc{unfccc2007bali,
+  file = {docs/articles/unfccc2007bali.pdf},
   author    = {{UNFCCC}},
   title     = {Bali Action Plan},
   year      = {2007},
@@ -406,6 +435,7 @@
 }
 
 @book{unfccc2015paris,
+  file = {docs/articles/unfccc2015paris.pdf},
   author    = {{United Nations}},
   title     = {Paris Agreement},
   year      = {2015},
@@ -415,6 +445,7 @@
 }
 
 @article{skovgaard2017,
+  file = {docs/articles/skovgaard2017.pdf},
   author    = {Jakob Skovgaard},
   title     = {Limiting Costs or Correcting Market Failures? Finance Ministries and Frame Alignment in {UN} Climate Finance Negotiations},
   journal   = {International Environmental Agreements: Politics, Law and Economics},
@@ -426,6 +457,7 @@
 }
 
 @article{atteridge_dzebo2015,
+  file = {docs/articles/atteridge_dzebo2015.pdf},
   author    = {Aaron Atteridge and Adis Dzebo},
   title     = {When Does Private Finance Count as Climate Finance? Accounting for Private Contributions towards International Pledges},
   journal   = {Stockholm Environment Institute},
@@ -435,6 +467,7 @@
 }
 
 @article{monasterolo2020,
+  file = {docs/articles/monasterolo2020.pdf},
   author    = {Irene Monasterolo},
   title     = {Climate Change and the Financial System},
   journal   = {Annual Review of Resource Economics},
@@ -445,6 +478,7 @@
 }
 
 @book{stern2010,
+  file = {docs/articles/stern2010.pdf},
   author    = {{United Nations Secretary-General's High-level Advisory Group on Climate Change Financing}},
   title     = {Report of the Secretary-General's High-level Advisory Group on Climate Change Financing},
   publisher = {United Nations},
@@ -494,6 +528,7 @@
 }
 
 @article{espeland_stevens1998,
+  file = {docs/articles/espeland_stevens1998.pdf},
   author    = {Wendy Nelson Espeland and Mitchell L. Stevens},
   title     = {Commensuration as a Social Process},
   journal   = {Annual Review of Sociology},
@@ -515,6 +550,7 @@
 % -- Added for revision (2026-03) --
 
 @article{star_griesemer1989,
+  file = {docs/articles/star_griesemer1989.pdf},
   author    = {Susan Leigh Star and James R. Griesemer},
   title     = {Institutional Ecology, `Translations' and Boundary Objects: Amateurs and Professionals in {Berkeley's} {Museum} of {Vertebrate} {Zoology}, 1907--39},
   journal   = {Social Studies of Science},
@@ -535,6 +571,7 @@
 }
 
 @article{weikmans_roberts2019,
+  file = {docs/articles/weikmans_roberts2019.pdf},
   author    = {Romain Weikmans and J. Timmons Roberts},
   title     = {The International Climate Finance Accounting Muddle: Is There Hope on the Horizon?},
   journal   = {Climate and Development},

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1531,6 +1531,7 @@
 }
 
 @book{escobar1995,
+  file = {docs/articles/escobar1995.pdf},
   author    = {Arturo Escobar},
   title     = {Encountering Development: The Making and Unmaking of the Third World},
   publisher = {Princeton University Press},
@@ -1541,6 +1542,7 @@
 }
 
 @article{escobar1988,
+  file = {docs/articles/escobar1988.pdf},
   author    = {Arturo Escobar},
   title     = {Power and Visibility: Development and the Invention and Management of the {Third World}},
   journal   = {Cultural Anthropology},
@@ -1552,6 +1554,7 @@
 }
 
 @book{mitchell2002,
+  file = {docs/articles/mitchell2002.pdf},
   author    = {Timothy Mitchell},
   title     = {Rule of Experts: Egypt, Techno-Politics, and Modernity},
   publisher = {University of California Press},
@@ -1561,6 +1564,7 @@
 }
 
 @article{mitchell1998,
+  file = {docs/articles/mitchell1998.pdf},
   author    = {Timothy Mitchell},
   title     = {Fixing the Economy},
   journal   = {Cultural Studies},
@@ -1572,6 +1576,7 @@
 }
 
 @book{poppberman2022,
+  file = {docs/articles/poppberman2022.pdf},
   author    = {Elizabeth Popp Berman},
   title     = {Thinking Like an Economist: How Efficiency Replaced Equality in {U.S.} Public Policy},
   publisher = {Princeton University Press},
@@ -1579,3 +1584,262 @@
   address   = {Princeton, NJ},
   isbn      = {978-0-691-16738-1}
 }
+
+@article{aghion_bolton1997,
+  file = {docs/articles/aghion_bolton1997.pdf},
+  author = {Philippe Aghion and Patrick Bolton},
+  title = {A Theory of Trickle-Down Growth and Development},
+  year = {1997},
+  journal = {The Review of Economic Studies},
+  volume = {64},
+  number = {2},
+  pages = {151--172},
+}
+
+@techreport{bourguignon2025,
+  file = {docs/articles/bourguignon2025.pdf},
+  author = {François Bourguignon},
+  title = {Climate Finance: An ill-designed instrument for development and environment assistance},
+  year = {2025},
+  institution = {Finance for Development Lab},
+  number = {Policy Note 25},
+  url = {https://findevlab.org/climate-finance-an-ill-designed-instrument-for-development-and-environment-assistance/},
+  howpublished = {Finance for Development Lab Policy Note},
+}
+
+@article{masini2021,
+  file = {docs/articles/masini2021.pdf},
+  author = {Fabio Masini},
+  title = {William Nordhaus: A disputable Nobel [Prize]? Externalities, climate change, and governmental action},
+  year = {2021},
+  journal = {The European Journal of the History of Economic Thought},
+  volume = {28},
+  number = {6},
+  pages = {985--1004},
+  doi = {10.1080/09672567.2021.1963798},
+}
+
+@article{goutsmedt_sergi2025,
+  file = {docs/articles/goutsmedt_sergi2025.pdf},
+  author = {Aurélien Goutsmedt and Francesco Sergi},
+  title = {Redefining scientization: Central banks between science and politics},
+  year = {2025},
+  journal = {Finance and Society},
+  volume = {11},
+  pages = {209--229},
+  doi = {10.1017/fas.2025.7},
+}
+
+@article{claveau_dion2018,
+  file = {docs/articles/claveau_dion2018.pdf},
+  author = {François Claveau and Jérémie Dion},
+  title = {Quantifying Central Banks' Scientization: Why and How to Do a Quantified Organizational History of Economics},
+  year = {2018},
+  journal = {Journal of Economic Methodology},
+  volume = {25},
+  number = {4},
+  pages = {349--366},
+  doi = {10.1080/1350178x.2018.1529216},
+}
+
+@article{king_levine1993,
+  file = {docs/articles/king_levine1993.pdf},
+  author = {Robert G. King and Ross Levine},
+  title = {Finance and Growth: Schumpeter Might be Right},
+  year = {1993},
+  journal = {The Quarterly Journal of Economics},
+  volume = {108},
+  number = {3},
+  pages = {717-737},
+  doi = {10.2307/2118406},
+}
+
+@article{hirschman_poppberman2014,
+  file = {docs/articles/hirschman_poppberman2014.pdf},
+  author = {Daniel Hirschman and Elizabeth Popp Berman},
+  title = {Do economists make policies? On the political effects of economics},
+  year = {2014},
+  journal = {Socio-Economic Review},
+  publisher = {Oxford University Press},
+  volume = {12},
+  number = {4},
+  pages = {779--811},
+  doi = {10.1093/ser/mwu017},
+}
+
+@book{mitchell2011,
+  file = {docs/articles/mitchell2011.pdf},
+  author = {Timothy Mitchell},
+  title = {Carbon Democracy: Political Power in the Age of Oil},
+  year = {2011},
+  publisher = {Verso},
+  address = {London},
+}
+
+@article{acosta_etal2023,
+  file = {docs/articles/acosta_etal2023.pdf},
+  author = {Juan Acosta and Beatrice Cherrier and François Claveau and Clément Fontan and Aurélien Goutsmedt and Francesco Sergi},
+  title = {Six Decades of Economic Research at the Bank of England},
+  year = {2023},
+  journal = {History of Political Economy},
+  volume = {56},
+  number = {1},
+  pages = {1-40},
+  doi = {10.1215/00182702-10956544},
+}
+
+@article{star2010,
+  file = {docs/articles/star2010.pdf},
+  author = {Susan Leigh Star},
+  title = {This is Not a Boundary Object: Reflections on the Origin of a Concept},
+  year = {2010},
+  journal = {Science, Technology, & Human Values},
+  publisher = {Sage Publications, Inc.},
+  volume = {35},
+  number = {5},
+  pages = {601--617},
+  doi = {10.1177/0162243910377624},
+}
+
+@article{pouchain_etal2023,
+  file = {docs/articles/pouchain_etal2023.pdf},
+  author = {Delphine Pouchain and Emmanuel Petit and Jérôme Ballet},
+  title = {Changement climatique, colère et rationalité. Réflexions à la lumière de l'économie comportementale et du pragmatisme de John Dewey},
+  year = {2023},
+  journal = {Œconomia},
+  volume = {13},
+  number = {4},
+  pages = {1223--1255},
+  doi = {10.4000/oeconomia.16266},
+}
+
+@article{golka2024,
+  file = {docs/articles/golka2024.pdf},
+  author = {Philipp Golka},
+  title = {Epistemic gerrymandering: ESG, impact investing, and the financial governance of sustainability},
+  year = {2024},
+  journal = {Review of International Political Economy},
+  volume = {31},
+  number = {6},
+  pages = {1894--1918},
+  doi = {10.1080/09692290.2024.2382241},
+}
+
+@article{nordhaus2019,
+  file = {docs/articles/nordhaus2019.pdf},
+  author = {William Nordhaus},
+  title = {Climate Change: The Ultimate Challenge for Economics},
+  year = {2019},
+  journal = {American Economic Review},
+  volume = {109},
+  number = {6},
+  pages = {1991-2014},
+  doi = {10.1257/aer.109.6.1991},
+}
+
+@article{nordblad_vettese2022,
+  file = {docs/articles/nordblad_vettese2022.pdf},
+  author = {Julia Nordblad and Troy Vettese},
+  title = {European Histories of the Economic and Environmental: Introduction},
+  year = {2022},
+  journal = {Contemporary European History},
+  volume = {31},
+  pages = {481--490},
+  doi = {10.1017/s0960777322000698},
+}
+
+@article{calel2013,
+  file = {docs/articles/calel2013.pdf},
+  author = {Raphael Calel},
+  title = {Carbon markets: a historical overview},
+  year = {2013},
+  journal = {Wiley Interdisciplinary Reviews: Climate Change},
+  volume = {4},
+  number = {2},
+  pages = {107--119},
+  doi = {10.1002/wcc.208},
+}
+
+@article{cassen_cointe2022,
+  file = {docs/articles/cassen_cointe2022.pdf},
+  author = {Christophe Cassen and Béatrice Cointe},
+  title = {From The Limits to Growth to Greenhouse Gas Emissions Pathways: Technological Change in Global Computer Models (1972–2007)},
+  year = {2022},
+  journal = {Contemporary European History},
+  publisher = {Cambridge University Press},
+  volume = {31},
+  pages = {610--626},
+  doi = {10.1017/s096077732200042x},
+}
+
+@misc{acemoglu2021,
+  file = {docs/articles/acemoglu2021.pdf},
+  author = {Daron Acemoglu},
+  title = {What Climate Change Requires of Economics},
+  year = {2021},
+  url = {https://www.project-syndicate.org/magazine/what-climate-change-requires-of-economics-by-daron-acemoglu-2021-09},
+  howpublished = {Project Syndicate},
+}
+
+@article{gaspard_missemer2022,
+  file = {docs/articles/gaspard_missemer2022.pdf},
+  author = {Marion Gaspard and Antoine Missemer},
+  title = {Optimalité, équité et prix du carbone. À propos de Harold Hotelling et de sa règle en économie du climat},
+  year = {2022},
+  journal = {Revue de l'OFCE},
+  publisher = {OFCE},
+  volume = {176},
+  number = {1},
+  pages = {203--228},
+  doi = {10.3917/reof.176.0203},
+  url = {https://shs.cairn.info/revue-de-l-ofce-2022-1-page-203?lang=fr},
+}
+
+@article{cointe_etal2019,
+  file = {docs/articles/cointe_etal2019.pdf},
+  author = {Béatrice Cointe and Christophe Cassen and Alain Nadaï},
+  title = {Organising Policy-Relevant Knowledge for Climate Action: Integrated Assessment Modelling, the IPCC, and the Emergence of a Collective Expertise on Socioeconomic Emission Scenarios},
+  year = {2019},
+  journal = {Science & Technology Studies},
+  volume = {32},
+  number = {4},
+  pages = {36--57},
+  doi = {10.23987/sts.65031},
+}
+
+@article{cherrier2023,
+  file = {docs/articles/cherrier2023.pdf},
+  author = {Beatrice Cherrier},
+  title = {The Price of Virtue: Some Hypotheses on How Tractability Has Shaped Economic Models},
+  year = {2023},
+  journal = {Œconomia - History/Methodology/Philosophy},
+  volume = {13},
+  number = {1},
+  pages = {23-48},
+  doi = {10.4000/oeconomia.14116},
+}
+
+@article{stern2022,
+  file = {docs/articles/stern2022.pdf},
+  author = {Nicholas Stern},
+  title = {A Time for Action on Climate Change and A Time for Change in Economics},
+  year = {2022},
+  journal = {The Economic Journal},
+  publisher = {Oxford University Press},
+  volume = {132},
+  number = {644},
+  pages = {1259-1289},
+  doi = {10.1093/ej/ueac005},
+}
+
+@techreport{cherrier_duarte2024,
+  file = {docs/articles/cherrier_duarte2024.pdf},
+  author = {Beatrice Cherrier and Pedro Garcia Duarte},
+  title = {How the "Ramsey formula" came to define time discounting in economics (1950-2000)},
+  year = {2024},
+  institution = {SSRN Working Paper},
+  number = {4973044},
+  url = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4973044},
+  note = {September 2024},
+}
+

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -114,6 +114,7 @@
 % ---- TRANCHE B: Climate economics genealogy ----
 
 @article{ayres_kneese1969,
+  file = {docs/articles/ayres_kneese1969.pdf},
   author    = {Robert U. Ayres and Allen V. Kneese},
   title     = {Production, Consumption, and Externalities},
   journal   = {American Economic Review},
@@ -378,6 +379,7 @@
 % -- Other key empirical papers --
 
 @article{pauw2022,
+  file = {docs/articles/pauw2022.pdf},
   author    = {Pieter Pauw and Richard J. T. Klein and Kennedy Mbeva and Adis Dzebo and Davide Cassanmagnago and Anna Rudolph},
   title     = {Post-2025 Climate Finance Target: How Much More and How Much Better?},
   journal   = {Climate Policy},

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -1594,6 +1594,7 @@
   volume = {64},
   number = {2},
   pages = {151--172},
+  doi = {10.2307/2971707},
 }
 
 @techreport{bourguignon2025,


### PR DESCRIPTION
Indexes the local fulltext collection `docs/articles/` (gitignored) into `content/bibliography/main.bib`, in three passes as requested.

## Pass 1 — rename PDFs to bibkeys
`docs/articles/` held 58 PDFs under mixed naming (author-year, DOI, title, publisher slug). 37 correspond to a bib entry.
- Renamed 19 matched files to `<bibkey>.pdf`; 18 already conformed.
- DOI-named files matched against each entry's `doi` field (e.g. `10.1146_annurev-…-031134` → `monasterolo2020`).
- Two tiny landing-page **stub duplicates** (`buchner2011`, `monasterolo2020`) moved to `docs/articles/_superseded/`, keeping the fulltext.
- Renames are physical only — `docs/articles` is gitignored — so they don't appear in the diff; the map lives in the Pass-1 commit body.

## Pass 2 — add `file=` fields
Inserted `file = {docs/articles/<key>.pdf}` into the 37 matched entries. Each field was verified against an on-disk PDF before writing (0 dangling references).

## Pass 3 — fill gaps from Zotero
Matched the 116 PDF-less entries against the local Zotero library (`/home/haduong/data/Zotero`) by DOI then normalised title. **Overlap is weak** (1827 distinct Zotero DOIs; 1/76 of the PDF-less DOIs present), so Zotero supplied only two works, both verified by title+year:
- `pauw2022` (DOI match)
- `ayres_kneese1969` (title match: *Production, Consumption, and Externalities*)

**Result: 39 of 148 bib entries now carry local fulltext** (`grep -c '^  file = {'` → 39).

## Not addressed (reported, not changed)
- **~19 PDFs are reading-set items with no bib entry** (Escobar ×2, Mitchell ×2, Popp Berman's book, Calel 2013, Cherrier & Duarte 2024, Stern 2022 *EJ*, Cassen & Cointe 2022, Masini 2021, Acemoglu op-ed, FDL note, Goutsmedt & Sergi 2025, Hirschman & Popp Berman 2014, Gaspard 2022, Cointe 2019, Nordblad & Vettese 2022, Nordhaus 2019, "Price of Virtue", Dewey paper). Left in place — no bibkey to rename to. Several are plausible future citations.
- **109 bib entries still have no local fulltext** — absent from this Zotero library. A DOIfetch pass (not Zotero) would close that gap.

## Notes
- `file=` path format is repo-root-relative `docs/articles/<key>.pdf` (Better BibTeX round-trips this cleanly). Easy to switch to the JabRef `{:path:PDF}` triple if preferred.
- Quarto ignores `file=`; the field serves the author's reference manager.

Ticket: none

---

## Pass 4 — catalogue the reading-set PDFs (follow-up to the "not addressed" list)

The ~19 uncited reading-set PDFs (grown to **27** as parallel sessions dropped in more) now get bib entries. A 27-agent swarm read each PDF's first page and resolved canonical metadata via OpenAlex/Crossref.

- **22 new entries** appended, DOI-confirmed where one exists (e.g. `stern2022` 10.1093/ej/ueac005, `nordhaus2019` 10.1257/aer.109.6.1991, `calel2013` 10.1002/wcc.208, `acosta_etal2023` 10.1215/00182702-10956544, `golka2024`, `goutsmedt_sergi2025`, `hirschman_poppberman2014`, `claveau_dion2018`, `masini2021`, `king_levine1993`, `aghion_bolton1997`, `cassen_cointe2022`, `nordblad_vettese2022`, `cointe_etal2019`, `pouchain_etal2023`, `cherrier2023`, `cherrier_duarte2024`, `gaspard_missemer2022`). Books/op-eds/working papers typed accordingly (`mitchell2011` @book, `acemoglu2021` @misc, `bourguignon2025`/`cherrier_duarte2024` @techreport).
- **5 works were already catalogued** (a parallel session added the Escobar/Mitchell/Popp Berman theory entries). Their PDFs were renamed to the existing key and a `file=` field added to the existing entry — **not duplicated**: `escobar1988`, `escobar1995`, `mitchell1998`, `mitchell2002`, `poppberman2022`. Dedup keyed on DOI + bibkey collision.
- Swarm corrected two filename errors: "Acosta 2024" publishes **2023**; bare "gaspard 2022" is **Gaspard & Missemer**.

**main.bib now carries 66 `file=` fields**, every one resolving to an on-disk PDF; brace balance verified, no duplicate keys. 26/27 identifications high-confidence (Crossref/DOI-confirmed); `bourguignon2025` medium (FDL policy note, no DOI).

Every PDF in `docs/articles/` is now either indexed in `main.bib` or in `_superseded/`.