### PR TITLE
ticket(0208): evict heavy analysis intermediates out of content/tables/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ data/raw/
 data/run_reports/
 data/teaching_sources.yaml
 data/catalogs/.citations_batch_checkpoint.csv
+# Analysis-side scratch dir for large Phase-2 intermediates (ticket 0208) —
+# regenerable, not a writing deliverable, not DVC-tracked.
+data/derived/
 
 # Make sentinel files (dynamic-output targets)
 *.stamp

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@
 # Data lives in data/catalogs/ (managed by DVC).
 # Python scripts resolve the same path via utils.py (BASE_DIR/data).
 DATA_DIR     := data/catalogs
+# Analysis-side scratch dir for large Phase-2 intermediates consumed only by
+# other Phase-2 scripts (not writing deliverables). Python resolves the same
+# path via utils.DERIVED_TABLES_DIR (DATA_DIR/derived/tables). Ticket 0208.
+DERIVED      := data/derived/tables
 CONFIG       := config/analysis.yaml
 BIB         := content/bibliography/main.bib
 CSL         := content/bibliography/oeconomia.csl
@@ -349,8 +353,8 @@ corpus-validate: $(REFINED)
 content/tables/tab_citation_coverage.md: scripts/export_citation_coverage.py scripts/utils.py $(REFINED)
 	$(PYTHON) $< --output $@
 
-content/tables/tab_venues.md: scripts/export_tab_venues.py scripts/utils.py $(REFINED) content/tables/tab_pole_papers.csv
-	$(PYTHON) $< --output $@
+content/tables/tab_venues.md: scripts/export_tab_venues.py scripts/utils.py $(REFINED) $(DERIVED)/tab_pole_papers.csv
+	$(PYTHON) $< --output $@ --pole-papers $(DERIVED)/tab_pole_papers.csv
 
 content/tables/tab_corpus_sources.csv content/tables/tab_corpus_sources.md &: scripts/export_corpus_table.py scripts/utils.py $(REFINED)
 	$(PYTHON) $< --output $@
@@ -475,21 +479,21 @@ content/figures/fig_breaks.png: scripts/plot_fig2_breaks.py scripts/plot_style.p
 
 # Bimodality tables (computation only — figures are separate targets below)
 content/tables/tab_bimodality.csv content/tables/tab_axis_detection.csv \
-content/tables/tab_pole_papers.csv &: \
+$(DERIVED)/tab_pole_papers.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(CONFIG) $(REFINED)
 	$(PYTHON) $< --output content/tables/tab_bimodality.csv
 
 # Bimodality figures (each reads tab_pole_papers.csv)
 content/figures/fig_bimodality.png: scripts/plot_bimodality.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(PYTHON) $< --output $@
 
 content/figures/fig_bimodality_lexical.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(PYTHON) $< --output $@
 
 content/figures/fig_bimodality_keywords.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(PYTHON) $< --output $@
 
 # Seed-axis violin (core, manuscript figure)
@@ -502,7 +506,7 @@ content/figures/fig_pca_scatter.png: scripts/plot_fig45_pca_scatter.py scripts/u
 
 # Citation genealogy: model (lineage table) then renderers
 content/tables/tab_lineages.csv: scripts/analyze_genealogy.py scripts/utils.py $(CONFIG) \
-		$(REFINED) $(REFINED_CIT) content/tables/tab_pole_papers.csv $(SEMANTIC_CLUSTERS)
+		$(REFINED) $(REFINED_CIT) $(DERIVED)/tab_pole_papers.csv $(SEMANTIC_CLUSTERS)
 	$(PYTHON) $< --output $@
 
 content/figures/fig_genealogy.png: scripts/plot_genealogy.py scripts/utils.py $(CONFIG) \
@@ -540,21 +544,21 @@ content/figures/fig_alluvial_core.png: \
 
 # Bimodality core variant tables
 content/tables/tab_bimodality_core.csv content/tables/tab_axis_detection_core.csv \
-content/tables/tab_pole_papers_core.csv &: \
+$(DERIVED)/tab_pole_papers_core.csv &: \
 		scripts/analyze_bimodality.py scripts/utils.py $(CONFIG) $(REFINED)
 	$(PYTHON) $< --output content/tables/tab_bimodality_core.csv --core-only
 
 # Bimodality core variant figures
 content/figures/fig_bimodality_core.png: scripts/plot_bimodality.py scripts/utils.py \
