### PR TITLE
ticket(0170): wire host modules to openalex-corpus via re-export shims (Move A shim)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -80,6 +80,28 @@ never touch `enrich_cache/` or the Phase 1/2 contract files. The figure and
 its methodology note are committed in `polycentric_activity/conception/`,
 not here.
 
+Those reused conventions now live in the `openalex-corpus` package (see below),
+not in `scripts/` directly. Ticket 0170 tracks relocating the `het_*.py`
+scripts to `polycentric_activity` so they consume the package by git source;
+until that lands they remain here, importing the conventions via this repo's
+own `scripts/` re-export shims.
+
+## Shared conventions package (`libs/openalex-corpus`)
+
+The model-agnostic OpenAlex conventions — `retry_get` (polite HTTP with
+backoff, `mailto` injected by the caller), `reconstruct_abstract`,
+`normalize_doi`, `build_text`, `is_boilerplate_abstract` — live in a standalone
+path package `libs/openalex-corpus`, this repo's source of truth for them
+(ticket 0170). It ships no deployment config (`MAILTO`/API keys are injected as
+parameters) and no embedding model choice. This repo's `scripts/pipeline_io.py`,
+`pipeline_text.py`, and `enrich_embeddings.py` import from it and **re-export**
+the symbols, so every existing `from utils import …` / `from pipeline_io import …`
+call site is unchanged; `pipeline_io.retry_get` is a thin shim that injects this
+repo's `MAILTO` and User-Agent. Behavioural parity is pinned by
+`tests/test_openalex_corpus_equivalence.py`. The package is consumed via a
+non-editable `[tool.uv.sources]` path entry; `polycentric_activity` will consume
+it by git source.
+
 ## Data location
 
 Data lives **outside the repo**, at `CLIMATE_FINANCE_DATA` in `.env`.

--- a/libs/openalex-corpus/src/openalex_corpus/__init__.py
+++ b/libs/openalex-corpus/src/openalex_corpus/__init__.py
@@ -7,17 +7,33 @@ repo's own ``scripts/`` modules re-export these to preserve their public API.
 
 Scope note: this package holds *conventions* only. Deployment config
 (``MAILTO``, API keys) is injected by the caller, never shipped here.
+
+Imports are lazy (PEP 562): pulling a pure-text symbol
+(``normalize_doi``/``reconstruct_abstract``/``build_text``) does not load the
+HTTP layer, so a text-only consumer never transitively imports ``requests``.
 """
 
-from openalex_corpus.crawl import RETRY_MAX_RETRIES, retry_get
-from openalex_corpus.embedding import build_text, is_boilerplate_abstract
-from openalex_corpus.text import normalize_doi, reconstruct_abstract
+import importlib
 
-__all__ = [
-    "RETRY_MAX_RETRIES",
-    "build_text",
-    "is_boilerplate_abstract",
-    "normalize_doi",
-    "reconstruct_abstract",
-    "retry_get",
-]
+# symbol -> submodule that defines it
+_LAZY = {
+    "retry_get": "crawl",
+    "RETRY_MAX_RETRIES": "crawl",
+    "build_text": "embedding",
+    "is_boilerplate_abstract": "embedding",
+    "normalize_doi": "text",
+    "reconstruct_abstract": "text",
+}
+
+__all__ = sorted(_LAZY)
+
+
+def __getattr__(name: str):
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(f"{__name__}.{module}"), name)
+
+
+def __dir__():
+    return sorted(__all__)

--- a/libs/openalex-corpus/src/openalex_corpus/embedding.py
+++ b/libs/openalex-corpus/src/openalex_corpus/embedding.py
@@ -8,7 +8,7 @@ Depends on pandas only for NaN handling in ``build_text``.
 import pandas as pd
 
 
-def is_boilerplate_abstract(abstract, title=None):
+def is_boilerplate_abstract(abstract: object, title: str | None = None) -> bool:
     """Return True if abstract is boilerplate/junk that should be skipped.
 
     Detects repository metadata strings, known boilerplate phrases,
@@ -41,7 +41,7 @@ def is_boilerplate_abstract(abstract, title=None):
     return False
 
 
