### PR TITLE
tickets: close 0135 + 0141 (economists reframe done; concretize tracker complete)

### DIFF
--- a/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -15,10 +15,11 @@ Author: HDMX-coding-agent
 2026-07-08T13:23Z HDMX-coding-agent note Mitchell works added (both, verified on PDFs): mitchell2002 (Rule of Experts, UC Press, ISBN 0-520-23262-3) + mitchell1998 (Fixing the Economy, Cultural Studies 12(1):82-101, doi 10.1080/095023898335627); Timothy not Ian. All 4 Escobar/Mitchell works now in bib + docs/. Remaining: which to cite where, and replace-vs-complement Desrosieres/Porter at the DAC passage (0141).
 2026-07-08T13:28Z HDMX-coding-agent note poppberman2022 added (Thinking Like an Economist, Princeton UP 2022, ISBN 978-0-691-16738-1; verified from EPUB OPF metadata; epub in docs/). For the conclusion 0171 (Œconomia symposium link).
 2026-07-08T16:10Z R2.30 read-and-decide: read Mitchell 1998 (Fixing the Economy) + 2002 (Rule of Experts ch.7 The Object of Development). Decision: cite Mitchell 2002 at the DAC/Desrosieres passage (biased aid architectures) COMPLEMENTING Desrosieres/Porter; cite Mitchell 1998 in the intro for the object-construction lineage. Escobar NOT read yet -- deferred, author will read later before deciding. Prose landed in branch t0141-mitchell-refs.
+2026-07-08T21:35Z HDMX-coding-agent note 0135 disconnected from 0143 (2026-07-08): the Golka(2024) prose-integration route via 0135 is dropped; Golka stays a bib candidate under 0143's own scope, not tied to the economists-reframe ticket
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;
-integration into prose lives in the content tickets (0135/0139/0141). Validate
+integration into prose lives in the content tickets (0139/0141; 0135 disconnected 2026-07-08 — Golka not integrated there). Validate
 every entry (DOI/venue) before adding — do not fabricate metadata.
 
 ## Actions — add to bibliography/main.bib (verified)

--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -3,8 +3,6 @@ Title: v2.0.5 implementation — version tracker
 Created: 2026-06-18
 Author: HDMX-coding-agent
 Blocked-by: 0134
-Blocked-by: 0135
-Blocked-by: 0141
 Blocked-by: 0143
 Blocked-by: 0152
 Blocked-by: 0153
@@ -24,6 +22,8 @@ Blocked-by: 0171
 2026-07-08T16:02Z HDMX-coding-agent note blocker 0138 closed — Blocked-by removed.
 2026-07-08T20:10Z HDMX-coding-agent note blocker 0139 closed — Blocked-by removed.
 2026-07-08T20:11Z HDMX-coding-agent note blocker 0137 closed — Blocked-by removed.
+2026-07-08T21:33Z HDMX-coding-agent note blocker 0135 closed — Blocked-by removed.
+2026-07-08T21:33Z HDMX-coding-agent note blocker 0141 closed — Blocked-by removed.
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →

--- a/tickets/closed/0135-r-r-reframe-the-economists-claim-economi.erg
+++ b/tickets/closed/0135-r-r-reframe-the-economists-claim-economi.erg
@@ -2,7 +2,7 @@
 Title: R&R reframe the economists claim — economic rationality vs individual economists
 Created: 2026-06-18
 Author: HDMX-coding-agent
-Closed: Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) intentionally uncited per read-before-cite, remains a 0143 candidate
+Closed: Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) not pursued and disconnected from 0143 per author (read-before-cite)
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -11,7 +11,8 @@ Closed: Reframed to rationality-diffusion (L155-161) + econ-journal-absence addr
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
 2026-07-07T20:55Z HDMX-coding-agent note Vannes input appended to body (OECD GREEN-team continuity lead)
 2026-07-08T13:05Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
