### PR TITLE
qa(0203): migrate qa_metadata + qa_embeddings to shared script-io

### DIFF
--- a/scripts/qa_embeddings.py
+++ b/scripts/qa_embeddings.py
@@ -7,10 +7,11 @@ nearest-neighbour spot-check for human inspection.
 
 No API calls — all computation is local (numpy/scipy on refined_embeddings.npz).
 
-Saves results to content/tables/qa_embeddings_report.json
+Saves the JSON report to the caller-supplied --output path.
 
 Usage:
-    uv run python scripts/qa_embeddings.py [--n-pairs 200] [--n-neighbours 5] [--seed 42]
+    uv run python scripts/qa_embeddings.py --output content/tables/qa_embeddings_report.json
+        [--n-pairs 200] [--n-neighbours 5] [--seed 42]
 """
 
 import argparse
@@ -20,6 +21,7 @@ import os
 import numpy as np
 import pandas as pd
 from scipy import stats
+from script_io_args import parse_io_args, validate_io
 from utils import (
     CATALOGS_DIR,
     REFINED_EMBEDDINGS_PATH,
@@ -30,9 +32,6 @@ from utils import (
 log = get_logger("qa_embeddings")
 
 CLUSTERS_PATH = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
-OUTPUT_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "content", "tables", "qa_embeddings_report.json"
-)
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +305,8 @@ def find_nearest_neighbours(
 # ---------------------------------------------------------------------------
 
 def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--n-pairs", type=int, default=200,
                         help="Number of pairs to sample for within/between test (default: 200)")
@@ -313,7 +314,7 @@ def main():
                         help="Number of nearest neighbours per landmark (default: 5)")
     parser.add_argument("--seed", type=int, default=42,
                         help="Random seed for reproducibility (default: 42)")
-    args = parser.parse_args()
+    args = parser.parse_args(extra)
 
     rng = np.random.default_rng(args.seed)
 
@@ -343,10 +344,9 @@ def main():
         },
     }
 
-    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
-    with open(OUTPUT_PATH, "w") as f:
+    with open(io_args.output, "w") as f:
         json.dump(report, f, indent=2)
-    log.info("Report saved to %s", OUTPUT_PATH)
+    log.info("Report saved to %s", io_args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/qa_metadata.py
+++ b/scripts/qa_metadata.py
@@ -12,10 +12,11 @@ Checks:
 
 Reports proportions with 95% Wilson confidence intervals.
 
-Saves results to content/tables/qa_metadata_report.json
+Saves the JSON report to the caller-supplied --output path.
 
 Usage:
-    uv run python scripts/qa_metadata.py [--sample-n 100] [--seed 42]
+    uv run python scripts/qa_metadata.py --output content/tables/qa_metadata_report.json
+        [--sample-n 100] [--seed 42]
 """
 
 import argparse
@@ -30,14 +31,12 @@ import numpy as np
 import pandas as pd
 import requests
 from scipy.stats import binomtest
+from script_io_args import parse_io_args, validate_io
 from utils import CATALOGS_DIR, MAILTO, get_logger, normalize_doi
 
 log = get_logger("qa_metadata")
 
 HEADERS = {"User-Agent": f"ClimateFinancePipeline/1.0 (mailto:{MAILTO})"}
-OUTPUT_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "content", "tables", "qa_metadata_report.json"
-)
 
 CROSSREF_DELAY = 0.15  # seconds between Crossref API calls
 DOI_RESOLVE_TIMEOUT = 15  # seconds for DOI resolution HEAD request
@@ -372,6 +371,8 @@ def _valid_doi(s):
 
 
 def main():
+    io_args, extra = parse_io_args()
+    validate_io(output=io_args.output)
     parser = argparse.ArgumentParser(
         description="QA metadata: spot-check titles/years against Crossref"
     )
@@ -389,7 +390,7 @@ def main():
         default=os.path.join(CATALOGS_DIR, "refined_works.csv"),
         help="Works CSV (default: refined_works.csv)"
     )
-    args = parser.parse_args()
+    args = parser.parse_args(extra)
 
     # ── Load data ─────────────────────────────────────────────────────────────
     if not os.path.isfile(args.works_input):