-def build_text(row):
+def build_text(row: pd.Series) -> str:
     """Concatenate title, abstract, and keywords for embedding.
 
     Skips boilerplate abstracts (repository metadata, known junk phrases,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "ruptures>=1.1.9",
     "pybursts>=0.1.1",
     "python-louvain",
+    "openalex-corpus",
 ]
 
 [project.optional-dependencies]
@@ -62,6 +63,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+# libs/openalex-corpus is a separate installed package with its own test suite
+# (run standalone / on install); the host suite never collects it, so an
+# unscoped root `pytest` does not choke on `import openalex_corpus`.
+norecursedirs = ["libs"]
 markers = [
     "slow: marks tests that require network access or external data (deselect with '-m \"not slow\"')",
     "integration: marks tests that spawn subprocesses or use sleep-based timing (deselect with '-m \"not integration\"')",
@@ -88,6 +93,9 @@ torch = [
     { index = "pytorch-cpu", extra = "cpu" },
     { index = "pytorch-cu130", extra = "cu130" },
 ]
+# Non-editable path source: uv builds a wheel and installs it into the env, so
+# the shared /data env never .pth-links to a (throwaway) worktree checkout.
+openalex-corpus = { path = "libs/openalex-corpus" }
 
 [tool.ruff]
 target-version = "py310"

--- a/scripts/enrich_embeddings.py
+++ b/scripts/enrich_embeddings.py
@@ -20,6 +20,8 @@ os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
 import numpy as np
 import pandas as pd
+from openalex_corpus.embedding import build_text as build_text
+from openalex_corpus.embedding import is_boilerplate_abstract as is_boilerplate_abstract
 from utils import (
     CATALOGS_DIR,
     EMBEDDINGS_CACHE_DIR,
@@ -36,56 +38,6 @@ log = get_logger("enrich_embeddings")
 MODEL_NAME = "BAAI/bge-m3"
 TEXT_FIELDS = "title+abstract+keywords"
 EMBEDDING_DIM = 1024
-
-
-def is_boilerplate_abstract(abstract, title=None):
-    """Return True if abstract is boilerplate/junk that should be skipped.
-
-    Detects repository metadata strings, known boilerplate phrases,
-    title-as-abstract duplication, and short ALL CAPS fragments (truncated titles).
-    """
-    if not abstract or len(str(abstract).strip()) < 30:
-        return True
-    low = str(abstract).strip().lower()
-    # Known boilerplate phrases (exact match after lowering)
-    boilerplate = {"international audience", "editorial reviewed", "peer reviewed"}
-    if low in boilerplate:
-        return True
-    # Repository metadata URIs
-    if low.startswith("info:eu-repo/"):
-        return True
-    # Abstract is just the title repeated
-    if title and low == str(title).strip().lower():
-        return True
-    # Paywall / publisher stub abstracts (#455)
-    if low.startswith("no access"):
-        return True
-    if "10.5751/es-" in low and len(low) < 500:
-        return True
-    if "not available for this content" in low:
-        return True
-    # Short ALL CAPS text — truncated title fragments (e.g. "AZRBAYCANDA YAIL")
-    stripped = str(abstract).strip()
-    if len(stripped) < 50 and stripped == stripped.upper() and not stripped.islower():
-        return True
-    return False
-
-
-def build_text(row):
-    """Concatenate title, abstract, and keywords for embedding.
-
-    Skips boilerplate abstracts (repository metadata, known junk phrases,
-    title duplication) so they don't pollute embeddings.
-    """
-    title = str(row["title"])
-    parts = [title]
-    abstract = row.get("abstract")
-    if pd.notna(abstract) and not is_boilerplate_abstract(str(abstract), title=title):
-        parts.append(str(abstract))
-    keywords = row.get("keywords")
-    if pd.notna(keywords):
-        parts.append(str(keywords).replace(";", ", "))
-    return ". ".join(parts)
 
 
 def text_hash(text):

--- a/scripts/pipeline_io.py
+++ b/scripts/pipeline_io.py
@@ -32,13 +32,14 @@ import gzip
 import json
 import logging
 import os
-import random
 import re
 import time
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import requests  # type: ignore[import-untyped]
+from openalex_corpus import RETRY_MAX_RETRIES
+from openalex_corpus import retry_get as _pkg_retry_get
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -52,9 +53,9 @@ _log = logging.getLogger("pipeline.io")
 MAILTO = "minh.ha-duong@cnrs.fr"
 OPENALEX_API_KEY = os.environ.get("OPENALEX_API_KEY", "")
 
-# Retry budgets — single source of truth for polite_get and retry_get defaults
+# Retry budgets. RETRY_MAX_RETRIES is the single source of truth in the
+# openalex-corpus package (re-exported above for callers using it from here).
 POLITE_MAX_RETRIES = 3   # catalog scrapers (quick, many URLs)
-RETRY_MAX_RETRIES = 5    # enrichment fetchers (heavy, fewer URLs)
 CONSECUTIVE_FAIL_LIMIT = 5  # circuit breaker: abort after this many consecutive 429s
 
 
@@ -95,104 +96,18 @@ def retry_get(url: str, params: dict[str, Any] | None = None,
               backoff_base: float = 2.0, jitter_max: float = 1.0) -> requests.Response:
     """HTTP GET with bounded exponential backoff+jitter and optional counter tracking.
 