-2026-07-08T21:33Z HDMX-coding-agent closed — Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) intentionally uncited per read-before-cite, remains a 0143 candidate
+2026-07-08T21:33Z HDMX-coding-agent closed — Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) not pursued and disconnected from 0143 per author (read-before-cite)
+2026-07-08T21:40Z HDMX-coding-agent note action 4 (Golka via 0143) dropped: 0135 is disconnected from 0143 per author; no Golka citation added, no reverse dependency on the bibliography ticket.
 --- body ---
 ## Context
 Reviewer 1 §1 + editor E2. The paper attributes climate-finance construction to

--- a/tickets/closed/0135-r-r-reframe-the-economists-claim-economi.erg
+++ b/tickets/closed/0135-r-r-reframe-the-economists-claim-economi.erg
@@ -2,6 +2,7 @@
 Title: R&R reframe the economists claim — economic rationality vs individual economists
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) intentionally uncited per read-before-cite, remains a 0143 candidate
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
 2026-07-07T20:55Z HDMX-coding-agent note Vannes input appended to body (OECD GREEN-team continuity lead)
 2026-07-08T13:05Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
+2026-07-08T21:33Z HDMX-coding-agent closed — Reframed to rationality-diffusion (L155-161) + econ-journal-absence addressed (L254, AER/QJE/JEEM finding-not-artifact); Golka(2024) intentionally uncited per read-before-cite, remains a 0143 candidate
 --- body ---
 ## Context
 Reviewer 1 §1 + editor E2. The paper attributes climate-finance construction to

--- a/tickets/closed/0141-r-r-concretize-actors-sites-and-mechanis.erg
+++ b/tickets/closed/0141-r-r-concretize-actors-sites-and-mechanis.erg
@@ -2,6 +2,7 @@
 Title: R&R concretize actors sites and mechanisms across flagged passages
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: All children 0189-0194 closed; routed actions done (0135 closed, 0139 merged); integration re-read verified union on origin/main + full prose suite green; cover-letter traceability tracked in 0152
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -12,6 +13,7 @@ Author: HDMX-coding-agent
 2026-07-08T13:05Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 2026-07-08T16:10Z R2.30/object-construction: Mitchell 2002 cited at the development-economics DAC passage (line 96), Mitchell 1998 at the intro thesis (line 64). Selection rationale + Escobar-deferred note in 0143.
 2026-07-08T20:01Z HDMX-coding-agent note SPLIT into PR-sized children (0189-0194); this becomes a tracking ticket. Stays open until every child is closed. Two actions routed to existing siblings (0135, 0139) rather than duplicated.
+2026-07-08T21:33Z HDMX-coding-agent closed — All children 0189-0194 closed; routed actions done (0135 closed, 0139 merged); integration re-read verified union on origin/main + full prose suite green; cover-letter traceability tracked in 0152
 --- body ---
 ## Context
 Reviewer 2 (general + linear) + Reviewer 1 other comments: replace abstract /


### PR DESCRIPTION
## What

Closes **0135** (economists-claim reframe) and **0141** (concretize tracker), per author instruction.

### 0135 — closed
- ✅ rationality-diffusion reframing present (L155–161: "a mode of reasoning", "No single economist determined this architecture", "quantitative grammar"); the old "it was economists who built the instruments" claim is gone.
- ✅ econ-journal absence addressed as a *finding* (L254: under-representation of AER/QJE/JEEM records where the work was done).
- ⛔ Golka (2024) **not** cited and **disconnected from 0143** (author decision). Adding an unread citation to tick the box would violate read-before-cite; the 0135→0143 Golka route is dropped. 0143 updated to drop 0135 from its integration list.

### 0141 — tracker closed
All six children (0189–0194) closed+archived this session; routed actions done (0135 now closed, 0139 merged, aid-reporting via Mitchell #901 + 0192); integration re-read verified the merged union on origin/main with the full prose suite green. Cover-letter traceability rows live in 0152.

Both closed+archived; 0156 tracker's Blocked-by refs auto-removed by `erg close`. `erg check` PASS (191 tickets).

## Merge note
Tickets are already closed+archived in-branch — **merge with plain `gh pr merge --merge`** (not erg-pr-merge, which would try to re-close and bounce).

Ticket-ref: tickets/closed/0135-r-r-reframe-the-economists-claim-economi.erg
Ticket-ref: tickets/closed/0141-r-r-concretize-actors-sites-and-mechanis.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)