### PR TITLE
qa(0196): migrate qa_* to shared script-io + tighten AUTHOR_MISMATCH

### DIFF
--- a/.agent/guidelines/coding-guidelines.md
+++ b/.agent/guidelines/coding-guidelines.md
@@ -138,7 +138,7 @@ When adding a new enrichment script: put incremental state in `enrich_cache/<nam
 uv run python scripts/enrich_citations_batch.py                  # Crossref → enrich_cache/crossref_refs.csv
 uv run python scripts/enrich_citations_openalex.py               # OpenAlex → enrich_cache/openalex_refs.csv
 uv run python scripts/corpus_merge_citations.py                         # Concat caches → citations.csv (the DVC output)
-uv run python scripts/qa_citations.py                            # Verify citation quality (n=300, accuracy + completeness)
+uv run python scripts/qa_citations.py --output content/tables/qa_citations_report.json  # Verify citation quality (n=300, accuracy + completeness)
 # Or simply: make citations  (runs all four; Crossref + OpenAlex in parallel)
 
 # Figures — alluvial pipeline (split into focused scripts as of #73)

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ deploy-corpus:
 # ── Corpus diagnostics (Phase 1 — reads enrichment caches) ──
 content/tables/qa_citations_report.json: scripts/qa_citations.py scripts/utils.py \
 		$(DATA_DIR)/citations.csv
-	$(PYTHON) $<
+	$(PYTHON) $< --output $@
 
 # ═══════════════════════════════════════════════════════════
 # PHASE 2 — Analysis & Figures (fast, deterministic, run often)

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -234,7 +234,7 @@ stages:
 
   # Phase 1b.4: Citation QC — verify against Crossref ground truth
   qa_citations:
-    cmd: uv run --env-file .env python scripts/qa_citations.py --works-input data/catalogs/enriched_works.csv
+    cmd: uv run --env-file .env python scripts/qa_citations.py --output content/tables/qa_citations_report.json --works-input data/catalogs/enriched_works.csv
     deps:
       - scripts/qa_citations.py
       - scripts/utils.py

--- a/scripts/qa_bib_doi.py
+++ b/scripts/qa_bib_doi.py
@@ -23,6 +23,7 @@ Run as a CLI to regenerate the report; import ``run_audit`` from the standing
 test (``tests/test_bib_doi_title.py``).
 """
 
+import argparse
 import csv
 import os
 import re
@@ -33,6 +34,7 @@ from difflib import SequenceMatcher
 
 import bibtexparser
 import requests
+from script_io_args import parse_io_args, validate_io
 from utils import get_logger
 
 log = get_logger("qa_bib_doi")
@@ -80,6 +82,11 @@ def normalize_title(title):
     return t
 
 
+def _fold_surname(surname):
+    """Normalize a surname for comparison: LaTeX macros + accents + case folded."""
+    return _strip_accents(_delatex(surname).lower()).strip()
+
+
 def first_author_surname(author_field):
     """Best-effort last name of the first author from a bibtex author string.
 
@@ -94,7 +101,21 @@ def first_author_surname(author_field):
         surname = first.split(",")[0]
     else:                                  # 'Barbara Buchner'
         surname = first.split()[-1] if first.split() else ""
-    return _strip_accents(_delatex(surname).lower()).strip()
+    return _fold_surname(surname)
+
+
+def author_mismatch(bib_surname, cr_surname):
+    """True when both surnames are present and differ after accent/LaTeX fold.
+
+    Surname-token *equality*, not the old substring containment: "li" and "lin"
+    are different authors and must be flagged, where ``bib not in cr`` let a
+    short surname slip inside a longer one unreported (ticket 0196). Folding is
+    idempotent, so callers may pass already-folded or raw surnames. Advisory
+    only — AUTHOR_MISMATCH never gates CI.
+    """
+    if not bib_surname or not cr_surname:
+        return False
+    return _fold_surname(bib_surname) != _fold_surname(cr_surname)
 
 
 PREFIX_MATCH_MIN_WORDS = 4  # a prefix only proves identity if it is substantial
@@ -191,8 +212,7 @@ def _verdict(entry, session, delay):
     row["title_ratio"] = f"{ratio:.2f}"
     if ratio < TITLE_THRESHOLD:
         row["verdict"] = "WRONG_PAPER"
-    elif cr_surname and bib_surname and cr_surname != bib_surname \
-            and bib_surname not in cr_surname and cr_surname not in bib_surname:
+    elif author_mismatch(bib_surname, cr_surname):
         row["verdict"] = "AUTHOR_MISMATCH"
     else:
         row["verdict"] = "OK"
@@ -235,26 +255,22 @@ def advisories(rows):
 
 
 def main(argv=None):
-    import argparse
-
+    io_args, extra = parse_io_args(argv)
+    validate_io(output=io_args.output)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", default=DEFAULT_BIB, help="Path to main.bib")
-    parser.add_argument("--output", default=None,
-                        help="CSV report path (default: stdout summary only)")
     parser.add_argument("--delay", type=float, default=0.2,
                         help="Seconds between Crossref calls (politeness)")
     parser.add_argument("--limit", type=int, default=None,
                         help="Cap entries checked (debugging)")
-    args = parser.parse_args(argv)
+    args = parser.parse_args(extra)
 
-    rows = run_audit(args.input, delay=args.delay, limit=args.limit)
+    bib_path = io_args.input[0] if io_args.input else DEFAULT_BIB
+    rows = run_audit(bib_path, delay=args.delay, limit=args.limit)
 
-    if args.output:
-        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
-        with open(args.output, "w", newline="", encoding="utf-8") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
-            writer.writeheader()
-            writer.writerows(rows)
+    with open(io_args.output, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
 
     counts = {}
     for r in rows:

--- a/scripts/qa_bib_doi.py
+++ b/scripts/qa_bib_doi.py
@@ -107,15 +107,24 @@ def first_author_surname(author_field):
 def author_mismatch(bib_surname, cr_surname):
     """True when both surnames are present and differ after accent/LaTeX fold.
 
-    Surname-token *equality*, not the old substring containment: "li" and "lin"
+    Surname-token equality, not the old substring containment: "li" and "lin"
     are different authors and must be flagged, where ``bib not in cr`` let a
-    short surname slip inside a longer one unreported (ticket 0196). Folding is
-    idempotent, so callers may pass already-folded or raw surnames. Advisory
-    only — AUTHOR_MISMATCH never gates CI.
+    short surname slip inside a longer one unreported (ticket 0196).
+
+    Compared on the shorter trailing token run so a dropped particle is not a
+    mismatch: ``first_author_surname`` yields only the last token of a
+    "First Last" bib name ("Jan van der Berg" -> "berg") while Crossref keeps
+    the particle ("van der Berg" -> "van der berg"); the tails ["berg"] match.
+    A genuine short-surname swap still differs on its trailing token
+    (["li"] != ["lin"]). Folding is idempotent, so callers may pass folded or
+    raw surnames. Advisory only — AUTHOR_MISMATCH never gates CI.
     """
-    if not bib_surname or not cr_surname:
+    bib = _fold_surname(bib_surname).split()
+    cr = _fold_surname(cr_surname).split()
+    if not bib or not cr:
         return False
-    return _fold_surname(bib_surname) != _fold_surname(cr_surname)
+    n = min(len(bib), len(cr))
+    return bib[-n:] != cr[-n:]
 
 
 PREFIX_MATCH_MIN_WORDS = 4  # a prefix only proves identity if it is substantial

--- a/scripts/qa_bibliography.py
+++ b/scripts/qa_bibliography.py
@@ -4,9 +4,12 @@ Matches the 47 entries in bibliography/main.bib against
 refined_works.csv by DOI (exact) then by title+year (fuzzy).
 
 Produces:
-- tables/bib_corpus_match.csv: per-entry match results
+- --output CSV (e.g. content/tables/bib_corpus_match.csv): per-entry match results
 - Console summary: DOI matches, fuzzy matches, unmatched keys
 - Reverse check: highly-cited corpus papers by bib authors not in bib
+
+Run with:
+  uv run python scripts/qa_bibliography.py --output content/tables/bib_corpus_match.csv
 """
 
 import os

--- a/scripts/qa_bibliography.py
+++ b/scripts/qa_bibliography.py
@@ -9,24 +9,20 @@ Produces:
 - Reverse check: highly-cited corpus papers by bib authors not in bib
 """
 
-import argparse
 import os
 import re
 
 import bibtexparser
 import pandas as pd
 from rapidfuzz import fuzz
+from script_io_args import parse_io_args, validate_io
 from utils import BASE_DIR, CATALOGS_DIR, get_logger, normalize_doi
 
 log = get_logger("qa_bibliography")
 
 # --- Paths ---
-TABLES_DIR = os.path.join(BASE_DIR, "content", "tables")
-os.makedirs(TABLES_DIR, exist_ok=True)
-
 BIB_PATH = os.path.join(BASE_DIR, "bibliography", "main.bib")
 CORPUS_PATH = os.path.join(CATALOGS_DIR, "refined_works.csv")
-OUTPUT_PATH = os.path.join(TABLES_DIR, "bib_corpus_match.csv")
 
 FUZZY_THRESHOLD = 85
 
@@ -248,6 +244,9 @@ def reverse_check(bib_entries, corpus, cited_threshold=500):
 
 
 def main():
+    io_args, _ = parse_io_args()
+    validate_io(output=io_args.output)
+
     log.info("=" * 70)
     log.info("Bibliography-Corpus Verification")
     log.info("=" * 70)
@@ -266,8 +265,8 @@ def main():
 
     # Save
     df = pd.DataFrame(results)
-    df.to_csv(OUTPUT_PATH, index=False, encoding="utf-8")
-    log.info("Saved %d rows to %s", len(df), OUTPUT_PATH)
+    df.to_csv(io_args.output, index=False, encoding="utf-8")
+    log.info("Saved %d rows to %s", len(df), io_args.output)
 
     # Summary
     doi_matches = [r for r in results if r["match_type"] == "doi"]
@@ -319,6 +318,4 @@ def main():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args()
     main()

--- a/scripts/qa_citations.py
+++ b/scripts/qa_citations.py
@@ -9,11 +9,11 @@ Test A (accuracy): sample citation rows, verify each (source_doi, ref_doi) pair
 Test B (completeness): sample source DOIs, re-fetch from Crossref, check all
     their ref DOIs are in our data. Reports proportion captured with 95% Wilson CI.
 
-Saves results to content/tables/qa_citations_report.json
+Saves the JSON report to the caller-supplied --output path.
 
 Usage:
-    uv run python scripts/qa_citations.py [--sample-n 300] [--seed 42]
-        [--works-input data/catalogs/enriched_works.csv]
+    uv run python scripts/qa_citations.py --output content/tables/qa_citations_report.json
+        [--sample-n 300] [--seed 42] [--works-input data/catalogs/enriched_works.csv]
 """
 
 import argparse

--- a/scripts/qa_citations.py
+++ b/scripts/qa_citations.py
@@ -24,14 +24,12 @@ import time
 import numpy as np
 import pandas as pd
 import requests
+from script_io_args import parse_io_args, validate_io
 from utils import CATALOGS_DIR, MAILTO, get_logger, normalize_doi
 
 log = get_logger("qa_citations")
 
 HEADERS = {"User-Agent": f"ClimateFinancePipeline/1.0 (mailto:{MAILTO})"}
-OUTPUT_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "content", "tables", "qa_citations_report.json"
-)
 CROSSREF_DELAY = 0.15  # seconds between API calls (polite rate limiting)
 
 
@@ -254,6 +252,8 @@ def test_completeness(
 
 
 def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
     parser = argparse.ArgumentParser(
         description="Citation QA: verify accuracy and completeness against Crossref"
     )
@@ -264,7 +264,7 @@ def main():
     parser.add_argument("--works-input",
                         default=os.path.join(CATALOGS_DIR, "enriched_works.csv"),
                         help="Works CSV to read DOIs from (default: enriched_works.csv)")
-    args = parser.parse_args()
+    args = parser.parse_args(extra)
 
     rng = np.random.default_rng(args.seed)
 
@@ -310,10 +310,9 @@ def main():
         "completeness": completeness,
     }
 
-    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
-    with open(OUTPUT_PATH, "w") as f:
+    with open(io_args.output, "w") as f:
         json.dump(report, f, indent=2)
-    log.info("Report saved to: %s", OUTPUT_PATH)
+    log.info("Report saved to: %s", io_args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/qa_missing_references.py
+++ b/scripts/qa_missing_references.py
@@ -15,7 +15,7 @@ Output format mirrors the doifetch input convention:
   #	<Label>
 
 Run with:
-  uv run python scripts/qa_missing_references.py
+  uv run python scripts/qa_missing_references.py --output docs/missing_references.txt
 """
 
 import os

--- a/scripts/qa_missing_references.py
+++ b/scripts/qa_missing_references.py
@@ -18,11 +18,11 @@ Run with:
   uv run python scripts/qa_missing_references.py
 """
 
-import argparse
 import os
 import re
 
 import bibtexparser
+from script_io_args import parse_io_args, validate_io
 from utils import get_logger
 
 log = get_logger("qa_missing_references")
@@ -33,7 +33,6 @@ log = get_logger("qa_missing_references")
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BIB_PATH = os.path.join(BASE_DIR, "content", "bibliography", "main.bib")
 ARTICLES_DIR = os.path.join(BASE_DIR, "docs", "articles")
-OUTPUT_PATH = os.path.join(BASE_DIR, "docs", "missing_references.txt")
 
 # ---------------------------------------------------------------------------
 # Hard-coded ISBNs for books that lack a DOI in the .bib file.
@@ -196,6 +195,9 @@ def _format_output_lines(doi_lines, url_lines, isbn_lines, no_id_lines):
 
 
 def main() -> None:
+    io_args, _ = parse_io_args()
+    validate_io(output=io_args.output)
+
     # Parse bibliography
     with open(BIB_PATH, encoding="utf-8") as f:
         bib_db = bibtexparser.load(f)
@@ -226,20 +228,17 @@ def main() -> None:
 
     lines = _format_output_lines(doi_lines, url_lines, isbn_lines, no_id_lines)
 
-    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
-    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+    with open(io_args.output, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
     sections = [("DOI", doi_lines), ("URL", url_lines),
                 ("ISBN", isbn_lines), ("no identifier", no_id_lines)]
     n_missing = sum(len(s) for _, s in sections)
-    log.info("Written %d missing entries to %s", n_missing, OUTPUT_PATH)
+    log.info("Written %d missing entries to %s", n_missing, io_args.output)
     for label, section in sections:
         if section:
             log.info("  %d with %s", len(section), label)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args()
     main()

--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -101,6 +101,18 @@ def test_missing_surname_is_not_a_mismatch():
     assert not author_mismatch("smith", "")
 
 
+def test_dropped_particle_is_not_a_mismatch():
+    """'First Last' bib order keeps only the trailing token ('berg'); Crossref
+    keeps the particle ('van der berg'). The shared tail matches — no false flag
+    (ticket 0196 gaze finding: don't turn the tightening into particle noise)."""
+    assert not author_mismatch("berg", "van der berg")
+    assert not author_mismatch("van der berg", "berg")
+
+
+def test_genuinely_different_surnames_are_flagged():
+    assert author_mismatch("smith", "jones")
+
+
 @pytest.mark.slow
 def test_every_bib_doi_resolves_to_the_right_paper():
     """Live Crossref audit: no entry's DOI points at the wrong paper.

--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -23,6 +23,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from qa_bib_doi import (
+    author_mismatch,
     first_author_surname,
     normalize_title,
     run_audit,
@@ -77,6 +78,27 @@ def test_corporate_author_yields_no_surname():
 
 def test_normalize_title_strips_latex_and_case():
     assert normalize_title("Latent {Dirichlet} Allocation") == "latent dirichlet allocation"
+
+
+def test_short_surname_swap_is_flagged():
+    """'li' vs 'lin' are different authors — the old substring test hid this
+    (ticket 0196: surname-token equality, not containment)."""
+    assert author_mismatch("li", "lin")
+
+
+def test_identical_surnames_not_flagged():
+    assert not author_mismatch("buchner", "buchner")
+
+
+def test_latex_accent_surnames_fold_equal():
+    """Accent/LaTeX-only differences are not an author mismatch."""
+    assert not author_mismatch(r"Barab{\'a}si", "barabasi")
+
+
+def test_missing_surname_is_not_a_mismatch():
+    """A corporate author (no surname) or an authorless Crossref record: skip."""
+    assert not author_mismatch("", "smith")
+    assert not author_mismatch("smith", "")
 
 
 @pytest.mark.slow

--- a/tests/test_corpus_acceptance.py
+++ b/tests/test_corpus_acceptance.py
@@ -801,7 +801,8 @@ class TestCitationQuality:
             import warnings
             warnings.warn(
                 f"qa_citations_report.json not found at {QC_CITATIONS_REPORT_PATH}. "
-                "Run: uv run python scripts/qa_citations.py to generate it."
+                "Run: uv run python scripts/qa_citations.py "
+                "--output content/tables/qa_citations_report.json to generate it."
             )
             pytest.skip("qa_citations_report.json not found (needs live API calls)")
 
@@ -821,7 +822,8 @@ class TestCitationQuality:
             import warnings
             warnings.warn(
                 f"qa_citations_report.json is {age_days:.0f} days old. "
-                "Consider re-running: uv run python scripts/qa_citations.py"
+                "Consider re-running: uv run python scripts/qa_citations.py "
+                "--output content/tables/qa_citations_report.json"
             )
 
         # Check DOI count matches current corpus
@@ -845,7 +847,8 @@ class TestCitationQuality:
         assert "verification" in report, \
             "Report missing 'verification' section" + _diagnosis(
                 "qa_citations.py report format changed",
-                "Re-run: uv run python scripts/qa_citations.py",
+                "Re-run: uv run python scripts/qa_citations.py "
+                "--output content/tables/qa_citations_report.json",
                 "~3 min",
                 "Cannot verify citation link quality",
             )
@@ -853,7 +856,8 @@ class TestCitationQuality:
         assert "sample_n" in data, \
             "verification missing sample_n" + _diagnosis(
                 "qa_citations.py report incomplete",
-                "Re-run: uv run python scripts/qa_citations.py",
+                "Re-run: uv run python scripts/qa_citations.py "
+                "--output content/tables/qa_citations_report.json",
                 "~3 min",
                 "Cannot assess sample size",
             )

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -138,6 +138,64 @@ class TestMigratedScripts:
         assert result.returncode != 0
         assert "output" in result.stderr.lower()
 
+    def test_qa_bib_doi_requires_output(self):
+        """qa_bib_doi.py rejects invocation without --output (ticket 0196)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_bib_doi.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
+    def test_qa_bibliography_requires_output(self):
+        """qa_bibliography.py rejects invocation without --output (ticket 0196)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_bibliography.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
+    def test_qa_citations_requires_output(self):
+        """qa_citations.py rejects invocation without --output (ticket 0196)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_citations.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
+    def test_qa_missing_references_requires_output(self):
+        """qa_missing_references.py rejects invocation without --output (ticket 0196)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_missing_references.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
+
+class TestQaScriptsUseSharedIo:
+    """qa_* audit scripts adopt the shared parse_io_args parser (ticket 0196).
+
+    Source inspection (not subprocess) per coding-python: cheap, no import cost.
+    """
+
+    QA_SCRIPTS = [
+        "qa_bib_doi.py",
+        "qa_bibliography.py",
+        "qa_citations.py",
+        "qa_missing_references.py",
+    ]
+
+    @pytest.mark.parametrize("script", QA_SCRIPTS)
+    def test_imports_parse_io_args(self, script):
+        with open(os.path.join(SCRIPTS_DIR, script)) as f:
+            source = f.read()
+        assert "parse_io_args" in source, (
+            f"{script} must import parse_io_args from script_io_args"
+        )
+
 
 class TestComputeBreakpointsOneOutput:
     """compute_breakpoints.py writes exactly one file to --output (#594)."""

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1055,7 +1055,8 @@ class TestOutputFlag:
     # Scripts with __main__ that legitimately don't need --output:
     OUTPUT_EXEMPT = {
         # QA reporters (stdout / fixed JSON)
-        "qa_citations.py",
+        # qa_citations.py, qa_bibliography.py, qa_missing_references.py migrated
+        # to parse_io_args with required --output (ticket 0196) — no longer exempt.
         "qa_detect_language.py",
         "qa_detect_type.py",
         "qa_embeddings.py",
@@ -1093,8 +1094,6 @@ class TestOutputFlag:
         "build_smoke_fixture.py",
         "compute_regression_hashes.py",
         "compute_regression_history.py",
-        "qa_bibliography.py",
-        "qa_missing_references.py",
         "analyze_unfccc_topics.py",
         # Analysis-only reporters (stdout, no output file)
         "analyze_zscore_vs_pvalue.py",

--- a/tickets/closed/0196-migrate-qa-scripts-to-shared-script-io-h.erg
+++ b/tickets/closed/0196-migrate-qa-scripts-to-shared-script-io-h.erg
@@ -2,10 +2,12 @@
 Title: Migrate qa_* scripts to shared script-io + harden bib-audit heuristics
 Created: 2026-07-08
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #929
 
 --- log ---
 2026-07-08T20:33Z HDMX-coding-agent created
 
+2026-07-09T12:24Z HDMX-coding-agent closed — autoclosed — PR #929
 --- body ---
 ## Context
 Surfaced by the /gaze review of PR #908 (ticket 0164). Two low-risk,


### PR DESCRIPTION
**Ticket:** tickets/0196-migrate-qa-scripts-to-shared-script-io-h.erg

Two low-risk findings deferred from the #908 /gaze review of ticket 0164.

## 1. script-io migration
The four `qa_*` audit scripts hand-rolled argparse and wrote to a hardcoded
`OUTPUT_PATH` (or an optional `--output` for `qa_bib_doi`). All four now use the
shared `parse_io_args`/`validate_io` with a **required `--output`**.

**Author decision (2026-07-09): `--output` required everywhere — no QA carve-out
in `script-io.md`.** Even though an audit's product is a verdict, the file it
emits is a real artifact and the uniform rule is simpler to hold. `qa_citations`
is in the DVC repro chain, so its `dvc.yaml` stage and the `Makefile` target now
pass `--output` explicitly.

## 2. AUTHOR_MISMATCH heuristic
The old test used substring containment (`bib not in cr and cr not in bib`), so a
short-surname swap (`"li"` inside `"lin"`) was silently unflagged. Extracted
`author_mismatch()` and tightened to surname-token equality after accent/LaTeX
fold. Advisory-only — `AUTHOR_MISMATCH` never gates CI.

## Tests (red first)
- `test_io_discipline.py`: each `qa_*` rejects missing `--output` (integration) and
  imports `parse_io_args` (source inspection).
- `test_bib_doi_title.py`: `author_mismatch` flags the short-surname swap, folds
  accents/LaTeX, skips missing surnames.

## Invariant preserved
`run_audit`/`suspects` public API unchanged (standing `test_bib_doi_title.py` import).

## Gate
`make check-fast`: 1094 passed, 21 skipped, exit 0 (ruff adherence included).
4 new `qa_*` integration tests pass separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)