-    Parameters
-    ----------
-    url : str
-        Request URL.
-    params : dict, optional
-        Query parameters.
-    headers : dict, optional
-        HTTP headers.
-    delay : float
-        Base polite delay before each attempt (seconds).
-    max_retries : int
-        Maximum retry attempts for 429/5xx/timeout.
-    timeout : float
-        Per-request timeout in seconds.
-    counters : dict, optional
-        Mutable dict updated with keys ``retries``, ``rate_limited``,
-        ``server_errors``, ``client_errors``.
-    backoff_base : float
-        Base for exponential backoff (seconds).
-    jitter_max : float
-        Maximum random jitter added to each backoff (seconds).
-
-    Returns
-    -------
-    requests.Response on success.
-
-    Raises
-    ------
-    RuntimeError after all retries are exhausted.
-
+    Thin project shim over ``openalex_corpus.retry_get``: injects this repo's
+    deployment config (``MAILTO`` and the ``ClimateFinancePipeline`` User-Agent),
+    which the package keeps out of its convention layer. The retry/backoff logic
+    itself lives in the package (ticket 0170). Signature and behaviour are
+    unchanged for all existing callers; see ``tests/test_openalex_corpus_equivalence.py``.
     """
-    if params is None:
-        params = {}
-    if "mailto" not in params and "mailto" not in url:
-        params["mailto"] = MAILTO
-    if headers is None:
-        headers = {}
-    headers.setdefault("User-Agent", f"ClimateFinancePipeline/1.0 (mailto:{MAILTO})")
-    if counters is None:
-        counters = {}
-
-    from urllib.parse import urlparse
-    host = urlparse(url).hostname or url
-
-    last_exc = None
-    for attempt in range(max_retries):
-        try:
-            time.sleep(delay)
-            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
-        except requests.exceptions.Timeout as exc:
-            last_exc = exc
-            counters["retries"] = counters.get("retries", 0) + 1
-            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
-            _log.warning("Timeout on attempt %d/%d, retrying in %.1fs...",
-                         attempt + 1, max_retries, backoff)
-            time.sleep(backoff)
-            continue
-        except requests.exceptions.RequestException as exc:
-            last_exc = exc
-            counters["retries"] = counters.get("retries", 0) + 1
-            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
-            time.sleep(backoff)
-            continue
-
-        if resp.status_code == 429:
-            counters["rate_limited"] = counters.get("rate_limited", 0) + 1
-            counters["retries"] = counters.get("retries", 0) + 1
-            if attempt == max_retries - 1:
-                # Return the 429 response instead of raising — lets callers
-                # inspect budget headers and degrade gracefully.
-                _log.warning("Rate limited (429) by %s after %d attempts, returning response.",
-                             host, max_retries)
-                return resp
-            retry_after = min(
-                int(resp.headers.get("Retry-After", backoff_base ** (attempt + 1))), 120
-            )
-            jitter = random.uniform(0, min(jitter_max * 2, 2))
-            wait = retry_after + jitter
-            _log.warning("Rate limited (429) by %s, waiting %.1fs...", host, wait)
-            time.sleep(wait)
-            continue
-        if resp.status_code >= 500:
-            counters["server_errors"] = counters.get("server_errors", 0) + 1
-            counters["retries"] = counters.get("retries", 0) + 1
-            backoff = min(backoff_base ** attempt + random.uniform(0, jitter_max), 60)
-            _log.warning("Server error %d on attempt %d/%d, retrying in %.1fs...",
-                         resp.status_code, attempt + 1, max_retries, backoff)
-            time.sleep(backoff)
-            last_exc = resp.status_code
-            continue
-        if resp.status_code >= 400:
-            counters["client_errors"] = counters.get("client_errors", 0) + 1
-            resp.raise_for_status()
-        return resp
-
-    raise RuntimeError(
-        f"Failed after {max_retries} attempts: {url} "
-        f"(last error: {last_exc})"
+    return _pkg_retry_get(
+        url, params=params, headers=headers, delay=delay,
+        max_retries=max_retries, timeout=timeout, counters=counters,
+        backoff_base=backoff_base, jitter_max=jitter_max,
+        mailto=MAILTO,
+        user_agent=f"ClimateFinancePipeline/1.0 (mailto:{MAILTO})",
     )
 
 

--- a/scripts/pipeline_text.py
+++ b/scripts/pipeline_text.py
@@ -1,7 +1,10 @@
 """Pure text-transform utilities for the literature indexing pipeline.
 
 All functions here are stateless: no I/O, no side effects, no imports
-beyond stdlib + pandas + ftfy. Safe to import in any context.
+beyond stdlib + pandas + ftfy. Safe to import in any context. ``normalize_doi``
+and ``reconstruct_abstract`` are re-exported from the ``openalex_corpus``
+convention package (their single source of truth, ticket 0170); the package's
+pure-text submodule has no third-party imports, so the guarantee holds.
 
 Exports
 -------
@@ -33,6 +36,8 @@ import re
 
 import ftfy
 import pandas as pd
+from openalex_corpus.text import normalize_doi as normalize_doi
+from openalex_corpus.text import reconstruct_abstract as reconstruct_abstract
 
 # ---------------------------------------------------------------------------
 # General text normalization
@@ -73,23 +78,6 @@ def normalize_text(text: str | None) -> str:
 # ---------------------------------------------------------------------------
 # DOI helpers
 # ---------------------------------------------------------------------------
