### PR TITLE
test: mark heavy tests integration so check-fast honors its <30s contract

### DIFF
--- a/tests/test_bias_flag.py
+++ b/tests/test_bias_flag.py
@@ -8,6 +8,12 @@ import os
 import subprocess
 import sys
 
+import pytest
+
+# Both tests spawn compute_divergence.py via subprocess — excluded from
+# check-fast per the subprocess-tests-are-integration rule (coding-python.md).
+pytestmark = pytest.mark.integration
+
 
 def test_no_equal_n_flag_accepted(tmp_path):
     """compute_divergence.py must accept --no-equal-n flag without argparse error.

--- a/tests/test_c2st.py
+++ b/tests/test_c2st.py
@@ -12,6 +12,7 @@ import sys
 
 import numpy as np
 import pandas as pd
+import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
@@ -246,7 +247,6 @@ class TestC2STSchemaStrict:
     def test_rejects_missing_variance_columns(self):
         """Missing auc_std must fail strict C2STDivergenceSchema validation."""
         import pandera.errors
-        import pytest
         from schemas import C2STDivergenceSchema
 
         bad = pd.DataFrame(
@@ -294,6 +294,7 @@ class TestC2STDispatcherIntegration:
         )
         assert hasattr(compute_divergence, "DivergenceSchema")
 
+    @pytest.mark.integration
     def test_end_to_end_c2st_lexical_on_smoke_fixture(self, tmp_path):
         """Run compute_divergence.py --method C2ST_lexical against the smoke
         fixture; output must pass C2STDivergenceSchema.

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -835,6 +835,7 @@ class TestSharedRngContamination:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestBackendComparison:
     """Compare sequential, parallel-CPU, and GPU permutation backends.
 

--- a/tests/test_null_model_lexical_l2_l3.py
+++ b/tests/test_null_model_lexical_l2_l3.py
@@ -13,6 +13,7 @@ import sys
 
 import numpy as np
 import pandas as pd
+import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
@@ -245,8 +246,13 @@ class TestL3Permutations:
 # ── L2 tests ─────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.integration
 class TestL2Permutations:
-    """Tests for _run_l2_permutations."""
+    """Tests for _run_l2_permutations.
+
+    Heavy parallel-vs-sequential backend equivalence — excluded from
+    check-fast, consistent with the other backend tests in this suite.
+    """
 
     def test_l2_output_schema(self):
         """_run_l2_permutations returns DataFrame matching NullModelSchema."""

--- a/tests/test_subsampling_ribbon.py
+++ b/tests/test_subsampling_ribbon.py
@@ -170,8 +170,13 @@ class TestDivergenceSubsampleSchema:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestSubsampleReplicatesPresent:
-    """compute_divergence_subsampled.py produces R rows per (year, window)."""
+    """compute_divergence_subsampled.py produces R rows per (year, window).
+
+    Spawns compute_divergence_subsampled.py via subprocess — excluded from
+    check-fast per the subprocess-tests-are-integration rule.
+    """
 
     def test_subsample_replicates_present_s2(self, tmp_path):
         """Smoke: R=3 replicates per cell for S2_energy on the smoke fixture."""


### PR DESCRIPTION
## Problem

`make check-fast` was running in ~90-100s (contract: unit tests + lint, <30s). It filters `-m "not slow and not integration"`, but several heavy tests were unmarked and ran on the fast path.

## Fix — markers only (no behavior change, no coverage loss; `make check` still runs them all)

| Test | ~time | Why excluded |
|------|------|--------------|
| `test_bias_flag.py` (both) | 31.8s + 3.8s | spawn `compute_divergence.py` via subprocess |
| `test_subsampling_ribbon.py::TestSubsampleReplicatesPresent` | 27.6s + 21.7s | spawn `compute_divergence_subsampled.py` via subprocess |
| `test_null_model.py::TestBackendComparison` | 22s | backend equivalence; matches file convention (lines 491, 576) |
| `test_null_model_lexical_l2_l3.py::TestL2Permutations` | 8s+ | parallel-vs-sequential equivalence |
| `test_c2st.py::…::test_end_to_end_c2st_lexical_on_smoke_fixture` | 10s | runs `compute_divergence.py` via `run_compute()` (subprocess) |

The subprocess ones are direct violations of the `coding-python.md` rule ("Tests using `subprocess.run()` → mark `@pytest.mark.integration`").

## Investigation of the residual tail (no code change — findings only)

Two big non-subprocess costs were profiled to root cause:

- **`test_mypy_passes` (~19s) was a COLD `.mypy_cache`, not steady-state.** Direct mypy on a warm cache is **0.36s** (cold 9.4s; ~19s under `-n4` contention). `dmypy` does not help — it rejects `--follow-imports=silent` outright — and is unnecessary: mypy's own incremental cache already gives the 26× win. The cold cost is only paid in a fresh worktree / first run. `.mypy_cache/` is gitignored and `make clean` leaves it intact, so steady-state dev already pays 0.36s.
- **`test_self_distance_near_zero` (~11-14s) is import-bound, not compute-bound.** `import dcor` alone is ~7s (dcor eagerly JIT-compiles its numba functions at import and writes no disk cache; the 50×10 math is 0.00s). It is already lazy-imported at the tightest scope, so there is nothing to defer. `NUMBA_DISABLE_JIT=1` halves it to ~3.4s with byte-identical results, but that is a blunt global toggle for a ~3s win — not worth it. Torch is NOT involved (imports lazily, not hit on this path).

## Result

check-fast: **~100s → ~50-65s** (machine-load noisy). All heavy subprocess/backend tests off the fast path. The remaining tail is legitimate import-bound / matplotlib-figure unit tests; pushing under 30s would trade fast-path coverage, left as an author decision.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)