### PR TITLE
fix(0201): drop fabricated manne_richels1992 DOI from scout ANCHORS

### DIFF
--- a/scripts/scout_tradition_coupling.py
+++ b/scripts/scout_tradition_coupling.py
@@ -70,8 +70,8 @@ ANCHORS: dict[str, dict[str, tuple[str | None, str]]] = {
             "An Optimal Transition Path for Controlling Greenhouse Gases",
         ),
         "manne_richels1992": (
-            "10.1016/0301-4215(92)90024-V",
-            "Buying Greenhouse Insurance",
+            None,
+            "Buying Greenhouse Insurance: The Economic Costs of CO2 Emission Limits",
         ),
         "stern2007": (None, "The Economics of Climate Change: The Stern Review"),
         "weitzman2007": (

--- a/tests/test_scout_anchors.py
+++ b/tests/test_scout_anchors.py
@@ -1,0 +1,48 @@
+"""Guard the scout_tradition_coupling ANCHORS dict against fabricated DOIs.
+
+The @tbl-traditions anchors carry a (doi, title) fresh-embed fallback key. A
+fabricated DOI here fetches the wrong paper's metadata for the embedding
+fallback -- a silent correctness defect, not just dead metadata. Ticket 0188
+(#928) removed the same LLM-fabricated string from main.bib; the standing
+DOI-title audit only scans main.bib, so this Python-dict instance needs its
+own guard (ticket 0201).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import scout_tradition_coupling as scout
+
+# 0188 (#928): resolves to an unrelated energy-demand paper. manne_richels1992
+# is the 1992 MIT Press *book*, which has no Crossref DOI.
+FABRICATED_DOI = "10.1016/0301-4215(92)90024-V"
+
+
+def _iter_anchor_dois():
+    """Yield (tradition, citekey, doi) over every ANCHORS entry."""
+    for tradition, entries in scout.ANCHORS.items():
+        for citekey, (doi, _title) in entries.items():
+            yield tradition, citekey, doi
+
+
+def test_no_fabricated_doi_in_anchors():
+    """No ANCHORS entry may carry the known-fabricated DOI string."""
+    offenders = [
+        f"{tradition}.{citekey}"
+        for tradition, citekey, doi in _iter_anchor_dois()
+        if doi == FABRICATED_DOI
+    ]
+    assert not offenders, (
+        f"Fabricated DOI {FABRICATED_DOI} still present in ANCHORS: {offenders}"
+    )
+
+
+def test_manne_richels1992_has_no_doi():
+    """manne_richels1992 is a book: no DOI, full book title for fresh-embed."""
+    doi, title = scout.ANCHORS["env_econ"]["manne_richels1992"]
+    assert doi is None, f"manne_richels1992 should have no DOI, got {doi!r}"
+    assert title == (
+        "Buying Greenhouse Insurance: The Economic Costs of CO2 Emission Limits"
+    ), f"manne_richels1992 title should be the full book title, got {title!r}"

--- a/tickets/closed/0201-drop-fabricated-manne-richels1992-doi-fr.erg
+++ b/tickets/closed/0201-drop-fabricated-manne-richels1992-doi-fr.erg
@@ -2,10 +2,12 @@
 Title: Drop fabricated manne_richels1992 DOI from scout_tradition_coupling ANCHORS
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #943
 
 --- log ---
 2026-07-09T12:11Z HDMX-coding-agent created
 
+2026-07-09T15:56Z HDMX-coding-agent closed — autoclosed — PR #943
 --- body ---
 ## Context
 Ticket 0188 (#928) removed the LLM-fabricated DOI `10.1016/0301-4215(92)90024-V`


### PR DESCRIPTION
## Summary
`scripts/scout_tradition_coupling.py` ANCHORS carried the LLM-fabricated DOI `10.1016/0301-4215(92)90024-V` for `manne_richels1992`. That DOI resolves to an unrelated energy-demand paper; Manne & Richels 1992 is the MIT Press *book* "Buying Greenhouse Insurance", which has no Crossref DOI. Ticket 0188/#928 removed the same string from `main.bib`, but the standing DOI-title audit (`test_bib_doi_title.py`) only scans `main.bib`, so this Python-dict instance survived.

ANCHORS `(doi, title)` is a fresh-embed fallback key: a wrong DOI fetches the wrong paper's metadata for the embedding fallback — a silent correctness defect, not just dead metadata.

## Change
- Set `env_econ.manne_richels1992` to `(None, "Buying Greenhouse Insurance: The Economic Costs of CO2 Emission Limits")` — no DOI (book), full book title so the fallback matches the correct work.
- New guard `tests/test_scout_anchors.py`: a class-guard scanning every ANCHORS entry for the known fabricated string, plus a pin on the manne book entry. RED before the fix, GREEN after.

## Spot-check
All 7 other anchor DOIs resolve on Crossref to titles matching their ANCHORS entries exactly (nordhaus1992, weitzman2007/2009, michaelowa2007/2019, negishi1960, stadelmann2011). No other fabricated DOIs found. Only the manne entry changed.

## Gate
`make check-fast`: 1106 passed, 21 skipped. Warnings are pre-existing hygiene smells unrelated to this change.

**Ticket:** tickets/0201-drop-fabricated-manne-richels1992-doi-fr.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)