-
-def normalize_doi(doi_raw: str | list | None) -> str:
-    """Normalize a DOI: handle lists, strip URL prefix, lowercase, trim."""
-    if doi_raw is None:
-        return ""
-    if isinstance(doi_raw, list):
-        if not doi_raw:
-            return ""
-        doi_raw = doi_raw[0]
-    doi = str(doi_raw).strip()
-    for prefix in ("https://doi.org/", "http://doi.org/", "http://dx.doi.org/",
-                    "https://dx.doi.org/", "doi:"):
-        if doi.lower().startswith(prefix):
-            doi = doi[len(prefix):]
-            break
-    return doi.strip().lower()
-
 
 def normalize_doi_safe(doi_raw: object) -> str:
     """Normalize a DOI, returning "" for NaN/None values.
@@ -143,18 +131,6 @@ def normalize_title(title: str | None) -> str:
 # ---------------------------------------------------------------------------
 # Abstract helpers
 # ---------------------------------------------------------------------------
-
-def reconstruct_abstract(inverted_index: dict | None) -> str:
-    """Rebuild plain text from an OpenAlex abstract_inverted_index dict."""
-    if not inverted_index:
-        return ""
-    word_positions = []
-    for word, positions in inverted_index.items():
-        for pos in positions:
-            word_positions.append((pos, word))
-    word_positions.sort()
-    return " ".join(w for _, w in word_positions)
-
 
 # ---------------------------------------------------------------------------
 # Language normalisation

--- a/tests/test_openalex_corpus_equivalence.py
+++ b/tests/test_openalex_corpus_equivalence.py
@@ -1,29 +1,17 @@
-"""Migration-safety guard: openalex_corpus.retry_get == pipeline_io.retry_get.
+"""Migration-safety guard: pipeline_io.retry_get delegates faithfully to the package.
 
-Ticket 0170 extracts the OpenAlex conventions into the standalone
-``openalex-corpus`` package. Before the host modules are rewired to re-export
-from it (the deferred shim slice), this test freezes the fact that the package
-port is behaviourally identical to the original — same status codes, same
-counter bookkeeping, same injected ``mailto`` param, same raised exceptions —
-when the package is called with ``mailto=MAILTO``.
-
-Once the shim lands, ``pipeline_io.retry_get`` IS the package function and the
-comparison becomes trivially true; the guard remains harmless. Until the
-package is a wired dependency, it is reached via an explicit path insert (the
-package is not yet installed into the host env); the test skips if either side
-is unimportable rather than failing the suite.
+Ticket 0170 extracts the OpenAlex conventions into the ``openalex-corpus``
+package and rewires ``pipeline_io.retry_get`` into a thin shim that injects this
+repo's ``MAILTO`` and User-Agent and delegates to ``openalex_corpus.retry_get``.
+This test freezes the behavioural parity: same status codes, same counter
+bookkeeping, same injected ``mailto`` param, same raised exceptions — asserting
+``pipeline_io.retry_get(...) == openalex_corpus.retry_get(..., mailto=MAILTO)``
+across every retry path. It is the safety net for that shim; if a future edit
+diverges the two, this fails loudly. ``importorskip`` keeps it from breaking a
+suite run in an env where the package is not installed.
 """
 
-import os
-import sys
-
 import pytest
-
-_PKG_SRC = os.path.join(
-    os.path.dirname(__file__), "..", "libs", "openalex-corpus", "src"
-)
-if _PKG_SRC not in sys.path:
-    sys.path.insert(0, _PKG_SRC)
 
 pipeline_io = pytest.importorskip("pipeline_io")
 _pkg = pytest.importorskip("openalex_corpus")

--- a/tests/test_shim_resolution.py
+++ b/tests/test_shim_resolution.py
@@ -1,0 +1,65 @@
+"""Shim-resolution guard: carved symbols re-exported via their old host paths.
+
+Ticket 0170 Move A extracts the OpenAlex convention layer into the
+``openalex-corpus`` package and turns ``pipeline_io``/``pipeline_text``/
+``enrich_embeddings`` into re-export shims. A typo in a re-export line would
+silently break a rarely-run script rather than fail a test.
+
+This test imports every carved symbol via its OLD path (the one existing call
+sites use) and asserts it resolves to the package definition. For the four pure
+passthroughs that is object identity; ``retry_get`` is a thin shim (it injects
+this repo's ``MAILTO``/User-Agent), so it is deliberately *not* the package
+function — behavioural parity for it is pinned separately by
+``test_openalex_corpus_equivalence.py``. Here we only assert the shim exists,
+is distinct from the package function, and that ``RETRY_MAX_RETRIES`` is the
+package's single source of truth re-exported unchanged.
+
+``importorskip`` keeps the suite green in an env where the package is not
+installed.
+"""
+
+import pytest
+
+pkg = pytest.importorskip("openalex_corpus")
+
+
+@pytest.mark.parametrize(
+    "module_path, symbol",
+    [
+        # pure passthroughs — old path must BE the package object
+        ("pipeline_text", "normalize_doi"),
+        ("pipeline_text", "reconstruct_abstract"),
+        ("enrich_embeddings", "build_text"),
+        ("enrich_embeddings", "is_boilerplate_abstract"),
+        # utils re-export facade chains through to the same package objects.
+        # (utils re-exports the pipeline_text symbols; build_text /
+        # is_boilerplate_abstract are imported directly from enrich_embeddings
+        # by call sites, not via the utils facade — covered above.)
+        ("utils", "normalize_doi"),
+        ("utils", "reconstruct_abstract"),
+    ],
+)
+def test_pure_symbol_resolves_to_package(module_path, symbol):
+    module = pytest.importorskip(module_path)
+    host_obj = getattr(module, symbol)
+    pkg_obj = getattr(pkg, symbol)
+    assert host_obj is pkg_obj, (
+        f"{module_path}.{symbol} must re-export the package definition "
+        f"(openalex_corpus.{symbol}); got a distinct object — the re-export "
+        f"line is broken."
+    )
+
+
+def test_retry_max_retries_re_exported():
+    pipeline_io = pytest.importorskip("pipeline_io")
+    assert pipeline_io.RETRY_MAX_RETRIES == pkg.RETRY_MAX_RETRIES
+
+
+def test_retry_get_is_shim_not_package_fn():
+    pipeline_io = pytest.importorskip("pipeline_io")
+    utils = pytest.importorskip("utils")
+    # The shim wraps the package fn (injects MAILTO/User-Agent), so it must be a
+    # distinct callable, and utils must re-export that same shim.
+    assert callable(pipeline_io.retry_get)
+    assert pipeline_io.retry_get is not pkg.retry_get
+    assert utils.retry_get is pipeline_io.retry_get

