### PR TITLE
refactor(0199): migrate 4 variable-path contract-read offenders to loaders

### DIFF
--- a/scripts/analyze_unfccc_topics.py
+++ b/scripts/analyze_unfccc_topics.py
@@ -134,16 +134,17 @@ def build_citation_cooccurrence(df: pd.DataFrame, max_works: int = 10000) -> np.
     Only uses shared-citation overlap as a proxy for citation-space proximity.
     Limited to max_works for memory reasons.
     """
-    from utils import CATALOGS_DIR
-    citations_path = os.path.join(CATALOGS_DIR, "refined_citations.csv")
-    if not os.path.exists(citations_path):
-        log.warning("refined_citations.csv not found — skipping citation silhouette")
+    from pipeline_loaders import load_refined_citations
+    try:
+        cit = load_refined_citations()
+    except FileNotFoundError:
+        log.warning("refined_citations not found — skipping citation silhouette")
         return None
 
-    log.info("Loading refined_citations.csv for citation-space silhouette …")
-    # refined_citations.csv columns: source_doi, source_id, ref_doi, ref_title, ...
-    cit = pd.read_csv(citations_path, usecols=["source_id", "ref_doi"],
-                      low_memory=False)
+    log.info("Loading refined_citations for citation-space silhouette …")
+    # refined_citations columns: source_doi, source_id, ref_doi, ref_title, ...
+    # The loader returns all columns; take the same subset the usecols read did.
+    cit = cit[["source_id", "ref_doi"]]
 
     # Index works present in df
     n = min(len(df), max_works)

--- a/scripts/compute_vars.py
+++ b/scripts/compute_vars.py
@@ -15,6 +15,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from pipeline_loaders import load_refined_citations, load_refined_works
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
@@ -141,11 +142,11 @@ def _read_json(filename, directory=TABLES_DIR):
 
 def corpus_stats(v):
     """Corpus size, language, multi-source from refined_works.csv."""
-    path = os.path.join(CATALOGS_DIR, "refined_works.csv")
-    if not os.path.isfile(path):
-        warnings.warn(f"Missing: {path}")
+    try:
+        df = load_refined_works()
+    except FileNotFoundError as exc:
+        warnings.warn(str(exc))
         return
-    df = pd.read_csv(path)
     n = len(df)
     v["corpus_total"] = _int(n)
     v["corpus_total_approx"] = _int(round(n, -3))
@@ -368,15 +369,13 @@ def citation_stats(v):
     from utils import REFINED_CITATIONS_PATH, REFINED_WORKS_PATH, normalize_doi
 
     if os.path.isfile(REFINED_CITATIONS_PATH):
-        ref_cite_df = pd.read_csv(REFINED_CITATIONS_PATH)[["source_doi"]]
+        ref_cite_df = load_refined_citations()[["source_doi"]]
         v["cite_refined_rows"] = _int(len(ref_cite_df))
         v["cite_refined_sources"] = _int(ref_cite_df["source_doi"].nunique())
 
         # Coverage: % of refined DOIs that appear as citation sources
         if os.path.isfile(REFINED_WORKS_PATH):
-            refined_df = pd.read_csv(
-                REFINED_WORKS_PATH, usecols=["doi", "cited_by_count"]
-            )
+            refined_df = load_refined_works()[["doi", "cited_by_count"]]
             refined_dois = {normalize_doi(d) for d in refined_df["doi"].dropna()} - {""}
             source_dois = {normalize_doi(d) for d in ref_cite_df["source_doi"].dropna()}
             covered = len(source_dois & refined_dois)

--- a/scripts/export_corpus_table.py
+++ b/scripts/export_corpus_table.py
@@ -12,6 +12,7 @@ and abstract availability.
 import os
 
 import pandas as pd
+from pipeline_loaders import load_refined_works
 from script_io_args import parse_io_args, validate_io
 from utils import BASE_DIR, CATALOGS_DIR, get_logger, save_csv
 
@@ -84,11 +85,10 @@ def _write_md_table(summary: pd.DataFrame, path: str) -> None:
 
 
 def main():
-    # Load refined corpus (after filtering)
-    path = os.path.join(CATALOGS_DIR, "refined_works.csv")
-    df = pd.read_csv(path)
-    df["year"] = pd.to_numeric(df["year"], errors="coerce")
-    df["cited_by_count"] = pd.to_numeric(df["cited_by_count"], errors="coerce").fillna(0)
+    # Load refined corpus (after filtering). load_refined_works() coerces
+    # year to numeric and cited_by_count to numeric-filled-0 — the same
+    # coercion this script did inline before the loader migration.
+    df = load_refined_works()
     df["doi_lower"] = df["doi"].str.lower().str.strip()
     df["has_doi"] = df["doi_lower"].apply(
         lambda x: bool(x) and str(x) not in ("", "nan", "none")
@@ -100,7 +100,7 @@ def main():
     abs_s = df["abstract"].fillna("").astype(str).str.strip()
     df["has_abstract"] = (abs_s.str.len() > 10) & (abs_s != "nan")
 
-    log.info("Loaded %d refined works from %s", len(df), path)
+    log.info("Loaded %d refined works", len(df))
 
     # Load unified corpus (before filtering) for raw counts
     # Must include from_* columns — usecols=["source"] dropped them (#251 bug)

--- a/scripts/plot_fig1_bars.py
+++ b/scripts/plot_fig1_bars.py
@@ -13,6 +13,7 @@ import re
 import matplotlib
 import matplotlib.pyplot as plt
 import pandas as pd
+from pipeline_loaders import load_refined_works
 from plot_style import (
     DARK,
     DPI,
@@ -22,7 +23,7 @@ from plot_style import (
     apply_style,
 )
 from script_io_args import parse_io_args, validate_io
-from utils import CATALOGS_DIR, save_figure
+from utils import save_figure
 
 apply_style()
 
@@ -48,18 +49,34 @@ def main():
     args = parser.parse_args(extra)
 
     # --- Load corpus ---
-    csv_path = io_args.input[0] if io_args.input else os.path.join(CATALOGS_DIR, "refined_works.csv")
+    # An explicit --input path reads that file directly (usecols/Int64 kept);
+    # the default contract read goes through load_refined_works(). The loader
+    # returns all columns and coerces `year` to numeric (float64, NaN for
+    # unparseable) rather than the usecols Int64 optimisation — but the plot
+    # bins by whole-number year and filters to 1992..2023, so 1992.0 vs 1992
+    # groups identically and drops the same NaN rows: the bars are unchanged.
     usecols = ["year", "title", "abstract"]
-    if args.v1_only:
-        # Check column exists before loading
-        header = pd.read_csv(csv_path, nrows=0).columns
-        if "in_v1" not in header:
-            raise RuntimeError(
-                "--v1-only requires 'in_v1' column in refined_works.csv. "
-                "Re-run: uv run python scripts/corpus_filter.py --apply"
-            )
-        usecols.append("in_v1")
-    df = pd.read_csv(csv_path, usecols=usecols, dtype={"year": "Int64"})
+    if io_args.input:
+        csv_path = io_args.input[0]
+        if args.v1_only:
+            header = pd.read_csv(csv_path, nrows=0).columns
+            if "in_v1" not in header:
+                raise RuntimeError(
+                    "--v1-only requires 'in_v1' column in refined_works.csv. "
+                    "Re-run: uv run python scripts/corpus_filter.py --apply"
+                )
+            usecols.append("in_v1")
+        df = pd.read_csv(csv_path, usecols=usecols, dtype={"year": "Int64"})
+    else:
+        df = load_refined_works()
+        if args.v1_only:
+            if "in_v1" not in df.columns:
+                raise RuntimeError(
+                    "--v1-only requires 'in_v1' column in refined_works.csv. "
+                    "Re-run: uv run python scripts/corpus_filter.py --apply"
+                )
+            usecols.append("in_v1")
+        df = df[usecols]
     if args.v1_only:
         df = df[df["in_v1"] == 1]
     df = df[(df["year"] >= 1992) & (df["year"] <= 2023)].copy()

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -350,11 +350,6 @@ class TestCorpusThroughLoaders:
         "plot_alluvial_html.py",
         "plot_fig_seed_axis.py",
         "plot_interactive_corpus.py",
-        # Surfaced by the strengthened variable-path detector (0198): each binds
-        # a path variable to a contract literal, then reads it — invisible to the
-        # old same-line matcher. Migration deferred to 0199 (needs a data-side
-        # figure/table byte-check that this checkout cannot run).
-        "compute_vars.py",
     }
 
     _CONTRACT_FILES = re.compile(r"refined_works|refined_citations|refined_embeddings")

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -356,7 +356,6 @@ class TestCorpusThroughLoaders:
         # figure/table byte-check that this checkout cannot run).
         "analyze_unfccc_topics.py",
         "compute_vars.py",
-        "export_corpus_table.py",
         "plot_fig1_bars.py",
     }
 

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -356,7 +356,6 @@ class TestCorpusThroughLoaders:
         # figure/table byte-check that this checkout cannot run).
         "analyze_unfccc_topics.py",
         "compute_vars.py",
-        "plot_fig1_bars.py",
     }
 
     _CONTRACT_FILES = re.compile(r"refined_works|refined_citations|refined_embeddings")

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -354,7 +354,6 @@ class TestCorpusThroughLoaders:
         # a path variable to a contract literal, then reads it — invisible to the
         # old same-line matcher. Migration deferred to 0199 (needs a data-side
         # figure/table byte-check that this checkout cannot run).
-        "analyze_unfccc_topics.py",
         "compute_vars.py",
     }
 

--- a/tickets/closed/0199-migrate-4-variable-path-contract-read-of.erg
+++ b/tickets/closed/0199-migrate-4-variable-path-contract-read-of.erg
@@ -2,10 +2,12 @@
 Title: Migrate 4 variable-path contract-read offenders surfaced by 0198 detector
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #949
 
 --- log ---
 2026-07-09T11:47Z HDMX-coding-agent created
 
+2026-07-09T20:05Z HDMX-coding-agent closed — autoclosed — PR #949
 --- body ---
 ## Context
 Strengthening the rule-9 detector in 0198 (variable bound to a contract


### PR DESCRIPTION
## Summary
Migrates the four variable-path contract-read offenders surfaced by the 0198 detector (and allowlisted in `tests/test_arch_compliance.py::TestCorpusThroughLoaders.KNOWN_VIOLATIONS`) to read the Phase-1→2 contract files through `pipeline_loaders`, and removes each from the allowlist. Each read was rerouted preserving its column/dtype semantics; the shared `_read_csv(directory=TABLES_DIR)` helper and all non-contract reads (unified_works, corpus_audit, citations, tables) are left untouched.

## Per-offender migration + byte-check
Byte-checks compare **pre-migration code vs migrated code on the same current data** — the gitignored golden artifacts in the main checkout are a stale corpus snapshot (31713 vs current 30987 refined rows), so a diff-vs-golden reflects data drift, not the migration. Old-vs-new on identical data is the correct isolation.

| offender | loader | semantics preserved | byte-check |
|----------|--------|---------------------|-----------|
| `export_corpus_table.py` | `load_refined_works()` | full read | `tab_corpus_sources.csv` + `.md` **byte-identical** |
| `plot_fig1_bars.py` | `load_refined_works()` (default; `--input` still direct) | year Int64→float via loader coercion | `fig_bars.png` + `fig_bars_v1.png` **byte-identical** — the dtype change does not alter the figure |
| `compute_vars.py` | `load_refined_works()` / `load_refined_citations()` | column subsets taken after load; isfile guards kept | all 3 `*-vars.yml` **byte-identical** |
| `analyze_unfccc_topics.py` | `load_refined_citations()[["source_id","ref_doi"]]` | usecols subset preserved | `tab_unfccc_topics.csv` **byte-identical** |

## Verification
- All 4 removed from `KNOWN_VIOLATIONS`; the post-0202 detector `_has_direct_contract_read` returns False for each.
- `test_no_new_direct_contract_reads` + `test_known_violations_not_stale` pass (17 arch-compliance tests green); remaining allowlist entries still flagged.
- `make check-fast` green (1114 passed, 20 skipped). No under-match regression against the 0202 forward-flow detector.

**Ticket:** tickets/0199-migrate-4-variable-path-contract-read-of.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)