### PR TITLE
ticket(0170): add retry_get to openalex-corpus (slice A2 lib)

### DIFF
--- a/libs/openalex-corpus/.gitignore
+++ b/libs/openalex-corpus/.gitignore
@@ -1,0 +1,4 @@
+.venv*
+dist/
+*.egg-info/
+__pycache__/

--- a/libs/openalex-corpus/pyproject.toml
+++ b/libs/openalex-corpus/pyproject.toml
@@ -5,6 +5,13 @@ description = "Shared OpenAlex crawl + canonical-text conventions (model-agnosti
 requires-python = ">=3.10"
 dependencies = [
     "pandas",
+    "requests",
+]
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "requests-mock",
 ]
 
 [build-system]

--- a/libs/openalex-corpus/src/openalex_corpus/__init__.py
+++ b/libs/openalex-corpus/src/openalex_corpus/__init__.py
@@ -6,16 +6,18 @@ repos (e.g. polycentric_activity) depend on it as a git source. The engine
 repo's own ``scripts/`` modules re-export these to preserve their public API.
 
 Scope note: this package holds *conventions* only. Deployment config
-(``MAILTO``, API keys) is injected by the caller, never shipped here. The
-HTTP layer (``retry_get``) is a separate follow-up slice (ticket 0170, A2).
+(``MAILTO``, API keys) is injected by the caller, never shipped here.
 """
 
+from openalex_corpus.crawl import RETRY_MAX_RETRIES, retry_get
 from openalex_corpus.embedding import build_text, is_boilerplate_abstract
 from openalex_corpus.text import normalize_doi, reconstruct_abstract
 
 __all__ = [
+    "RETRY_MAX_RETRIES",
     "build_text",
     "is_boilerplate_abstract",
     "normalize_doi",
     "reconstruct_abstract",
+    "retry_get",
 ]

--- a/libs/openalex-corpus/src/openalex_corpus/crawl.py
+++ b/libs/openalex-corpus/src/openalex_corpus/crawl.py
@@ -1,0 +1,140 @@
+"""OpenAlex crawl convention — polite, resilient HTTP GET.
+
+``retry_get`` is the shared HTTP fetcher: bounded exponential backoff with
+jitter, 429/5xx retry, graceful 429-exhaustion, and optional counter tracking.
+
+Deployment config is injected, never shipped: the caller supplies its own
+``mailto`` (for the polite ``mailto`` query param and User-Agent) and, if it
+wants a branded agent string, ``user_agent``. The package hardcodes no email,
+no API key, no product name.
+"""
+
+import logging
+import random
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import requests  # type: ignore[import-untyped]
+
+_log = logging.getLogger("openalex_corpus.crawl")
+
+RETRY_MAX_RETRIES = 5    # enrichment fetchers (heavy, fewer URLs)
+
+
+def retry_get(url: str, params: dict[str, Any] | None = None,
+              headers: dict[str, str] | None = None, delay: float = 0.2,
+              max_retries: int = RETRY_MAX_RETRIES,
+              timeout: float = 60, counters: dict[str, int] | None = None,
+              backoff_base: float = 2.0, jitter_max: float = 1.0,
+              mailto: str | None = None,
+              user_agent: str | None = None) -> requests.Response:
+    """HTTP GET with bounded exponential backoff+jitter and optional counter tracking.
+
+    Parameters
+    ----------
+    url : str
+        Request URL.
+    params : dict, optional
+        Query parameters.
+    headers : dict, optional
+        HTTP headers.
+    delay : float
+        Base polite delay before each attempt (seconds).
+    max_retries : int
+        Maximum retry attempts for 429/5xx/timeout.
+    timeout : float
+        Per-request timeout in seconds.
+    counters : dict, optional
+        Mutable dict updated with keys ``retries``, ``rate_limited``,
+        ``server_errors``, ``client_errors``.
+    backoff_base : float
+        Base for exponential backoff (seconds).
+    jitter_max : float
+        Maximum random jitter added to each backoff (seconds).
+    mailto : str, optional
+        Contact email for OpenAlex's polite pool. When given and absent from
+        ``params``/``url``, it is added as the ``mailto`` query param and used
+        in the default User-Agent. Injected by the caller — never hardcoded.
+    user_agent : str, optional
+        Explicit User-Agent. Overrides the ``mailto``-derived default.
+
+    Returns
+    -------
+    requests.Response on success.
+
+    Raises
+    ------
+    RuntimeError after all retries are exhausted.
+
+    """
+    if params is None:
+        params = {}
+    if mailto and "mailto" not in params and "mailto" not in url:
+        params["mailto"] = mailto
+    if headers is None:
+        headers = {}
+    if user_agent is not None:
+        headers.setdefault("User-Agent", user_agent)
+    elif mailto:
+        headers.setdefault("User-Agent", f"openalex-corpus/1.0 (mailto:{mailto})")
+    if counters is None:
+        counters = {}
+
+    host = urlparse(url).hostname or url
+
+    last_exc = None
+    for attempt in range(max_retries):
+        try:
+            time.sleep(delay)
+            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+        except requests.exceptions.Timeout as exc:
+            last_exc = exc
+            counters["retries"] = counters.get("retries", 0) + 1
+            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
+            _log.warning("Timeout on attempt %d/%d, retrying in %.1fs...",
+                         attempt + 1, max_retries, backoff)
+            time.sleep(backoff)
+            continue
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            counters["retries"] = counters.get("retries", 0) + 1
+            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
+            time.sleep(backoff)
+            continue
+
+        if resp.status_code == 429:
+            counters["rate_limited"] = counters.get("rate_limited", 0) + 1
+            counters["retries"] = counters.get("retries", 0) + 1
+            if attempt == max_retries - 1:
+                # Return the 429 response instead of raising — lets callers
+                # inspect budget headers and degrade gracefully.
+                _log.warning("Rate limited (429) by %s after %d attempts, returning response.",
+                             host, max_retries)
+                return resp
+            retry_after = min(
+                int(resp.headers.get("Retry-After", backoff_base ** (attempt + 1))), 120
+            )
+            jitter = random.uniform(0, min(jitter_max * 2, 2))
+            wait = retry_after + jitter
+            _log.warning("Rate limited (429) by %s, waiting %.1fs...", host, wait)
+            time.sleep(wait)
+            continue
+        if resp.status_code >= 500:
+            counters["server_errors"] = counters.get("server_errors", 0) + 1
+            counters["retries"] = counters.get("retries", 0) + 1
+            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
+            _log.warning("Server error %d on attempt %d/%d, retrying in %.1fs...",
+                         resp.status_code, attempt + 1, max_retries, backoff)
+            time.sleep(backoff)
+            last_exc = resp.status_code
+            continue
+        if resp.status_code >= 400:
+            counters["client_errors"] = counters.get("client_errors", 0) + 1
+            resp.raise_for_status()
+        return resp
+
+    raise RuntimeError(
+        f"Failed after {max_retries} attempts: {url} "
+        f"(last error: {last_exc})"
+    )

--- a/libs/openalex-corpus/tests/test_crawl.py
+++ b/libs/openalex-corpus/tests/test_crawl.py
@@ -1,0 +1,90 @@
+"""Contract tests for retry_get — the shared polite HTTP fetcher.
+
+Uses requests-mock (no real network) and stubs sleep to keep the suite fast.
+Freezes the retry/backoff contract both consuming repos depend on.
+"""
+
+import pytest
+import requests
+from openalex_corpus import retry_get
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Neutralise backoff/politeness delays so tests run instantly."""
+    monkeypatch.setattr("openalex_corpus.crawl.time.sleep", lambda *_: None)
+
+
+def test_success_returns_response(requests_mock):
+    requests_mock.get("https://api.openalex.org/works", json={"ok": True})
+    resp = retry_get("https://api.openalex.org/works")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_retries_429_then_succeeds(requests_mock):
+    requests_mock.get(
+        "https://api.openalex.org/works",
+        [{"status_code": 429, "headers": {"Retry-After": "0"}},
+         {"status_code": 200, "json": {"ok": True}}],
+    )
+    counters: dict[str, int] = {}
+    resp = retry_get("https://api.openalex.org/works", counters=counters)
+    assert resp.status_code == 200
+    assert counters["rate_limited"] == 1
+    assert requests_mock.call_count == 2
+
+
+def test_retries_500_then_succeeds(requests_mock):
+    requests_mock.get(
+        "https://api.openalex.org/works",
+        [{"status_code": 503}, {"status_code": 200, "json": {"ok": True}}],
+    )
+    counters: dict[str, int] = {}
+    resp = retry_get("https://api.openalex.org/works", counters=counters)
+    assert resp.status_code == 200
+    assert counters["server_errors"] == 1
+
+
+def test_persistent_429_returns_last_response_not_raise(requests_mock):
+    requests_mock.get(
+        "https://api.openalex.org/works",
+        status_code=429, headers={"Retry-After": "0"},
+    )
+    resp = retry_get("https://api.openalex.org/works", max_retries=3)
+    assert resp.status_code == 429  # graceful degrade, not RuntimeError
+
+
+def test_4xx_raises_immediately(requests_mock):
+    requests_mock.get("https://api.openalex.org/works", status_code=404)
+    with pytest.raises(requests.exceptions.HTTPError):
+        retry_get("https://api.openalex.org/works")
+
+
+def test_persistent_500_exhausts_to_runtimeerror(requests_mock):
+    requests_mock.get("https://api.openalex.org/works", status_code=500)
+    with pytest.raises(RuntimeError, match="Failed after 2 attempts"):
+        retry_get("https://api.openalex.org/works", max_retries=2)
+
+
+class TestMailtoInjection:
+    """mailto is injected by the caller, never hardcoded in the package."""
+
+    def test_mailto_added_to_params_and_user_agent(self, requests_mock):
+        requests_mock.get("https://api.openalex.org/works", json={})
+        retry_get("https://api.openalex.org/works", mailto="a@b.org")
+        req = requests_mock.last_request
+        assert req.qs["mailto"] == ["a@b.org"]
+        assert "mailto:a@b.org" in req.headers["User-Agent"]
+
+    def test_no_mailto_means_no_mailto_param(self, requests_mock):
+        requests_mock.get("https://api.openalex.org/works", json={})
+        retry_get("https://api.openalex.org/works")
+        assert "mailto" not in requests_mock.last_request.qs
+
+    def test_explicit_user_agent_overrides_default(self, requests_mock):
+        requests_mock.get("https://api.openalex.org/works", json={})
+        retry_get("https://api.openalex.org/works", mailto="a@b.org",
+                  user_agent="MyPipeline/2.0 (mailto:a@b.org)")
+        assert requests_mock.last_request.headers["User-Agent"] == \
+            "MyPipeline/2.0 (mailto:a@b.org)"