--- a/tickets/0170-cross-repo-dependency-extract-shared-cor.erg
+++ b/tickets/0170-cross-repo-dependency-extract-shared-cor.erg
@@ -12,6 +12,8 @@ Author: HDMX-coding-agent
 
 2026-07-09T02:00Z claude note Move A split into A1/A2 for locally-verifiable delivery. PR #954 lands A1: libs/openalex-corpus/ with the four PURE convention functions (reconstruct_abstract, normalize_doi, build_text, is_boilerplate_abstract) copied verbatim + a 14-case contract test; standalone (not yet in make check). Deferred to A2 (a session with safe shared /data-env access): retry_get + RETRY_MAX_RETRIES (live Phase-1 HTTP path, 13 call sites) AND the shim rewire of pipeline_io/pipeline_text/enrich_embeddings + [tool.uv.sources] (needs uv sync against the shared env). So Actions Move A step 1 above is delivered only for the pure functions; retry_get moves in A2. Moves B (relocate het_*.py) and C (architecture.md) remain separate PRs. Ticket stays OPEN.
 
+2026-07-09T00:00Z claude note bump verify-reroll — round 1 (PR #958 / A2): the Test-section second red test (shim-resolution guard asserting every carved symbol resolves via its old path to the package definition) was specified for the shim slice but omitted; only retry_get parity was committed. Added tests/test_shim_resolution.py (commit 4411c3b); round 2 gate APPROVED. Ticket stays OPEN (Moves B/C pending).
+
 --- body ---
 ## Context
 Ticket 0167 (PR #860) added `scripts/het_*.py` to this repo to generate a

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130'",
@@ -765,6 +765,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "openalex-corpus" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
     { name = "pandera" },
@@ -823,6 +824,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.30.0,<=1.82.6" },
     { name = "matplotlib" },
     { name = "networkx" },
+    { name = "openalex-corpus", directory = "libs/openalex-corpus" },
     { name = "pandas" },
     { name = "pandera", specifier = ">=0.30.1" },
     { name = "pdfplumber" },
@@ -3490,6 +3492,28 @@ wheels = [
 ]
 
 [[package]]
+name = "openalex-corpus"
+version = "0.1.0"
+source = { directory = "libs/openalex-corpus" }
+dependencies = [
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pandas" },
+    { name = "requests" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest" },
+    { name = "requests-mock" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -5964,21 +5988,21 @@ dependencies = [
     { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-19-climate-finance-het-cpu') or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:4db72a4d257c45c3502f11764ee41460a87312fdc3dff47a8957812efe961725" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0826ac8e409551e12b2360ac18b4161a838cbd111933e694752f351191331d09" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7417ef370d7c3969dd509dae8d5c7daeb945af335ab76dd38358ba30a91251c1" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:90821a3194b8806d9fa9fdaa9308c1bc73df0c26808274b14129a97c99f35794" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2d16abfce6c92584ceeb00c3b2665d5798424dd9ed235ea69b72e045cd53ae97" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:4584ab167995c0479f6821e3dceaf199c8166c811d3adbba5d8eedbbfa6764fd" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:4db72a4d257c45c3502f11764ee41460a87312fdc3dff47a8957812efe961725", upload-time = "2026-02-06T16:27:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:0826ac8e409551e12b2360ac18b4161a838cbd111933e694752f351191331d09", upload-time = "2026-02-06T16:27:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e", upload-time = "2026-02-06T16:27:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:b39cafff7229699f9d6e172cac74d85fd71b568268e439e08d9c540e54732a3e", upload-time = "2026-02-06T16:27:17Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7417ef370d7c3969dd509dae8d5c7daeb945af335ab76dd38358ba30a91251c1", upload-time = "2026-02-10T19:55:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:90821a3194b8806d9fa9fdaa9308c1bc73df0c26808274b14129a97c99f35794", upload-time = "2026-02-10T19:55:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023", upload-time = "2026-02-10T19:55:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:470de4176007c2700735e003a830828a88d27129032a3add07291da07e2a94e8", upload-time = "2026-02-10T19:55:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2d16abfce6c92584ceeb00c3b2665d5798424dd9ed235ea69b72e045cd53ae97", upload-time = "2026-01-23T15:09:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:4584ab167995c0479f6821e3dceaf199c8166c811d3adbba5d8eedbbfa6764fd", upload-time = "2026-01-23T15:09:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407", upload-time = "2026-01-23T15:09:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:339e05502b6c839db40e88720cb700f5a3b50cda332284873e851772d41b2c1e", upload-time = "2026-01-23T15:09:57Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:840351da59cedb7bcbc51981880050813c19ef6b898a7fecf73a3afc71aff3fe", upload-time = "2026-01-23T15:09:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c88b1129fd4e14f0f882963c6728315caae35d2f47374d17edeed1edc7697497", upload-time = "2026-01-23T15:09:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f4bea7dc451267c028593751612ad559299589304e68df54ae7672427893ff2c", upload-time = "2026-01-23T15:10:01Z" },
 ]
 
 [[package]]
@@ -6082,44 +6106,44 @@ dependencies = [
     { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-19-climate-finance-het-cpu') or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_aarch64.whl", hash = "sha256:31ae44836c8b9bbd1a3943d29c7c7457709ddf7c6173aa34aefe9d2203e4c405" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:beadc2a6a1785b09a46daad378de91ef274b8d3eea7af0bc2d017d97f115afdf" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d63ee6a80982fd73fe44bb70d97d2976e010312ff6db81d7bfb9167b06dd45b9" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a280ffaea7b9c828e0c1b9b3bd502d9b6a649dc9416997b69b84544bd469f215" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:6c6f0df770144907092a0d067048d96ed4f278a6c840376d2ff0e27e7579b925" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_aarch64.whl", hash = "sha256:ce5c113d1f55f8c1f5af05047a24e50d11d293e0cbbb5bf7a75c6c761edd6eaa" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:0e286fcf6ce0cc7b204396c9b4ea0d375f1f0c3e752f68ce3d3aeb265511db8c" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1cfcb9b1558c6e52dffd0d4effce83b13c5ae5d97338164c372048c21f9cfccb" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7cb1ec66cefb90fd7b676eac72cfda3b8d4e4d0cacd7a531963bc2e0a9710ab" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:17a09465bab2aab8f0f273410297133d8d8fb6dd84dccbd252ca4a4f3a111847" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:c35c0de592941d4944698dbfa87271ab85d3370eca3b694943a2ab307ac34b3f" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_aarch64.whl", hash = "sha256:31ae44836c8b9bbd1a3943d29c7c7457709ddf7c6173aa34aefe9d2203e4c405", upload-time = "2026-01-23T15:10:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:beadc2a6a1785b09a46daad378de91ef274b8d3eea7af0bc2d017d97f115afdf", upload-time = "2026-01-23T15:10:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d63ee6a80982fd73fe44bb70d97d2976e010312ff6db81d7bfb9167b06dd45b9", upload-time = "2026-01-23T15:10:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a280ffaea7b9c828e0c1b9b3bd502d9b6a649dc9416997b69b84544bd469f215", upload-time = "2026-01-23T15:10:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:6c6f0df770144907092a0d067048d96ed4f278a6c840376d2ff0e27e7579b925", upload-time = "2026-01-23T15:10:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_aarch64.whl", hash = "sha256:ce5c113d1f55f8c1f5af05047a24e50d11d293e0cbbb5bf7a75c6c761edd6eaa", upload-time = "2026-01-23T15:10:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:0e286fcf6ce0cc7b204396c9b4ea0d375f1f0c3e752f68ce3d3aeb265511db8c", upload-time = "2026-01-23T15:10:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1cfcb9b1558c6e52dffd0d4effce83b13c5ae5d97338164c372048c21f9cfccb", upload-time = "2026-01-23T15:10:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7cb1ec66cefb90fd7b676eac72cfda3b8d4e4d0cacd7a531963bc2e0a9710ab", upload-time = "2026-01-23T15:10:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:17a09465bab2aab8f0f273410297133d8d8fb6dd84dccbd252ca4a4f3a111847", upload-time = "2026-01-23T15:10:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:c35c0de592941d4944698dbfa87271ab85d3370eca3b694943a2ab307ac34b3f", upload-time = "2026-01-23T15:10:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c", upload-time = "2026-01-23T15:10:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596", upload-time = "2026-01-23T15:10:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87", upload-time = "2026-01-23T15:10:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d", upload-time = "2026-01-23T15:10:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1", upload-time = "2026-01-23T15:10:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78", upload-time = "2026-01-23T15:10:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_aarch64.whl", hash = "sha256:fd215f3d0f681905c5b56b0630a3d666900a37fcc3ca5b937f95275c66f9fd9c", upload-time = "2026-01-23T15:10:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:170a0623108055be5199370335cf9b41ba6875b3cb6f086db4aee583331a4899", upload-time = "2026-01-23T15:10:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e51994492cdb76edce29da88de3672a3022f9ef0ffd90345436948d4992be2c7", upload-time = "2026-01-23T15:10:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8d316e5bf121f1eab1147e49ad0511a9d92e4c45cc357d1ab0bee440da71a095", upload-time = "2026-01-23T15:10:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:b719da5af01b59126ac13eefd6ba3dd12d002dc0e8e79b8b365e55267a8189d3", upload-time = "2026-01-23T15:10:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:b67d91326e4ed9eccbd6b7d84ed7ffa43f93103aa3f0b24145f3001f3b11b714", upload-time = "2026-01-23T15:10:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_aarch64.whl", hash = "sha256:5af75e5f49de21b0bdf7672bc27139bd285f9e8dbcabe2d617a2eb656514ac36", upload-time = "2026-01-23T15:10:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:ba51ef01a510baf8fff576174f702c47e1aa54389a9f1fba323bb1a5003ff0bf", upload-time = "2026-01-23T15:10:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0fedcb1a77e8f2aaf7bfd21591bf6d1e0b207473268c9be16b17cb7783253969", upload-time = "2026-01-23T15:10:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:106dd1930cb30a4a337366ba3f9b25318ebf940f51fd46f789281dd9e736bdc4", upload-time = "2026-01-23T15:10:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:eb1bde1ce198f05c8770017de27e001d404499cf552aaaa014569eff56ca25c0", upload-time = "2026-01-23T15:10:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_aarch64.whl", hash = "sha256:ea2bcc9d1fca66974a71d4bf9a502539283f35d61fcab5a799b4e120846f1e02", upload-time = "2026-01-23T15:10:53Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:f8294fd2fc6dd8f4435a891a0122307a043b14b21f0dac1bca63c85bfb59e586", upload-time = "2026-01-23T15:10:55Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a28fdbcfa2fbacffec81300f24dd1bed2b0ccfdbed107a823cff12bc1db070f6", upload-time = "2026-01-23T15:10:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aada8afc068add586464b2a55adb7cc9091eec55caf5320447204741cb6a0604", upload-time = "2026-01-23T15:10:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:2adc71fe471e98a608723bfc837f7e1929885ebb912c693597711e139c1cda41", upload-time = "2026-01-23T15:11:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_aarch64.whl", hash = "sha256:9412bd37b70f5ebd1205242c4ba4cabae35a605947f2b30806d5c9b467936db9", upload-time = "2026-01-23T15:11:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:e71c476517c33e7db69825a9ff46c7f47a723ec4dac5b2481cff4246d1c632be", upload-time = "2026-01-23T15:11:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:23882f8d882460aca809882fc42f5e343bf07585274f929ced00177d1be1eb67", upload-time = "2026-01-23T15:11:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4fcd8b4cc2ae20f2b7749fb275349c55432393868778c2d50a08e81d5ee5591e", upload-time = "2026-01-23T15:11:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:ffc8da9a1341092d6a90cb5b1c1a33cd61abf0fb43f0cd88443c27fa372c26ae", upload-time = "2026-01-23T15:11:10Z" },
 ]
 
 [[package]]
@@ -6169,27 +6193,27 @@ dependencies = [
     { name = "typing-extensions", marker = "extra == 'extra-19-climate-finance-het-cu130'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:adfb2bca94f12a5baca6ccf9aa40d6c5b1259748ebb38938be670b07a24d4e15" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0f8566d1b3d8353b7f18d5a15375a00dae89d886bb7d01143bb394f475832286" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:0de43ec229a78a2e80ae8578252f9eb14f898457d1cf2be81c8c91a4108c6c79" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ea3239d544b2e569a8f47db5c7fa4fd42a2fe96aefb84bb1eda45ce213020fd2" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:22cfa45e73f1e8c64f4012737987a727d01d152121b93d196b0ca22f39a3f8e3" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:218ae0f323d5ebe8f2770e46cbfb7bbff9af2c8d192d5187878d0964d43c8b71" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4fc8f67637f4c92b989a07d80ffe755e79a3510ca02ebf23ce66396fb277c88d" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:858f0cbcc78d726fea9499eb3464faa98392fa093845a3262209bd226b7844d6" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:224649fa0ab181ec483cc368e3303dda1760e4ba31bea806b88979f855436aaa" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:75780283308df9fede371eeda01e9607c8862a1803a2f2f31a08a2c0deaed342" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7e0d9922e9e91f780b2761a0c5ebac3c15c9740bab042e1b59149afa6d6474eb" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:48af94af745a9dd9b42be81ea15b56aba981666bcfe10394dceca6d9476a50fa" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:46699da91f0367d8dfa1b606cb0352aaf190b5853f463010e75ff08f15a94e7d" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:775d1fff07e302fb669d555a5005f781aa460aa80dff7a512e8e6e723f9def83" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:b38e5b505b015903a51c2b3f12e50a9f152f92fe7e3992e79f504138cf90601d" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:18f87ae628c02f095f2e97756e4fa249ceef6ed6e87d5a3c79b5338abf842511" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db5a61791b7da3c1aa5a496e64cd72dbd4ef3ef2cbb69680fd45dc255b0da2f3" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:dda35d473dd34cafa0668be176b9ad2cb69b1ff570d0336715a6541e89e27640" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7781235583ea06b214075c10fa95f83b9805f06af44efc6e9946808413cff94f" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:526b737db11d632281795484ec729baae5f193a5a0d76a1f7d822f7897c8b4f5" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:d5ea18790a18b660d655f6e75a8ca6e8d6298b55fc338f8c921764b94c886743" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:adfb2bca94f12a5baca6ccf9aa40d6c5b1259748ebb38938be670b07a24d4e15", upload-time = "2026-01-21T19:02:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0f8566d1b3d8353b7f18d5a15375a00dae89d886bb7d01143bb394f475832286", upload-time = "2026-01-21T19:02:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:0de43ec229a78a2e80ae8578252f9eb14f898457d1cf2be81c8c91a4108c6c79", upload-time = "2026-01-21T19:00:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ea3239d544b2e569a8f47db5c7fa4fd42a2fe96aefb84bb1eda45ce213020fd2", upload-time = "2026-01-21T19:01:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:22cfa45e73f1e8c64f4012737987a727d01d152121b93d196b0ca22f39a3f8e3", upload-time = "2026-01-21T19:02:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:218ae0f323d5ebe8f2770e46cbfb7bbff9af2c8d192d5187878d0964d43c8b71", upload-time = "2026-01-21T19:00:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4fc8f67637f4c92b989a07d80ffe755e79a3510ca02ebf23ce66396fb277c88d", upload-time = "2026-01-21T19:01:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:858f0cbcc78d726fea9499eb3464faa98392fa093845a3262209bd226b7844d6", upload-time = "2026-01-21T19:02:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:224649fa0ab181ec483cc368e3303dda1760e4ba31bea806b88979f855436aaa", upload-time = "2026-01-21T19:00:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:75780283308df9fede371eeda01e9607c8862a1803a2f2f31a08a2c0deaed342", upload-time = "2026-01-21T19:01:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7e0d9922e9e91f780b2761a0c5ebac3c15c9740bab042e1b59149afa6d6474eb", upload-time = "2026-01-21T19:02:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:48af94af745a9dd9b42be81ea15b56aba981666bcfe10394dceca6d9476a50fa", upload-time = "2026-01-21T19:00:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:46699da91f0367d8dfa1b606cb0352aaf190b5853f463010e75ff08f15a94e7d", upload-time = "2026-01-21T19:02:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:775d1fff07e302fb669d555a5005f781aa460aa80dff7a512e8e6e723f9def83", upload-time = "2026-01-21T19:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:b38e5b505b015903a51c2b3f12e50a9f152f92fe7e3992e79f504138cf90601d", upload-time = "2026-01-21T19:01:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:18f87ae628c02f095f2e97756e4fa249ceef6ed6e87d5a3c79b5338abf842511", upload-time = "2026-01-21T19:01:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db5a61791b7da3c1aa5a496e64cd72dbd4ef3ef2cbb69680fd45dc255b0da2f3", upload-time = "2026-01-21T19:02:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:dda35d473dd34cafa0668be176b9ad2cb69b1ff570d0336715a6541e89e27640", upload-time = "2026-01-21T19:00:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7781235583ea06b214075c10fa95f83b9805f06af44efc6e9946808413cff94f", upload-time = "2026-01-21T19:01:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:526b737db11d632281795484ec729baae5f193a5a0d76a1f7d822f7897c8b4f5", upload-time = "2026-01-21T19:02:44Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:d5ea18790a18b660d655f6e75a8ca6e8d6298b55fc338f8c921764b94c886743", upload-time = "2026-01-21T19:01:35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes **Move A** of ticket 0170: the host repo now *consumes* the `openalex-corpus` package instead of defining the OpenAlex conventions itself. Behaviour-preserving — every existing call site keeps its imports.

## Rewire
- `pipeline_io.retry_get` → thin shim delegating to `openalex_corpus.retry_get`, injecting this repo's `MAILTO` and the exact original User-Agent (`ClimateFinancePipeline/1.0`). `RETRY_MAX_RETRIES` re-exported from the package; orphaned `import random` dropped.
- `pipeline_text`: `normalize_doi`, `reconstruct_abstract` re-exported from `openalex_corpus.text`.
- `enrich_embeddings`: `build_text`, `is_boilerplate_abstract` re-exported from `openalex_corpus.embedding`.
- `utils` facade unchanged → all `from utils import …` / `from pipeline_io import …` call sites (159/50/13/5/3 files) work untouched.

## Packaging / correctness
- **Non-editable** `[tool.uv.sources]` path entry: uv builds a wheel into the env, so the shared `/data` env never `.pth`-links to a throwaway worktree. `norecursedirs=["libs"]` so an unscoped root `pytest` doesn't choke on the package's own tests.
- **Lazy package `__init__`** (PEP 562): importing a pure-text symbol no longer transitively imports `requests`, preserving `pipeline_text`'s "safe in any context" guarantee.
- **`py.typed` + annotations**: the untyped import would have caused a `no-any-return` mypy failure in `pipeline_text.normalize_doi_safe`; shipping the library typed is the correct fix (`TestTypingCoreModules` passes).

## Verification
Shared `/data` env synced (authorized) — **only `openalex-corpus` added to the lock, zero other version churn**.
- Import smoke: re-exports resolve to the package; `retry_get` is the shim with the original signature.
- Equivalence guard `tests/test_openalex_corpus_equivalence.py` **6/6**; package suite **25/25**; mypy gate passes; ruff clean.
- **Canonical `check-fast` (`-n 4`): 1127 passed, 21 skipped, 0 failed.**

## Follow-ups (unchanged)
- **Move B**: relocate `het_*.py` → `polycentric_activity` (consume the package by git source). Cross-repo.
- **Move C**: rewrite the "Companion pipelines" section of `architecture.md` once the scripts move (this PR adds the package's own architecture note).

**Ticket-ref:** tickets/0170-cross-repo-dependency-extract-shared-cor.erg
**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)