@@ -426,10 +427,9 @@ def main():
                           doi_counters, doi_details,
                           no_doi_counters, no_doi_details)
 
-    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
-    with open(OUTPUT_PATH, "w") as f:
+    with open(io_args.output, "w") as f:
         json.dump(report, f, indent=2)
-    log.info("Report saved to: %s", OUTPUT_PATH)
+    log.info("Report saved to: %s", io_args.output)
 
     log_mismatches(doi_details)
 

--- a/tests/test_corpus_acceptance.py
+++ b/tests/test_corpus_acceptance.py
@@ -1066,7 +1066,8 @@ class TestEmbeddingQuality:
         if not os.path.isfile(QA_REPORT_PATH):
             pytest.skip(
                 "qa_embeddings_report.json not found — "
-                "run: uv run python scripts/qa_embeddings.py"
+                "run: uv run python scripts/qa_embeddings.py "
+                "--output content/tables/qa_embeddings_report.json"
             )
         with open(QA_REPORT_PATH) as f:
             return json.load(f)
@@ -1076,14 +1077,16 @@ class TestEmbeddingQuality:
         assert "within_vs_between" in report, \
             "Missing 'within_vs_between' section in QA report" + _diagnosis(
                 "qa_embeddings.py produced incomplete output",
-                "uv run python scripts/qa_embeddings.py",
+                "uv run python scripts/qa_embeddings.py "
+                "--output content/tables/qa_embeddings_report.json",
                 "< 1 min",
                 "Cannot verify embedding semantic validity",
             )
         assert "nearest_neighbours" in report, \
             "Missing 'nearest_neighbours' section in QA report" + _diagnosis(
                 "qa_embeddings.py produced incomplete output",
-                "uv run python scripts/qa_embeddings.py",
+                "uv run python scripts/qa_embeddings.py "
+                "--output content/tables/qa_embeddings_report.json",
                 "< 1 min",
                 "Cannot inspect nearest-neighbour quality",
             )
@@ -1099,7 +1102,8 @@ class TestEmbeddingQuality:
         assert not missing, \
             f"Missing keys in within_vs_between: {missing}" + _diagnosis(
                 "qa_embeddings.py output schema changed",
-                "uv run python scripts/qa_embeddings.py",
+                "uv run python scripts/qa_embeddings.py "
+                "--output content/tables/qa_embeddings_report.json",
                 "< 1 min",
                 "Downstream consumers expect these fields",
             )
@@ -1152,7 +1156,8 @@ class TestMetadataQuality:
             import warnings
             warnings.warn(
                 f"qa_metadata_report.json not found at {QA_METADATA_REPORT_PATH}. "
-                "Run: uv run python scripts/qa_metadata.py to generate it."
+                "Run: uv run python scripts/qa_metadata.py "
+                "--output content/tables/qa_metadata_report.json to generate it."
             )
             pytest.skip("qa_metadata_report.json not found (needs live API calls)")
 
@@ -1168,7 +1173,8 @@ class TestMetadataQuality:
                 f"Missing '{key}' in qa_metadata_report.json"
                 + _diagnosis(
                     "qa_metadata.py output schema changed",
-                    "Re-run: uv run python scripts/qa_metadata.py",
+                    "Re-run: uv run python scripts/qa_metadata.py "
+                    "--output content/tables/qa_metadata_report.json",
                     "~2 min",
                     "Metadata quality metrics unavailable for technical report",
                 )

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -174,6 +174,24 @@ class TestMigratedScripts:
         assert result.returncode != 0
         assert "output" in result.stderr.lower()
 
+    def test_qa_metadata_requires_output(self):
+        """qa_metadata.py rejects invocation without --output (ticket 0203)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_metadata.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
+    def test_qa_embeddings_requires_output(self):
+        """qa_embeddings.py rejects invocation without --output (ticket 0203)."""
+        result = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS_DIR, "qa_embeddings.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "output" in result.stderr.lower()
+
 
 class TestQaScriptsUseSharedIo:
     """qa_* audit scripts adopt the shared parse_io_args parser (ticket 0196).
@@ -185,6 +203,8 @@ class TestQaScriptsUseSharedIo:
         "qa_bib_doi.py",
         "qa_bibliography.py",
         "qa_citations.py",
