### PR TITLE
bib: Copenhagen Accord + India DEA rebuttal (accounting-wars primaries)

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -417,6 +417,19 @@
   doi       = {10.21201/2023.621500}
 }
 
+% -- Global South rebuttal to OECD counting --
+
+@book{dasgupta2015,
+  file = {docs/articles/dasgupta2015.pdf},
+  author    = {Dipak Dasgupta and {Climate Change Finance Unit Staff}},
+  title     = {Climate Change Finance, Analysis of a Recent {OECD} Report: Some Credible Facts Needed},
+  publisher = {Department of Economic Affairs, Ministry of Finance, Government of India},
+  address   = {New Delhi},
+  year      = {2015},
+  note      = {Discussion Paper},
+  url       = {http://www.dea.gov.in/files/discussion_paper_documents/ClimateChangeOEFDReport.pdf}
+}
+
 @book{unfccc1992,
   file = {docs/articles/unfccc1992.pdf},
   author    = {{United Nations}},
@@ -434,6 +447,15 @@
   year      = {2007},
   note      = {Decision 1/CP.13, FCCC/CP/2007/6/Add.1},
   url       = {https://unfccc.int/resource/docs/2007/cop13/eng/06a01.pdf}
+}
+
+@misc{unfccc2009copenhagen,
+  file = {docs/articles/unfccc2009copenhagen.pdf},
+  author    = {{UNFCCC}},
+  title     = {Copenhagen Accord},
+  year      = {2009},
+  note      = {Decision 2/CP.15, FCCC/CP/2009/11/Add.1; para.~8 states the goal of mobilizing jointly USD 100 billion a year by 2020},
+  url       = {https://unfccc.int/resource/docs/2009/cop15/eng/11a01.pdf}
 }
 
 @book{unfccc2015paris,

--- a/docs/framing-aggregate-strategic-ambiguity.md
+++ b/docs/framing-aggregate-strategic-ambiguity.md
@@ -48,7 +48,9 @@ bibliography already carries:
    under incompatible rules, so the aggregate cannot be reliably totalled or
    disaggregated (`weikmans_roberts2019`, the accounting-muddle anchor;
    `roberts_weikmans2017` on "what counts"; `roberts2021` on the failed
-   promise).
+   promise). A state actor makes the same charge: India's finance ministry
+   reads the OECD-CPI count as self-reported, "bent" to inflate, and
+   unverifiable (`dasgupta2015`).
 2. **The construction sites are visible.** The OECD DAC Rio markers and the MRV
    framework decide, one activity at a time, what enters the total
    (`corfee-morlot2009`); mobilised-private-finance attribution is an openly
@@ -63,8 +65,9 @@ bibliography already carries:
    sur pièce from the local PDFs at drafting time; not transcribed here.)*
 4. **The referent was underdetermined from birth.** The Copenhagen commitment
    named "$100 billion a year, mobilised jointly" without fixing public vs
-   private, gross vs net, grants vs loans, or the additionality baseline. The
-   slack was diplomatic, and it survived into the accounting regime.
+   private, gross vs net, grants vs loans, or the additionality baseline
+   (`unfccc2009copenhagen`, Decision 2/CP.15, para. 8). The slack was
+   diplomatic, and it survived into the accounting regime.
 
 ## The load-bearing claim
 
@@ -76,17 +79,16 @@ consolidate. Framed as strategic ambiguity institutionalised as convention, the
 vagueness becomes evidence *for* the crystallisation thesis. That is the paper to
 write.
 
-## Residual acquisitions (author's call)
+## Primary sources acquired
 
-The bibliography already covers the accounting wars. Two primary sources would
-strengthen §4 but are not yet local:
+The two primary sources are now local (`docs/articles/`) and in `main.bib`,
+verified sur pièce:
 
-- **Copenhagen Accord, decision 2/CP.15, para. 8** (UNFCCC, 2009) — the founding
-  under-specification, citable as primary text.
-- **Government of India, Dept. of Economic Affairs (2015), *Climate Change
-  Finance: Analysis of a Recent OECD Report*** — a Global-South state actor
-  contesting the OECD mobilisation count; supplies the "specific actors, not
-  policymakers" grounding the writing rules require.
-
-Both are freely available. Acquire into `docs/articles/` and add to `main.bib`
-only if the drafting session wants para. 4 evidenced by primary text.
+- **Copenhagen Accord, Decision 2/CP.15, para. 8** (UNFCCC, 2009,
+  `unfccc2009copenhagen`) — the founding under-specification. Para. 8 reads
+  "developed countries commit to a goal of mobilizing jointly USD 100 billion
+  dollars a year by 2020".
+- **Dasgupta & Climate Change Finance Unit (2015, `dasgupta2015`)** — India's
+  Department of Economic Affairs contesting the OECD-CPI mobilisation count;
+  supplies the "specific actors, not policymakers" grounding the writing rules
+  require.


### PR DESCRIPTION
## Summary
Acquires the two primary sources flagged as the only genuine gaps in the 0186 framing note, both verified sur pièce against the downloaded PDFs.

| key | source | verification |
|-----|--------|--------------|
| `unfccc2009copenhagen` | Copenhagen Accord, Decision 2/CP.15 (FCCC/CP/2009/11/Add.1), UNFCCC 2009 | Para. 8 confirmed verbatim in the PDF: *"developed countries commit to a goal of mobilizing jointly USD 100 billion dollars a year by 2020"* |
| `dasgupta2015` | Dipak Dasgupta & Climate Change Finance Unit, Dept of Economic Affairs, Ministry of Finance, Govt of India — 2015 Discussion Paper | Byline verified on p.1; abstract confirms the OECD-CPI counting rebuttal ("green-washing", methodology "bent" to inflate) |

## Changes
- `content/bibliography/main.bib`: +2 entries (177 total, all keys unique), placed in the existing counter-accounting / UNFCCC-chronology clusters, matching house entry style.
- `docs/framing-aggregate-strategic-ambiguity.md`: wired both keys into the argument spine (para 1 state-actor rebuttal; para 4 founding under-specification); "residual acquisitions" section updated to "acquired".

PDFs live in the gitignored `docs/articles/` library (not committed, as with all cited works).

Ticket: none