### PR TITLE
ticket(0206): close — re-acquire 3 HTML-not-PDF files via DOIfetch

### DIFF
--- a/tickets/closed/0206-re-acquire-3-html-not-pdf-cited-uncited.erg
+++ b/tickets/closed/0206-re-acquire-3-html-not-pdf-cited-uncited.erg
@@ -2,10 +2,12 @@
 Title: Re-acquire 3 HTML-not-PDF cited/uncited files flagged by 0200 audit
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: Re-acquired all three PDFs via DOIfetch; content verified against copyright pages; make audit-pdf-content reports 0 not-a-PDF.
 
 --- log ---
 2026-07-09T19:20Z HDMX-coding-agent created
 
+2026-07-10T07:20Z HDMX-coding-agent closed — Re-acquired all three PDFs via DOIfetch; content verified against copyright pages; make audit-pdf-content reports 0 not-a-PDF.
 --- body ---
 ## Context
 The 0200 PDF-content audit (`scripts/qa_pdf_content.py`, `make audit-pdf-content`)


### PR DESCRIPTION
## Summary
The 0200 PDF-content audit flagged three files in `docs/articles/` as HTML documents (saved paywall/error pages) stored under `.pdf` names: `michaelowa2007.pdf` (cited), `stadelmann2011.pdf` (cited), `roberts2021.pdf` (uncited).

Ran DOIfetch on each DOI:
- `10.1007/s10584-007-9270-3` — Michaelowa & Michaelowa 2007, *Climatic Change* 84:5–21 ✓
- `10.1080/17565529.2011.599550` — Stadelmann et al. 2011, *Climate and Development* ✓
- `10.1038/s41558-021-00990-2` — Roberts et al. 2021, *Nature Climate Change* comment ✓

All three resolved to genuine PDFs; content verified against each copyright/title page. Files dropped in over the broken HTML (docs/articles is gitignored — not committed).

## Verification
- `file docs/articles/{michaelowa2007,stadelmann2011,roberts2021}.pdf` → each "PDF document" ✓
- `make audit-pdf-content` → **0 not-a-PDF** rows ✓
- michaelowa2007 + stadelmann2011 content confirmed against copyright page ✓

**Ticket:** tickets/0206-re-acquire-3-html-not-pdf-cited-uncited.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)