### PR TITLE
test(0195): fix vacuous z-score check in A.5 provenance test

### DIFF
--- a/tests/test_separation_provenance.py
+++ b/tests/test_separation_provenance.py
@@ -84,16 +84,20 @@ def test_a5_prose_matches_committed_csv():
     z_score = float(row["z_score"])
     n_perm = int(row["n_perm"])
 
-    checks = {
-        f"{n_nodes} nodes": f"{n_nodes} nodes",
-        f"{n_edges} edges": f"{n_edges} edges",
-        f"share {observed:.2f}": f"{observed:.2f}",
-        f"null {null_mean:.2f}": f"{null_mean:.2f}",
-        f"z ≈ {round(z_score)}": f"{round(z_score)}",
-        f"N = {n_perm} permutations": str(n_perm),
-    }
-    for label, needle in checks.items():
+    # Each needle is context-anchored: a bare number is not enough, because a
+    # two-digit value like z can be a substring of an unrelated figure in the
+    # bullet (e.g. "25" inside "250 most-cited"). Anchoring each needle to the
+    # surrounding prose words makes the check non-vacuous.
+    checks = [
+        f"{n_nodes} nodes",
+        f"{n_edges} edges",
+        f"share {observed:.2f}",
+        f"null of {null_mean:.2f}",
+        f"z ≈ {round(z_score)},",
+        f"N = {n_perm} permutations",
+    ]
+    for needle in checks:
         assert needle in bullet, (
-            f"A.5 prose does not cite the committed {label!r} "
+            f"A.5 prose does not cite the committed {needle!r} "
             f"(CSV value not found in bullet). Bullet:\n{bullet}"
         )


### PR DESCRIPTION
## Summary

Follow-up fix to PR #939. A `/review-pr` correctness pass caught that the z-score assertion in `tests/test_separation_provenance.py` passed **vacuously**: the needle was the bare string `"25"`, which is a substring of `"250 most-cited pre-2007 references"` earlier in the A.5 bullet. So the check matched regardless of the genuine `"z ≈ 25"` citation and would not catch a corrupted z — contradicting the test's own docstring ("only a silent drift turns it red").

## Fix

Anchor every needle to its surrounding prose words instead of matching bare numbers:
- `z ≈ 25,` (trailing comma anchors past `"250"`)
- `null of 0.37`, `share 0.89`, `N = 1000 permutations`, `84 nodes`, `369 edges`

## Verification
- Real z=25 → `"z ≈ 25,"` matches (green).
- Drifted z=30 → `"z ≈ 30,"` absent → the check now **fails**, as intended.
- `tests/test_separation_provenance.py` — 2 passed; ruff-clean.

**Ticket-ref:** tickets/0195-0161-follow-up-regenerate-and-archive-ap.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)