--- a/libs/openalex-corpus/tests/test_crawl.py
+++ b/libs/openalex-corpus/tests/test_crawl.py
@@ -67,6 +67,18 @@ def test_persistent_500_exhausts_to_runtimeerror(requests_mock):
         retry_get("https://api.openalex.org/works", max_retries=2)
 
 
+def test_retries_timeout_then_succeeds(requests_mock):
+    requests_mock.get(
+        "https://api.openalex.org/works",
+        [{"exc": requests.exceptions.Timeout},
+         {"status_code": 200, "json": {"ok": True}}],
+    )
+    counters: dict[str, int] = {}
+    resp = retry_get("https://api.openalex.org/works", counters=counters)
+    assert resp.status_code == 200
+    assert counters["retries"] == 1
+
+
 class TestMailtoInjection:
     """mailto is injected by the caller, never hardcoded in the package."""
 
@@ -88,3 +100,12 @@ class TestMailtoInjection:
                   user_agent="MyPipeline/2.0 (mailto:a@b.org)")
         assert requests_mock.last_request.headers["User-Agent"] == \
             "MyPipeline/2.0 (mailto:a@b.org)"
+
+    def test_neither_mailto_nor_user_agent_sets_no_package_ua(self, requests_mock):
+        # With neither given, the package injects no User-Agent — requests uses
+        # its own default, not an openalex-corpus/mailto string.
+        requests_mock.get("https://api.openalex.org/works", json={})
+        retry_get("https://api.openalex.org/works")
+        ua = requests_mock.last_request.headers.get("User-Agent", "")
+        assert "openalex-corpus" not in ua
+        assert "mailto:" not in ua

