### PR TITLE
ticket(0163): split into children 0207 + 0208; make 0163 a tracker

### DIFF
--- a/tickets/0163-split-build-remaining-writing-workpackag.erg
+++ b/tickets/0163-split-build-remaining-writing-workpackag.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-28T19:43Z HDMX-coding-agent created
 
 2026-07-09T20:00Z note Re-homed 0131 exit criterion 4 (README writing-toolchain spec) into exit criteria; corrected stale 'can close once children land' framing now that 0131 closed via #948.
+2026-07-09T20:11Z note Split into children 0207 (mk extraction) + 0208 (intermediate eviction); 0163 now a tracker, stays open until both land.
 --- body ---
 ## Context
 
@@ -24,7 +25,29 @@ the rest of 0131 for the other papers and the analysis-intermediate eviction.
 - `content/tables/tab_lexical_tfidf.csv` (35 MB), `tab_pole_papers.csv` (3.8 MB),
   `qa_type_report.csv` (3.7 MB) — analysis intermediates living under content/tables/.
 
-## Actions
+## Tracker (2026-07-09)
+
+0163 is now a TRACKER — its work is delegated to two children, split to
+isolate the risky eviction from the mechanical `.mk` extraction and to avoid
+same-file merge churn (both extractions edit the same Makefile block +
+`.gitignore`). 0163 stays open until BOTH close, then a short integration
+re-read confirms `make papers` still builds all six and the clean-room per-paper
+builds pass.
+
+- **0207** — extract render `.mk` + Quarto profile for the 4 remaining papers
+  (corpus-report, technical-report+zoo, data-paper, multilayer+techrep);
+  git-track their small deliverables; document the writing toolchain in README.
+  Covers actions 1, 2 and the re-homed README exit criterion.
+- **0208** — evict the 3 large analysis intermediates out of `content/tables/`,
+  rewiring the `&:` grouped target + `.lexical_tfidf.stamp` chain. Covers
+  actions 3 and 4.
+
+Scope note: NCC has no `.qmd` and is absent from the `papers:` target, so it is
+not a writing workpackage (the earlier "ncc.mk" mention below is dropped).
+`multilayer-detection.mk` is a *figures* `.mk`, not a render workpackage, so the
+multilayer render rule still lives in the main Makefile and is 0207's job.
+
+## Actions (delegated to children above; kept for reference)
 1. Per remaining paper, extract a `<wp>.mk` (datapaper.mk, techrep.mk,
    companion/multilayer, ncc) plus a `_quarto-<wp>.yml` profile that excludes
    sibling docs, mirroring manuscript.mk. Each builds clean-room from committed