-		content/tables/tab_pole_papers_core.csv
+		$(DERIVED)/tab_pole_papers_core.csv
 	$(PYTHON) $< --core-only --output $@
 
 content/figures/fig_bimodality_lexical_core.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
-		content/tables/tab_pole_papers_core.csv
+		$(DERIVED)/tab_pole_papers_core.csv
 	$(PYTHON) $< --core-only --output $@
 
 content/figures/fig_bimodality_keywords_core.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
-		content/tables/tab_pole_papers_core.csv
+		$(DERIVED)/tab_pole_papers_core.csv
 	$(PYTHON) $< --core-only --output $@
 
 # Pre-2007 co-citation traditions network
@@ -572,11 +576,11 @@ content/figures/fig_communities.png: scripts/plot_cocitation.py scripts/utils.py
 
 # KDE supplementary
 content/figures/fig_kde.png: scripts/plot_figS_kde.py scripts/plot_style.py scripts/utils.py $(CONFIG) \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(PYTHON) $< --output $@
 
 # Lexical TF-IDF table (diagnostic, not in manuscript)
-content/tables/tab_lexical_tfidf.csv: scripts/compute_lexical.py scripts/utils.py $(REFINED) \
+$(DERIVED)/tab_lexical_tfidf.csv: scripts/compute_lexical.py scripts/utils.py $(REFINED) \
 		content/tables/tab_breakpoint_robustness.csv
 	$(PYTHON) $< --output $@
 