--- a/tests/test_openalex_corpus_equivalence.py
+++ b/tests/test_openalex_corpus_equivalence.py
@@ -1,0 +1,80 @@
+"""Migration-safety guard: openalex_corpus.retry_get == pipeline_io.retry_get.
+
+Ticket 0170 extracts the OpenAlex conventions into the standalone
+``openalex-corpus`` package. Before the host modules are rewired to re-export
+from it (the deferred shim slice), this test freezes the fact that the package
+port is behaviourally identical to the original — same status codes, same
+counter bookkeeping, same injected ``mailto`` param, same raised exceptions —
+when the package is called with ``mailto=MAILTO``.
+
+Once the shim lands, ``pipeline_io.retry_get`` IS the package function and the
+comparison becomes trivially true; the guard remains harmless. Until the
+package is a wired dependency, it is reached via an explicit path insert (the
+package is not yet installed into the host env); the test skips if either side
+is unimportable rather than failing the suite.
+"""
+
+import os
+import sys
+
+import pytest
+
+_PKG_SRC = os.path.join(
+    os.path.dirname(__file__), "..", "libs", "openalex-corpus", "src"
+)
+if _PKG_SRC not in sys.path:
+    sys.path.insert(0, _PKG_SRC)
+
+pipeline_io = pytest.importorskip("pipeline_io")
+_pkg = pytest.importorskip("openalex_corpus")
+
+MAILTO = pipeline_io.MAILTO
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr("pipeline_io.time.sleep", lambda *_: None)
+    monkeypatch.setattr("openalex_corpus.crawl.time.sleep", lambda *_: None)
+
+
+def _run(fn, responses, requests_mock, **kwargs):
+    """Drive one retry_get against a mocked endpoint; return an outcome tuple."""
+    url = "https://api.openalex.org/w"
+    requests_mock.get(url, responses)
+    counters: dict[str, int] = {}
+    try:
+        resp = fn(url, counters=counters, **kwargs)
+        status = resp.status_code
+        exc = None
+    except Exception as e:
+        status = None
+        exc = type(e).__name__
+    mailto = requests_mock.last_request.qs.get("mailto")
+    return status, counters, mailto, exc
+
+
+SCENARIOS = {
+    "success": [{"status_code": 200, "json": {"x": 1}}],
+    "429_then_ok": [
+        {"status_code": 429, "headers": {"Retry-After": "0"}},
+        {"status_code": 200, "json": {}},
+    ],
+    "503_then_ok": [
+        {"status_code": 503},
+        {"status_code": 200, "json": {}},
+    ],
+    "429_exhaust": [{"status_code": 429, "headers": {"Retry-After": "0"}}] * 5,
+    "404_raises": [{"status_code": 404}],
+    "500_exhaust": [{"status_code": 500}] * 2,
+}
+
+
+@pytest.mark.parametrize("name", list(SCENARIOS))
+def test_retry_get_port_is_equivalent(name, requests_mock):
+    responses = SCENARIOS[name]
+    orig = _run(pipeline_io.retry_get, responses, requests_mock, max_retries=5
+                if "exhaust" not in name or name == "429_exhaust" else 2)
+    pkg = _run(_pkg.retry_get, responses, requests_mock,
+               max_retries=5 if "exhaust" not in name or name == "429_exhaust" else 2,
+               mailto=MAILTO)
+    assert orig == pkg, f"{name}: orig={orig} pkg={pkg}"