--- a/tickets/0207-extract-render-mk-remaining-writing-papers.erg
+++ b/tickets/0207-extract-render-mk-remaining-writing-papers.erg
@@ -1,0 +1,79 @@
+%erg 0.1
+Title: Extract render .mk + Quarto profile for the 4 remaining writing papers
+Created: 2026-07-09
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-09T20:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Child of tracker 0163 (which is a child of 0131). The manuscript writing
+workpackage is already split out (`manuscript.mk` + `_quarto-manuscript.yml`,
+clean-room build proven). This ticket replicates that pattern for the four
+remaining papers so each renders standalone from committed deliverables with
+no analysis toolchain (no `uv`, no data). It does NOT touch the large analysis
+intermediates — that eviction is the sibling ticket 0208, deliberately kept
+separate because it carries the cross-cutting `make papers` risk.
+
+Grouped as one ticket (not one-per-paper) on purpose: every extraction edits
+the same Makefile render block (~lines 664-718) and the same `.gitignore`
+negate-block, so separate PRs would serialize into merge-conflict churn (the
+multi-PR-on-one-file trap, feedback_fetch_before_sibling_merge). One coherent
+edit avoids it; each paper is still independently verified by the clean-room
+test below.
+
+## Relevant files
+- `Makefile` — render rules to move out: `output/content/corpus-report.pdf`
+  (~677), `technical-report.pdf` (~680, depends on `.lexical_tfidf.stamp` +
+  `ZOO_INCLUDES` + `$(TECHREP_FIGS)` + `$(MULTILAYER_FIGS)`),
+  `data-paper.pdf` (~683), `multilayer-detection.pdf` (~686) and its
+  `multilayer-detection-techrep.pdf` variant. Also the `papers:` target (664),
+  `.PHONY` (226), and the `datapaper-render`/`datapaper-figures` aliases.
+- `manuscript.mk`, `_quarto-manuscript.yml` — the exact pattern to mirror
+  (per-target `QUARTO_PROFILE` export, sibling-doc exclusion in the profile).
+- `.gitignore` — ignore-then-negate block (lines 29-40) for
+  `content/{figures,tables}`; add negations for each paper's small deliverables.
+- `content/_includes/` — already git-tracked; the model for what "committed
+  deliverable" means.
+- `README.md` — writing-toolchain spec goes here (re-homed 0131 exit criterion 4).
+
+## Actions
+1. Extract a `<wp>.mk` + `_quarto-<wp>.yml` per paper — corpus-report,
+   technical-report (carrying the breakpoint-detect-method-zoo sub-include),
+   data-paper, multilayer-detection (+ its techrep variant). Each profile
+   excludes sibling docs so a bare render does not walk all papers. Mirror
+   `manuscript.mk`'s per-target `QUARTO_PROFILE` export (not file-scope).
+2. git-track each paper's small byte-stable writing deliverables (figures +
+   the paper's includes/tables) via `.gitignore` negations. Note:
+   `tab_corpus_sources.md` / `tab_languages.md` / `tab_citation_coverage.md`
+   are data-paper/techrep includes — track them under those slices.
+3. Document the writing toolchain in README (0131 exit criterion 4, re-homed
+   via 0163): the clean-room writing build needs only Quarto + TeX Live +
+   Pandoc — no `uv`, no `dvc` client, no data.
+4. Keep the top-level `Makefile` render targets working by `-include`-ing the
+   new `.mk` files, exactly as `manuscript.mk`/`multilayer-detection.mk` are.
+
+## Test
+For EACH of the four papers, in a data-less worktree (no `uv`, no data pull):
+`make -f <wp>.mk output/content/<doc>.pdf` builds the PDF with only Quarto +
+TeX. This is the proof `manuscript.mk` already passes — replicate it per paper.
+Write the phase-separation guard test first (mirror
+`tests/` manuscript-WP RED test) asserting each `<wp>.mk` reads only committed
+deliverables + source prose, no Phase-1/2 script prerequisites.
+
+## Invariants
+- `make papers` from the full Makefile still builds all six PDFs (with data).
+- Per-target `QUARTO_PROFILE` export so profiles don't leak across docs.
+- No analysis-intermediate eviction here — that is 0208. This ticket must not
+  move `tab_lexical_tfidf.csv` / `tab_pole_papers.csv` / `qa_type_report.csv`.
+
+## Exit criteria
+- One `<wp>.mk` + profile per remaining paper (4 papers), each buildable
+  clean-room, proven by the per-paper test.
+- Each paper's small deliverables git-tracked via `.gitignore` negations.
+- Writing-toolchain spec present in README.
+- `make papers` unaffected.
+
+Parent tracker: tickets/0163-split-build-remaining-writing-workpackag.erg

