### PR TITLE
tickets: defer 34 dormant backlog tickets

### DIFF
--- a/tickets/0001-multilingual-paper.erg
+++ b/tickets/0001-multilingual-paper.erg
@@ -2,11 +2,13 @@
 Title: Submit multilingual epistemic blind spots paper
 Created: 2026-04-13
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 2026-04-13T19:30Z claude note superseded by tickets 0013 (global corpus) + 0014 (finding paper). Original plan was a standalone QSS methods paper; new strategy targets higher-impact venues with expanded corpus. This epic and children (0003-0011) are on hold pending the new plan.
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:d41611fcbce4
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Bibliometric studies of climate finance use English-only databases and lexical

--- a/tickets/0003-assess-affiliation-coverage.erg
+++ b/tickets/0003-assess-affiliation-coverage.erg
@@ -2,10 +2,12 @@
 Title: Assess affiliation coverage for go/no-go gate
 Created: 2026-04-13
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:ed514fcd2d3a
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The paper classifies works into four quadrants by language x geography. This

--- a/tickets/0004-temporal-decomposition.erg
+++ b/tickets/0004-temporal-decomposition.erg
@@ -3,10 +3,12 @@ Title: Add temporal decomposition to multilingual analysis
 Created: 2026-04-13
 Author: claude
 Blocked-by: 0003
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Research note Step 4: repeat isolation scores and citation directionality by

--- a/tickets/0005-multilingual-figures.erg
+++ b/tickets/0005-multilingual-figures.erg
@@ -3,10 +3,12 @@ Title: Create figures for multilingual paper
 Created: 2026-04-13
 Author: claude
 Blocked-by: 0004
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Research note originally specified 7 figures and 7 tables. Peer review simulation

