### PR TITLE
analysis(0195): commit A.5 separation tables + provenance test; reconcile co-citation builders

### DIFF
--- a/content/tables/tab_null_separation_pre2007.csv
+++ b/content/tables/tab_null_separation_pre2007.csv
@@ -1,0 +1,5 @@
+labelling,statistic,observed,null_mean,null_std,z_score,p_value,n_perm,seed,n_nodes,n_edges,n_truncated
+louvain_anchored,within_tradition_share,0.8888888888888888,0.3726016260162602,0.020407170692855615,25.299306339088773,0.000999000999000999,1000,42,84,369,0
+louvain_anchored,modularity,0.5029744199881023,-0.01331284288452639,0.020407170692855615,25.299306339088773,0.000999000999000999,1000,42,84,369,0
+a_priori_anchors,within_tradition_share,1.0,1.0,0.0,,1.0,1000,42,3,1,0
+a_priori_anchors,modularity,0.0,0.0,0.0,,1.0,1000,42,3,1,0

--- a/content/tables/tab_pre2007_coverage.csv
+++ b/content/tables/tab_pre2007_coverage.csv
@@ -1,0 +1,10 @@
+metric,value
+cutoff_year,2006.0
+n_works,1344.0
+n_with_doi,608.0
+n_with_outgoing_edge,407.0
+share_with_outgoing_edge,0.30282738095238093
+median_refs_per_work,0.0
+n_academic,1342.0
+n_grey,2.0
+share_grey,0.001488095238095238

--- a/tests/test_separation_provenance.py
+++ b/tests/test_separation_provenance.py
@@ -1,0 +1,91 @@
+"""Provenance: the A.5 separation figures cited in the manuscript equal the
+committed CSV (ticket 0195, follow-up to the 0161 stat-provenance audit).
+
+The 0161 audit found the A.5 numbers (nodes, edges, within-tradition share,
+null mean, z, permutation count) were hand-transcribed into the manuscript
+with no committed source table. This test closes that gap: it reads the
+values from ``content/tables/tab_null_separation_pre2007.csv`` and asserts
+each one appears, at the precision the prose uses, in the A.5 bullet of
+``content/manuscript.qmd``.
+
+The test extracts numbers from the CSV rather than pinning literals, so a
+legitimate regeneration on a frozen corpus that updates *both* the CSV and
+the prose together keeps it green; only a silent drift between the two
+turns it red. This is a mechanical cross-consistency guard, not a positive
+prose pin (cf. the prose-polarity rule): it does not assert any particular
+wording, only that the numbers the prose cites are the numbers the pipeline
+committed.
+"""
+
+import os
+
+import pandas as pd
+
+REPO = os.path.dirname(os.path.dirname(__file__))
+CSV = os.path.join(REPO, "content", "tables", "tab_null_separation_pre2007.csv")
+MANUSCRIPT = os.path.join(REPO, "content", "manuscript.qmd")
+
+
+def _louvain_share_row():
+    """The primary A.5 statistic: within_tradition_share, louvain_anchored."""
+    df = pd.read_csv(CSV)
+    row = df[
+        (df["labelling"] == "louvain_anchored")
+        & (df["statistic"] == "within_tradition_share")
+    ]
+    assert len(row) == 1, (
+        "expected exactly one louvain_anchored/within_tradition_share row, "
+        f"got {len(row)}"
+    )
+    return row.iloc[0]
+
+
+def _a5_bullet():
+    """The manuscript's A.5 co-citation-separation bullet text."""
+    with open(MANUSCRIPT, encoding="utf-8") as f:
+        text = f.read()
+    # The bullet begins with the bold label and runs to the next newline.
+    marker = "**Co-citation community separation.**"
+    start = text.find(marker)
+    assert start != -1, "A.5 co-citation-separation bullet not found in manuscript"
+    end = text.find("\n", start)
+    return text[start:end]
+
+
+def test_separation_csv_committed():
+    """The A.5 source table exists and is committed (0195 exit criterion)."""
+    assert os.path.exists(CSV), (
+        f"{CSV} missing — A.5 figures have no committed source. "
+        "Run `make separation` and commit the table."
+    )
+
+
+def test_a5_prose_matches_committed_csv():
+    """Every figure the A.5 bullet cites equals the committed CSV value.
+
+    Node and edge counts exact; share and null mean at two decimals; z to
+    the nearest integer (the prose writes 'z ≈ N'); permutation count exact.
+    """
+    row = _louvain_share_row()
+    bullet = _a5_bullet()
+
+    n_nodes = int(row["n_nodes"])
+    n_edges = int(row["n_edges"])
+    observed = float(row["observed"])
+    null_mean = float(row["null_mean"])
+    z_score = float(row["z_score"])
+    n_perm = int(row["n_perm"])
+
+    checks = {
+        f"{n_nodes} nodes": f"{n_nodes} nodes",
+        f"{n_edges} edges": f"{n_edges} edges",
+        f"share {observed:.2f}": f"{observed:.2f}",
+        f"null {null_mean:.2f}": f"{null_mean:.2f}",
+        f"z ≈ {round(z_score)}": f"{round(z_score)}",
+        f"N = {n_perm} permutations": str(n_perm),
+    }
+    for label, needle in checks.items():
+        assert needle in bullet, (
+            f"A.5 prose does not cite the committed {label!r} "
+            f"(CSV value not found in bullet). Bullet:\n{bullet}"
+        )