--- a/tickets/0208-evict-analysis-intermediates-content-tables.erg
+++ b/tickets/0208-evict-analysis-intermediates-content-tables.erg
@@ -1,0 +1,75 @@
+%erg 0.1
+Title: Evict large analysis intermediates out of content/tables/
+Created: 2026-07-09
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-09T20:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Child of tracker 0163 (child of 0131), action 8. `content/tables/` conflates
+two roles: small byte-stable *writing deliverables* (git-tracked, consumed by
+papers) and large *analysis intermediates* (consumed only by other Phase-2
+scripts). The 44 MB of `content/tables/` is ~80% one file. This ticket moves
+the analysis intermediates to an analysis-side derived/scratch directory and
+rewires the producing + consuming Make targets, so `content/tables/` holds only
+writing deliverables.
+
+Kept separate from the `.mk` extraction (sibling 0207) because this is the
+cross-cutting, `make papers`-breaking part: the files sit on grouped targets
+and stamp chains that feed a git-tracked deliverable and the technical report.
+Isolating it makes the risky diff reviewable on its own.
+
+## Relevant files
+- `content/tables/tab_lexical_tfidf.csv` (35 MB) — produced by
+  `Makefile:579` (`compute_lexical.py`); consumed by
+  `scripts/plot_fig_lexical_tfidf.py` → `.lexical_tfidf.stamp` (`Makefile:599`)
+  → **`output/content/technical-report.pdf` prerequisite (`Makefile:680`)**.
+- `content/tables/tab_pole_papers.csv` (3.8 MB) — produced by the grouped
+  `&:` target at `Makefile:478`; consumed by **`tab_venues.md`**
+  (`Makefile:352`, a git-tracked manuscript deliverable) and rules at
+  `Makefile:505`, `543`. The grouped-target coupling is the main trap: every
+  consumer path must move in the same commit.
+- `content/tables/qa_type_report.csv` (3.7 MB) — produced by
+  `scripts/qa_detect_type.py`; no downstream consumer found (QA output only).
+- `.gitignore` lines 33-40 — `content/tables/*` ignore + negations; the evicted
+  files were never negated (already gitignored), so eviction is a path move.
+
+## Actions
+1. Choose an analysis-side derived/scratch dir (e.g. `data/derived/tables/` or
+   an analysis-local path consistent with the DATA_DIR convention — NOT under
+   `content/`). Confirm it is gitignored / DVC-scoped per architecture rules.
+2. Move the three intermediates there; update every producing target
+   (`Makefile:478` grouped `&:`, `579`, `qa_detect_type.py` output path) and
+   every consuming target/script (`plot_fig_lexical_tfidf.py`,
+   `.lexical_tfidf.stamp`, `export_tab_venues.py`, rules at 352/505/543).
+   Follow `.claude/rules/script-io.md`: pass paths via `--output`/`--input`,
+   no hardcoded `content/tables/` in scripts.
+3. Keep DVC scoped to genuine corpus data (0163 action 4) — DVC the moved
+   intermediates only if they must persist across machines.
+
+## Test
+- `make papers` still builds all six PDFs (regression; the load-bearing test).
+- `make -f manuscript.mk output/content/manuscript.pdf` clean-room still passes
+  (tab_venues.md deliverable unaffected by the tab_pole_papers.csv move).
+- Grep guard (mirror the arch-compliance style): assert no script hardcodes
+  `content/tables/tab_lexical_tfidf.csv` / `tab_pole_papers.csv` /
+  `qa_type_report.csv` after the move.
+- Write the failing grep guard first (RED), then move + rewire to green.
+
+## Invariants
+- `make papers` unaffected.
+- `tab_venues.md` still regenerates from the relocated `tab_pole_papers.csv`.
+- `technical-report.pdf` still builds via the relocated `tab_lexical_tfidf.csv`
+  → `.lexical_tfidf.stamp` chain.
+- No writing deliverable leaves `content/tables/`.
+
+## Exit criteria
+- The three analysis intermediates live outside `content/tables/`; all
+  producing + consuming targets updated in one commit.
+- `content/tables/` contains only writing-facing deliverables.
+- `make papers` and the manuscript clean-room build both pass.
+
+Parent tracker: tickets/0163-split-build-remaining-writing-workpackag.erg


### PR DESCRIPTION
Restructures 0163 from a single large ticket into a tracker with two children, per the /hunt planning decision (author chose "split into children first").

**Why split:** 0163 bundles two separable validation units with different risk profiles. The per-paper `.mk` extraction is mechanical and additive; the analysis-intermediate eviction is the cross-cutting part that can break `make papers` (grouped `&:` target feeding a tracked deliverable, plus the `.lexical_tfidf.stamp` → `technical-report.pdf` chain). Isolating the eviction keeps its diff reviewable on its own.

**Why the extractions are grouped (not one child per paper):** every per-paper extraction edits the same Makefile render block (~664–718) and the same `.gitignore` negate-block, so separate paper-PRs would serialize into merge-conflict churn. One coherent child avoids it; each paper is still independently verified by the clean-room test.

**Children filed:**
- **0207** — extract render `.mk` + Quarto profile for the 4 remaining papers (corpus-report, technical-report+zoo, data-paper, multilayer+techrep); git-track their small deliverables; document the writing toolchain in README (re-homed 0131 exit criterion 4).
- **0208** — evict the 3 large analysis intermediates from `content/tables/`, rewiring the `&:` grouped target + `.lexical_tfidf.stamp` chain.

**Scope corrections from inspection:** NCC has no `.qmd` and is absent from `papers:` — no `ncc.mk` (dropped from scope). `multilayer-detection.mk` is a *figures* `.mk`, not a render workpackage, so the multilayer render rule remains 0207's job.

0163 stays open as the tracker until both children land, then a short integration re-read (tracking-ticket convention).

Ticket-ref: tickets/0163-split-build-remaining-writing-workpackag.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)