### PR TITLE
fix(0188): correct 3 mis-attributed bib DOIs, unallowlist the audit gate

### DIFF
--- a/content/_includes/zoo/G3_coupling_age.md
+++ b/content/_includes/zoo/G3_coupling_age.md
@@ -40,4 +40,4 @@ for all citations made by papers published in year $t$.
 ### References
 
 Seminal: @kessler1963bibliographic (Kessler 1963, "Bibliographic coupling between scientific papers").
-Recent analogue: @min2021measuring (Min et al. 2021, "Measuring knowledge accumulation in science").
+Recent analogue: @min2021measuring (Min et al. 2021, "Predicting scientific breakthroughs based on knowledge structure variations").

--- a/content/bibliography/main.bib
+++ b/content/bibliography/main.bib
@@ -205,16 +205,13 @@
   doi       = {10.1162/rest.91.1.1}
 }
 
-@article{manne_richels1992,
+@book{manne_richels1992,
   file = {docs/articles/manne_richels1992.pdf},
   author    = {Alan S. Manne and Richard G. Richels},
-  title     = {Buying Greenhouse Insurance},
-  journal   = {Energy Policy},
-  volume    = {20},
-  number    = {6},
-  pages     = {498--552},
-  year      = {1992},
-  doi       = {10.1016/0301-4215(92)90024-V}
+  title     = {Buying Greenhouse Insurance: The Economic Costs of {CO$_2$} Emission Limits},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  year      = {1992}
 }
 
 @book{hourcade2015,
@@ -751,10 +748,10 @@
   author    = {Lukoye Atwoli and Abdullah H. Baqui and Thomas Benfield and Raffaella Bosurgi and Fiona Godlee and Stephen Hancocks and Richard Horton and Laurie Laybourn-Langton and Carlos Augusto Monteiro and Ian Norman and Kirsten Patrick and Nigel Praities and Marcel G. M. Olde Rikkert and Eric J. Rubin and Peush Sahni and Richard Smith and Nick Talley and Sue Turale and Damián Vázquez},
   title     = {Call for Emergency Action to Limit Global Temperature Increases, Restore Biodiversity, and Protect Health},
   journal   = {The BMJ},
-  volume    = {376},
-  pages     = {o851},
-  year      = {2022},
-  doi       = {10.1136/bmj.o851}
+  volume    = {374},
+  pages     = {n1734},
+  year      = {2021},
+  doi       = {10.1136/bmj.n1734}
 }
 
 % -- Topic models --
@@ -1544,12 +1541,12 @@
 
 @article{min2021measuring,
   author  = {Min, Chao and Bu, Yi and Sun, Jianjun},
-  title   = {Measuring Knowledge Accumulation in Science: The Role of Intellectual Debts},
-  journal = {Scientometrics},
+  title   = {Predicting Scientific Breakthroughs Based on Knowledge Structure Variations},
+  journal = {Technological Forecasting and Social Change},
   year    = {2021},
-  volume  = {126},
-  pages   = {7535--7550},
-  doi     = {10.1007/s11192-021-04068-w}
+  volume  = {164},
+  pages   = {120502},
+  doi     = {10.1016/j.techfore.2020.120502}
 }
 
 @article{murdock2017exploration,

--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -31,14 +31,11 @@ from qa_bib_doi import (
 )
 
 # DOI-bearing entries whose Crossref title does NOT match — each a known
-# LLM-fabricated identifier awaiting an author judgment call, tracked by
-# ticket 0188 (article-vs-book, which co-published version, real Scientometrics
-# DOI). Shrinks to empty as 0188 lands; a new key here means a new defect.
-KNOWN_WRONG_PAPER = {
-    "manne_richels1992": "0188 — article (1991 DOI) vs 1992 MIT Press book, author call",
-    "atwoli_etal2022": "0188 — multi-journal editorial, pick the BMJ-version DOI",
-    "min2021measuring": "0188 — resolve the real Scientometrics DOI",
-}
+# LLM-fabricated identifier awaiting an author judgment call. Empty since 0188
+# resolved the last three (manne → 1992 MIT Press book, no DOI; atwoli → BMJ
+# 10.1136/bmj.n1734; min → real 2021 techfore DOI). A new key here means a new
+# defect; the gate below is now unallowlisted.
+KNOWN_WRONG_PAPER: dict[str, str] = {}
 
 
 def test_subtitle_truncation_is_a_match():

--- a/tickets/closed/0188-fix-3-mis-attributed-bib-dois-found-by-c.erg
+++ b/tickets/closed/0188-fix-3-mis-attributed-bib-dois-found-by-c.erg
@@ -2,10 +2,13 @@
 Title: Fix 3 mis-attributed bib DOIs found by Crossref audit
 Created: 2026-07-08
 Author: HDMX-coding-agent
+Closed: 3 mis-attributed DOIs fixed; standing DOI-title audit now unallowlisted
 
 --- log ---
 2026-07-08T16:17Z HDMX-coding-agent created
 
+2026-07-09T12:00Z author decision (AskUserQuestion): manne_richels1992 -> MIT Press 1992 book (@book, no DOI); min2021measuring -> replace with real Min/Bu/Sun 2021 techfore paper 10.1016/j.techfore.2020.120502; atwoli -> BMJ 10.1136/bmj.n1734 (n2177 is a news item about the editorial, not the editorial)
+2026-07-09T12:00Z HDMX-coding-agent closed — 3 mis-attributed DOIs fixed; standing DOI-title audit now unallowlisted
 --- body ---
 ## Context
 A DOI↔title audit of `content/bibliography/main.bib` against Crossref (run


### PR DESCRIPTION
## What

Fixes the three `content/bibliography/main.bib` entries flagged by the #899 Crossref DOI↔title audit as LLM-fabricated identifiers. Each required an author judgment call; decisions taken this session via AskUserQuestion.

| Entry | Before | After | Rationale |
|-------|--------|-------|-----------|
| `manne_richels1992` | `@article` Energy Policy, DOI `(92)90024-V` (→ unrelated energy-demand paper) | `@book` MIT Press 1992, no DOI | Cited as an integrated model (Global 2100); matches the `_1992` key |
| `atwoli_etal2022` | `10.1136/bmj.o851` (→ 2022 Covid NHS news item) | `10.1136/bmj.n1734` (BMJ 2021;374) | Real BMJ version of the multi-journal editorial; `n2177` is a *news story about* it |
| `min2021measuring` | "Measuring Knowledge Accumulation…", DOI `…04068-w` (→ "Letters to the editor in exercise science") | "Predicting Scientific Breakthroughs Based on Knowledge Structure Variations", `10.1016/j.techfore.2020.120502` | Titled paper does not exist (Crossref/OpenAlex/Scientometrics); replaced with the real Min/Bu/Sun 2021 paper. Citekey unchanged; G3 include prose updated |

## Verification
- Live Crossref audit (`qa_bib_doi.run_audit`): manne → NO_DOI (book, skipped), atwoli → OK, min → OK; **zero title-mismatch suspects** across the whole bib.
- `KNOWN_WRONG_PAPER` allowlist emptied — the `@slow` gate now runs unallowlisted.
- `make check-fast`: 1085 passed, 21 skipped.
- `tests/test_bib_doi_title.py`: 8 passed (incl. the live `@slow` audit).

**Ticket:** tickets/closed/0188-fix-3-mis-attributed-bib-dois-found-by-c.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)