### PR TITLE
ticket(0143): index 7 decided R&R bibliography additions

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -2,7 +2,7 @@
 % Bibliography — Climate Finance History (Œconomia submission)
 % Organised by tranche: A (theory), B (climate econ), C (actors & grey lit)
 % Key convention: lastname_year (or lastname_lastname_year for two authors)
-% Entry types per Œconomia: @article, @book, @inproceedings only
+% Entry types per Œconomia: @article, @book, @incollection, @inproceedings
 % Grey literature uses @book with note field
 % ======================================================================
 
@@ -1539,4 +1539,84 @@
   year      = {2022},
   address   = {Princeton, NJ},
   isbn      = {978-0-691-16738-1}
+}
+
+% ======================================================================
+% R&R additions (ticket 0143): referee-requested refs + monetary-aggregate
+% analogy set. PDFs held locally in docs/articles/. Prose integration lives
+% in the content tickets; Escobar/Mitchell and the scientization set stay
+% out pending the author's works-selection.
+% ======================================================================
+
+@article{golka2024,
+  author    = {Philipp Golka},
+  title     = {Epistemic Gerrymandering: {ESG}, Impact Investing, and the Financial Governance of Sustainability},
+  journal   = {Review of International Political Economy},
+  volume    = {31},
+  number    = {6},
+  pages     = {1894--1918},
+  year      = {2024},
+  doi       = {10.1080/09692290.2024.2382241}
+}
+
+@article{king_levine1993,
+  author    = {Robert G. King and Ross Levine},
+  title     = {Finance and Growth: {Schumpeter} Might Be Right},
+  journal   = {The Quarterly Journal of Economics},
+  volume    = {108},
+  number    = {3},
+  pages     = {717--737},
+  year      = {1993},
+  doi       = {10.2307/2118406}
+}
+
+@article{aghion_bolton1997,
+  author    = {Philippe Aghion and Patrick Bolton},
+  title     = {A Theory of Trickle-Down Growth and Development},
+  journal   = {The Review of Economic Studies},
+  volume    = {64},
+  number    = {2},
+  pages     = {151--172},
+  year      = {1997},
+  doi       = {10.2307/2971707}
+}
+
+@article{star2010,
+  author    = {Susan Leigh Star},
+  title     = {This is Not a Boundary Object: Reflections on the Origin of a Concept},
+  journal   = {Science, Technology, \& Human Values},
+  volume    = {35},
+  number    = {5},
+  pages     = {601--617},
+  year      = {2010},
+  doi       = {10.1177/0162243910377624}
+}
+
+@incollection{morgan2007,
+  author    = {Mary S. Morgan},
+  title     = {An Analytical History of Measuring Practices: The Case of Velocities of Money},
+  booktitle = {Measurement in Economics: A Handbook},
+  editor    = {Marcel Boumans},
+  publisher = {Academic Press},
+  address   = {Amsterdam},
+  year      = {2007},
+  pages     = {105--132}
+}
+
+@book{lepenies2016,
+  author    = {Philipp Lepenies},
+  title     = {The Power of a Single Number: A Political History of {GDP}},
+  publisher = {Columbia University Press},
+  address   = {New York},
+  year      = {2016},
+  isbn      = {978-0-231-17510-4}
+}
+
+@book{tooze2001,
+  author    = {J. Adam Tooze},
+  title     = {Statistics and the {German} State, 1900--1945: The Making of Modern Economic Knowledge},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  year      = {2001},
+  isbn      = {978-0-521-03912-3}
 }


### PR DESCRIPTION
## What

Adds 7 verified `.bib` entries to `content/bibliography/main.bib` for the R&R bibliography additions whose selection is **already decided**, with local PDFs staged in `docs/articles/` (gitignored):

| Key | Work | Slot |
|-----|------|------|
| `golka2024` | Golka 2024, *Epistemic Gerrymandering* (RIPE) | action 1 (R1 §1) |
| `king_levine1993` | King & Levine 1993 (QJE) | action 4 |
| `aghion_bolton1997` | Aghion & Bolton 1997 (RES) | action 5 |
| `star2010` | Star 2010, *This is Not a Boundary Object* (ST&HV) | action 7 / brief 0171 |
| `morgan2007` | Morgan 2007, velocities of money (Boumans handbook chapter) | monetary-aggregate analogy |
| `lepenies2016` | Lepenies 2016, *The Power of a Single Number* (GDP) | monetary-aggregate analogy |
| `tooze2001` | Tooze 2001, *Statistics and the German State* | monetary-aggregate analogy |

The last three fill the ticket's "history-of-monetary-aggregates reference for the aggregate-birth analogy" (complement to Desrosières), proposed and approved this session.

## Verification

- Every DOI re-resolved against Crossref.
- Whole set renders through **pandoc citeproc** (the manuscript's engine, `oeconomia.csl`) with no error — Morgan formats correctly as a chapter ("In *Measurement in Economics*, edited by Marcel Boumans, 105–32").
- No duplicate keys; braces balanced; 153 → 160 entries.

## Note for review

`morgan2007` is the file's first `@incollection`. It is genuinely a handbook chapter, and both `oeconomia.csl` and `OEconomia_EN_2.bst` support the type, so I widened the stale header comment ("@article, @book, @inproceedings only") to include it. Flag if the journal truly forbids chapter cites.

## Held out (not in this PR)

Author-pick-gated per the ticket — PDFs staged in `docs/articles/`, entries **not** added: Escobar ×2, Mitchell (incl. *Carbon Democracy*), and the scientization set (Claveau & Dion, Hirschman & Popp Berman, Acosta et al., Goutsmedt & Sergi). These await your works-selection, which the ticket designates as its sole home.

Ticket-ref: tickets/0143-r-r-bibliography-additions-golka-escobar.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)