+        "qa_embeddings.py",
+        "qa_metadata.py",
         "qa_missing_references.py",
     ]
 

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1057,10 +1057,9 @@ class TestOutputFlag:
         # QA reporters (stdout / fixed JSON)
         # qa_citations.py, qa_bibliography.py, qa_missing_references.py migrated
         # to parse_io_args with required --output (ticket 0196) — no longer exempt.
+        # qa_embeddings.py, qa_metadata.py migrated likewise (ticket 0203).
         "qa_detect_language.py",
         "qa_detect_type.py",
-        "qa_embeddings.py",
-        "qa_metadata.py",
         "qa_word_count.py",
         "qa_llm_judge_guards.py",
         # Catalog harvesters (DVC-managed)

--- a/tickets/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
+++ b/tickets/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
@@ -2,12 +2,10 @@
 Title: Migrate qa_metadata + qa_embeddings to shared script-io
 Created: 2026-07-09
 Author: HDMX-coding-agent
-Closed: migrated qa_metadata + qa_embeddings to shared script-io; OUTPUT_EXEMPT shrunk
 
 --- log ---
 2026-07-09T12:28Z HDMX-coding-agent created
 
-2026-07-09T12:45Z HDMX-coding-agent closed — migrated qa_metadata + qa_embeddings to shared script-io; OUTPUT_EXEMPT shrunk
 --- body ---
 ## Context
 Surfaced by the /roar sweep after ticket 0196 (PR #929) migrated the

--- a/tickets/closed/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
+++ b/tickets/closed/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
@@ -2,10 +2,12 @@
 Title: Migrate qa_metadata + qa_embeddings to shared script-io
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: migrated qa_metadata + qa_embeddings to shared script-io; OUTPUT_EXEMPT shrunk
 
 --- log ---
 2026-07-09T12:28Z HDMX-coding-agent created
 
+2026-07-09T12:45Z HDMX-coding-agent closed — migrated qa_metadata + qa_embeddings to shared script-io; OUTPUT_EXEMPT shrunk
 --- body ---
 ## Context
 Surfaced by the /roar sweep after ticket 0196 (PR #929) migrated the

--- a/tickets/closed/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
+++ b/tickets/closed/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg
@@ -2,10 +2,12 @@
 Title: Migrate qa_metadata + qa_embeddings to shared script-io
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #934
 
 --- log ---
 2026-07-09T12:28Z HDMX-coding-agent created
 
+2026-07-09T12:56Z HDMX-coding-agent closed — autoclosed — PR #934
 --- body ---
 ## Context
 Surfaced by the /roar sweep after ticket 0196 (PR #929) migrated the


### PR DESCRIPTION
## Summary
Migrates the last two QA reporters on the hand-rolled `OUTPUT_PATH` anti-pattern
to the shared `parse_io_args`/`validate_io` with a required `--output`, direct
siblings of the `qa_citations` family migrated in 0196. The 0196 decision applies
unchanged: **`--output` required, no QA carve-out**.

- `scripts/qa_metadata.py`, `scripts/qa_embeddings.py` — adopt the shared parser;
  script-specific flags threaded through the `extra` parser; module-level
  `OUTPUT_PATH` constant and `os.makedirs` dropped (`validate_io` asserts the dir
  exists); docstring `Usage:` updated to pass `--output`.
- Neither script is wired into a Makefile or dvc stage (grepped) — manual-runnable,
  docstring is the only invocation site.
- Both removed from `tests/test_script_hygiene.py::OUTPUT_EXEMPT`, so
  `test_all_producing_scripts_accept_output` now asserts they comply.

## Tests (TDD red → green)
- `test_io_discipline.py::TestMigratedScripts`: `test_qa_metadata_requires_output`,
  `test_qa_embeddings_requires_output` (subprocess, integration).
- `test_io_discipline.py::TestQaScriptsUseSharedIo::QA_SCRIPTS`: both added
  (source-inspection import check).
- Report JSON schema unchanged — `test_corpus_acceptance.py` keys preserved.
- `make check-fast`: 1104 passed, 21 skipped, exit 0.

**Ticket:** tickets/0203-migrate-qa-metadata-qa-embeddings-to-sha.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
