### PR TITLE
qa(0164): systematic main.bib DOI audit + fix 6 mis-attributed entries

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -9,7 +9,7 @@ v2.0.3 (prose-ratchet infra) and v2.0.4 (framing decisions) shipped. **Now: v2.0
 implementation** (tracker 0156) — the prose pass applying the decisions, then resubmission.
 
 ### Roadmap
-- **v2.0.5** (0156): base rebuild **0172 DONE** (VF translated + reimports + honest pre-2007 retreat in Appendix A.5; pre-2007 separation is NOT a corpus result — DEMOTE + scout NO-SIGNAL, reported as a negative result). **Next: content pass** → 0135/0137/0138/0139/0141 → conclusion **0171** (aggregate-birth landing + Star/Griesemer concede-then-displace) → title **0181** → prose 0134 → em-dash 0162. Parallel: bib 0143, letter 0152, audits 0161/0164. Resubmit 0153.
+- **v2.0.5** (0156): base rebuild **0172 DONE** (VF translated + reimports + honest pre-2007 retreat in Appendix A.5; pre-2007 separation is NOT a corpus result — DEMOTE + scout NO-SIGNAL, reported as a negative result). **Next: content pass** → 0135/0137/0138/0139/0141 → conclusion **0171** (aggregate-birth landing + Star/Griesemer concede-then-displace) → title **0181** → prose 0134 → em-dash 0162. Parallel: bib 0143, letter 0152, audit 0161. Resubmit 0153.
 - Parallel (not R&R): method paper **0026** — `multilayer-detection.qmd`.
 
 ## Status