@@ -597,8 +601,8 @@ content/figures/fig_k_sensitivity.png: scripts/plot_fig_k_sensitivity.py $(CONFI
 # Lexical TF-IDF figures (one per detected break year; output filenames are
 # dynamic, so we use a sentinel file to track freshness).
 .lexical_tfidf.stamp: scripts/plot_fig_lexical_tfidf.py scripts/plot_style.py $(CONFIG) \
-		content/tables/tab_lexical_tfidf.csv
-	$(PYTHON) $< --output $@
+		$(DERIVED)/tab_lexical_tfidf.csv
+	$(PYTHON) $< --output $@ --input $(DERIVED)/tab_lexical_tfidf.csv
 
 # DVC pipeline DAG (data paper)
 content/figures/fig_dag.png: scripts/plot_fig_dag.py scripts/plot_style.py $(CONFIG) dvc.yaml
@@ -633,7 +637,7 @@ content/figures/fig_ncc_core_comparison.png: \
 # NCC Figure (c): Bimodality KDE with period decomposition
 content/figures/fig_ncc_bimodality.png: \
 		scripts/plot_ncc_bimodality.py scripts/utils.py $(CONFIG) \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(PYTHON) $< --output $@
 
 # NCC Figure (d): Alluvial diagram (NCC format)
@@ -697,7 +701,7 @@ ANALYSIS_OUTPUTS := content/figures/fig_bars_v1.png \
                     content/tables/tab_core_shares.csv \
                     content/tables/tab_bimodality.csv \
                     content/tables/tab_axis_detection.csv \
-                    content/tables/tab_pole_papers.csv \
+                    $(DERIVED)/tab_pole_papers.csv \
                     content/tables/cluster_labels.json
 
 archive-analysis: check-manuscript-data $(ANALYSIS_OUTPUTS)

--- a/build/build_analysis_archive.sh
+++ b/build/build_analysis_archive.sh
@@ -26,7 +26,7 @@ ANALYSIS_OUTPUTS=(
     content/tables/tab_core_shares.csv
     content/tables/tab_bimodality.csv
     content/tables/tab_axis_detection.csv
-    content/tables/tab_pole_papers.csv
+    data/derived/tables/tab_pole_papers.csv
     content/tables/cluster_labels.json
 )
 

--- a/build/templates/Makefile.analysis-manuscript
+++ b/build/templates/Makefile.analysis-manuscript
@@ -20,6 +20,8 @@ export PATH := $(HOME)/.local/bin:$(PATH)
 
 DATA    := data/catalogs
 REFINED := $(DATA)/refined_works.csv
+# Analysis-side scratch dir for large intermediates (matches utils.DERIVED_TABLES_DIR).
+DERIVED := data/derived/tables
 
 .DEFAULT_GOAL := figures
 .PHONY: figures verify
@@ -43,22 +45,22 @@ $(DATA)/het_mostcited_50.csv: scripts/build_het_core.py scripts/utils.py $(REFIN
 	$(UV_RUN) python $<
 
 content/tables/tab_venues.md: scripts/export_tab_venues.py scripts/utils.py $(REFINED) \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
-content/tables/tab_pole_papers.csv &: scripts/analyze_bimodality.py scripts/utils.py $(REFINED)
+$(DERIVED)/tab_pole_papers.csv &: scripts/analyze_bimodality.py scripts/utils.py $(REFINED)
 	$(UV_RUN) python $<
 
 content/figures/fig_bimodality.png: scripts/plot_bimodality.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
 content/figures/fig_bimodality_lexical.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
 content/figures/fig_bimodality_keywords.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
-		content/tables/tab_pole_papers.csv
+		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
 # ── Verification ──────────────────────────────────────────

--- a/scripts/analyze_bimodality.py
+++ b/scripts/analyze_bimodality.py
@@ -8,9 +8,9 @@ Method:
 - Validate with TF-IDF and keyword co-occurrence
 
 Produces:
-- tables/tab_bimodality.csv: Dip test p-values, GMM BIC, pole paper counts
-- tables/tab_pole_papers.csv: Per-paper score and pole assignment
-- tables/tab_axis_detection.csv: Unsupervised TF-IDF components and alignment to pole axis
+- content/tables/tab_bimodality.csv: Dip test p-values, GMM BIC, pole paper counts
+- <derived>/tab_pole_papers.csv: Per-paper score and pole assignment (analysis intermediate)
+- content/tables/tab_axis_detection.csv: Unsupervised TF-IDF components and alignment to pole axis
 
 Usage:
     uv run python scripts/analyze_bimodality.py --output content/tables/tab_bimodality.csv
@@ -30,6 +30,7 @@ from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
     CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_config,
     load_analysis_periods,
@@ -176,8 +177,14 @@ def _save_all_tables(*, df, n_eff, n_acc, n_both, bic1, bic2, delta_bic,
                      lex_dbic, main_axis_label, best_corr, best_dbic,
                      best_idx, explained, period_stats, component_rows,
                      emb_component_rows, output_path,
-                     out_dir, tab_axis, tab_pole):
-    """Step 7: Save all output tables (bimodality summary, axis detection, pole papers)."""
+                     out_dir, tab_axis, tab_pole, pole_dir):
+    """Step 7: Save all output tables (bimodality summary, axis detection, pole papers).
+
+    The per-paper pole table is a large analysis intermediate consumed only by
+    other Phase-2 scripts; it is written to `pole_dir` (an analysis-side scratch
+    dir) rather than beside the small writing-facing summary/axis tables
+    (ticket 0208).
+    """
     summary_rows = [{
         "method": "embedding",
         "n_papers": len(df),
@@ -248,7 +255,8 @@ def _save_all_tables(*, df, n_eff, n_acc, n_both, bic1, bic2, delta_bic,
         df["axis_score"] > 0, "efficiency",
         np.where(df["axis_score"] < 0, "accountability", "neutral")
     )
-    pole_path = os.path.join(out_dir, tab_pole) if out_dir else tab_pole
+    os.makedirs(pole_dir, exist_ok=True)
+    pole_path = os.path.join(pole_dir, tab_pole)
     pole_papers.to_csv(pole_path, index=False)
     log.info("Saved -> %s (%d papers)", pole_path, len(pole_papers))
 
@@ -459,7 +467,7 @@ def main():
         period_stats=period_stats, component_rows=component_rows,
         emb_component_rows=emb_component_rows,
         output_path=io_args.output, out_dir=out_dir,
-        tab_axis=tab_axis, tab_pole=tab_pole,
+        tab_axis=tab_axis, tab_pole=tab_pole, pole_dir=DERIVED_TABLES_DIR,
     )
     log.info("Done.")
 

--- a/scripts/analyze_genealogy.py
+++ b/scripts/analyze_genealogy.py
@@ -8,7 +8,7 @@ Reads:
   data/catalogs/refined_works.csv
   data/catalogs/refined_citations.csv
   data/catalogs/semantic_clusters.csv
-  content/tables/tab_pole_papers.csv  (optional — from analyze_bimodality.py)
+  <derived>/tab_pole_papers.csv  (optional — from analyze_bimodality.py)
 
 Produces:
   content/tables/tab_lineages.csv — backbone papers with lineage, position, metadata
@@ -25,6 +25,7 @@ from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
     CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_config,
     load_analysis_periods,
@@ -149,7 +150,7 @@ CDM_CLUSTER = 2
 def assign_lineages(backbone_dois, doi_meta, doi_to_cluster):
     """Assign each backbone paper to one of three lineage bands."""
     # Load bimodality pole scores if available
-    pole_path = os.path.join(TABLES_DIR, "tab_pole_papers.csv")
+    pole_path = os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv")
     use_bimodal = os.path.exists(pole_path)
 
     if use_bimodal:

--- a/scripts/compute_lexical.py
+++ b/scripts/compute_lexical.py
@@ -185,8 +185,8 @@ if __name__ == "__main__":
         result = pd.concat(all_rows, ignore_index=True)
         result.to_csv(io_args.output, index=False)
         years_saved = sorted(result["break_year"].unique())
-        log.info("Saved TF-IDF table -> tables/tab_lexical_tfidf.csv "
-                 "(%d rows, break years: %s)", len(result), years_saved)
+        log.info("Saved TF-IDF table -> %s "
+                 "(%d rows, break years: %s)", io_args.output, len(result), years_saved)
         log.info("Run plot_fig_lexical_tfidf.py to generate the figures.")
     else:
         log.warning("No break years had enough abstracts for TF-IDF comparison.")

--- a/scripts/export_tab_venues.py
+++ b/scripts/export_tab_venues.py
@@ -7,7 +7,7 @@ among core works (cited >= 50). Output: content/tables/tab_venues.md
 Usage:
     uv run python scripts/export_tab_venues.py --output content/tables/tab_venues.md \
         [--refined-works data/catalogs/refined_works.csv] \
-        [--pole-papers content/tables/tab_pole_papers.csv] \
+        [--pole-papers <derived>/tab_pole_papers.csv] \
         [--min-papers 10] [--core-threshold 50]
 """
 
@@ -17,7 +17,7 @@ import os
 import numpy as np
 import pandas as pd
 from script_io_args import parse_io_args, validate_io
-from utils import BASE_DIR, CATALOGS_DIR, get_logger
+from utils import CATALOGS_DIR, DERIVED_TABLES_DIR, get_logger
 
 log = get_logger("export_tab_venues")
 
@@ -34,7 +34,7 @@ def main():
     parser.add_argument("--refined-works", default=os.path.join(CATALOGS_DIR, "refined_works.csv"),
                         help="Path to refined_works.csv")
     parser.add_argument("--pole-papers",
-                        default=os.path.join(BASE_DIR, "content", "tables", "tab_pole_papers.csv"),
+                        default=os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv"),
                         help="Path to tab_pole_papers.csv")
     args = parser.parse_args(extra)
 

--- a/scripts/pipeline_loaders.py
+++ b/scripts/pipeline_loaders.py
@@ -61,6 +61,12 @@ EXPORTS_DIR = os.path.join(DATA_DIR, "exports")
 RAW_DIR = os.path.join(DATA_DIR, "raw")
 POOL_DIR = os.path.join(DATA_DIR, "pool")
 
+# Analysis-side scratch dir for large Phase-2 intermediates consumed only by
+# other Phase-2 scripts (not writing deliverables): kept out of content/tables/
+# so that directory holds only byte-stable writing outputs (ticket 0208).
+# Regenerable — NOT a DVC output; DVC stays scoped to genuine corpus data.
+DERIVED_TABLES_DIR = os.path.join(DATA_DIR, "derived", "tables")
+
 # Embeddings live in a separate .npz rather than as columns in refined_works.csv:
 # - Size: 1024 floats × 30k rows as CSV text ≈ 1.3 GB vs. ~120 MB compressed binary
 # - Incremental cache: stores keys + text hashes + model config so only new/changed

--- a/scripts/plot_bimodality.py
+++ b/scripts/plot_bimodality.py
@@ -1,7 +1,7 @@
 """Embedding KDE by period with GMM overlay (bimodality validation A).
 
 Reads:
-  content/tables/tab_pole_papers.csv — per-paper axis scores and metadata
+  <derived>/tab_pole_papers.csv — per-paper axis scores and metadata (analysis intermediate)
 
 Produces:
   content/figures/fig_bimodality.png (and .pdf if --pdf)
@@ -19,6 +19,7 @@ from sklearn.mixture import GaussianMixture
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_periods,
     save_figure,
@@ -111,7 +112,7 @@ def main():
         input_path = io_args.input[0]
     else:
         suffix = "_core" if args.core_only else ""
-        input_path = os.path.join(TABLES_DIR, f"tab_pole_papers{suffix}.csv")
+        input_path = os.path.join(DERIVED_TABLES_DIR, f"tab_pole_papers{suffix}.csv")
 
     df = pd.read_csv(input_path)
     df["year"] = pd.to_numeric(df["year"], errors="coerce").astype(int)

--- a/scripts/plot_bimodality_keywords.py
+++ b/scripts/plot_bimodality_keywords.py
@@ -1,7 +1,7 @@
 """Keyword scatter + marginals (bimodality validation C).
 
 Reads:
-  content/tables/tab_pole_papers.csv — per-paper keyword counts and metadata
+  <derived>/tab_pole_papers.csv — per-paper keyword counts and metadata (analysis intermediate)
 
 Produces:
   content/figures/fig_bimodality_keywords.png (and .pdf if --pdf)
@@ -16,6 +16,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_periods,
     save_figure,
@@ -105,7 +106,7 @@ def main():
         input_path = io_args.input[0]
     else:
         suffix = "_core" if args.core_only else ""
-        input_path = os.path.join(TABLES_DIR, f"tab_pole_papers{suffix}.csv")
+        input_path = os.path.join(DERIVED_TABLES_DIR, f"tab_pole_papers{suffix}.csv")
 
     df = pd.read_csv(input_path)
     df["year"] = pd.to_numeric(df["year"], errors="coerce").astype(int)

--- a/scripts/plot_bimodality_lexical.py
+++ b/scripts/plot_bimodality_lexical.py
@@ -1,7 +1,7 @@
 """TF-IDF lexical KDE by period (bimodality validation B).
 
 Reads:
-  content/tables/tab_pole_papers.csv — per-paper lex_score and metadata
+  <derived>/tab_pole_papers.csv — per-paper lex_score and metadata (analysis intermediate)
 
 Produces:
   content/figures/fig_bimodality_lexical.png (and .pdf if --pdf)
@@ -18,6 +18,7 @@ from scipy.stats import gaussian_kde
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_periods,
     save_figure,
@@ -91,7 +92,7 @@ def main():
         input_path = io_args.input[0]
     else:
         suffix = "_core" if args.core_only else ""
-        input_path = os.path.join(TABLES_DIR, f"tab_pole_papers{suffix}.csv")
+        input_path = os.path.join(DERIVED_TABLES_DIR, f"tab_pole_papers{suffix}.csv")
 
     df = pd.read_csv(input_path)
     df["year"] = pd.to_numeric(df["year"], errors="coerce").astype(int)

--- a/scripts/plot_figS_kde.py
+++ b/scripts/plot_figS_kde.py
@@ -13,7 +13,7 @@ from plot_style import DARK, DPI, FIGWIDTH, FILL, LIGHT, MED, apply_style
 from scipy.stats import gaussian_kde
 from script_io_args import parse_io_args, validate_io
 from sklearn.mixture import GaussianMixture
-from utils import BASE_DIR, get_logger, save_figure
+from utils import DERIVED_TABLES_DIR, get_logger, save_figure
 
 log = get_logger("plot_figS_kde")
 
@@ -30,7 +30,7 @@ def main():
     args = parser.parse_args(extra)
 
     # Load scores
-    path = os.path.join(BASE_DIR, "content", "tables", "tab_pole_papers.csv")
+    path = os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv")
     df = pd.read_csv(path)
     scores = df["axis_score"].dropna().values
     log.info("Loaded %d axis scores from %s", len(scores), path)

--- a/scripts/plot_fig_lexical_tfidf.py
+++ b/scripts/plot_fig_lexical_tfidf.py
@@ -9,7 +9,7 @@ written) because the number of output files depends on the data.
 Usage:
     uv run python scripts/plot_fig_lexical_tfidf.py --output .lexical_tfidf.stamp
     uv run python scripts/plot_fig_lexical_tfidf.py --output .lexical_tfidf.stamp \
-        --input content/tables/tab_lexical_tfidf.csv [--pdf]
+        --input data/derived/tables/tab_lexical_tfidf.csv [--pdf]
 """
 
 import argparse
@@ -18,7 +18,7 @@ import os
 import matplotlib.pyplot as plt
 import pandas as pd
 from script_io_args import parse_io_args, validate_io
-from utils import BASE_DIR, get_logger, save_figure
+from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger, save_figure
 
 log = get_logger("plot_fig_lexical_tfidf")
 

--- a/scripts/plot_fig_lexical_tfidf.py
+++ b/scripts/plot_fig_lexical_tfidf.py
@@ -117,13 +117,12 @@ def main():
     args = parser.parse_args(extra)
 
     figures_dir = os.path.join(BASE_DIR, "content", "figures")
-    tables_dir = os.path.join(BASE_DIR, "content", "tables")
     os.makedirs(figures_dir, exist_ok=True)
 
     # --- Input resolution ---
     tfidf_path = (
         io_args.input[0] if io_args.input
-        else os.path.join(tables_dir, "tab_lexical_tfidf.csv")
+        else os.path.join(DERIVED_TABLES_DIR, "tab_lexical_tfidf.csv")
     )
 
     # --- Load pre-computed TF-IDF table ---

--- a/scripts/plot_interactive_corpus.py
+++ b/scripts/plot_interactive_corpus.py
@@ -27,6 +27,7 @@ import plotly.graph_objects as go
 from utils import (
     BASE_DIR,
     CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_config,
     normalize_doi,
@@ -50,9 +51,10 @@ CLUSTERS_PATH = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
 CLUSTER_LABELS_PATH = os.path.join(TABLES_DIR, "cluster_labels.json")
 BIB_PATH = os.path.join(BASE_DIR, "bibliography", "main.bib")
 
-# Tab5 can be in tables/ (repo) or catalogs/ (data dir) — try both
+# Pole papers is an analysis intermediate in the derived dir; also accept the
+# legacy catalogs/ location for older data snapshots.
 TAB5_CANDIDATES = [
-    os.path.join(TABLES_DIR, "tab_pole_papers.csv"),
+    os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv"),
     os.path.join(CATALOGS_DIR, "tab_pole_papers.csv"),
 ]
 
@@ -90,7 +92,7 @@ for candidate in TAB5_CANDIDATES:
 
 if tab5_path is None:
     raise FileNotFoundError(
-        "tab_pole_papers.csv not found in tables/ or catalogs/. "
+        "tab_pole_papers.csv not found in derived/ or catalogs/. "
         "Run analyze_bimodality.py first."
     )
 

--- a/scripts/plot_ncc_bimodality.py
+++ b/scripts/plot_ncc_bimodality.py
@@ -5,7 +5,7 @@ the period-decomposed KDE showing emergence of bimodality after 2015.
 Formatted for Nature Climate Change specifications.
 
 Reads:
-  content/tables/tab_pole_papers.csv — per-paper axis scores and metadata
+  <derived>/tab_pole_papers.csv — per-paper axis scores and metadata (analysis intermediate)
 
 Writes:
   content/figures/fig_ncc_bimodality.png (and .pdf if --pdf)
@@ -25,7 +25,13 @@ import pandas as pd
 from scipy.stats import gaussian_kde, norm
 from sklearn.mixture import GaussianMixture
 from script_io_args import parse_io_args, validate_io
-from utils import BASE_DIR, get_logger, load_analysis_periods, save_figure
+from utils import (
+    BASE_DIR,
+    DERIVED_TABLES_DIR,
+    get_logger,
+    load_analysis_periods,
+    save_figure,
+)
 
 log = get_logger("plot_ncc_bimodality")
 
@@ -166,7 +172,7 @@ def main():
     if io_args.input:
         input_path = io_args.input[0]
     else:
-        input_path = os.path.join(TABLES_DIR, "tab_pole_papers.csv")
+        input_path = os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv")
 
     df = pd.read_csv(input_path)
     df["year"] = pd.to_numeric(df["year"], errors="coerce").astype(int)

--- a/scripts/qa_detect_type.py
+++ b/scripts/qa_detect_type.py
@@ -12,7 +12,7 @@ Usage:
 
 Outputs:
     - stdout: type distribution summary
-    - content/tables/qa_type_report.csv: classification report
+    - <derived>/qa_type_report.csv: classification report (analysis intermediate)
     - data/catalogs/refined_works.csv: updated with doc_type column (with --apply)
 """
 
@@ -21,7 +21,7 @@ import os
 import re
 
 import pandas as pd
-from utils import BASE_DIR, CATALOGS_DIR, get_logger, save_csv
+from utils import CATALOGS_DIR, DERIVED_TABLES_DIR, get_logger, save_csv
 
 log = get_logger("qa_detect_type")
 
@@ -281,7 +281,7 @@ def main():
 
     # Save report
     report = df[["title", "journal", "source", "doc_type"]].copy()
-    report_path = os.path.join(BASE_DIR, "content", "tables", "qa_type_report.csv")
+    report_path = os.path.join(DERIVED_TABLES_DIR, "qa_type_report.csv")
     save_csv(report, report_path)
 
     if args.apply:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -58,6 +58,7 @@ from pipeline_loaders import (
     CATALOGS_DIR,
     CONFIG_DIR,
     DATA_DIR,
+    DERIVED_TABLES_DIR,
     EMBEDDINGS_CACHE_DIR,
     EMBEDDINGS_CACHE_PATH,
     EMBEDDINGS_PATH,

--- a/tests/test_archive_checksums.py
+++ b/tests/test_archive_checksums.py
@@ -24,7 +24,9 @@ EXPECTED_OUTPUTS = [
     "content/tables/tab_core_shares.csv",
     "content/tables/tab_bimodality.csv",
     "content/tables/tab_axis_detection.csv",
-    "content/tables/tab_pole_papers.csv",
+    # Large analysis intermediate evicted to the derived scratch dir (ticket 0208);
+    # ANALYSIS_OUTPUTS references it via the $(DERIVED) Make variable.
+    "$(DERIVED)/tab_pole_papers.csv",
     "content/tables/cluster_labels.json",
 ]
 

--- a/tests/test_bimodality_precision.py
+++ b/tests/test_bimodality_precision.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-from utils import BASE_DIR
+from utils import BASE_DIR, DERIVED_TABLES_DIR
 
 TABLES_DIR = os.path.join(BASE_DIR, "content", "tables")
 
@@ -86,7 +86,7 @@ class TestBimodalityPrecision:
             )
 
     def test_pole_papers_scores_max_4dp(self):
-        path = os.path.join(TABLES_DIR, "tab_pole_papers.csv")
+        path = os.path.join(DERIVED_TABLES_DIR, "tab_pole_papers.csv")
         if not os.path.exists(path):
             pytest.skip("tab_pole_papers.csv not built")
         df = pd.read_csv(path)

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -1,0 +1,92 @@
+"""Ticket 0208 — analysis intermediates evicted from content/tables/.
+
+`content/tables/` conflates small byte-stable *writing deliverables* with large
+*analysis intermediates* consumed only by other Phase-2 scripts. This guard
+pins the eviction of the heavy intermediates to an analysis-side derived dir:
+no producer/consumer target or script may resolve them back under
+`content/tables/`.
+
+Mirrors the arch-compliance grep-ratchet style: a stale hardcoded path is
+lexically stable, so a line-level scan is a durable regression guard.
+"""
+
+import glob
+import os
+
+PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
+
+# The heavy intermediates evicted by ticket 0208.
+EVICTED = [
+    "tab_lexical_tfidf.csv",
+    "tab_pole_papers.csv",
+    "tab_pole_papers_core.csv",
+    "qa_type_report.csv",
+]
+
+def _bad_patterns(basename):
+    """Path constructions that resolve `basename` under content/tables/.
+
+    Anchored on the basename so a legit content/tables/ deliverable elsewhere
+    on the same line (e.g. a tab_venues.md target that *reads* the evicted
+    file from $(DERIVED)) does not trip the guard.
+    """
+    return [
+        f"content/tables/{basename}",          # literal path (Make + docstrings)
+        f'TABLES_DIR, "{basename}"',            # os.path.join(TABLES_DIR, "…")
+        f"TABLES_DIR, '{basename}'",
+        f'"tables", "{basename}"',              # os.path.join(BASE_DIR, "content", "tables", "…")
+        f"'tables', '{basename}'",
+    ]
+
+
+def _makefiles():
+    paths = [os.path.join(PROJECT_ROOT, "Makefile")]
+    paths += glob.glob(os.path.join(PROJECT_ROOT, "*.mk"))
+    return paths
+
+
+def _scripts():
+    # Top-level scripts only — archived/ variants are frozen and not built.
+    return glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))
+
+
+def _offending_lines(path, basename):
+    """Lines in `path` that place `basename` under a content/tables marker.
+
+    The derived-dir constant `DERIVED_TABLES_DIR` is the *correct* destination,
+    so its occurrences are masked before matching (it superstring-contains the
+    `TABLES_DIR` marker).
+    """
+    patterns = _bad_patterns(basename)
+    hits = []
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            probe = line.replace("DERIVED_TABLES_DIR", "")
+            if any(pat in probe for pat in patterns):
+                hits.append((i, line.rstrip()))
+    return hits
+
+
+def test_makefiles_do_not_place_evicted_under_content_tables():
+    offenders = []
+    for path in _makefiles():
+        for basename in EVICTED:
+            for lineno, line in _offending_lines(path, basename):
+                offenders.append(f"{os.path.relpath(path, PROJECT_ROOT)}:{lineno}: {line}")
+    assert not offenders, (
+        "Evicted intermediates still resolve under content/tables/ in Make:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_scripts_do_not_place_evicted_under_content_tables():
+    offenders = []
+    for path in _scripts():
+        for basename in EVICTED:
+            for lineno, line in _offending_lines(path, basename):
+                offenders.append(f"{os.path.relpath(path, PROJECT_ROOT)}:{lineno}: {line}")
+    assert not offenders, (
+        "Evicted intermediates still resolve under content/tables/ in scripts:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -13,6 +13,11 @@ lexically stable, so a line-level scan is a durable regression guard.
 import glob
 import os
 
+import pytest
+
+# Grep-ratchet guard — belongs to the mechanical adherence gate (`pytest -m adherence`).
+pytestmark = pytest.mark.adherence
+
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
 SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 

--- a/tickets/closed/0208-evict-analysis-intermediates-content-tables.erg
+++ b/tickets/closed/0208-evict-analysis-intermediates-content-tables.erg
@@ -2,10 +2,12 @@
 Title: Evict large analysis intermediates out of content/tables/
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: done
 
 --- log ---
 2026-07-09T20:30Z HDMX-coding-agent created
 
+2026-07-10T08:07Z HDMX-coding-agent closed — done
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`content/tables/` conflated small byte-stable *writing deliverables* with large *analysis intermediates* consumed only by other Phase-2 scripts. This evicts the four heavy ones to an analysis-side scratch dir `data/derived/tables/` and rewires every producing + consuming target in one commit.

| File | Size | Producer | Now at |
|------|------|----------|--------|
| `tab_lexical_tfidf.csv` | 35 MB | `compute_lexical.py` | `data/derived/tables/` |
| `tab_pole_papers.csv` | 3.8 MB | `analyze_bimodality.py` | `data/derived/tables/` |
| `tab_pole_papers_core.csv` | ~0.3 MB | `analyze_bimodality.py --core-only` | `data/derived/tables/` |
| `qa_type_report.csv` | 3.7 MB | `qa_detect_type.py` (standalone) | `data/derived/tables/` |

New `utils.DERIVED_TABLES_DIR` (= `DATA_DIR/derived/tables`, gitignored, non-DVC) and the Make `$(DERIVED)` variable resolve the same path under the repo's existing repo-relative `data/` convention.

## Design decisions (judgment calls, flagged for review)

1. **The `_core` sibling moves too** (a 4th file beyond the ticket's named three). It shares `analyze_bimodality`'s suffix-based path logic (`tab_pole_papers{suffix}.csv`); splitting the two dirs would force per-suffix base-dir branching. It is also a gitignored intermediate, not a deliverable.
2. **Archive coupling the ticket under-specified.** `tab_pole_papers.csv` ships in the reviewer analysis archive. Repointed in `Makefile` `ANALYSIS_OUTPUTS`, `build/build_analysis_archive.sh`, and the shipped `Makefile.analysis-manuscript` template; the checksum test now greps the `$(DERIVED)` token.
3. **Scope of "content/tables/ only deliverables".** `content/tables/` still holds *other*, smaller intermediates (`tab_bimodality`, `tab_axis_detection`, `tab_breakpoints`, `tab_lineages`, `tab_alluvial`, …). This ticket evicts only the heavy ones enumerated in its Relevant-files section (~44 MB, ~80% one file). A full "deliverables only" sweep is a separate ticket.

## Test

- **RED-first grep guard** `tests/test_evict_analysis_intermediates.py` (`@pytest.mark.adherence`): no Make target or script may resolve the evicted basenames under `content/tables/`. Failed before, passes after.
- Affected suites green: `test_archive_checksums`, `test_bimodality_precision`, `test_io_discipline`, `test_script_hygiene` (106 passed, 5 skipped).
- **Not run here** (no corpus data in the worktree; heavy Quarto renders): the load-bearing `make papers` 6-PDF build and the manuscript clean-room build. The wiring is verified by import smoke + the grep guard + the stamp/prereq chain; **please run `make papers` before merge** to confirm the regression.

## Pre-PR adherence

`/verify-adherence` → **PASS** (mechanical gates green). The two nits it raised are fixed in the second commit: corrected `plot_fig_lexical_tfidf.py`'s `--input` default to the derived dir (cleared an F401) and marked the guard `@pytest.mark.adherence`.

**Ticket:** tickets/0208-evict-analysis-intermediates-content-tables.erg
Ticket-ref: tickets/0163-split-build-remaining-writing-workpackag.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)