### PR DESCRIPTION
Second execution slice of 0170. Ports `retry_get` into `libs/openalex-corpus/crawl.py`, completing the five-symbol shared convention library.

## Injection, not shipping
`retry_get` hardcoded only `MAILTO` (the polite `mailto` query param + User-Agent); it never referenced `OPENALEX_API_KEY` (callers thread that into `params`). So the package takes `mailto` (and optional `user_agent`) as parameters and hardcodes no email, key, or product name. Absent `mailto` → the fetcher omits the param and injects no User-Agent, correct for any non-OpenAlex caller.

## Review round 1 (fixed in 81b3b1d)
The `/gaze` code-review caught a real blocker I missed and I fixed it:
- **Missing `requests` dependency** — `crawl.py` imports `requests` at module top, but the package declared only `pandas`. A clean standalone install failed at `import openalex_corpus`. My original "23/23 green" run masked it by using the shared host interpreter (which already has `requests`) instead of a clean consumer install. **Fixed:** `requests` added to `dependencies`; `[dependency-groups] dev` adds `pytest` + `requests-mock`.
- **Verification redone correctly:** built an *isolated* venv for the package (`uv venv` + `uv pip install -e .`), confirmed `import openalex_corpus`, ran the suite there — **25/25 green**. No shared `/data` env mutation. Throwaway venv gitignored.
- **Two missing test cases added:** the `Timeout` retry branch (asserts `counters['retries']`), and "neither `mailto` nor `user_agent` → no package User-Agent" (23 → 25 tests).
- **Equivalence now committed, not prose-only:** `tests/test_openalex_corpus_equivalence.py` parametrizes six scenarios and asserts `pipeline_io.retry_get == openalex_corpus.retry_get(mailto=MAILTO)` (status, counters, injected mailto, exception type). 6/6 green in the host env — the migration-safety net for the shim slice.

## Still deferred (unchanged, env-/cross-repo-gated)
- **Shim rewire** + `[tool.uv.sources]` + **uv workspace membership** (so root `pytest` reaches the package tests — an adherence-reviewer nit) — needs `uv sync` against the shared `/data` env; folded into the shim slice.
- **Move B** (relocate `het_*.py` → polycentric) and **Move C** (`architecture.md`).

**Ticket-ref:** tickets/0170-cross-repo-dependency-extract-shared-cor.erg
**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)