@@ -36,4 +36,4 @@ Test failures: none (prose-ratchet 41 + 33 adherence). Blockers: none.
 
 - **Base rebuild complete (2026-07-08)** — 0172/0175 closed; content children unblocked. Start the **content pass**: 0135 economists · 0137 commensuration · 0138 loss&damage (R1.4) · 0139 finance-dev · 0141 concretize → **0171** conclusion → 0181 title → 0134 prose → 0162 em-dash → 0153 resubmit.
 - **Needs author (HITL):** 0143 — Escobar (2), Mitchell (2), Popp Berman imported to docs/articles/ + bib (#890); remaining author calls: which to cite where + replace-vs-complement Desrosières/Porter (0141), plus Golka/King-Levine/Aghion-Bolton; rest of the 0152 letter rows.
-- Base-independent, ready now: **0161** stats provenance · **0164** main.bib audit · **0166** lead-lag · **0185** loader arch-rule-9.
+- Base-independent, ready now: **0161** stats provenance · **0166** lead-lag · **0185** loader arch-rule-9.

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -542,7 +542,7 @@
   number    = {3},
   pages     = {282--292},
   year      = {2010},
-  doi       = {10.1016/j.shpsc.2010.08.002}
+  doi       = {10.1016/j.shpsb.2010.08.002}
 }
 
 @book{aykut_dahan2015,
@@ -721,7 +721,7 @@
   volume    = {3},
   pages     = {993--1022},
   year      = {2003},
-  doi       = {10.1162/jmlr.2003.3.4-5.993}
+  url       = {https://www.jmlr.org/papers/v3/blei03a.html}
 }
 
 @inproceedings{blei_lafferty2006,
@@ -768,7 +768,7 @@
 
 @article{puccetti2021,
   file = {docs/articles/puccetti2021.pdf},
-  author    = {Giovanni Puccetti and Christian Chiarcos and Roberto Navigli},
+  author    = {Diego Kozlowski and Jennifer Dusdal and Jun Pang and Andreas Zilian},
   title     = {Semantic and Relational Spaces in Science of Science: Deep Learning Models for Article Vectorisation},
   journal   = {Scientometrics},
   volume    = {128},
@@ -779,7 +779,7 @@
 
 @article{poetto2023,
   file = {docs/articles/poetto2023.pdf},
-  author    = {Matteo Poetto and Emilio Ferrara and Salvatore Malandrino},
+  author    = {Seyyed Reza Taher Harikandeh and Sadegh Aliakbary and Soroush Taheri},
   title     = {An Embedding Approach for Analyzing the Evolution of Research Topics with a Case Study on Computer Science Subdomains},
   journal   = {Scientometrics},
   volume    = {128},
@@ -943,7 +943,7 @@
 }
 
 @article{lealarcas2021,
-  author    = {Rafael Leal-Arcas and Filimoni Moretti and Mariam Noori Ali Al Ali and Antonio Cely Carvajal},
+  author    = {Luis H. Zamarioli and Pieter Pauw and Michael K\"onig and Hugues Chenet},
   title     = {The Climate Consistency Goal and the Transformation of Global Finance},
   journal   = {Nature Climate Change},
   volume    = {11},
@@ -975,7 +975,7 @@
 
 @article{simonet2022,
   file = {docs/articles/simonet2022.pdf},
-  author    = {Guillaume Simonet},
+  author    = {Machteld Catharina Simoens and Lea Fuenfschilling and Sina Leipold},
   title     = {Discursive Dynamics and Lock-Ins in Socio-Technical Systems: An Overview and a Way Forward},
   journal   = {Sustainability Science},
   year      = {2022},

--- a/scripts/qa_bib_doi.py
+++ b/scripts/qa_bib_doi.py
@@ -24,7 +24,6 @@ test (``tests/test_bib_doi_title.py``).
 """
 
 import csv
-import logging
 import os
 import re
 import sys
@@ -34,8 +33,9 @@ from difflib import SequenceMatcher
 
 import bibtexparser
 import requests
+from utils import get_logger
 
-log = logging.getLogger("qa_bib_doi")
+log = get_logger("qa_bib_doi")
 
 # Non-Crossref DOI registrars — Crossref's /works endpoint 404s on these by
 # design, so a 404 here is not evidence of a wrong identifier.
@@ -97,19 +97,28 @@ def first_author_surname(author_field):
     return _strip_accents(_delatex(surname).lower()).strip()
 
 
+PREFIX_MATCH_MIN_WORDS = 4  # a prefix only proves identity if it is substantial
+
+
 def title_ratio(bib_title, crossref_title):
     """Similarity of two titles, subtitle-truncation tolerant.
 
-    When one normalized title is a prefix of the other, Crossref has merely
-    dropped the subtitle — treat as a full match. Otherwise fall back to a
-    SequenceMatcher ratio.
+    When one normalized title is a prefix of the other *and* the shorter one is
+    at least ``PREFIX_MATCH_MIN_WORDS`` words, Crossref has merely dropped a
+    subtitle — treat as a full match. The word floor matters: a short generic
+    bib title ("Climate Policy") can be a prefix of an unrelated longer Crossref
+    title ("Climate Policy in the EU"), so accepting *any* prefix would let a
+    wrong DOI on a short title pass the hard WRONG_PAPER gate. Below the floor,
+    and for non-prefix pairs, fall back to a SequenceMatcher ratio.
     """
     a = normalize_title(bib_title)
     b = normalize_title(crossref_title)
     if not a or not b:
         return 0.0
     if a.startswith(b) or b.startswith(a):
-        return 1.0
+        shorter = a if len(a) <= len(b) else b
+        if len(shorter.split()) >= PREFIX_MATCH_MIN_WORDS:
+            return 1.0
     return SequenceMatcher(None, a, b).ratio()
 
 
@@ -237,7 +246,6 @@ def main(argv=None):
     parser.add_argument("--limit", type=int, default=None,
                         help="Cap entries checked (debugging)")
     args = parser.parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     rows = run_audit(args.input, delay=args.delay, limit=args.limit)
 

--- a/scripts/qa_bib_doi.py
+++ b/scripts/qa_bib_doi.py
@@ -1,0 +1,274 @@
+"""Audit main.bib DOIs against Crossref: resolution + title/author match.
+
+For every DOI-bearing entry in ``content/bibliography/main.bib`` this fetches
+``api.crossref.org/works/<doi>`` and compares the entry's title and first-author
+surname against the Crossref record. It catches the LLM-fabricated sub-class
+(valid DOI, wrong paper) that DOI resolution alone misses — the class that
+produced the ``delvenne2017`` / ``li2021`` / ``manne_richels1992`` errors.
+
+Non-Crossref registrars (arXiv, figshare, Zenodo, Dryad, DataCite books) return
+404 from the Crossref works endpoint by design; their prefixes are skipped so a
+legitimate arXiv DOI is not reported as a dead identifier.
+
+Verdicts per entry:
+  OK                  resolves, title and first-author both match
+  WRONG_PAPER         resolves (HTTP 200) but title similarity < threshold
+  AUTHOR_MISMATCH     title matches but first-author surname differs (advisory)
+  NOT_IN_CROSSREF     404 and prefix not a known non-Crossref registrar
+  SKIP_REGISTRAR      non-Crossref prefix (arXiv/figshare/Zenodo/…), not checked
+  NETWORK_ERROR       Crossref unreachable / timed out
+  NO_DOI              entry carries no DOI
+
+Run as a CLI to regenerate the report; import ``run_audit`` from the standing
+test (``tests/test_bib_doi_title.py``).
+"""
+
+import csv
+import logging
+import os
+import re
+import sys
+import time
+import unicodedata
+from difflib import SequenceMatcher
+
+import bibtexparser
+import requests
+
+log = logging.getLogger("qa_bib_doi")
+
+# Non-Crossref DOI registrars — Crossref's /works endpoint 404s on these by
+# design, so a 404 here is not evidence of a wrong identifier.
+NON_CROSSREF_PREFIXES = (
+    "10.48550",  # arXiv
+    "10.6084",   # figshare
+    "10.5281",   # Zenodo
+    "10.5061",   # Dryad
+    "10.17605",  # OSF
+)
+
+TITLE_THRESHOLD = 0.60  # SequenceMatcher ratio below which titles are "different"
+CROSSREF_WORKS = "https://api.crossref.org/works/"
+MAILTO = "minh.haduong@gmail.com"  # Crossref polite pool
+
+# Default bib path, relative to this file (scripts/ -> repo root -> content/…).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_BIB = os.path.join(_REPO_ROOT, "content", "bibliography", "main.bib")
+
+
+def _delatex(text):
+    r"""Collapse LaTeX accent macros so 'Barab{\'a}si' -> 'Barabasi'."""
+    # {\'a}, \'{a}, \'a  ->  a   (accent command + its letter)
+    text = re.sub(r"\\[`'^\"~=.]\{?(\w)\}?", r"\1", text)
+    return text.replace("{", "").replace("}", "").replace("\\", "")
+
+
+def _strip_accents(text):
+    """Fold accents so 'Büchner' compares equal to 'Buchner'."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    )
+
+
+def normalize_title(title):
+    """Lowercase, drop LaTeX/punctuation, collapse whitespace."""
+    if not title:
+        return ""
+    t = _strip_accents(_delatex(title).lower())
+    t = re.sub(r"[^a-z0-9 ]", " ", t)      # punctuation
+    t = re.sub(r"\s+", " ", t).strip()
+    return t
+
+
+def first_author_surname(author_field):
+    """Best-effort last name of the first author from a bibtex author string.
+
+    Handles 'Last, First and …' and 'First Last and …' orderings. Returns ''
+    for a braced corporate author ('{Nature Climate Change}') so the caller
+    skips the author check on entries with no personal first author.
+    """
+    if not author_field or author_field.lstrip().startswith("{"):
+        return ""
+    first = author_field.split(" and ")[0].strip()
+    if "," in first:                       # 'Buchner, Barbara'
+        surname = first.split(",")[0]
+    else:                                  # 'Barbara Buchner'
+        surname = first.split()[-1] if first.split() else ""
+    return _strip_accents(_delatex(surname).lower()).strip()
+
+
+def title_ratio(bib_title, crossref_title):
+    """Similarity of two titles, subtitle-truncation tolerant.
+
+    When one normalized title is a prefix of the other, Crossref has merely
+    dropped the subtitle — treat as a full match. Otherwise fall back to a
+    SequenceMatcher ratio.
+    """
+    a = normalize_title(bib_title)
+    b = normalize_title(crossref_title)
+    if not a or not b:
+        return 0.0
+    if a.startswith(b) or b.startswith(a):
+        return 1.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def is_non_crossref(doi):
+    return any(doi.startswith(p) for p in NON_CROSSREF_PREFIXES)
+
+
+def crossref_lookup(doi, session, timeout=15):
+    """Return (status, title, first_author_surname).
+
+    status in {'ok', 'not_found', 'error'}. On 'ok', title and surname come from
+    the Crossref record (surname may be '' when Crossref lists no authors).
+    """
+    url = CROSSREF_WORKS + requests.utils.quote(doi, safe="")
+    try:
+        resp = session.get(url, params={"mailto": MAILTO}, timeout=timeout)
+    except requests.RequestException:
+        return "error", "", ""
+    if resp.status_code == 404:
+        return "not_found", "", ""
+    if resp.status_code != 200:
+        return "error", "", ""
+    try:
+        msg = resp.json()["message"]
+    except (ValueError, KeyError):
+        return "error", "", ""
+    titles = msg.get("title") or [""]
+    cr_title = titles[0] if titles else ""
+    authors = msg.get("author") or []
+    cr_surname = ""
+    if authors:
+        fam = authors[0].get("family", "")
+        cr_surname = _strip_accents(fam.lower()).strip()
+    return "ok", cr_title, cr_surname
+
+
+def _verdict(entry, session, delay):
+    """Classify one bib entry. Returns a dict row."""
+    key = entry.get("ID", "")
+    doi = (entry.get("doi") or "").strip()
+    bib_title = entry.get("title", "")
+    bib_surname = first_author_surname(entry.get("author", ""))
+    row = {
+        "key": key,
+        "doi": doi,
+        "verdict": "",
+        "title_ratio": "",
+        "bib_title": bib_title,
+        "crossref_title": "",
+        "bib_author": bib_surname,
+        "crossref_author": "",
+    }
+    if not doi:
+        row["verdict"] = "NO_DOI"
+        return row
+    if is_non_crossref(doi):
+        row["verdict"] = "SKIP_REGISTRAR"
+        return row
+    time.sleep(delay)
+    status, cr_title, cr_surname = crossref_lookup(doi, session)
+    row["crossref_title"] = cr_title
+    row["crossref_author"] = cr_surname
+    if status == "error":
+        row["verdict"] = "NETWORK_ERROR"
+        return row
+    if status == "not_found":
+        row["verdict"] = "NOT_IN_CROSSREF"
+        return row
+    ratio = title_ratio(bib_title, cr_title)
+    row["title_ratio"] = f"{ratio:.2f}"
+    if ratio < TITLE_THRESHOLD:
+        row["verdict"] = "WRONG_PAPER"
+    elif cr_surname and bib_surname and cr_surname != bib_surname \
+            and bib_surname not in cr_surname and cr_surname not in bib_surname:
+        row["verdict"] = "AUTHOR_MISMATCH"
+    else:
+        row["verdict"] = "OK"
+    return row
+
+
+def run_audit(bib_path=DEFAULT_BIB, delay=0.2, limit=None):
+    """Audit every entry in ``bib_path``. Returns a list of verdict rows.
+
+    ``delay`` throttles Crossref calls; ``limit`` caps entries checked (testing).
+    """
+    with open(bib_path, encoding="utf-8") as fh:
+        db = bibtexparser.load(fh)
+    session = requests.Session()
+    session.headers["User-Agent"] = f"climate-finance-het bib-audit (mailto:{MAILTO})"
+    rows = []
+    entries = db.entries if limit is None else db.entries[:limit]
+    for entry in entries:
+        rows.append(_verdict(entry, session, delay))
+    return rows
+
+
+# Hard defects: a valid DOI pointing at the wrong paper, or a DOI Crossref
+# cannot resolve. These are mechanically decidable and gate the standing test.
+HARD_VERDICTS = {"WRONG_PAPER", "NOT_IN_CROSSREF"}
+# Advisory: first-author surname differs. Noisy (compound surnames, corporate
+# authors, name-order) — reported for human review, never auto-failing. The
+# ticket notes this sub-class "cannot be fully automated".
+ADVISORY_VERDICTS = {"AUTHOR_MISMATCH"}
+
+
+def suspects(rows):
+    """Rows with a hard, mechanically-decidable defect (wrong paper / dead DOI)."""
+    return [r for r in rows if r["verdict"] in HARD_VERDICTS]
+
+
+def advisories(rows):
+    """Rows with a soft author-name mismatch — review, don't gate on these."""
+    return [r for r in rows if r["verdict"] in ADVISORY_VERDICTS]
+
+
+def main(argv=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=DEFAULT_BIB, help="Path to main.bib")
+    parser.add_argument("--output", default=None,
+                        help="CSV report path (default: stdout summary only)")
+    parser.add_argument("--delay", type=float, default=0.2,
+                        help="Seconds between Crossref calls (politeness)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Cap entries checked (debugging)")
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    rows = run_audit(args.input, delay=args.delay, limit=args.limit)
+
+    if args.output:
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        with open(args.output, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+    counts = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    log.info("=== bib DOI audit ===")
+    for verdict, n in sorted(counts.items()):
+        log.info("  %-16s %d", verdict, n)
+    bad = suspects(rows)
+    if bad:
+        log.info("\n=== hard defects (wrong paper / dead DOI) ===")
+        for r in bad:
+            log.info("  [%s] %s  ratio=%s", r["verdict"], r["key"], r["title_ratio"])
+            log.info("      bib:      %s", r["bib_title"][:70])
+            log.info("      crossref: %s", r["crossref_title"][:70])
+    soft = advisories(rows)
+    if soft:
+        log.info("\n=== advisories (author-name mismatch — review manually) ===")
+        for r in soft:
+            log.info("  [%s] %s  bib=%s crossref=%s", r["verdict"], r["key"],
+                     r["bib_author"], r["crossref_author"])
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -54,6 +54,12 @@ def test_period_subtitle_truncation_is_a_match():
     assert title_ratio(bib, crossref) == 1.0
 
 
+def test_short_generic_prefix_is_not_a_full_match():
+    """A short bib title prefixing an unrelated longer one must not read as 1.0,
+    or a wrong DOI on a generic title would pass the hard WRONG_PAPER gate."""
+    assert title_ratio("Climate Policy", "Climate Policy in the EU") < 1.0
+
+
 def test_genuinely_different_titles_score_low():
     ratio = title_ratio("Buying Greenhouse Insurance",
                         "A comparison of aggregate energy demand models")

--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -1,0 +1,93 @@
+"""Guard the bib DOI↔title accuracy class (ticket 0164).
+
+Two layers:
+
+* Fast unit tests pin the matching logic — subtitle-truncation tolerance,
+  LaTeX-accent folding, corporate-author skipping — so the audit's false-positive
+  suppressions cannot silently regress. These run in ``make check-fast``.
+
+* One ``@slow`` test runs the live Crossref audit over the whole bib and asserts
+  that no DOI-bearing entry resolves to the wrong paper (or fails to resolve),
+  except the entries explicitly allowlisted below. It skips when Crossref is
+  unreachable so an offline ``make check`` still passes.
+
+The author-name sub-class is deliberately *advisory* (see ``qa_bib_doi``): first
+-author surname matching is too noisy (compound surnames, name order) to gate CI.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from qa_bib_doi import (
+    first_author_surname,
+    normalize_title,
+    run_audit,
+    suspects,
+    title_ratio,
+)
+
+# DOI-bearing entries whose Crossref title does NOT match — each a known
+# LLM-fabricated identifier awaiting an author judgment call, tracked by
+# ticket 0188 (article-vs-book, which co-published version, real Scientometrics
+# DOI). Shrinks to empty as 0188 lands; a new key here means a new defect.
+KNOWN_WRONG_PAPER = {
+    "manne_richels1992": "0188 — article (1991 DOI) vs 1992 MIT Press book, author call",
+    "atwoli_etal2022": "0188 — multi-journal editorial, pick the BMJ-version DOI",
+    "min2021measuring": "0188 — resolve the real Scientometrics DOI",
+}
+
+
+def test_subtitle_truncation_is_a_match():
+    """Crossref dropping a subtitle must not read as a wrong paper."""
+    bib = "Climate Finance Shadow Report 2023: Assessing the Delivery"
+    crossref = "Climate Finance Shadow Report 2023"
+    assert title_ratio(bib, crossref) == 1.0
+
+
+def test_period_subtitle_truncation_is_a_match():
+    bib = "Optimalite, equite et prix du carbone. A propos de Hotelling"
+    crossref = "Optimalite, equite et prix du carbone"
+    assert title_ratio(bib, crossref) == 1.0
+
+
+def test_genuinely_different_titles_score_low():
+    ratio = title_ratio("Buying Greenhouse Insurance",
+                        "A comparison of aggregate energy demand models")
+    assert ratio < 0.6
+
+
+def test_latex_accent_folds_in_surname():
+    assert first_author_surname(r"Barab{\'a}si, Albert-L{\'a}szl{\'o}") == "barabasi"
+
+
+def test_corporate_author_yields_no_surname():
+    """A braced organisation author has no personal surname to compare."""
+    assert first_author_surname("{Nature Climate Change}") == ""
+
+
+def test_normalize_title_strips_latex_and_case():
+    assert normalize_title("Latent {Dirichlet} Allocation") == "latent dirichlet allocation"
+
+
+@pytest.mark.slow
+def test_every_bib_doi_resolves_to_the_right_paper():
+    """Live Crossref audit: no entry's DOI points at the wrong paper.
+
+    Skips if Crossref is broadly unreachable (offline CI).
+    """
+    rows = run_audit(delay=0.1)
+    checked = [r for r in rows if r["verdict"] != "NO_DOI"
+               and r["verdict"] != "SKIP_REGISTRAR"]
+    errors = [r for r in checked if r["verdict"] == "NETWORK_ERROR"]
+    if not checked or len(errors) > 0.1 * len(checked):
+        pytest.skip(f"Crossref unreachable ({len(errors)}/{len(checked)} errored)")
+
+    offenders = {r["key"] for r in suspects(rows)} - set(KNOWN_WRONG_PAPER)
+    assert not offenders, (
+        "bib DOIs resolving to the wrong paper (not in the 0188 allowlist): "
+        f"{sorted(offenders)}"
+    )

--- a/tickets/0196-migrate-qa-scripts-to-shared-script-io-h.erg
+++ b/tickets/0196-migrate-qa-scripts-to-shared-script-io-h.erg
@@ -1,0 +1,59 @@
+%erg 0.1
+Title: Migrate qa_* scripts to shared script-io + harden bib-audit heuristics
+Created: 2026-07-08
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-08T20:33Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Surfaced by the /gaze review of PR #908 (ticket 0164). Two low-risk,
+non-blocking findings deferred so they don't scope-creep 0164:
+
+1. **script-io convention.** `.claude/rules/script-io.md` requires scripts that
+   produce a file to accept a required `--output` via the shared
+   `parse_io_args`/`validate_io` (`scripts/script_io_args.py`). The `qa_*` family
+   hand-rolls its own argparse instead: `qa_bib_doi.py` (new, #908),
+   `qa_bibliography.py`, `qa_citations.py`, `qa_missing_references.py`. This is a
+   pre-existing project-wide gap, not a #908 regression — the rule permits
+   migrate-on-touch, so batch it deliberately rather than one-off.
+
+2. **bib-audit heuristic edge cases** in `scripts/qa_bib_doi.py`:
+   - `AUTHOR_MISMATCH` uses substring containment (`bib not in cr and cr not in
+     bib`), so a short-surname swap ("li" vs "lin") is silently not flagged.
+     Advisory-only today (never gates CI), but worth tightening to token-equal.
+   - `title_ratio` prefix-match was hardened in #908 with a 4-word floor; revisit
+     whether a length-ratio guard is stronger than a raw word count.
+
+## Relevant files
+- `scripts/qa_bib_doi.py`, `scripts/qa_bibliography.py`,
+  `scripts/qa_citations.py`, `scripts/qa_missing_references.py`
+- `scripts/script_io_args.py` — the shared parser to adopt
+- `.claude/rules/script-io.md` — the convention
+
+## Actions
+1. Migrate each `qa_*` script to `parse_io_args`/`validate_io`; keep the
+   audit-summary log path working (an audit's product is the verdict, so decide
+   whether `--output` is genuinely required or the rule needs a QA carve-out —
+   raise with author if the latter).
+2. Tighten `AUTHOR_MISMATCH` to surname-token equality after accent/LaTeX fold.
+3. Add a unit test for the short-surname case.
+
+## Test
+- `tests/test_io_discipline.py::TestParseIoArgs` extended to assert each `qa_*`
+  script imports `parse_io_args` (red first).
+- Unit test: an author swap with a short surname is flagged.
+
+## Verification
+- [ ] Each `qa_*` script uses the shared I/O parser (or a documented carve-out).
+- [ ] Short-surname author swap is detected by the audit.
+- [ ] `make check-fast` passes.
+
+## Invariants
+- Do not change `qa_bib_doi.py`'s public `run_audit`/`suspects` API — the
+  standing test `tests/test_bib_doi_title.py` imports it.
+
+## Exit criteria
+- `qa_*` scripts consistent with script-io.md (or the rule amended); audit
+  heuristic edge cases closed with tests.

--- a/tickets/closed/0164-systematic-main-bib-accuracy-validation.erg
+++ b/tickets/closed/0164-systematic-main-bib-accuracy-validation.erg
@@ -2,10 +2,12 @@
 Title: Systematic main.bib accuracy validation (authors, correct-paper, DOI)
 Created: 2026-06-28
 Author: HDMX-coding-agent
+Closed: Systematic Crossref audit added (scripts/qa_bib_doi.py + standing test); 6 mechanical errors fixed; 3 HITL DOI retargets tracked by 0188
 
 --- log ---
 2026-06-28T22:31Z HDMX-coding-agent created
 
+2026-07-08T20:20Z HDMX-coding-agent closed — Systematic Crossref audit added (scripts/qa_bib_doi.py + standing test); 6 mechanical errors fixed; 3 HITL DOI retargets tracked by 0188
 --- body ---
 ## Context
 Three citation errors surfaced while preparing the Charles Gide paper, all in


### PR DESCRIPTION
## Summary

Systematic accuracy pass over `content/bibliography/main.bib` (ticket 0164). Adds a reusable Crossref audit (`scripts/qa_bib_doi.py`) and a standing test (`tests/test_bib_doi_title.py`), then fixes the 6 mechanical errors the audit found.

The audit fetches Crossref for every DOI-bearing entry and compares **title** (subtitle-truncation tolerant) and **first-author surname** (LaTeX-accent folded, corporate-author aware) — catching the LLM-fabricated sub-class (valid DOI, wrong paper/authors) that DOI resolution alone misses. Over 181 entries / 123 DOIs: **114 OK, 6 defects fixed, 3 deferred to 0188.**

## Fixes (source: Crossref)

**Fabricated author lists** (title + DOI correct, authors invented):
| key | was | now |
|-----|-----|-----|
| `puccetti2021` | Puccetti/Chiarcos/Navigli | Kozlowski, Dusdal, Pang, Zilian |
| `poetto2023` | Poetto/Ferrara/Malandrino | Taher Harikandeh, Aliakbary, Taheri |
| `lealarcas2021` | Leal-Arcas et al. | Zamarioli, Pauw, König, Chenet |
| `simonet2022` | Guillaume Simonet | Simoens, Fuenfschilling, Leipold |

**Dead / wrong DOIs:**
- `dahan2010` — `shpsc` → `shpsb` (`10.1016/j.shpsb.2010.08.002`; the `shpsc` DOI 404s, `shpsb` matches the entry's "Part B" journal and Crossref author Dahan).
- `blei2003` — dead DOI (redirects to Crossref `deleted_DOI`) dropped; JMLR's LDA has no DOI → `url = jmlr.org/papers/v3/blei03a.html`.

## Test

- **Fast unit tests** pin the matching logic (subtitle prefix match, LaTeX accents, corporate authors) — run in `check-fast`.
- **`@slow`** test runs the live audit and asserts no entry resolves to the wrong paper outside the allowlist. Skips when Crossref is unreachable (offline `make check` still passes).

## Invariants honoured

- Citation **keys unchanged** — `puccetti2021`/`poetto2023`/`blei2003` are cited in `multilayer-detection.qmd`; only fields fixed.
- No other bib entries altered. `make check-fast` passes (1071 passed).
- The three already-fixed entries (corfee-morlot2009, carty_lecomte2018, buchner2011/2013) remain clean in the audit.

## Deferred

Three `WRONG_PAPER` suspects — `manne_richels1992`, `atwoli_etal2022`, `min2021measuring` — need an author judgment call on DOI retargeting and are already tracked by **0188**. The test allowlists exactly these three and shrinks as 0188 lands.

**Ticket:** tickets/closed/0164-systematic-main-bib-accuracy-validation.erg
**Ticket-ref:** tickets/0188-fix-3-mis-attributed-bib-dois-found-by-c.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
**Ticket-ref:** tickets/0196-migrate-qa-scripts-to-shared-script-io-h.erg (deferred review items)
