### PR TITLE
bib: acquire Desrosières fulltext (EN 1998 + FR 1993), drop allowlist dodge

### DIFF
--- a/config/no-fulltext-allowlist.txt
+++ b/config/no-fulltext-allowlist.txt
@@ -14,7 +14,6 @@
 # --- copyrighted books, no legitimate open-access edition ---
 aykut_dahan2015
 callon1998
-desrosieres1998
 mackenzie2006
 merry2016
 north1990

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -14,7 +14,20 @@
   publisher = {Harvard University Press},
   year      = {1998},
   address   = {Cambridge, MA},
-  isbn      = {978-0674009691}
+  isbn      = {978-0674009691},
+  note      = {Translated by Camille Naish. Originally published as {\emph{La politique des grands nombres: Histoire de la raison statistique}}, Éditions La Découverte, Paris, 1993},
+  file      = {docs/articles/desrosieres1998.pdf}
+}
+
+@book{desrosieres1993,
+  author    = {Alain Desrosières},
+  title     = {La politique des grands nombres : histoire de la raison statistique},
+  publisher = {La Découverte},
+  year      = {1993},
+  address   = {Paris},
+  isbn      = {2-7071-2253-X},
+  note      = {Édition originale française ; traduite en anglais sous le titre {\emph{The Politics of Large Numbers}} (Harvard University Press, 1998)},
+  file      = {docs/articles/desrosieres1993.pdf}
 }
 
 @book{porter1995,


### PR DESCRIPTION
Closes the read-before-cite gap for `desrosieres1998` — cited three times in the manuscript (aid-statistics conventions §98, tradition anchor §111, statistical-convention thesis §163) but held only via a `config/no-fulltext-allowlist.txt` exception, the one book cited at thesis-level without a locally-held source.

## Changes
- **`content/bibliography/main.bib`**
  - `desrosieres1998`: add `file = {docs/articles/desrosieres1998.pdf}` (Harvard UP English translation, Camille Naish) + a `note` cross-referencing the French original.
  - `desrosieres1993`: **new** `@book` entry for the La Découverte first edition (ISBN 2-7071-2253-X). Metadata verified **on the copyright page** — Anna's Archive mislabelled the scan "2010", the book carries © 1993. Uncited but indexed at author request; CI-safe (gate is cite⇒available, not entry⇒cited).
- **`config/no-fulltext-allowlist.txt`**: remove `desrosieres1998` — the dodge is now false.

## Fulltext
Both editions in `docs/articles/` (gitignored, not committed): `desrosieres1998.pdf` (EN, 381 p.), `desrosieres1993.pdf` (FR first edition, 221 p.).

## Test
`test_cited_works_available.py`, `test_bib_doi_title.py`, `test_manuscript_prose.py` — 45 passed.

Groundwork for the conclusion rebuild (**0171**), whose action 7 anchors on Desrosières.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)