### PR TITLE
ticket(0168): guard enrich_embeddings model.half() with CUDA check

### DIFF
--- a/scripts/enrich_embeddings.py
+++ b/scripts/enrich_embeddings.py
@@ -204,8 +204,10 @@ def main():
         torch.set_num_threads(n_cpu)
         log.info("Loading %s (%d threads)...", MODEL_NAME, n_cpu)
         model = SentenceTransformer(MODEL_NAME)
-        # FP16 halves VRAM (~6.4 GB instead of ~12.8 GB), fits 16 GB GPUs
-        model.half()
+        # FP16 halves VRAM (~6.4 GB instead of ~12.8 GB), fits 16 GB GPUs.
+        # CPU has no fast fp16 kernels, so fp32 there (guard matches het_embed.py).
+        if torch.cuda.is_available():
+            model.half()
 
         new_texts = df.loc[~hit_mask, "_text"].tolist()
         log.info("Encoding %d texts...", n_new)

--- a/tickets/closed/0168-guard-enrich-embeddings-py-model-half-wi.erg
+++ b/tickets/closed/0168-guard-enrich-embeddings-py-model-half-wi.erg
@@ -2,10 +2,12 @@
 Title: guard enrich_embeddings.py model.half() with CUDA check
 Created: 2026-07-07
 Author: HDMX-coding-agent
+Closed: done
 
 --- log ---
 2026-07-07T20:18Z HDMX-coding-agent created
 
+2026-07-09T16:00Z HDMX-coding-agent closed — done
 --- body ---
 ## Context
 PR #860 (ticket 0167, HET citation-overlap companion pipeline) needed a


### PR DESCRIPTION
## Summary
`scripts/enrich_embeddings.py` called `model.half()` unconditionally. fp16 has no fast CPU kernels, so on a CPU-only host this forced a *slower* fp32→fp16 path, not a faster one. This wraps the call in `if torch.cuda.is_available():`, matching the guard the companion `scripts/het_embed.py` already uses.

## Behavior
- **GPU hosts (padme):** unchanged — CUDA present → same fp16 path, identical embedding output.
- **CPU-only hosts:** stay in fp32, no forced slow fp16.

## Verification
- `make check-fast` passes (ruff adherence + unit suite, exit 0).
- `/verify-adherence` → PASS (no mechanical failures, no semantic findings). Per-module tests `test_enrich_embeddings.py` + `test_embeddings_cache.py`: 23 passed.

**Ticket:** tickets/0168-guard-enrich-embeddings-py-model-half-wi.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)