### PR TITLE
bib(articles): fetch open-access fulltext for 75 more entries

### DIFF
--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -205,6 +205,7 @@
 }
 
 @book{hourcade2015,
+  file = {docs/articles/hourcade2015.pdf},
   author    = {Jean-Charles Hourcade and Michael Grubb and Aurélie Méjean},
   title     = {The `Dark Matter' in the Search for Sustainable Growth: Energy, Innovation and the Financially Paradoxical Role of Climate Confidence},
   publisher = {Palgrave Macmillan},
@@ -391,6 +392,7 @@
 }
 
 @book{forstater2012,
+  file = {docs/articles/forstater2012.pdf},
   author    = {Maya Forstater},
   title     = {Towards Climate Finance Transparency},
   publisher = {Publish What You Fund},
@@ -490,6 +492,7 @@
 }
 
 @book{bachus_becault2017,
+  file = {docs/articles/bachus_becault2017.pdf},
   author    = {Kris Bachus and Emilie Bécault},
   title     = {Public Climate Finance: The Challenge of Reporting Equity},
   year      = {2017},
@@ -587,6 +590,7 @@
 % --- Co-citation tradition anchors (added for §1.5) ---
 
 @article{weitzman1974,
+  file = {docs/articles/weitzman1974.pdf},
   author    = {Martin L. Weitzman},
   title     = {Prices vs.\ Quantities},
   journal   = {Review of Economic Studies},
@@ -675,6 +679,7 @@
 % ---- TRANCHE E: Scientometrics / companion paper references ----
 
 @article{atwoli_etal2022,
+  file = {docs/articles/atwoli_etal2022.pdf},
   author    = {Lukoye Atwoli and Abdullah H. Baqui and Thomas Benfield and Raffaella Bosurgi and Fiona Godlee and Stephen Hancocks and Richard Horton and Laurie Laybourn-Langton and Carlos Augusto Monteiro and Ian Norman and Kirsten Patrick and Nigel Praities and Marcel G. M. Olde Rikkert and Eric J. Rubin and Peush Sahni and Richard Smith and Nick Talley and Sue Turale and Damián Vázquez},
   title     = {Call for Emergency Action to Limit Global Temperature Increases, Restore Biodiversity, and Protect Health},
   journal   = {The BMJ},
@@ -687,6 +692,7 @@
 % -- Topic models --
 
 @article{blei2003,
+  file = {docs/articles/blei2003.pdf},
   author    = {David M. Blei and Andrew Y. Ng and Michael I. Jordan},
   title     = {Latent {Dirichlet} Allocation},
   journal   = {Journal of Machine Learning Research},
@@ -697,6 +703,7 @@
 }
 
 @inproceedings{blei_lafferty2006,
+  file = {docs/articles/blei_lafferty2006.pdf},
   author    = {David M. Blei and John D. Lafferty},
   title     = {Dynamic Topic Models},
   booktitle = {Proceedings of the 23rd International Conference on Machine Learning},
@@ -706,6 +713,7 @@
 }
 
 @article{roberts2014,
+  file = {docs/articles/roberts2014.pdf},
   author    = {Margaret E. Roberts and Brandon M. Stewart and Dustin Tingley and Christopher Lucas and Jetson Leder-Luis and Shana Kushner Gadarian and Bethany Albertson and David G. Rand},
   title     = {Structural Topic Models for Open-Ended Survey Responses},
   journal   = {American Journal of Political Science},
@@ -717,6 +725,7 @@
 }
 
 @article{grootendorst2022,
+  file = {docs/articles/grootendorst2022.pdf},
   author    = {Maarten Grootendorst},
   title     = {{BERTopic}: Neural Topic Modeling with a Class-Based {TF-IDF} Procedure},
   journal   = {arXiv preprint arXiv:2203.05794},
@@ -726,6 +735,7 @@
 % -- Embedding-based scientometrics --
 
 @inproceedings{cohan2020,
+  file = {docs/articles/cohan2020.pdf},
   author    = {Arman Cohan and Sergey Feldman and Iz Beltagy and Doug Downey and Daniel S. Weld},
   title     = {{SPECTER}: Document-Level Representation Learning Using Citation-Informed Transformers},
   booktitle = {Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
@@ -735,6 +745,7 @@
 }
 
 @article{puccetti2021,
+  file = {docs/articles/puccetti2021.pdf},
   author    = {Giovanni Puccetti and Christian Chiarcos and Roberto Navigli},
   title     = {Semantic and Relational Spaces in Science of Science: Deep Learning Models for Article Vectorisation},
   journal   = {Scientometrics},
@@ -745,6 +756,7 @@
 }
 
 @article{poetto2023,
+  file = {docs/articles/poetto2023.pdf},
   author    = {Matteo Poetto and Emilio Ferrara and Salvatore Malandrino},
   title     = {An Embedding Approach for Analyzing the Evolution of Research Topics with a Case Study on Computer Science Subdomains},
   journal   = {Scientometrics},
@@ -756,6 +768,7 @@
 }
 
 @article{constantino2025,
+  file = {docs/articles/constantino2025.pdf},
   author    = {Sabrina M. Constantino and Sadamori Kojaku and Santo Fortunato and Yong-Yeol Ahn},
   title     = {Representing the Disciplinary Structure of Physics: A Comparative Evaluation of Graph and Text Embedding Methods},
   journal   = {Quantitative Science Studies},
@@ -764,6 +777,7 @@
 }
 
 @article{xie_waltman2025,
+  file = {docs/articles/xie_waltman2025.pdf},
   author    = {Qianqian Xie and Ludo Waltman},
   title     = {A Comparison of Citation-Based Clustering and Topic Modeling for Science Mapping},
   journal   = {Scientometrics},
@@ -777,6 +791,7 @@
 % -- Change-point detection --
 
 @article{truong2020,
+  file = {docs/articles/truong2020.pdf},
   author    = {Charles Truong and Laurent Oudre and Nicolas Vayatis},
   title     = {Selective Review of Offline Change Point Detection Methods},
   journal   = {Signal Processing},
@@ -787,6 +802,7 @@
 }
 
 @article{delvenne2017,
+  file = {docs/articles/delvenne2017.pdf},
   author    = {Jean-Charles Delvenne and Renaud Lambiotte and Luis E. C. Rocha},
   title     = {Detecting Dynamical Changes in Time Series by Using the {Jensen--Shannon} Divergence},
   journal   = {Chaos},
@@ -798,6 +814,7 @@
 }
 
 @article{li2021,
+  file = {docs/articles/li2021.pdf},
   author    = {Suyu Li and Yizhou Sun and Aram Galstyan},
   title     = {Semantic Changepoint Detection for Finding Potentially Novel Research Publications},
   journal   = {Journal of Informetrics},
@@ -809,6 +826,7 @@
 }
 
 @article{bose2021,
+  file = {docs/articles/bose2021.pdf},
   author    = {Avik Bose and Ziang Xiao and Brice Acree and Justin Grimmer},
   title     = {Changepoint Analysis of Topic Proportions in Temporal Text Data},
   journal   = {arXiv preprint arXiv:2112.00827},
@@ -816,6 +834,7 @@
 }
 
 @article{darst2016,
+  file = {docs/articles/darst2016.pdf},
   author    = {Richard K. Darst and Clara Granell and Alex Arenas and Sergio Gómez and Jari Saramäki and Santo Fortunato},
   title     = {Detection of Timescales in Evolving Complex Systems},
   journal   = {Scientific Reports},
@@ -826,6 +845,7 @@
 }
 
 @inproceedings{hamilton2016,
+  file = {docs/articles/hamilton2016.pdf},
   author    = {William L. Hamilton and Jure Leskovec and Dan Jurafsky},
   title     = {Diachronic Word Embeddings Reveal Statistical Laws of Semantic Change},
   booktitle = {Proceedings of the 54th Annual Meeting of the Association for Computational Linguistics},
@@ -835,6 +855,7 @@
 }
 
 @article{soni2021,
+  file = {docs/articles/soni2021.pdf},
   author    = {Sandeep Soni and Kristina Lerman and Jacob Eisenstein},
   title     = {Follow the Leader: Documents on the Leading Edge of Semantic Change Get More Citations},
   journal   = {Journal of the Association for Information Science and Technology},
@@ -859,6 +880,7 @@
 }
 
 @article{pierson2000,
+  file = {docs/articles/pierson2000.pdf},
   author    = {Paul Pierson},
   title     = {Increasing Returns, Path Dependence, and the Study of Politics},
   journal   = {American Political Science Review},
@@ -880,6 +902,7 @@
 }
 
 @article{seto2016,
+  file = {docs/articles/seto2016.pdf},
   author    = {Karen C. Seto and Steven J. Davis and Ronald B. Mitchell and Eleanor C. Stokes and Gregory Unruh and Diana Ürge-Vorsatz},
   title     = {Carbon Lock-In: Types, Causes, and Policy Implications},
   journal   = {Annual Review of Environment and Resources},
@@ -908,6 +931,7 @@
 }
 
 @article{ncc_editorial2022,
+  file = {docs/articles/ncc_editorial2022.pdf},
   author    = {{Nature Climate Change}},
   title     = {Checking Contentious Counting},
   journal   = {Nature Climate Change},
@@ -928,6 +952,7 @@
 }
 
 @article{simonet2022,
+  file = {docs/articles/simonet2022.pdf},
   author    = {Guillaume Simonet},
   title     = {Discursive Dynamics and Lock-Ins in Socio-Technical Systems: An Overview and a Way Forward},
   journal   = {Sustainability Science},
@@ -959,6 +984,7 @@
 }
 
 @article{maria_etal2023,
+  file = {docs/articles/maria_etal2023.pdf},
   author    = {Mariana Reis Maria and Rosangela Ballini and Roney Fraga Souza},
   title     = {Evolution of Green Finance: A Bibliometric Analysis through Complex Networks and Machine Learning},
   journal   = {Sustainability},
@@ -972,6 +998,7 @@
 % -- Topic model evaluations --
 
 @inproceedings{chang2009,
+  file = {docs/articles/chang2009.pdf},
   author    = {Jonathan Chang and Sean Gerrish and Chong Wang and Jordan L. Boyd-Graber and David M. Blei},
   title     = {Reading Tea Leaves: How Humans Interpret Topic Models},
   booktitle = {Advances in Neural Information Processing Systems 22},
@@ -980,6 +1007,7 @@
 }
 
 @inproceedings{sia2020,
+  file = {docs/articles/sia2020.pdf},
   author    = {Suzanna Sia and Ayush Dalmia and Sabrina J. Mielke},
   title     = {Tired of Topic Models? Clusters of Pretrained Word Embeddings Make for Fast and Good Topics Too!},
   booktitle = {Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing},
@@ -1000,6 +1028,7 @@
 }
 
 @inproceedings{yang2024sweagent,
+  file = {docs/articles/yang2024sweagent.pdf},
   author    = {John Yang and Carlos E. Jimenez and Alexander Wettig and Kilian Lieret and Shunyu Yao and Karthik Narasimhan and Ofir Press},
   title     = {{SWE}-agent: Agent-Computer Interfaces Enable Automated Software Engineering},
   booktitle = {Advances in Neural Information Processing Systems 37},
@@ -1007,6 +1036,7 @@
 }
 
 @article{wang2024openhands,
+  file = {docs/articles/wang2024openhands.pdf},
   author    = {Xingyao Wang and Boxuan Li and Yufan Song and Frank F. Xu and Xiangru Tang and Mingchen Zhuge and Jiayi Pan and Yueqi Song and Bowen Li and Jaskirat Singh and Hoang H. Tran and Fuqiang Li and Ren Ma and Mingzhang Zheng and Bill Qian and Yanjun Shao and Niklas Muennighoff and Ziwen Liu and Kongyang Chen and Shengqi Chen and Graham Neubig},
   title     = {{OpenHands}: An Open Platform for {AI} Software Developers as Generalist Agents},
   journal   = {arXiv preprint arXiv:2407.16741},
@@ -1014,6 +1044,7 @@
 }
 
 @inproceedings{zhang2024aflow,
+  file = {docs/articles/zhang2024aflow.pdf},
   author    = {Jiayi Zhang and Jinyu Xiang and Zhaoyang Yu and Fengwei Teng and Xionghui Chen and Jiaqi Chen and Mingchen Zhuge and Xin Cheng and Sirui Hong and Jinlin Wang and Bingnan Zheng and Bang Liu and Yuyu Luo and Chenglin Wu},
   title     = {{AFlow}: Automating Agentic Workflow Generation},
   booktitle = {arXiv preprint arXiv:2410.10762},
@@ -1021,6 +1052,7 @@
 }
 
 @article{jimenez2024swebench,
+  file = {docs/articles/jimenez2024swebench.pdf},
   author    = {Carlos E. Jimenez and John Yang and Alexander Wettig and Shunyu Yao and Kexin Pei and Ofir Press and Karthik Narasimhan},
   title     = {{SWE}-bench: Can Language Models Resolve Real-World {GitHub} Issues?},
   journal   = {arXiv preprint arXiv:2310.06770},
@@ -1028,6 +1060,7 @@
 }
 
 @article{lu2024aiscientist,
+  file = {docs/articles/lu2024aiscientist.pdf},
   author    = {Chris Lu and Cong Lu and Robert Tjarko Lange and Jakob Foerster and Jeff Clune and David Ha},
   title     = {The {AI} Scientist: Towards Fully Automated Open-Ended Scientific Discovery},
   journal   = {arXiv preprint arXiv:2408.06292},
@@ -1035,6 +1068,7 @@
 }
 
 @inproceedings{shinn2023reflexion,
+  file = {docs/articles/shinn2023reflexion.pdf},
   author    = {Noah Shinn and Federico Cassano and Ashwin Gopinath and Karthik Narasimhan and Shunyu Yao},
   title     = {Reflexion: Language Agents with Verbal Reinforcement Learning},
   booktitle = {Advances in Neural Information Processing Systems 36},
@@ -1049,6 +1083,7 @@
 }
 
 @article{liu2024swesurvey,
+  file = {docs/articles/liu2024swesurvey.pdf},
   author    = {Junwei Liu and Kaixin Wang and Yixuan Chen and Xin Peng and Zhenpeng Chen and Lingming Zhang and Yiling Lou},
   title     = {Large Language Model-Based Agents for Software Engineering: A Survey},
   journal   = {ACM Transactions on Software Engineering and Methodology},
@@ -1059,6 +1094,7 @@
 % -- Reproducibility --
 
 @article{peng2011reproducible,
+  file = {docs/articles/peng2011reproducible.pdf},
   author    = {Roger D. Peng},
   title     = {Reproducible Research in Computational Science},
   journal   = {Science},
@@ -1085,6 +1121,7 @@
 }
 
 @article{molder2021snakemake,
+  file = {docs/articles/molder2021snakemake.pdf},
   author    = {Felix Mölder and Kim Philipp Jablonski and Brice Letcher and Michael B. Hall and Christopher H. Tomkins-Tinch and Vanessa Sochat and Jan Forster and Soohyun Lee and Sven O. Twarber and Alexander Kanitz and Andreas Wilm and Manuel Holtgrewe and Sven Rahmann and Sven Nahnsen and Johannes Köster},
   title     = {Sustainable Data Analysis with {Snakemake}},
   journal   = {F1000Research},
@@ -1105,6 +1142,7 @@
 % -- Human-AI collaboration --
 
 @inproceedings{horvitz1999principles,
+  file = {docs/articles/horvitz1999principles.pdf},
   author    = {Eric Horvitz},
   title     = {Principles of Mixed-Initiative User Interfaces},
   booktitle = {Proceedings of the SIGCHI Conference on Human Factors in Computing Systems},
@@ -1125,6 +1163,7 @@
 }
 
 @inproceedings{bansal2021complementary,
+  file = {docs/articles/bansal2021complementary.pdf},
   author    = {Gagan Bansal and Besmira Nushi and Ece Kamar and Daniel S. Weld and Walter S. Lasecki and Eric Horvitz},
   title     = {Is the Most Accurate {AI} the Best Teammate? Optimizing {AI} for Teamwork},
   booktitle = {Proceedings of the AAAI Conference on Artificial Intelligence},
@@ -1135,6 +1174,7 @@
 }
 
 @article{rebedea2023nemo,
+  file = {docs/articles/rebedea2023nemo.pdf},
   author    = {Traian Rebedea and Razvan Dinu and Makesh Sreedhar and Christopher Parisien and Jonathan Cohen},
   title     = {{NeMo Guardrails}: A Toolkit for Controllable and Safe {LLM} Applications with Programmable Rails},
   journal   = {arXiv preprint arXiv:2310.10501},
@@ -1144,6 +1184,7 @@
 % -- Dragon Dreaming --
 
 @book{croft2014dragondreaming,
+  file = {docs/articles/croft2014dragondreaming.pdf},
   author    = {John Croft},
   title     = {Dragon Dreaming Project Design},
   publisher = {Dragon Dreaming International},
@@ -1155,6 +1196,7 @@
 % -- Bibliometric methods used in the paper --
 
 @article{chen2006citespace,
+  file = {docs/articles/chen2006citespace.pdf},
   author    = {Chaomei Chen},
   title     = {{CiteSpace II}: Detecting and Visualizing Emerging Trends and Transient Patterns in Scientific Literature},
   journal   = {Journal of the American Society for Information Science and Technology},
@@ -1166,6 +1208,7 @@
 }
 
 @article{blondel2008fast,
+  file = {docs/articles/blondel2008fast.pdf},
   author    = {Vincent D. Blondel and Jean-Loup Guillaume and Renaud Lambiotte and Etienne Lefebvre},
   title     = {Fast Unfolding of Communities in Large Networks},
   journal   = {Journal of Statistical Mechanics: Theory and Experiment},
@@ -1179,6 +1222,7 @@
 % -- OpenAlex validation --
 
 @article{priem_etal2022,
+  file = {docs/articles/priem_etal2022.pdf},
   author    = {Jason Priem and Heather Piwowar and Richard Orr},
   title     = {{OpenAlex}: A Fully-Open Index of Scholarly Works, Authors, Venues, Institutions, and Concepts},
   journal   = {ArXiv preprint},
@@ -1189,6 +1233,7 @@
 % -- Two-sample testing and distribution comparison --
 
 @article{szekely2013,
+  file = {docs/articles/szekely2013.pdf},
   author    = {Gábor J. Székely and Maria L. Rizzo},
   title     = {Energy Statistics: A Class of Statistics Based on Distances},
   journal   = {Journal of Statistical Planning and Inference},
@@ -1200,6 +1245,7 @@
 }
 
 @article{gretton2012,
+  file = {docs/articles/gretton2012.pdf},
   author    = {Arthur Gretton and Karsten M. Borgwardt and Malte J. Rasch and Bernhard Schölkopf and Alexander Smola},
   title     = {A Kernel Two-Sample Test},
   journal   = {Journal of Machine Learning Research},
@@ -1210,6 +1256,7 @@
 }
 
 @inproceedings{lopez_paz_oquab2017,
+  file = {docs/articles/lopez_paz_oquab2017.pdf},
   author    = {David Lopez-Paz and Maxime Oquab},
   title     = {Revisiting Classifier Two-Sample Tests},
   booktitle = {International Conference on Learning Representations (ICLR)},
@@ -1218,6 +1265,7 @@
 }
 
 @article{kim2021,
+  file = {docs/articles/kim2021.pdf},
   author    = {Ilmun Kim and Aaditya Ramdas and Aarti Singh and Larry Wasserman},
   title     = {Classification Accuracy as a Proxy for Two-Sample Testing},
   journal   = {Annals of Statistics},
@@ -1229,6 +1277,7 @@
 }
 
 @article{barabasi1999emergence,
+  file = {docs/articles/barabasi1999emergence.pdf},
   author  = {Barab{\'a}si, Albert-L{\'a}szl{\'o} and Albert, R{\'e}ka},
   title   = {Emergence of Scaling in Random Networks},
   journal = {Science},
@@ -1240,6 +1289,7 @@
 }
 
 @article{barron2018individuals,
+  file = {docs/articles/barron2018individuals.pdf},
   author  = {Barron, Alexander T. J. and Huang, Jenny and Spang, Rebecca L. and DeDeo, Simon},
   title   = {Individuals, Institutions, and Innovation in the Debates of the {French Revolution}},
   journal = {Proceedings of the National Academy of Sciences},
@@ -1251,6 +1301,7 @@
 }
 
 @article{battiston2019taking,
+  file = {docs/articles/battiston2019taking.pdf},
   author  = {Battiston, Federico and Musciotto, Federico and Wang, Dashun and Barab{\'a}si, Albert-L{\'a}szl{\'o} and Szell, Michael and Sinatra, Roberta},
   title   = {Taking Census of Physics},
   journal = {Nature Reviews Physics},
@@ -1261,6 +1312,7 @@
 }
 
 @inproceedings{kolouri2019generalized,
+  file = {docs/articles/kolouri2019generalized.pdf},
   author    = {Kolouri, Soheil and Nadjahi, Kimia and Simsekli, Umut and Badeau, Roland and Rohde, Gustavo},
   title     = {Generalized Sliced {Wasserstein} Distances},
   booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
@@ -1270,6 +1322,7 @@
 }
 
 @inproceedings{bonneel2015sliced,
+  file = {docs/articles/bonneel2015sliced.pdf},
   author    = {Bonneel, Nicolas and Rabin, Julien and Peyr{\'e}, Gabriel and Pfister, Hanspeter},
   title     = {Sliced and {Radon} {Wasserstein} Barycenters of Measures},
   journal   = {Journal of Mathematical Imaging and Vision},
@@ -1281,6 +1334,7 @@
 }
 
 @article{clauset2009power,
+  file = {docs/articles/clauset2009power.pdf},
   author  = {Clauset, Aaron and Shalizi, Cosma Rohilla and Newman, Mark E. J.},
   title   = {Power-Law Distributions in Empirical Data},
   journal = {SIAM Review},
@@ -1292,6 +1346,7 @@
 }
 
 @inproceedings{hulkund2022interpretable,
+  file = {docs/articles/hulkund2022interpretable.pdf},
   author    = {Hulkund, Neha and Fusi, Nicol{\`o} and Wortman Vaughan, Jennifer and Alvarez-Melis, David},
   title     = {Interpretable Distribution Shift Detection Using Optimal Transport},
   booktitle = {ICML 2022 Workshop on {DataPerf}: Benchmarking Data for Data-Centric AI},
@@ -1300,6 +1355,7 @@
 }
 
 @article{tattershall2020detecting,
+  file = {docs/articles/tattershall2020detecting.pdf},
   author  = {Tattershall, Emma and Nenadic, Goran and Stevens, Robert D.},
   title   = {Detecting Bursty Terms in Computer Science Research},
   journal = {Scientometrics},
@@ -1322,6 +1378,7 @@
 }
 
 @article{funk2017dynamic,
+  file = {docs/articles/funk2017dynamic.pdf},
   author  = {Funk, Russell J. and Owen-Smith, Jason},
   title   = {A Dynamic Network Measure of Technological Change},
   journal = {Management Science},
@@ -1333,6 +1390,7 @@
 }
 
 @inproceedings{hall2008studying,
+  file = {docs/articles/hall2008studying.pdf},
   author    = {Hall, David and Jurafsky, Daniel and Manning, Christopher D.},
   title     = {Studying the History of Ideas Using Topic Models},
   booktitle = {Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
@@ -1342,6 +1400,7 @@
 }
 
 @inproceedings{heusel2017gans,
+  file = {docs/articles/heusel2017gans.pdf},
   author    = {Heusel, Martin and Ramsauer, Hubert and Unterthiner, Thomas and Nessler, Bernhard and Hochreiter, Sepp},
   title     = {{GANs} Trained by a Two Time-Scale Update Rule Converge to a Local {Nash} Equilibrium},
   booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
@@ -1350,6 +1409,7 @@
 }
 
 @inproceedings{jayasumana2024rethinking,
+  file = {docs/articles/jayasumana2024rethinking.pdf},
   author    = {Jayasumana, Sadeep and Ramalingam, Srikumar and Veit, Andreas and Glasner, Daniel and Chakrabarti, Ayan and Kumar, Sanjiv},
   title     = {Rethinking {FID}: Towards a Better Evaluation Metric for Image Generation},
   booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
@@ -1369,6 +1429,7 @@
 }
 
 @article{kleinberg2003bursty,
+  file = {docs/articles/kleinberg2003bursty.pdf},
   author  = {Kleinberg, Jon},
   title   = {Bursty and Hierarchical Structure in Streams},
   journal = {Data Mining and Knowledge Discovery},
@@ -1380,6 +1441,7 @@
 }
 
 @inproceedings{lemos2023sampling,
+  file = {docs/articles/lemos2023sampling.pdf},
   author    = {Lemos, Pablo and Coogan, Adam and Hezaveh, Yashar and Perreault-Levasseur, Laurence},
   title     = {Sampling-Based Accuracy Testing Posterior Estimation for General Inference},
   booktitle = {Proceedings of the 40th International Conference on Machine Learning (ICML)},
@@ -1387,6 +1449,7 @@
 }
 
 @article{lin1991divergence,
+  file = {docs/articles/lin1991divergence.pdf},
   author  = {Lin, Jianhua},
   title   = {Divergence Measures Based on the {Shannon} Entropy},
   journal = {IEEE Transactions on Information Theory},
@@ -1408,6 +1471,7 @@
 }
 
 @article{murdock2017exploration,
+  file = {docs/articles/murdock2017exploration.pdf},
   author  = {Murdock, Jaimie and Allen, Colin and DeDeo, Simon},
   title   = {Exploration and Exploitation of {Victorian} Science in {Darwin}'s Reading Notebooks},
   journal = {Cognition},
@@ -1418,6 +1482,7 @@
 }
 
 @article{newman2006modularity,
+  file = {docs/articles/newman2006modularity.pdf},
   author  = {Newman, Mark E. J.},
   title   = {Modularity and Community Structure in Networks},
   journal = {Proceedings of the National Academy of Sciences},
@@ -1429,6 +1494,7 @@
 }
 
 @techreport{page1998pagerank,
+  file = {docs/articles/page1998pagerank.pdf},
   author      = {Page, Lawrence and Brin, Sergey and Motwani, Rajeev and Winograd, Terry},
   title       = {The {PageRank} Citation Ranking: Bringing Order to the Web},
   institution = {Stanford InfoLab},
@@ -1437,6 +1503,7 @@
 }
 
 @article{park2023papers,
+  file = {docs/articles/park2023papers.pdf},
   author  = {Park, Michael and Leahey, Erin and Funk, Russell J.},
   title   = {Papers and Patents are Becoming Less Disruptive over Time},
   journal = {Nature},
@@ -1447,6 +1514,7 @@
 }
 
 @article{price1965networks,
+  file = {docs/articles/price1965networks.pdf},
   author  = {Price, Derek J. de Solla},
   title   = {Networks of Scientific Papers},
   journal = {Science},
@@ -1458,6 +1526,7 @@
 }
 
 @article{rosvall2019different,
+  file = {docs/articles/rosvall2019different.pdf},
   author  = {Rosvall, Martin and Esquivel, Alcides V. and Lancichinetti, Andrea and West, Jevin D. and Lambiotte, Renaud},
   title   = {Different Approaches to Community Detection},
   journal = {Advances in Network Clustering and Blockmodeling},
@@ -1467,6 +1536,7 @@
 }
 
 @article{shannon1948mathematical,
+  file = {docs/articles/shannon1948mathematical.pdf},
   author  = {Shannon, Claude E.},
   title   = {A Mathematical Theory of Communication},
   journal = {Bell System Technical Journal},
@@ -1478,6 +1548,7 @@
 }
 
 @article{von2007tutorial,
+  file = {docs/articles/von2007tutorial.pdf},
   author  = {Von Luxburg, Ulrike},
   title   = {A Tutorial on Spectral Clustering},
   journal = {Statistics and Computing},
@@ -1489,6 +1560,7 @@
 }
 
 @article{walker2007ranking,
+  file = {docs/articles/walker2007ranking.pdf},
   author  = {Walker, Dylan and Xie, Huafeng and Yan, Koon-Kiu and Maslov, Sergei},
   title   = {Ranking Scientific Publications Using a Model of Network Traffic},
   journal = {Journal of Statistical Mechanics: Theory and Experiment},
@@ -1500,6 +1572,7 @@
 }
 
 @article{leydesdorff2007betweenness,
+  file = {docs/articles/leydesdorff2007betweenness.pdf},
   author  = {Leydesdorff, Loet},
   title   = {Betweenness Centrality as an Indicator of the Interdisciplinarity of Scientific Journals},
   journal = {Journal of the American Society for Information Science and Technology},
@@ -1511,6 +1584,7 @@
 }
 
 @article{leydesdorff_rafols2011indicators,
+  file = {docs/articles/leydesdorff_rafols2011indicators.pdf},
   author  = {Leydesdorff, Loet and Rafols, Ismael},
   title   = {Indicators of the Interdisciplinarity of Journals: Diversity, Centrality, and Citations},
   journal = {Journal of Informetrics},
@@ -1522,6 +1596,7 @@
 }
 
 @inproceedings{perezcruz2008,
+  file = {docs/articles/perezcruz2008.pdf},
   author    = {Fernando Pérez-Cruz},
   title     = {Kullback-Leibler Divergence Estimation of Continuous Distributions},
   booktitle = {2008 IEEE International Symposium on Information Theory},

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -825,7 +825,7 @@
 
 @article{delvenne2017,
   file = {docs/articles/delvenne2017.pdf},
-  author    = {Jean-Charles Delvenne and Renaud Lambiotte and Luis E. C. Rocha},
+  author    = {D. M. Mateos and L. Riveaud and P. W. Lamberti},
   title     = {Detecting Dynamical Changes in Time Series by Using the {Jensen--Shannon} Divergence},
   journal   = {Chaos},
   volume    = {27},
@@ -835,16 +835,16 @@
   doi       = {10.1063/1.4999613}
 }
 
-@article{li2021,
+@inproceedings{li2021,
   file = {docs/articles/li2021.pdf},
-  author    = {Suyu Li and Yizhou Sun and Aram Galstyan},
+  author    = {Bhavish Dinakar and Mayla R. Boguslav and Carsten G{\"o}rg and Deendayal Dinakarpandian},
   title     = {Semantic Changepoint Detection for Finding Potentially Novel Research Publications},
-  journal   = {Journal of Informetrics},
-  volume    = {15},
-  number    = {3},
-  pages     = {101177},
+  booktitle = {Biocomputing 2021: Proceedings of the Pacific Symposium},
+  volume    = {26},
+  pages     = {107--118},
   year      = {2021},
-  doi       = {10.1016/j.joi.2021.101177}
+  publisher = {World Scientific},
+  doi       = {10.1142/9789811232701_0011}
 }
 
 @article{bose2021,


### PR DESCRIPTION
Follow-up to #893 (the DOIfetch gap): fetches local fulltext for bib entries that had no PDF, via a two-stage open-access harvest, and fixes two mis-attributed entries the harvest surfaced. **No ticket — direct swarm run per request.**

## Method
1. **Deterministic pass** — Unpaywall → `curl` → validate, over the 73 DOI-bearing PDF-less entries. **17 validated OA PDFs** (arXiv, ACL Anthology, Nature-OA, Springer-OA, f1000research).
2. **92-agent swarm** on the residual (56 DOI-misses + 36 no-DOI). Each agent hunted legitimate OA across arXiv / HAL / Semantic Scholar / Europe PMC / venue repos / author pages, downloaded, and validated (PDF magic bytes + `pdfinfo` pages + first-page title check). **58 more fetched.**

Every file was **re-validated on disk here** (not trusting agent self-reports): magic bytes, page count, first-page title match.

## Result
- **75 `file=` fields added** → main.bib now links **147 / 181 entries** to on-disk fulltext (was 72). No new entries added by this PR.
- All 147 links resolve; brace balance verified; no duplicate keys.

## Rejected (quality gate)
- `dimaggio1983` — OA copy was a **Portuguese translation**, not the cited English ASR original.
- `bara2025aibibliometric` — fetched a **different paper** (title/author mismatch).

## Legitimate OA only
Sci-Hub / LibGen / paywalled reposts were refused. The **34 still-unlinked** entries are genuinely paywalled — copyrighted books (Kuhn, Callon, MacKenzie, North, Porter, Power, Merry…) and closed Elsevier/JSTOR articles. No legit OA exists for them.

## Two mis-attributed entries fixed (commit c56abba)
The swarm caught two entries pairing a correct title with wrong author/venue/DOI (likely LLM-fabricated earlier), by fetching the real paper and noticing the mismatch. Both **corrected in this PR** (canonical metadata verified against the fetched PDF + Crossref):
- **`delvenne2017`** — author was "Delvenne, Lambiotte, Rocha"; DOI `10.1063/1.4999613` (Chaos 27(8), 2017) is actually by **Mateos, Riveaud & Lamberti**. Author corrected.
- **`li2021`** — claimed "Suyu Li et al., *J. Informetrics*, doi `10.1016/j.joi.2021.101177`"; that DOI is an unrelated paper. The real work of this title is the **PSB 2021** proceedings paper by **Dinakar, Boguslav, Görg & Dinakarpandian** (Biocomputing 2021, 26:107–118, doi `10.1142/9789811232701_0011`). Retyped `@article`→`@inproceedings`, author/venue/DOI corrected. Matches the citing prose ("biomedical literature", `multilayer-detection.qmd:56`).

**Author-confirm flags** (non-blocking, kept to avoid manuscript churn): the citation *keys* `delvenne2017`/`li2021` are retained (cited in the .qmd; renaming would edit prose) even though they no longer name the first author, and the `li2021` `@article`→`@inproceedings` retype is a citation-type call. Flagging for your sign-off.

## Caveat
Two fabricated entries surfaced here (both among the ~cited-but-unfetched set). The 34 still-unlinked entries were **not** fulltext-validated, so more latent metadata errors may remain — worth a targeted audit.

Ticket: none