--- a/tests/test_separation_provenance.py
+++ b/tests/test_separation_provenance.py
@@ -41,15 +41,23 @@ def _louvain_share_row():
 
 
 def _a5_bullet():
-    """The manuscript's A.5 co-citation-separation bullet text."""
+    """The manuscript's A.5 co-citation-separation bullet text.
+
+    Runs from the bold label to the end of the markdown list item — a blank
+    line or the start of the next bullet — so a legitimate prose reflow that
+    wraps the item across source lines does not truncate the checked text.
+    """
     with open(MANUSCRIPT, encoding="utf-8") as f:
         text = f.read()
-    # The bullet begins with the bold label and runs to the next newline.
     marker = "**Co-citation community separation.**"
     start = text.find(marker)
     assert start != -1, "A.5 co-citation-separation bullet not found in manuscript"
-    end = text.find("\n", start)
-    return text[start:end]
+    rest = text[start:]
+    # List item ends at a blank line or the next bullet ("\n- ").
+    ends = [rest.find("\n\n"), rest.find("\n- ")]
+    ends = [e for e in ends if e != -1]
+    end = min(ends) if ends else len(rest)
+    return rest[:end]
 
 
 def test_separation_csv_committed():

--- a/tickets/0195-0161-follow-up-regenerate-and-archive-ap.erg
+++ b/tickets/0195-0161-follow-up-regenerate-and-archive-ap.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-08T20:24Z HDMX-coding-agent created
+2026-07-09T13:20Z HDMX-coding-agent note Author HITL (proceed fully on current pre-v1.1.2 corpus, not waiting for the freeze). Action 1 DONE: make separation on current corpus; committed tab_null_separation_pre2007.csv + tab_pre2007_coverage.csv; A.5 prose (84 nodes/369 edges/share 0.89/null 0.37/z25/N1000) matches the CSV exactly, no drift; added tests/test_separation_provenance.py (CSV<->prose guard). Action 2 DONE (reconciled): on the SAME current corpus builder A (compute_null_separation full graph) = 243 nodes/1335 edges/10 comm/mod 0.6623; builder B (compute_temporal_communities) = 244 nodes/1335 edges/9 comm/mod 0.6602 -- edges identical, one node on the isolate/top-250 tie-break boundary, modularity equal to 2 dp. The old ~2x gap (committed cocitation-communities.md 169/1056/18/0.18) was citation-snapshot drift, NOT a code bug -- confirms the 0161 diagnosis. Manuscript A.5 already cites one construction (builder A) and defers community counts to the technical report as "too fragile". Action 3 (regenerate clustering-comparison.md + human-review + drop AI-generated warning) split to a follow-up: needs author sign-off and is best on the frozen corpus.
 
 --- body ---
 ## Context
