### PR TITLE
ticket(0143): close — bib entries done, remove usage-tracker coupling

### DIFF
--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -3,7 +3,6 @@ Title: v2.0.5 implementation — version tracker
 Created: 2026-06-18
 Author: HDMX-coding-agent
 Blocked-by: 0134
-Blocked-by: 0143
 Blocked-by: 0152
 Blocked-by: 0153
 Blocked-by: 0162
@@ -24,6 +23,7 @@ Blocked-by: 0171
 2026-07-08T20:11Z HDMX-coding-agent note blocker 0137 closed — Blocked-by removed.
 2026-07-08T21:33Z HDMX-coding-agent note blocker 0135 closed — Blocked-by removed.
 2026-07-08T21:33Z HDMX-coding-agent note blocker 0141 closed — Blocked-by removed.
+2026-07-09T08:45Z HDMX-coding-agent note blocker 0143 closed — Blocked-by removed.
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →

--- a/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
+++ b/tickets/0171-v2-0-5-conclusion-rebuild-land-on-the-bi.erg
@@ -48,7 +48,13 @@ this ticket).
 6. Migrate the « chantiers » to the book project (`docs/projet livre -
    pitch.md`), keeping at most one limits line.
 7. Anchor bibliographically: Popp Berman 2022, Desrosières, history of
-   monetary aggregates (entries via 0143).
+   monetary aggregates (entries via 0143). Candidate history-of-
+   quantification anchors verified and available in main.bib but not yet
+   cited: morgan2007, lepenies2016 (Power of a Single Number / GDP),
+   tooze2001 (Statistics and the German State). Inherited from 0143 on its
+   close (2026-07-09) — pick what serves the aggregate-birth landing;
+   uncited is CI-safe (the cited-works gate is cite⇒available, not
+   entry⇒cited), so no obligation to force all three.
 
 ## Test
 - `/review-pr-prose` brief auditor passes the new conclusion against

--- a/tickets/closed/0143-r-r-bibliography-additions-golka-escobar.erg
+++ b/tickets/closed/0143-r-r-bibliography-additions-golka-escobar.erg
@@ -2,6 +2,7 @@
 Title: R&R bibliography additions Golka Escobar Mitchell King-Levine Aghion-Bolton
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: bib entries all added + verified; prose integration owned by content tickets (0141, 0171), usage-tracking coupling removed per author decision
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -19,6 +20,7 @@ Author: HDMX-coding-agent
 2026-07-09T08:13Z HDMX-coding-agent note fetching DONE — all 12 verified entries confirmed on main (golka2024, king_levine1993, aghion_bolton1997, star2010, morgan2007, lepenies2016, tooze2001, escobar1995/1988, mitchell2002/1998, poppberman2022), landed via other bib PRs. The stale t143-bib-additions branch (commit ed3cd71) held nothing main lacked and was dropped (local + remote). Do NOT go hunting for unmerged bib work on a branch. Remaining = reading + writing only: Escobar read-later before cite decision; replace-vs-complement call at the DAC passage; prose integration (Mitchell refs landed t0141-mitchell-refs). Ticket stays open until each entry is used by a content ticket (exit criterion).
 2026-07-09T08:32Z HDMX-coding-agent note golka2024 integrated (R1.1): §165 already stated the "productive circularity" mechanism R1 pointed to; added the citation at that locus as a parallel case in sustainable/impact finance (Golka's object is private finance, so framed "comparable dynamic", not attribution to the ODA apparatus). Read in full first. Commit ac11a96.
 2026-07-09T08:32Z HDMX-coding-agent note escobar1988 integrated (R2.30, author decision this session): NOT a second apparatus-critique cite at §98 (Mitchell 2002 already there, would double); placed at §161 visibility passage where "Power and Visibility" carries a load Mitchell does not. Complement, not replace — Desrosières/Porter + Mitchell 2002 all kept at §98. Framed as attribution, not endorsement of Escobar's totalizing thesis. escobar1988 (article, read in full) chosen over escobar1995 (book). Commit 8f7636b. Remaining entries (star2010, morgan2007, lepenies2016, tooze2001, poppberman2022) owned by conclusion 0171; king_levine1993/aghion_bolton1997/mitchell already used.
+2026-07-09T08:45Z HDMX-coding-agent closed — bib entries all added + verified; prose integration owned by content tickets (0141, 0171), usage-tracking coupling removed per author decision
 --- body ---
 ## Context
 New references requested by the referees. QUICK to add as verified bib entries;
@@ -95,4 +97,15 @@ Scientization set (supports 0166 framing if kept):
 - `related-work-note-validate`-style DOI re-resolution on each new entry.
 
 ## Exit criteria
-- [ ] Each entry added with a resolving DOI/URL and used by at least one content ticket
+- [x] Each entry added with a resolving DOI/URL, metadata verified against the source
+
+Note (2026-07-09): the original second clause ("and used by at least one
+content ticket") is dropped as the close condition. 0143's job — add and verify
+the 12 entries — is done. Prose integration is owned by the content tickets that
+cite each entry, not tracked here (kept-open-as-usage-tracker is an anti-pattern;
+see harness memory feedback_followup_lets_parent_close). Standing at close:
+golka2024 §165 (#916), escobar1988 §161 (#916), mitchell2002/1998 + king_levine1993
++ aghion_bolton1997 already cited; star2010 + poppberman2022 owned by conclusion
+0171 (actions 4, 7); morgan2007 + lepenies2016 + tooze2001 inherited by 0171 as
+candidate history-of-quantification anchors. Uncited entries are CI-safe (the
+cited-works gate is cite⇒available, not entry⇒cited).


### PR DESCRIPTION
Closes ticket 0143 within the diff (file moved to `tickets/closed/` with a `Closed:` header + log line via `erg close`/`erg archive`).

## Why
0143's job — add and verify the 12 referee-requested bibliography entries — is done. Its original exit criterion also required each entry be "used by at least one content ticket", which kept 0143 open as a usage-tracker spanning several content tickets. That is the kept-open-as-pseudo-tracker anti-pattern. Author decision (2026-07-09): close now; each content ticket owns the prose it cites.

## Where each entry stands
- `golka2024` §165, `escobar1988` §161 — landed in #916
- `mitchell2002/1998`, `king_levine1993`, `aghion_bolton1997` — already cited
- `star2010`, `poppberman2022` — owned by conclusion **0171** (actions 4, 7)
- `morgan2007`, `lepenies2016`, `tooze2001` — history-of-quantification refs, **inherited by 0171** as candidate anchors (named there this PR so nothing is silently orphaned)

Uncited entries are CI-safe: `test_cited_works_available.py` gates cite⇒available, not entry⇒cited.

## Changed
- `0143` → closed + archived
- `0171` — action 7 extended to name the three inherited candidate anchors
- `0156` version tracker — `Blocked-by: 0143` removed by `erg close`

`erg check`: PASS (191 tickets).

Ticket-ref: tickets/closed/0143-r-r-bibliography-additions-golka-escobar.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)