### PR TITLE
ticket(0209): purge fabricated manne DOI + standing class guard

### DIFF
--- a/scripts/archive_traditions/detect_traditions_v3.py
+++ b/scripts/archive_traditions/detect_traditions_v3.py
@@ -58,8 +58,9 @@ TRADITION_SEEDS = {
         {"title_fragment": "production consumption externalities", "author": "ayres", "year": 1969},
         # Nordhaus 1992
         {"doi": "10.1126/science.258.5086.1315", "author": "nordhaus", "year": 1992},
-        # Manne & Richels 1992
-        {"doi": "10.1016/0301-4215(92)90024-v", "author": "manne", "year": 1992},
+        # Manne & Richels 1992 - MIT Press book, no Crossref DOI; the prior
+        # doi literal here was LLM-fabricated (0188/0201/0209)
+        {"title_fragment": "buying greenhouse insurance", "author": "manne", "year": 1992},
         # Stern 2007
         {"title_fragment": "economics of climate change", "author": "stern", "year": 2007},
         # Weitzman 2007

--- a/tests/test_fabricated_doi_class_guard.py
+++ b/tests/test_fabricated_doi_class_guard.py
@@ -1,0 +1,62 @@
+"""Standing class guard: no known-fabricated DOI may appear in any script.
+
+The LLM-fabricated DOI ``10.1016/0301-4215(92)90024-V`` (an unrelated
+energy-demand paper; Manne & Richels 1992 is a MIT Press *book* with no
+Crossref DOI) was removed three times, each caught only after the fact:
+``main.bib`` (0188/#928), ``scout_tradition_coupling.py`` ANCHORS (0201/#943),
+and ``archive_traditions/detect_traditions_v3.py`` (0209). Three instances of
+one fabricated string is a class, not a coincidence.
+
+The prior guards are file-scoped: ``tests/test_bib_doi_title.py`` scans only
+``main.bib``; ``tests/test_scout_anchors.py`` only the scout dict. Neither
+covers ``archive_traditions/`` — and ``tests/test_script_hygiene.py`` explicitly
+skips ``scripts/archive/`` (and would skip nothing under ``archive_traditions/``
+only by accident of its walk). This guard scans **every** ``scripts/**/*.py``,
+archived or not, against an extensible set. A future discovery adds one line to
+``FABRICATED_DOIS``.
+
+Matching is case-insensitive: the string appears as ``...90024-V`` in main.bib
+and ``...90024-v`` in the archived detector.
+"""
+
+import os
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO / "scripts"
+
+# Known LLM-fabricated DOIs. Add one line per confirmed fabrication.
+# - 10.1016/0301-4215(92)90024-V: resolves to an unrelated energy-demand paper;
+#   Manne & Richels 1992 ("Buying Greenhouse Insurance") is a MIT Press book
+#   with no Crossref DOI. Removed by 0188/#928, 0201/#943, 0209.
+FABRICATED_DOIS = [
+    "10.1016/0301-4215(92)90024-V",
+]
+
+
+def _all_script_files():
+    """Yield every .py file under scripts/, including archived subtrees.
+
+    Unlike test_script_hygiene._all_scripts(), this deliberately does NOT
+    skip archive/ or archive_traditions/: a fabricated DOI in dead code is a
+    latent copy source and must be purged everywhere.
+    """
+    for dirpath, _dirnames, filenames in os.walk(SCRIPTS_DIR):
+        for f in filenames:
+            if f.endswith(".py"):
+                yield Path(dirpath) / f
+
+
+def test_no_fabricated_doi_in_any_script():
+    """No script anywhere under scripts/ may contain a known-fabricated DOI."""
+    needles = [d.casefold() for d in FABRICATED_DOIS]
+    offenders = []
+    for path in _all_script_files():
+        text = path.read_text(encoding="utf-8", errors="replace").casefold()
+        for needle, original in zip(needles, FABRICATED_DOIS):
+            if needle in text:
+                rel = path.relative_to(REPO)
+                offenders.append(f"{rel}: {original}")
+    assert not offenders, "Fabricated DOI(s) found in scripts:\n" + "\n".join(
+        offenders
+    )

--- a/tickets/closed/0209-purge-fabricated-manne-doi-from-archived.erg
+++ b/tickets/closed/0209-purge-fabricated-manne-doi-from-archived.erg
@@ -2,10 +2,12 @@
 Title: Purge fabricated manne DOI from archived detect_traditions_v3 + standing class guard
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: Fabricated manne DOI purged from detect_traditions_v3; standing class guard added scanning all scripts/**/*.py
 
 --- log ---
 2026-07-09T20:19Z HDMX-coding-agent created
 
+2026-07-09T22:13Z HDMX-coding-agent closed — Fabricated manne DOI purged from detect_traditions_v3; standing class guard added scanning all scripts/**/*.py
 --- body ---
 ## Context
 The LLM-fabricated DOI `10.1016/0301-4215(92)90024-V` (an unrelated energy-demand


### PR DESCRIPTION
## Summary
Purges the third and final instance of the LLM-fabricated DOI
`10.1016/0301-4215(92)90024-V` — at
`scripts/archive_traditions/detect_traditions_v3.py:62` — and adds a **standing
class guard** so this class of defect fails any future PR.

Manne & Richels 1992 is a MIT Press book with no Crossref DOI. The string was
removed from `main.bib` (0188/#928) and the scout ANCHORS (0201/#943); PR #953's
/roar sweep found this dormant archived copy and filed 0209.

## What changed
- **`tests/test_fabricated_doi_class_guard.py`** (new): walks **every**
  `scripts/**/*.py` — including `archive_traditions/`, which
  `test_script_hygiene._all_scripts()` does not cover — case-insensitively
  against an extensible `FABRICATED_DOIS` set. Red-first: failed against main on
  the surviving instance, passes after the fix. A future fabrication adds one line.
- **`detect_traditions_v3.py`**: the manne seed now matches on a title fragment
  (`"buying greenhouse insurance"`) like the other DOI-less seeds; no DOI. The
  comment avoids reproducing the literal so the guard stays green.

## Verification
- `grep -rn '0301-4215(92)90024' scripts/` → clean
- new guard passes; `make check-fast` green (exit 0)

**Ticket:** tickets/0209-purge-fabricated-manne-doi-from-archived.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)