### PR TITLE
fix(0198): catch variable-path contract reads in rule-9 detector; migrate 3 offenders

### DIFF
--- a/scripts/export_citation_coverage.py
+++ b/scripts/export_citation_coverage.py
@@ -12,6 +12,7 @@ Usage:
 import os
 
 import pandas as pd
+from pipeline_loaders import load_refined_works
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
@@ -24,7 +25,6 @@ from utils import (
 
 log = get_logger("export_citation_coverage")
 
-REFINED_PATH = os.path.join(CATALOGS_DIR, "refined_works.csv")
 CITATIONS_PATH = os.path.join(CATALOGS_DIR, "citations.csv")
 OUTPUT_PATH = os.path.join(BASE_DIR, "content", "tables", "tab_citation_coverage.md")
 
@@ -33,8 +33,11 @@ _period_tuples, _period_labels = load_analysis_periods()
 PERIODS = [(label, start, end) for label, (start, end) in zip(_period_labels, _period_tuples)]
 
 
-def main(refined_path=REFINED_PATH, citations_path=CITATIONS_PATH):
-    refined = pd.read_csv(refined_path, low_memory=False)
+def main(refined_path=None, citations_path=CITATIONS_PATH):
+    if refined_path is not None:
+        refined = pd.read_csv(refined_path, low_memory=False)
+    else:
+        refined = load_refined_works()
     citations = pd.read_csv(citations_path, usecols=["source_doi"], low_memory=False)
 
     # Normalize DOIs for matching
@@ -85,6 +88,6 @@ if __name__ == "__main__":
     OUTPUT_PATH = io_args.output
     inputs = io_args.input or []
     main(
-        refined_path=inputs[0] if len(inputs) > 0 else REFINED_PATH,
+        refined_path=inputs[0] if len(inputs) > 0 else None,
         citations_path=inputs[1] if len(inputs) > 1 else CITATIONS_PATH,
     )

--- a/scripts/plot_fig45_pca_scatter.py
+++ b/scripts/plot_fig45_pca_scatter.py
@@ -24,13 +24,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from pipeline_loaders import load_refined_works
+from script_io_args import parse_io_args, validate_io
 from sklearn.decomposition import PCA
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.mixture import GaussianMixture
-from script_io_args import parse_io_args, validate_io
 from utils import (
-    BASE_DIR,
-    CATALOGS_DIR,
     get_logger,
     load_analysis_config,
     load_analysis_periods,
@@ -333,10 +332,7 @@ def main():
     out_dir = os.path.dirname(io_args.output)
     os.makedirs(out_dir or ".", exist_ok=True)
 
-    works_path = (
-        io_args.input[0] if io_args.input
-        else os.path.join(CATALOGS_DIR, "refined_works.csv")
-    )
+    works_path = io_args.input[0] if io_args.input else None
     emb_path = (
         io_args.input[1] if io_args.input and len(io_args.input) >= 2
         else None
@@ -354,7 +350,10 @@ def main():
     _year_min = _cfg["periodization"]["year_min"]
     _year_max = _cfg["periodization"]["year_max"]
 
-    works = pd.read_csv(works_path)
+    if works_path is not None:
+        works = pd.read_csv(works_path)
+    else:
+        works = load_refined_works()
     works["year"] = pd.to_numeric(works["year"], errors="coerce")
     has_title = works["title"].notna() & (works["title"].str.len() > 0)
     in_range = (works["year"] >= _year_min) & (works["year"] <= _year_max)

--- a/scripts/plot_heatmap_communities_clusters.py
+++ b/scripts/plot_heatmap_communities_clusters.py
@@ -24,12 +24,11 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from pipeline_loaders import load_refined_works
 from plot_style import DARK, DPI, MED, apply_style
 from scipy.sparse import lil_matrix
 from script_io_args import parse_io_args, validate_io
 from utils import (
-    BASE_DIR,
-    CATALOGS_DIR,
     get_logger,
     load_analysis_config,
     load_cluster_labels,
@@ -230,10 +229,7 @@ def _render_heatmap(heatmap_data, cluster_short, out_stem, pdf):
 
 def _resolve_inputs(input_list):
     """Resolve works, embeddings, and citations paths from --input."""
-    works_path = (
-        input_list[0] if input_list
-        else os.path.join(CATALOGS_DIR, "refined_works.csv")
-    )
+    works_path = input_list[0] if input_list else None
     emb_path = input_list[1] if input_list and len(input_list) >= 2 else None
     cit_path = input_list[2] if input_list and len(input_list) >= 3 else None
     return works_path, emb_path, cit_path
@@ -267,7 +263,10 @@ def main():
     log.info("=" * 70)
 
     log.info("--- Step 1: Load data and run KMeans ---")
-    works = pd.read_csv(works_path)
+    if works_path is not None:
+        works = pd.read_csv(works_path)
+    else:
+        works = load_refined_works()
     works["year"] = pd.to_numeric(works["year"], errors="coerce")
 
     _cfg = load_analysis_config()

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -400,3 +400,40 @@ class TestCorpusThroughLoaders:
                 f"'{name}' no longer reads contract files directly — "
                 f"remove it from KNOWN_VIOLATIONS"
             )
+
+    # -- Detector unit tests (0198): variable-path reads must be caught --------
+    # The same-line matcher missed `pd.read_csv(works_path)` where works_path
+    # defaults to the refined_works.csv literal a few lines up — a live
+    # violation that stayed green until a human caught it by eye (PR #876,
+    # ticket 0185). These fixtures pin the strengthened detector.
+
+    def test_detector_flags_variable_path_contract_read(self):
+        """A read via a variable bound to a contract literal (multi-line
+        ternary default) must be flagged — the 0185 blind spot."""
+        fixture = (
+            "works_path = (\n"
+            "    input_list[0] if input_list\n"
+            "    else os.path.join(CATALOGS_DIR, 'refined_works.csv')\n"
+            ")\n"
+            "works = pd.read_csv(works_path)\n"
+        )
+        assert TestCorpusThroughLoaders()._has_direct_contract_read(fixture)
+
+    def test_detector_flags_param_default_contract_read(self):
+        """A read via a parameter defaulting to a contract-bound constant is
+        caught (the export_citation_coverage.py pattern)."""
+        fixture = (
+            "REFINED_PATH = os.path.join(CATALOGS_DIR, 'refined_works.csv')\n"
+            "def main(refined_path=REFINED_PATH):\n"
+            "    refined = pd.read_csv(refined_path, low_memory=False)\n"
+        )
+        assert TestCorpusThroughLoaders()._has_direct_contract_read(fixture)
+
+    def test_detector_ignores_noncontract_variable_read(self):
+        """A read of a non-contract table via a variable must NOT be flagged —
+        guards against over-broad detection of legitimate content/tables reads."""
+        fixture = (
+            "table_path = os.path.join(TABLES_DIR, 'tab_venues.csv')\n"
+            "df = pd.read_csv(table_path)\n"
+        )
+        assert not TestCorpusThroughLoaders()._has_direct_contract_read(fixture)

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -350,17 +350,77 @@ class TestCorpusThroughLoaders:
         "plot_alluvial_html.py",
         "plot_fig_seed_axis.py",
         "plot_interactive_corpus.py",
+        # Surfaced by the strengthened variable-path detector (0198): each binds
+        # a path variable to a contract literal, then reads it — invisible to the
+        # old same-line matcher. Migration deferred to 0199 (needs a data-side
+        # figure/table byte-check that this checkout cannot run).
+        "analyze_unfccc_topics.py",
+        "compute_vars.py",
+        "export_corpus_table.py",
+        "plot_fig1_bars.py",
     }
 
     _CONTRACT_FILES = re.compile(r"refined_works|refined_citations|refined_embeddings")
+    # A *quoted* contract-file path literal — distinct from _CONTRACT_FILES so
+    # binding does not match loader function names (load_refined_citations) or
+    # argparse attribute reads (args.refined_works), only genuine path strings.
+    _CONTRACT_LITERAL = re.compile(
+        r"""["'][^"']*refined_(?:works|citations|embeddings)[^"']*\.(?:csv|npz|feather)["']"""
+    )
     _DIRECT_READ = re.compile(r"read_csv|read_feather|np\.load")
+    _READ_OF_VAR = re.compile(r"(?:read_csv|read_feather|np\.load)\(\s*([A-Za-z_]\w*)")
+    _ASSIGN = re.compile(r"^\s*([A-Za-z_]\w*)\s*=(?!=)")
+    _ALIAS = re.compile(r"([A-Za-z_]\w*)\s*=(?!=)\s*([A-Za-z_]\w*)\b")
+
+    def _contract_bound_vars(self, source):
+        """Names bound to a contract-file path within this source.
+
+        Catches three bindings the same-line matcher misses: a direct
+        assignment whose (possibly multi-line, parenthesised) statement names a
+        contract file, and — propagated to a fixpoint — plain aliases and
+        function parameter defaults (`def main(refined_path=REFINED_PATH)`).
+        """
+        lines = source.splitlines()
+        bound = set()
+        i = 0
+        while i < len(lines):
+            m = self._ASSIGN.match(lines[i])
+            if not m:
+                i += 1
+                continue
+            # Accumulate the logical statement by balancing parentheses so a
+            # multi-line ternary default (`x = (... else ".../refined_works.csv")`)
+            # is attributed to its target.
+            stmt = lines[i]
+            depth = stmt.count("(") - stmt.count(")")
+            j = i
+            while depth > 0 and j + 1 < len(lines):
+                j += 1
+                stmt += "\n" + lines[j]
+                depth += lines[j].count("(") - lines[j].count(")")
+            if self._CONTRACT_LITERAL.search(stmt):
+                bound.add(m.group(1))
+            i = j + 1
+        for _ in range(5):  # fixpoint over aliases / parameter defaults
+            added = False
+            for a in self._ALIAS.finditer(source):
+                lhs, rhs = a.group(1), a.group(2)
+                if rhs in bound and lhs not in bound:
+                    bound.add(lhs)
+                    added = True
+            if not added:
+                break
+        return bound
 
     def _has_direct_contract_read(self, source):
         """Return True if source reads a contract file without loaders.
 
-        Checks each non-comment line for both a direct-read call (read_csv,
-        np.load, read_feather) and a contract filename on the same line.
+        Flags a direct-read call (read_csv, np.load, read_feather) that names a
+        contract file on the same line, OR that reads a variable bound to a
+        contract-file path elsewhere in the source (the variable-path pattern
+        the same-line matcher missed — ticket 0198).
         """
+        bound = self._contract_bound_vars(source)
         for line in source.splitlines():
             stripped = line.strip()
             if stripped.startswith("#"):
@@ -368,6 +428,9 @@ class TestCorpusThroughLoaders:
             if "pipeline_loaders" in line:
                 continue
             if self._DIRECT_READ.search(line) and self._CONTRACT_FILES.search(line):
+                return True
+            rm = self._READ_OF_VAR.search(line)
+            if rm and rm.group(1) in bound:
                 return True
         return False
 

--- a/tickets/0199-migrate-4-variable-path-contract-read-of.erg
+++ b/tickets/0199-migrate-4-variable-path-contract-read-of.erg
@@ -1,0 +1,64 @@
+%erg 0.1
+Title: Migrate 4 variable-path contract-read offenders surfaced by 0198 detector
+Created: 2026-07-09
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-09T11:47Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Strengthening the rule-9 detector in 0198 (variable bound to a contract
+literal, then read via the variable — the same-line matcher's blind spot)
+surfaced four Phase-2 offenders the human post-0185 sweep missed. 0198 migrated
+its three named targets and seeded these four into
+`TestCorpusThroughLoaders.KNOWN_VIOLATIONS` (allowlisted, so `make check-fast`
+stays green). They need migration through `pipeline_loaders`, each with a
+figure/table byte-check that the 0198 checkout could not run (no data).
+
+## The four offenders
+- `scripts/analyze_unfccc_topics.py:138,145` — `citations_path = os.path.join(
+  CATALOGS_DIR, "refined_citations.csv")` then `pd.read_csv(citations_path,
+  usecols=[...])`. Migrate to `load_refined_citations()` (mind the `usecols`).
+- `scripts/export_corpus_table.py:88,89` — `path = os.path.join(CATALOGS_DIR,
+  "refined_works.csv")` then `pd.read_csv(path)`. Trivial — mirror 0198's
+  export_citation_coverage.py migration.
+- `scripts/compute_vars.py:144,148,371,377` — a contract-bound `path` read at
+  144→148, plus `pd.read_csv(REFINED_CITATIONS_PATH)` at 371 and a refined read
+  at 377. The `_read_csv(filename, directory=TABLES_DIR)` helper (120–126) is
+  shared with legitimate content/tables reads — disentangle contract vs table
+  reads; only route the contract ones through loaders.
+- `scripts/plot_fig1_bars.py:51,55,62` — `csv_path = io_args.input[0] if
+  io_args.input else os.path.join(CATALOGS_DIR, "refined_works.csv")` then
+  `pd.read_csv(csv_path, usecols=..., dtype={"year": "Int64"})`. NOT a clean
+  drop-in: `load_refined_works()` returns all columns and coerces `year` to
+  float, dropping the `usecols`/`Int64` optimisation — verify the bars figure
+  byte-identically or justify the dtype change.
+
+## Relevant files
+- `tests/test_arch_compliance.py` — remove each entry from `KNOWN_VIOLATIONS`
+  as it is migrated (the not-stale guard forces this).
+- `scripts/pipeline_loaders.py` — `load_refined_works()` / `load_refined_citations()`.
+
+## Actions
+1. Migrate each offender to the loader, mirroring 0198's conditional pattern
+   (explicit `--input` path → direct read; default `None` → loader).
+2. Remove each from `KNOWN_VIOLATIONS` in the same commit.
+3. Byte-check each regenerated figure/table on a data-provisioned checkout
+   (`make figures` / the relevant target), or justify the diff analytically.
+
+## Test
+- `tests/test_arch_compliance.py::TestCorpusThroughLoaders` already covers the
+  detector; migration is green when each script drops off KNOWN_VIOLATIONS and
+  `test_known_violations_not_stale` still passes for the remainder.
+
+## Verification
+- [ ] The four offenders read contracts through `pipeline_loaders`.
+- [ ] Each output byte-identical or diff justified.
+- [ ] `KNOWN_VIOLATIONS` no longer lists the four; `make check-fast` green.
+
+## Invariants
+- Do not weaken the detector. Migrations preserve figure/table bytes.
+
+## Exit criteria
+- All four offenders migrated; `make check-fast` green.

--- a/tickets/0202-harden-rule-9-detector-against-over-match.erg
+++ b/tickets/0202-harden-rule-9-detector-against-over-match.erg
@@ -1,0 +1,69 @@
+%erg 0.1
+Title: Harden rule-9 variable-path detector against over-match false positives
+Created: 2026-07-09
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-09T12:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Ticket 0198 (PR #927) strengthened the rule-9 detector
+(`tests/test_arch_compliance.py::TestCorpusThroughLoaders._contract_bound_vars`)
+to catch variable-path contract reads — fixing the *under*-matching blind spot
+that let a live violation ship green (0185). Two independent /gaze reviewers then
+reproduced three *over*-matching false positives in the new whole-source alias
+fixpoint. All are **dormant** today (green CI proves no current script triggers
+them) and all fail in the safe direction — a future false positive is a loud CI
+failure a developer sees immediately, never a silent wrong-ship. They are
+out of 0198's scope (under-match fix), hence this follow-up.
+
+The defect class: `_contract_bound_vars` has no lexical awareness of comments,
+strings, reassignment, or call-vs-binding context.
+
+1. **Taint never decays on reassignment.** A name added to `bound` is never
+   removed. Reproduced fixture:
+   ```
+   path = os.path.join(CATALOGS_DIR, 'refined_works.csv')
+   df1 = pd.read_csv(path)
+   path = os.path.join(TABLES_DIR, 'tab_venues.csv')   # reused name, different file
+   df2 = pd.read_csv(path)                              # falsely flagged
+   ```
+2. **Alias pass scans comments.** `_ALIAS.finditer` runs over raw `source`; the
+   main read scan skips `#`-lines but the alias pass does not, so a commented
+   `# legacy = works_path` taints `legacy`.
+3. **Alias pass fires on keyword arguments.** `_ALIAS`'s `ident=ident` pattern
+   matches call-site kwargs (`helper(low_memory=works_path)`), spuriously binding
+   the kwarg name.
+
+## Relevant files
+- `tests/test_arch_compliance.py` — `_contract_bound_vars`, `_ALIAS`, `_ASSIGN`
+
+## Actions
+1. Strip `#`-comments before the alias/assignment passes (reuse the main scan's
+   comment filter).
+2. Anchor `_ALIAS` to statement-start (an assignment / def-default), not any
+   `ident=ident` anywhere on a line, so call-site kwargs don't bind.
+3. Decide the reassignment-decay question: either drop taint on a later
+   non-contract assignment to the same name, or accept it and document why
+   (a per-function scope reset may be simpler than flow-sensitive decay).
+
+## Test
+- First: add three fixtures pinning the intended NON-detection (each of the
+  three cases above must return False), confirming they fail red against the
+  current fixpoint. Then harden to green.
+
+## Verification
+- [ ] Reassignment fixture: non-contract read after name reuse → NOT flagged
+- [ ] Comment fixture: aliased-in-comment name → NOT flagged
+- [ ] Kwarg fixture: kwarg name matching a bound name → NOT flagged
+- [ ] The three real 0198 offenders + the 4 in KNOWN_VIOLATIONS still flagged
+      (no under-match regression); `make check-fast` green
+
+## Invariants
+- Must not reintroduce the 0185/0198 under-match blind spot: every currently
+  caught variable-path read stays caught.
+
+## Exit criteria
+- The three over-match false positives are fixed with pinning fixtures, no
+  under-match regression, `make check-fast` green.

--- a/tickets/closed/0198-strengthen-rule-9-detector-to-catch-vari.erg
+++ b/tickets/closed/0198-strengthen-rule-9-detector-to-catch-vari.erg
@@ -2,10 +2,12 @@
 Title: Strengthen rule-9 detector to catch variable-path contract reads + migrate 3 offenders
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #927
 
 --- log ---
 2026-07-09T09:52Z HDMX-coding-agent created
 
+2026-07-09T12:32Z HDMX-coding-agent closed — autoclosed — PR #927
 --- body ---
 ## Context
 Ticket 0185 migrated `plot_fig_traditions.py::_load_data()` off a direct


### PR DESCRIPTION
## Summary
Closes the rule-9 detector blind spot from ticket 0185: `pd.read_csv(works_path)`
where `works_path` defaults to the `refined_works.csv` literal a few lines up was
invisible to the same-line matcher, so a live violation shipped green until a human
caught it by eye (PR #876).

**Detector** — `_has_direct_contract_read` now also flags a read whose argument is a
variable bound to a *quoted* contract-file literal elsewhere in the source: direct
assignment, multi-line ternary default, or parameter default
(`def main(refined_path=REFINED_PATH)`) propagated to a fixpoint. Binding uses a new
quoted-literal regex distinct from the loose substring regex (kept for the
backward-compatible same-line branch), so it does **not** match loader function
names (`load_refined_citations`) or argparse attribute reads (`args.refined_works`).
The argparse-default→dest→read chain (`build_het_core`) is a distinct pattern beyond
a regex detector's principled reach and is correctly left un-flagged.

**Migrations** (the 3 named offenders) → `load_refined_works()`, mirroring 0185
(explicit `--input` → direct read; default `None` → loader):
`plot_heatmap_communities_clusters.py`, `plot_fig45_pca_scatter.py`,
`export_citation_coverage.py`.

## Byte-equivalence
Justified analytically (no data on the CI checkout): the default path routes the
same `refined_works.csv` through the loader; the only added transforms are
`year` coercion (already applied identically downstream in all three) and
`cited_by_count` numeric-fill (each script self-coerces it or never uses it).
A data-side `make figures` byte-check remains the author's final gate, as in 0185.

## Scope note
The strengthened detector surfaced **four further offenders** the human sweep missed
(`analyze_unfccc_topics`, `compute_vars`, `export_corpus_table`, `plot_fig1_bars`).
Seeded into `KNOWN_VIOLATIONS` (allowlisted, `make check-fast` green) and split to
0199 — each needs a data-side byte-check (`plot_fig1_bars` in particular is not a
clean drop-in: its `usecols`/`dtype={"year":"Int64"}` optimisation changes under the
loader).

## Tests
Three fixture unit tests pin the detector (variable-path caught, param-default
caught, non-contract table read NOT flagged). `make check-fast` green: 1088 passed.

**Ticket:** tickets/0198-strengthen-rule-9-detector-to-catch-vari.erg
Related follow-up: tickets/0199-migrate-4-variable-path-contract-read-of.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)