### PR TITLE
ticket(0213): test-suite rethink — classify by cost, enforce by ratchet

### DIFF
--- a/tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
+++ b/tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
@@ -1,0 +1,72 @@
+%erg 0.1
+Title: Test-suite rethink: classify by cost, enforce by ratchet (tracking)
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+`make check-fast` (contract: unit tests + lint, <30s inner loop) had drifted to
+~90-100s. Investigation (PR #966) traced it to heavy tests leaking onto the fast
+path. The five worst were fixed tactically by adding `@pytest.mark.integration`.
+But the fixes are mole-whacking; the **root cause is structural**:
+
+1. **Markers classify by *mechanism* (subprocess / sleep / network) as a proxy
+   for *cost*, and the proxy leaks.** A 22s numba permutation test spawns nothing
+   and touches no network, so it sits on the fast path. A metric-axiom test does
+   50x10 arithmetic but pays ~7s to `import dcor` (numba eager-JIT at import, no
+   disk cache) — also fast by mechanism, slow by cost.
+2. **No enforcement → silent drift.** Nothing fails when a slow test lands on the
+   fast path; #966 found five by accident and nothing prevents a sixth.
+3. **Lint is conflated with unit testing.** `test_mypy_passes` costs 0.36s warm
+   but 9-19s cold (fresh worktree / cold `.mypy_cache`), and carries no marker;
+   other hygiene tests are `adherence`. check-fast does not even exclude
+   `adherence`, so lint runs inside the inner loop.
+4. **The <30s target is measured on doudou** (contended shared box); the same
+   suite timed 49s and 64s minutes apart. A hard wall-clock number there is
+   theater — enforce *composition*, let wall-clock fall out.
+
+Key measurements (PR #966 worktree, doudou):
+- cold mypy 9.4s / warm 0.36s; `dmypy` rejects `--follow-imports=silent` (moot).
+- `import dcor` ~7s every fresh process; the `energy_distance` call is 0.00s.
+- Only `tests/test_pipeline_io.py` imports a heavy dep at *module* level — the
+  rest lazy-import inside test bodies, so a static-import guard misses them.
+  Cost is only visible at runtime → enforcement must be duration-based.
+
+## Proposed architecture
+Reclassify marker semantics from mechanism to **cost/purpose**, rewire the gates,
+and add a runtime guard so drift is caught automatically:
+
+| Tier | Means | Gate |
+|------|-------|------|
+| *(none)* fast | pure-Python logic; pandas/numpy OK; no dcor/torch/ot/matplotlib, no subprocess, no lint | check-fast |
+| integration | spawns a subprocess / drives a script | check |
+| slow | network, real data, **heavy numerical dep, or heavy compute** (broadened) | check |
+| adherence | ruff / mypy / hygiene / contracts (applied consistently) | make lint |
+
+- check-fast → `-m "not slow and not integration and not adherence"`
+- make lint → `-m adherence` (warm mypy ~1s; runs alongside tests)
+- check → everything (unchanged)
+
+## Children
+- 0214 — rewire gates: cost-based tiers + `make lint`; broaden `slow` semantics
+- 0215 — apply `adherence` marker consistently to all lint/hygiene tests
+- 0216 — duration-ratchet guard: fail a fast-path test that exceeds budget
+- 0217 — evaluate pytest-testmon for the true TDD inner loop (spike)
+
+This tracker stays open until all four children close, then closes after an
+integration review confirming check-fast is composed of pure-logic tests only
+and the ratchet is green.
+
+## Invariants
+- No coverage loss: every test reclassified to slow/integration/adherence still
+  runs in `make check` before every PR.
+- PR #966 (tactical marker fixes) is independent and merges on its own.
+
+## Exit criteria
+- All four children merged; check-fast selects pure-logic tests only; the
+  duration-ratchet guard is active and green; `make lint` runs the adherence
+  tier; the <30s claim is either met structurally or replaced by a
+  composition-based contract measured on a clean runner.

--- a/tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
+++ b/tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T08:04Z MinhHaDuong approved the inner-loop trade-off (see 0214 log): numerical-kernel tests move off the fast path. Load-bearing design decision resolved; children unblocked pending ticket review.
 --- body ---
 ## Context
 `make check-fast` (contract: unit tests + lint, <30s inner loop) had drifted to

--- a/tickets/0214-rewire-test-gates-cost-tiers-make-lint.erg
+++ b/tickets/0214-rewire-test-gates-cost-tiers-make-lint.erg
@@ -7,6 +7,7 @@ Blocked-by: 0215
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T08:04Z MinhHaDuong decision: "I agree with the inner loop" — endorses moving numerical-kernel tests (dcor/torch-bound) to slow; the fast inner loop covers only pure logic + what you edit (testmon 0217), full numerical validation stays in make check.
 --- body ---
 ## Context
 Part of tracker 0213. The fast gate must be composed of pure-Python logic tests

--- a/tickets/0214-rewire-test-gates-cost-tiers-make-lint.erg
+++ b/tickets/0214-rewire-test-gates-cost-tiers-make-lint.erg
@@ -1,0 +1,64 @@
+%erg 0.1
+Title: Rewire test gates: cost-based tiers + make lint; broaden slow
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0215
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Part of tracker 0213. The fast gate must be composed of pure-Python logic tests
+only. Today check-fast is `-m "not slow and not integration"` — it still runs
+`adherence` (lint) and any heavy-import/heavy-compute test that isn't marked.
+This ticket rewires the Make gates and broadens the `slow` marker's documented
+scope to include heavy numerical dependencies and heavy compute (closing the
+taxonomy gap that let backend-equivalence and dcor-import tests onto the fast
+path). Blocked by 0215, which must first give every lint/hygiene test the
+`adherence` marker so `not adherence` actually deselects them.
+
+## Relevant files
+- `Makefile` — `check-fast` (742), `check` (738) targets; add `lint` target
+- `pyproject.toml` — `[tool.pytest.ini_options] markers` (70-73): reword the
+  `slow` description to include "heavy numerical dependency or heavy compute"
+- `.claude/rules/coding-python.md` (global) + `.claude/rules/coding.md` (project)
+  — the marker table documents mechanism-based rules; update to cost-based
+- Tests currently on the fast path that need `slow` under the new definition:
+  `test_divergence.py::TestMetricProperties` (dcor/ot import), and any test that
+  lazy-imports dcor/torch/ot/sentence_transformers or renders matplotlib
+
+## Actions
+1. `make check-fast` → `-m "not slow and not integration and not adherence"`.
+2. Add `make lint` → `-m adherence` (depends on `venv-canonicalize`); document
+   that it is run alongside tests, not inside the inner loop.
+3. Reword the `slow` marker description in pyproject.toml to: "network access,
+   external/real data, a heavy numerical dependency (dcor/torch/ot/
+   sentence_transformers), or heavy compute".
+4. Mark the heavy-numerical fast-path tests `slow` (e.g. `TestMetricProperties`,
+   `TestCommunityDivergence` if dcor/ot-bound) — verify by the ratchet from 0216
+   or by `--durations` that no >3s test remains unmarked on the fast path.
+5. Update both marker-rule tables (global coding-python.md, project coding.md) to
+   the cost-based taxonomy and cross-reference this ticket.
+
+## Test
+Write first (red): a test asserting `make check-fast`'s pytest `-m` expression
+excludes `adherence` (source-inspect the Makefile line — string match, no
+subprocess), and that `make lint` selects `-m adherence`. Fails today (check-fast
+does not exclude adherence).
+
+## Verification
+- [ ] `make check-fast` marker expression excludes slow, integration, adherence.
+- [ ] `make lint` exists and runs the adherence tier.
+- [ ] pyproject.toml `slow` description names heavy deps + heavy compute.
+- [ ] `uv run pytest -m "not slow and not integration and not adherence"
+      --durations=10` shows no >3s test (once 0216's ratchet exists, it enforces).
+- [ ] Both rule tables updated; `make check` unchanged and green.
+
+## Invariants
+- No coverage loss: `make check` still runs slow + integration + adherence.
+- Don't weaken any acceptance test; markers move tests between gates, never skip.
+
+## Exit criteria
+- check-fast is pure-logic-only; `make lint` owns the adherence tier; `slow`
+  documents the broadened cost-based meaning; rule docs match.

--- a/tickets/0215-apply-adherence-marker-to-all-lint-hygiene.erg
+++ b/tickets/0215-apply-adherence-marker-to-all-lint-hygiene.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Apply adherence marker consistently to all lint/hygiene tests
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Part of tracker 0213, and a prerequisite for 0214 (which deselects `adherence`
+from check-fast). The `adherence` marker is applied inconsistently: 50 tests
+carry it, but `test_script_hygiene.py::TestTypingCoreModules::test_mypy_passes`
+(the cold-cache 9-19s offender) carries no marker, and other ruff/mypy/contract
+checks may be equally unmarked. Until every rule-enforcement test is `adherence`,
+`-m "not adherence"` will not actually remove lint from the fast path.
+
+## Relevant files
+- `tests/test_script_hygiene.py` — mix of adherence-marked and unmarked hygiene
+  tests; `test_mypy_passes` (737), ruff/version checks, complexity/length smells
+- `tests/test_editorial_governance.py`, `tests/test_manuscript_prose.py` —
+  already carry adherence (confirm complete)
+- Any `test_ruff` / contract / schema-presence / arch-rule tests across `tests/`
+
+## Actions
+1. Audit `tests/` for rule-enforcement tests: mypy, ruff, complexity/length
+   smells, arch-rule-N contract checks, hygiene (no-stubs/TODO), doc-drift.
+2. Mark each `@pytest.mark.adherence` (class- or method-level as appropriate).
+   `test_mypy_passes` and any ruff-invoking test are the priority — they carry
+   the cold-cache and subprocess cost.
+3. Where a hygiene test also spawns a subprocess (ruff/mypy via `subprocess.run`),
+   `adherence` is the governing tier for gating; keep any existing `integration`
+   only if needed, but ensure `-m "not adherence"` deselects it. Prefer a single
+   `adherence` marker for lint tests over stacking.
+
+## Test
+Write first (red): a meta-test that scans `tests/` and asserts every test which
+invokes `ruff` or `mypy` (source contains `"ruff"`/`"mypy"` + `subprocess`) is
+marked `adherence`. Fails today on `test_mypy_passes`.
+
+## Verification
+- [ ] `uv run pytest -m adherence --co -q` count rises to include mypy/ruff tests.
+- [ ] `uv run pytest -m "not adherence" -k "mypy or ruff" --co` collects nothing.
+- [ ] The red meta-test passes after marking.
+
+## Invariants
+- No coverage loss: adherence tests still run in `make check` (and `make lint`
+  once 0214 lands).
+- Do not change what any hygiene test asserts — only its marker.
+
+## Exit criteria
+- Every lint/hygiene/contract test carries `adherence`; the meta-test guards it;
+  `-m "not adherence"` cleanly removes all lint from a selection.

--- a/tickets/0216-duration-ratchet-guard-fast-path-budget.erg
+++ b/tickets/0216-duration-ratchet-guard-fast-path-budget.erg
@@ -1,0 +1,60 @@
+%erg 0.1
+Title: Duration-ratchet guard: fail a fast-path test that exceeds budget
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Part of tracker 0213. This is the enforcement that converts "whack-a-mole
+forever" into "caught automatically". Heavy deps are lazy-imported inside test
+bodies (only `test_pipeline_io.py` imports one at module level), so a static
+import guard cannot see the cost — only runtime duration reveals it. A meta-test
+reads recorded per-test durations and fails if any test selected by the fast
+gate exceeds a budget. The threshold is generous (~3s) — far above the doudou
+timing noise (heavies are 7-30s) so it never false-trips, while still catching a
+new heavy test the moment it lands unmarked on the fast path.
+
+## Relevant files
+- `pyproject.toml` — pytest config; add a durations-store mechanism
+- `tests/test_script_hygiene.py` (or a new `tests/test_fast_path_budget.py`) —
+  the ratchet meta-test (itself marked `adherence`)
+- `Makefile` — `check` may need `--store-durations` (or a JSON dump) so the
+  ratchet has fresh data; `.test_durations` gitignored or committed (decide)
+
+## Actions
+1. Record per-test durations on a full `make check` run — either
+   `pytest --durations=0` parsed, `pytest-split --store-durations`
+   (`.test_durations` JSON), or a small `--durations` JSON hook. Prefer the
+   lightest that needs no new heavy dep (see feedback_no_heavy_deps).
+2. Write the ratchet meta-test (`@pytest.mark.adherence`): load the durations,
+   compute the fast-path selection (`not slow and not integration and not
+   adherence`), assert `max(fast_path_durations) <= BUDGET_S` (BUDGET_S=3.0,
+   from config). On breach, name the offending test and the tier it should join.
+2b. Handle cold-start: skip with a clear reason if no durations file exists yet
+    (first run), so the guard never blocks on missing data.
+3. Wire regeneration so stale durations are obvious — a target or a note that the
+   ratchet reflects the last `make check` run.
+
+## Test
+Write first (red): feed the ratchet a synthetic durations record containing one
+fast-path test at 10s and assert the meta-test fails naming that test; feed one
+where the 10s test is marked slow and assert it passes.
+
+## Verification
+- [ ] Ratchet fails on a synthetic 10s unmarked fast-path test (red fixture).
+- [ ] Ratchet passes when the same test is marked slow/integration/adherence.
+- [ ] On a fresh checkout with no durations file, the guard skips, not errors.
+- [ ] No new heavy runtime dependency added for this (config-light).
+
+## Invariants
+- Threshold lives in config (`config/analysis.yaml` or pyproject), not hardcoded.
+- The guard is deterministic given a durations file; timing noise must not flip
+  it (budget >> noise).
+
+## Exit criteria
+- A duration-ratchet `adherence` test guards the fast path; a heavy unmarked
+  fast-path test turns it red with an actionable message; documented in the
+  marker rule table.

--- a/tickets/0217-evaluate-pytest-testmon-tdd-inner-loop.erg
+++ b/tickets/0217-evaluate-pytest-testmon-tdd-inner-loop.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Evaluate pytest-testmon for the TDD inner loop (spike)
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Part of tracker 0213. Even a perfectly-composed 20-30s fast suite is too slow to
+run on every save. The true TDD inner loop wants only the tests affected by the
+uncommitted edit. `pytest-testmon` tracks per-test coverage and reruns only tests
+whose dependencies changed — sub-second, marker-independent. This is a spike:
+decide whether testmon earns a place as the keystroke loop, with check-fast
+demoted to the pre-commit gate. Time-boxed; the deliverable is a recommendation,
+not necessarily adoption.
+
+## Relevant files
+- `pyproject.toml` — dev dependency group (would add `pytest-testmon`)
+- `Makefile` — a possible `make tdd` / `make watch` target
+- `.claude/rules/coding-python.md` — testing-loop guidance would gain a line
+
+## Actions
+1. Add `pytest-testmon` to a dev-only dep group; measure warm inner-loop latency
+   after editing one core module (e.g. `pipeline_text.py`) vs full check-fast.
+2. Assess friction: `.testmondata` lifecycle, interaction with `-n 4` xdist
+   (testmon + xdist historically conflict — verify), worktree portability, and
+   whether it plays with the heavy lazy imports (dcor/torch) without re-paying
+   import cost per selection.
+3. Recommend: adopt (with a `make tdd` target + docs), defer, or reject — with
+   the measured numbers behind the call.
+
+## Test
+No production code under test — this is a spike. If adopted, the follow-up adds a
+`make tdd` target and a test asserting the target exists and invokes testmon
+(source-inspection, no subprocess).
+
+## Verification
+- [ ] Measured inner-loop latency (testmon warm) vs check-fast, single-module edit.
+- [ ] xdist interaction resolved or documented (run testmon without `-n`).
+- [ ] Clear recommendation with numbers; if adopt, a `make tdd` target + doc line.
+
+## Invariants
+- testmon is an inner-loop convenience only — it never replaces `make check` as
+  the PR gate, and never gates CI (its selection is machine-local state).
+- No heavy runtime dep added to the shipping package; dev group only.
+
+## Exit criteria
+- A written recommendation (adopt/defer/reject) backed by measured latency; if
+  adopt, `make tdd` + a one-line rule doc; if not, a note on why for the record.


### PR DESCRIPTION
Files the strategic follow-up to #966 (which fixed 5 fast-path leaks tactically). This PR adds **tickets only** — no code changes — for review before any implementation starts.

## The structural problem

`make check-fast` (inner loop, contract <30s) drifted to ~90-100s. Markers classify by **mechanism** (subprocess / sleep / network) as a proxy for **cost**, and the proxy leaks:

- a 22s numba permutation test spawns nothing → sits on the fast path
- a metric-axiom test does 50×10 math but pays ~7s to `import dcor` → also fast-by-mechanism, slow-by-cost
- `test_mypy_passes` is 0.36s warm / 9-19s cold and carries no marker at all

Nothing fails when a slow test lands on the fast path, so drift is guaranteed. Heavy deps are lazy-imported **inside** test bodies (only `test_pipeline_io.py` imports at module level), so a static-import guard can't catch them — enforcement must be runtime.

## Proposed tiers (mechanism → cost/purpose)

| Tier | Means | Gate |
|------|-------|------|
| *(none)* fast | pure-Python logic; pandas/numpy OK; no dcor/torch/ot/matplotlib, no subprocess, no lint | check-fast |
| integration | spawns a subprocess / drives a script | check |
| slow | network, real data, **heavy numerical dep, or heavy compute** (broadened) | check |
| adherence | ruff / mypy / hygiene / contracts (applied consistently) | `make lint` |

## Tickets

- **0213** (tracking) — the rethink; stays open until children close
- **0214** — rewire gates: cost-based tiers + `make lint`; broaden `slow` *(blocked-by 0215)*
- **0215** — apply `adherence` consistently to all lint/hygiene tests
- **0216** — duration-ratchet guard: a `~3s` fast-path budget checked against recorded durations, so a new heavy test goes red until marked
- **0217** — spike `pytest-testmon` for the sub-second TDD inner loop

## Key measurements (from #966 investigation)

- cold mypy 9.4s / warm **0.36s**; `dmypy` rejects `--follow-imports=silent` (moot — the cache already wins)
- `import dcor` ~7s per fresh process; the `energy_distance` call is 0.00s
- same suite timed 49s and 64s minutes apart on doudou → wall-clock target there is noise; enforce **composition**, not a number

No coverage is lost anywhere: every reclassified test still runs in `make check`.

Ticket-ref: tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)