@@ -28,31 +29,39 @@ numbers do not immediately go stale.
   un-ignored (PR #907), awaiting generation + commit.
 
 ## Actions
-1. On the frozen v1.1.2 corpus, `make separation`; commit
-   `tab_null_separation_pre2007.csv` (+ coverage). Verify the A.5 prose numbers match
-   the committed CSV; fix any drift in `manuscript.qmd`.
-2. Reconcile the pre-2007 co-citation graph: run builder A and builder B on the *same*
-   frozen `refined_citations` and diff node/edge counts. If they agree, it was
-   citation-snapshot drift — cite one construction and note it. If they still disagree
-   ~2×, it is a code bug (two canonical graphs) — fix and cite one.
-3. Regenerate `clustering-comparison.md` (`compute_clustering_comparison`); re-check the
-   nine A.3 numbers against the fresh include; drop the STALE/AI-generated warnings once
-   human-reviewed.
+1. DONE (PR for this ticket, 2026-07-09, current pre-v1.1.2 corpus per author HITL).
+   `make separation`; committed `tab_null_separation_pre2007.csv` (+ coverage). A.5 prose
+   numbers match the committed CSV exactly, no drift; guarded by
+   `tests/test_separation_provenance.py`.
+2. DONE — reconciled. Builder A and builder B run on the same current `refined_citations`
+   agree (243 vs 244 nodes, 1335 edges identical, modularity 0.66 both); the old ~2× gap
+   was citation-snapshot drift, not a code bug. Manuscript A.5 already cites one
+   construction (builder A) and defers community counts to the technical report.
+3. REMAINING (deferred to the frozen v1.1.2 corpus + author review). Regenerate
+   `clustering-comparison.md` (`compute_clustering_comparison`); re-check the nine A.3
+   numbers against the fresh include; drop the STALE/AI-generated warnings once
+   human-reviewed. Deferred because dropping the "not human-reviewed" warning is an
+   author sign-off, and the numbers should be archived on the frozen corpus so they do
+   not immediately go stale (the parent-ticket rationale). The A.3 numbers are disclosed
+   in the manuscript as confirmatory robustness (A.2), so this is technical-report
+   hygiene, not a manuscript-blocking gap.
 
 ## Test
 - `content/tables/tab_null_separation_pre2007.csv` exists, is committed, and its values
   equal the A.5 prose numbers (red first: assert the CSV row matches the cited figures).
 
 ## Verification
-- [ ] A.5 numbers backed by a committed CSV, values match prose
-- [ ] Builder A vs builder B pre-2007 graph reconciled; manuscript cites one construction
-- [ ] `clustering-comparison.md` regenerated + human-reviewed; A.3 numbers re-checked
-- [ ] `make manuscript` renders clean
+- [x] A.5 numbers backed by a committed CSV, values match prose
+- [x] Builder A vs builder B pre-2007 graph reconciled; manuscript cites one construction
+- [ ] `clustering-comparison.md` regenerated + human-reviewed; A.3 numbers re-checked (action 3, deferred to freeze + author review)
+- [x] `make manuscript` renders clean (unaffected — this ticket adds committed tables + a test, no manuscript prose change)
 
 ## Invariants
 - Keep the v1 figures frozen (policy C); do not re-baseline the figures here.
 - Do not silently rewrite a cited number — every change traces to the committed CSV.
 
 ## Exit criteria
-- Every A.5/A.3 number has a committed, reproducible source; the two co-citation
-  builders reconciled to one construction; clustering include refreshed.
+- Every A.5 number has a committed, reproducible source (DONE); the two co-citation
+  builders reconciled to one construction (DONE). Remaining: the A.3 clustering include
+  refreshed + human-reviewed on the frozen corpus (action 3) — this ticket stays open on
+  that remainder.


### PR DESCRIPTION
## Summary

Follow-up to the 0161 stat-provenance audit. Lands the two provenance-critical, manuscript-facing actions of ticket 0195 on the **current pre-v1.1.2 corpus** (author HITL: proceed rather than wait for the in-progress v1.1.2 freeze).

### Action 1 — A.5 separation tables committed + provenance test ✅
The 0161 audit found the A.5 co-citation-separation figures were hand-transcribed into `manuscript.qmd` with no committed source table. This PR:
- Generates and commits `content/tables/tab_null_separation_pre2007.csv` and `tab_pre2007_coverage.csv` via `make separation` (un-ignored by PR #907).
- Adds `tests/test_separation_provenance.py`: extracts each figure from the committed CSV and asserts it appears, at the prose's precision, in the A.5 bullet. Extracts from the CSV rather than pinning literals, so a legitimate regeneration that updates both CSV and prose stays green; only a silent drift turns it red.

On the current corpus the generated numbers match the prose **exactly** (84 nodes, 369 edges, within-tradition share 0.89, configuration-model null 0.37, z ≈ 25, N = 1000) — no drift correction needed.

### Action 2 — co-citation builders reconciled ✅
Ran both builders on the **same** current `refined_citations`:

| Builder | Nodes | Edges | Communities | Modularity |
|---|---|---|---|---|
| A (`compute_null_separation`, full pre-2007 graph) | 243 | 1,335 | 10 | 0.6623 |
| B (`compute_temporal_communities`) | 244 | 1,335 | 9 | 0.6602 |

Edges identical; the one-node/one-community difference is a single node on the isolate/top-250 tie-break boundary. **The old ~2× gap (committed `cocitation-communities.md`: 169/1,056/18/0.18) was citation-snapshot drift, not a code bug** — confirming the 0161 diagnosis. The manuscript A.5 already cites one construction (builder A) and defers community counts to the technical report as "too fragile".

### Action 3 — deferred (ticket stays open)
Regenerating `clustering-comparison.md` + re-checking the nine A.3 numbers + dropping its "AI-generated, not human-reviewed" warning is left open on 0195: dropping that warning is an author sign-off, and the numbers are best archived on the frozen v1.1.2 corpus. The A.3 numbers are disclosed in the manuscript as confirmatory robustness (A.2), so this is technical-report hygiene, not a manuscript-blocking gap.

## Caveat
Numbers generated on the current (pre-v1.1.2) corpus per author decision. A re-run at the v1.1.2 freeze updates the CSV and the prose together, keeping the provenance test green.

## Test
- `tests/test_separation_provenance.py` — 2 tests, green.
- `make check-fast` — 1104 passed, 21 skipped. Adherence: new test ruff-clean; no manuscript prose changed.

**Ticket-ref:** tickets/0195-0161-follow-up-regenerate-and-archive-ap.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)