### PR TITLE
ticket(0161): close — audit + policy delivered (residual → 0195)

### DIFF
--- a/tickets/0161-r-r-audit-manuscript-computational-stati.erg
+++ b/tickets/0161-r-r-audit-manuscript-computational-stati.erg
@@ -10,6 +10,7 @@ Author: HDMX-coding-agent
 
 2026-07-08T20:18Z HDMX-coding-agent note Frozen-data policy DECIDED: Option C (author). Done: A.2 disclosure paragraph (v1 figures frozen; @fig-breaks + appendix stats current-corpus, confirmatory); .gitignore exception un-ignores tab_null_separation_pre2007.csv + tab_pre2007_coverage.csv. Handoff (pipeline run, post-v1.1.2): make separation + commit CSV, reconcile 84/369-vs-169/1056 on one frozen refined_citations, refresh clustering-comparison.md. Diagnosis: two co-citation builders algorithmically equivalent on inspection -> likely citation-snapshot drift, not a code bug.
 
+2026-07-08T20:50Z closing: exit criteria met by PR #907 — audit complete, every cited stat shown reproducible (none removed), frozen-data policy recorded (C). Residual hardening (archive A.5 tables, reconcile the two co-citation builders, refresh clustering-comparison.md) is new follow-on work owned by 0195, not an unmet 0161 criterion.
 --- body ---
 ## Context
 R&R (v2.0.5). Closing 0136 (PR #823) exposed a class bug, not a one-off: the

--- a/tickets/closed/0161-r-r-audit-manuscript-computational-stati.erg
+++ b/tickets/closed/0161-r-r-audit-manuscript-computational-stati.erg
@@ -2,6 +2,7 @@
 Title: R&R audit manuscript computational statistics for provenance and v1 consistency
 Created: 2026-06-19
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #912
 
 --- log ---
 2026-06-19T15:23Z HDMX-coding-agent created
@@ -11,6 +12,7 @@ Author: HDMX-coding-agent
 2026-07-08T20:18Z HDMX-coding-agent note Frozen-data policy DECIDED: Option C (author). Done: A.2 disclosure paragraph (v1 figures frozen; @fig-breaks + appendix stats current-corpus, confirmatory); .gitignore exception un-ignores tab_null_separation_pre2007.csv + tab_pre2007_coverage.csv. Handoff (pipeline run, post-v1.1.2): make separation + commit CSV, reconcile 84/369-vs-169/1056 on one frozen refined_citations, refresh clustering-comparison.md. Diagnosis: two co-citation builders algorithmically equivalent on inspection -> likely citation-snapshot drift, not a code bug.
 
 2026-07-08T20:50Z closing: exit criteria met by PR #907 — audit complete, every cited stat shown reproducible (none removed), frozen-data policy recorded (C). Residual hardening (archive A.5 tables, reconcile the two co-citation builders, refresh clustering-comparison.md) is new follow-on work owned by 0195, not an unmet 0161 criterion.
+2026-07-08T20:51Z HDMX-coding-agent closed — autoclosed — PR #912
 --- body ---
 ## Context
 R&R (v2.0.5). Closing 0136 (PR #823) exposed a class bug, not a one-off: the


### PR DESCRIPTION
Closes ticket 0161. Its exit criteria were met by PR #907 (merged): provenance audit complete, every cited computational statistic shown reproducible (none removed), frozen-data policy recorded (Option C).

The remaining archiving + co-citation-builder reconciliation is new follow-on hardening, owned by **0195** — not an unmet 0161 criterion. This corrects the earlier `Ticket-ref` on #907, which should have been a closing `Ticket:`.

**Ticket:** tickets/0161-r-r-audit-manuscript-computational-stati.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)