--- a/tickets/0006-multilingual-robustness.erg
+++ b/tickets/0006-multilingual-robustness.erg
@@ -3,10 +3,12 @@ Title: Run robustness checks for multilingual paper
 Created: 2026-04-13
 Author: claude
 Blocked-by: 0003
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Two robustness dimensions. Neighbor sensitivity already covered (k=5/10/20 in

--- a/tickets/0007-write-multilingual-paper.erg
+++ b/tickets/0007-write-multilingual-paper.erg
@@ -6,10 +6,12 @@ Blocked-by: 0005
 Blocked-by: 0006
 Blocked-by: 0010
 Blocked-by: 0011
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Paper outline in docs/research-note-multilingual.md specifies seven sections

--- a/tickets/0009-submit-multilingual-paper.erg
+++ b/tickets/0009-submit-multilingual-paper.erg
@@ -3,10 +3,12 @@ Title: Submit multilingual paper
 Created: 2026-04-13
 Author: claude
 Blocked-by: 0007
+Label: deferred
 
 --- log ---
 2026-04-13T15:45Z claude created
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Final submission step. Follows the same packaging process as the Oeconomia

--- a/tickets/0010-fix-isolation-density-bias.erg
+++ b/tickets/0010-fix-isolation-density-bias.erg
@@ -2,11 +2,13 @@
 Title: Fix isolation score density confound
 Created: 2026-04-13
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-13T16:00Z claude created
 2026-04-13T16:00Z claude note identified by peer review simulation agent 3 (statistics)
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:1e64ed2e6acd
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The isolation score computes mean cosine distance to k nearest EN-North neighbors.

--- a/tickets/0011-validate-bge-m3-crosslingual.erg
+++ b/tickets/0011-validate-bge-m3-crosslingual.erg
@@ -2,11 +2,13 @@
 Title: Validate bge-m3 cross-lingual embedding quality
 Created: 2026-04-13
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-13T16:00Z claude created
 2026-04-13T16:00Z claude note identified by peer review simulation agent 5 (adversarial)
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:503b9901a0d7
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The paper's core argument is that multilingual embeddings place works in a shared

--- a/tickets/0013-global-corpus-expansion.erg
+++ b/tickets/0013-global-corpus-expansion.erg
@@ -2,6 +2,7 @@
 Title: Expand corpus to CNKI and SciELO for global coverage (Paper 5 — Corpus v2.0)
 Created: 2026-04-13
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-13T19:30Z claude created
@@ -9,6 +10,7 @@ Author: user
 
 2026-04-26T06:00Z claude note sweep-skip: scope-too-large expires:2026-04-27T06:00Z hash:74eceb157efd
 2026-04-26T22:06Z claude note sweep-skip: scope-too-large expires:2026-04-27T22:06Z hash:23b5edfaf8b8
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The current corpus (v1.1.1) is 93% English because its sources (OpenAlex,

--- a/tickets/0014-whose-evidence-finding-paper.erg
+++ b/tickets/0014-whose-evidence-finding-paper.erg
@@ -3,11 +3,13 @@ Title: Submit "Whose evidence shapes climate policy?" finding paper (Paper 4 —
 Created: 2026-04-13
 Author: user
 Blocked-by: 0013
+Label: deferred
 
 --- log ---
 2026-04-13T19:30Z claude created
 2026-04-13T19:30Z claude note epic — the high-impact empirical paper, depends on global corpus
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Built on the expanded v2.0 corpus (ticket 0013). Not a methods paper. Not a

--- a/tickets/0026-periodization-paper-epic.erg
+++ b/tickets/0026-periodization-paper-epic.erg
@@ -2,6 +2,7 @@
 Title: Companion paper — multi-layer structural change detection
 Created: 2026-04-14
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-14T14:40Z claude created
@@ -17,6 +18,7 @@ Author: user
 2026-04-16T19:55Z claude add 0042 and 0064 to Wave 3; 0047 closed (PR #675)
 
 2026-04-26T06:00Z claude note sweep-skip: scope-too-large expires:2026-04-27T06:00Z hash:97c2a4837f8b
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0027-polarization-paper-epic.erg
+++ b/tickets/0027-polarization-paper-epic.erg
@@ -2,12 +2,14 @@
 Title: Polarization paper — efficiency-accountability divide
 Created: 2026-04-14
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-14T14:40Z claude created
 2026-04-14T14:40Z claude note epic — future paper, separate from periodization
 
 2026-04-26T06:00Z claude note sweep-skip: scope-too-large expires:2026-04-27T06:00Z hash:7ea1830cb506
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The efficiency-accountability bimodality is the most original finding.

--- a/tickets/0032-changepoint-detection.erg
+++ b/tickets/0032-changepoint-detection.erg
@@ -2,11 +2,13 @@
 Title: Apply change point detectors CP1-CP3 to all divergence series
 Created: 2026-04-14
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-14T16:30Z claude created
 2026-04-14T16:30Z claude note wave 2, blocked by all three divergence tickets
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:3f560f854ff8
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Tickets 0029-0031 each produce a CSV of divergence time series. This

--- a/tickets/0035-validation-corpora.erg
+++ b/tickets/0035-validation-corpora.erg
@@ -2,11 +2,13 @@
 Title: Acquire validation corpora for external break detection tests
 Created: 2026-04-14
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-14T16:30Z claude created
 2026-04-14T16:30Z claude note wave 4, needs ISTEX access or padme for OpenAlex
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:ad37463d7dfb
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The periodization paper (ticket 0026, Option A) needs external validation:

--- a/tickets/0036-embedding-sensitivity.erg
+++ b/tickets/0036-embedding-sensitivity.erg
@@ -2,11 +2,13 @@
 Title: Embedding method insensitivity analysis (PCA + random projections)
 Created: 2026-04-14
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-14T17:30Z claude created
 2026-04-14T17:30Z claude note levels 2+3 (PCA sweep + JL random projections); level 4 (multi-model) deferred to padme
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:08fc26b2266b
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Reviewer concern: "your semantic breaks only hold for BGE-M3." The multi-

--- a/tickets/0038-test-strategy.erg
+++ b/tickets/0038-test-strategy.erg
@@ -2,11 +2,13 @@
 Title: Test strategy: golden values, fast/slow split, missing coverage
 Created: 2026-04-15
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note from simplify review; 52 tests take 128s
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The test suite works but has gaps in strategy: no regression guards

--- a/tickets/0039-pipeline-robustness.erg
+++ b/tickets/0039-pipeline-robustness.erg
@@ -2,11 +2,13 @@
 Title: Pipeline robustness: seeds, fallbacks, year-range validation
 Created: 2026-04-15
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note from simplify review
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 Several robustness gaps identified during code review.

--- a/tickets/0041-pipeline-efficiency.erg
+++ b/tickets/0041-pipeline-efficiency.erg
@@ -2,11 +2,13 @@
 Title: Pipeline efficiency: profiling, make -j, test speed
 Created: 2026-04-15
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-15T20:00Z claude created
 2026-04-15T20:00Z claude note from simplify review efficiency discussion
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:f09bf2523b98
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The pipeline has never been profiled on real data. Estimated ~20 min

--- a/tickets/0043-migrate-corpus-loaders.erg
+++ b/tickets/0043-migrate-corpus-loaders.erg
@@ -2,10 +2,12 @@
 Title: Migrate direct corpus reads to pipeline_loaders (arch rule 9)
 Created: 2026-04-15
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-15T12:00Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0044-migrate-pandera-schemas.erg
+++ b/tickets/0044-migrate-pandera-schemas.erg
@@ -2,10 +2,12 @@
 Title: Add Pandera schema validation to CSV-writing scripts (arch rule 2)
 Created: 2026-04-15
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-15T12:05Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0046-robustness-suite.erg
+++ b/tickets/0046-robustness-suite.erg
@@ -2,10 +2,12 @@
 Title: Robustness suite: five bias checks for divergence pipeline
 Created: 2026-04-15
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-15T23:30Z claude created — bias inventory from first real-data run
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:3a7a5709be03
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 The divergence pipeline has a growth-rate confound (ticket 0045) plus

--- a/tickets/0049-alternative-embeddings.erg
+++ b/tickets/0049-alternative-embeddings.erg
@@ -2,10 +2,12 @@
 Title: Robustness R2: re-embed with alternative model, compare breaks
 Created: 2026-04-15
 Author: user
+Label: deferred
 
 --- log ---
 2026-04-16T00:45Z claude created — split from 0046 R2, heavy compute
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:77b10105f640
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 BGE-M3 may encode 1990s text less faithfully than 2020s text,

--- a/tickets/0071-retro-indexing-skew.erg
+++ b/tickets/0071-retro-indexing-skew.erg
@@ -2,10 +2,12 @@
 Title: Characterize retro-indexing skew (indexed vs publication year)
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B2
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:aeef77e3e199
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0072-language-stratified-sensitivity.erg
+++ b/tickets/0072-language-stratified-sensitivity.erg
@@ -2,10 +2,12 @@
 Title: Language-stratified S2/L1 sensitivity (English-only subset)
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B3
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:b366cbae9e14
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0074-louvain-across-seed-variance.erg
+++ b/tickets/0074-louvain-across-seed-variance.erg
@@ -2,10 +2,12 @@
 Title: Across-seed Louvain variance for G9 Z-scores
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B6
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:72206f3db605
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0075-reconcile-window-set.erg
+++ b/tickets/0075-reconcile-window-set.erg
@@ -2,9 +2,11 @@
 Title: Reconcile window set and state lead-window rationale
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B7 2026-04-21Z orchestrator reimagine: no w=5 results anywhere; drop from config (option 1b). Test should reference §4.8 not §6.4. 2026-04-28Z orchestrator close: all exit criteria met — config=[2,3,4], paper §4.8 matches, lead-window rationale present, test_windows_match PASSED.
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0076-joint-type-one-error.erg
+++ b/tickets/0076-joint-type-one-error.erg
@@ -2,10 +2,12 @@
 Title: Joint Type I error for validated transition zones (meta-null)
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B8
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:2adb0a1b27f5
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0077-citation-graph-density.erg
+++ b/tickets/0077-citation-graph-density.erg
@@ -2,10 +2,12 @@
 Title: Citation-graph edge density per year
 Created: 2026-04-17
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-17T07:40Z claude created as child of 0070 for bias B10
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:6b6afa636977
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0104-g1-pagerank-oscillation-diagnosis.erg
+++ b/tickets/0104-g1-pagerank-oscillation-diagnosis.erg
@@ -2,10 +2,12 @@
 Title: Investigate G1 PageRank alternating oscillation in w=3 Z-score curve
 Created: 2026-04-24
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-24T11:35Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0106-zoo-s0-cosine-centroid.erg
+++ b/tickets/0106-zoo-s0-cosine-centroid.erg
@@ -2,10 +2,12 @@
 Title: Add S0_centroid cosine-centroid distance as zoo method
 Created: 2026-04-24
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-24T11:45Z claude created
 2026-04-27T02:07Z claude note sweep-assess: not picked
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0108-null-model-lexical-drivers.erg
+++ b/tickets/0108-null-model-lexical-drivers.erg
@@ -2,11 +2,13 @@
 Title: Null model permutation drivers for L2 (NTR) and L3 (term bursts)
 Created: 2026-04-24
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-24T12:00Z claude created
 2026-04-24T12:30Z orchestrator reimagine: (1) L2 is three-way (past, year-y, future) — not before/after. iter_lexical_windows cannot be reused. Null: pool past+future, shuffle into same-size buckets, recompute resonance against unchanged year-y docs. (2) L3 window label is "0" not "cumulative" in both tab_div_L3.csv and tab_crossyear_L3.csv. Fix test assertion accordingly.
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:3294c8bdfde3
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0110-null-model-citation-cumulative.erg
+++ b/tickets/0110-null-model-citation-cumulative.erg
@@ -2,10 +2,12 @@
 Title: Null model drivers for cumulative citation methods G3, G4, G7 (null-hypothesis design needed)
 Created: 2026-04-24
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-24T12:30Z claude created — split from 0109 by orchestrator reimagine. G3/G4/G7 are cumulative per-year methods; the G2 node-permutation template does not apply.
 2026-04-27T02:07Z claude note sweep-skip: scope-too-large expires:2026-04-28T02:07Z hash:e033cb5b8270
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 

--- a/tickets/0121-test-empty-corpus-dispatcher-guard.erg
+++ b/tickets/0121-test-empty-corpus-dispatcher-guard.erg
@@ -2,6 +2,7 @@
 Title: Standing regression test — dispatcher must never emit 1-column DataFrame on empty corpus
 Created: 2026-04-25
 Author: claude
+Label: deferred
 
 --- log ---
 2026-04-25T23:55Z claude created — follow-up from 0118/0120 sweep; guards the class, not just instances
@@ -9,6 +10,7 @@ Author: claude
 2026-04-27T02:07Z claude note sweep-assess: not picked
 2026-04-29T00:09Z claude note sweep-skip: three-strikes hash:6fee5392f4bc
 
+2026-07-09T13:27Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

Applies the `deferred` label (defined in `.ergrc`, previously used by zero tickets) to the 34 open backlog tickets untouched since 2026-04-29, shrinking `erg ready` from **41 → 13**.

## Why

The open pipeline had split into two disjoint populations:

| | Count | Last touched | What |
|---|---|---|---|
| Live front | 16 | 2026-06-18 → 07-09 | Œconomia R&R track + recent hygiene |
| Dormant backlog | 34 | 2026-04-13 → 04-29 | Other papers + methodology hardening |

`erg ready` reported all 41 unblocked tickets as actionable, so `/pick-ticket` and autonomous raids saw the whole backlog as candidate work. The backlog is legitimate future work (rest of the 4-paper programme + robustness hardening), deferred in practice while the single-track R&R deadline is live — but that fact lived only in creation dates.

## Deferred set (34)

- **Multilingual paper**: 0001, 0003-0007, 0009, 0010, 0011
- **Paper 5 corpus expansion**: 0013, 0014
- **Companion/polarization epics**: 0026, 0027
- **Methodology & robustness** (21): 0032, 0035, 0036, 0038, 0039, 0041, 0043, 0044, 0046, 0049, 0071, 0072, 0074, 0075, 0076, 0077, 0104, 0106, 0108, 0110, 0121

The 16-ticket live front is untouched. `erg check` PASS (198 tickets, no cycles/dupes). Reversible via `erg unlabel <id> deferred`.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)