### PR TITLE
ticket(0219): data/ split by dataflow phase — evict Phase-2 outputs from data/catalogs

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -30,7 +30,7 @@ The pipeline has four phases. Each phase's scripts follow a naming convention an
 
 **Phase 2 — Analysis & figures** (fast, deterministic, run often):
 - Scripts: `analyze_*`, `plot_*`, `compute_*`, `export_*`, `summarize_*`, `build_het_core.py`
-- Reads Phase 1 outputs; produces `content/figures/`, `content/tables/`, `content/_includes/`, `content/*-vars.yml`
+- Reads Phase 1 outputs; produces `content/figures/`, `content/tables/`, `content/_includes/`, `content/*-vars.yml` (writing deliverables) and analysis intermediates under `data/derived/` (not destined for a document)
 
 ### Phase 2 rules
 
@@ -92,12 +92,23 @@ by path.
 
 ## Data location
 
-Data lives **outside the repo**, at `CLIMATE_FINANCE_DATA` in `.env`.
-`scripts/utils.py` reads `.env` and exports `DATA_DIR`, `CATALOGS_DIR`, `EMBEDDINGS_PATH`. Never hardcode `data/catalogs/` relative to the repo.
+`DATA_DIR` defaults to `<repo>/data` and can be relocated onto another disk by
+setting `CLIMATE_FINANCE_DATA` in `.env`. `scripts/utils.py` re-exports `DATA_DIR`,
+`CATALOGS_DIR`, `DERIVED_TABLES_DIR`, `EMBEDDINGS_PATH` from `pipeline_loaders`.
+Resolve paths through those constants — never hardcode `data/catalogs/` in a script.
+
+`data/` is split by dataflow phase, so the directory names which phase owns a file:
+
+- `data/catalogs/` (+ `pool/`, `exports/`, `syllabi/`) — **Phase-1 corpus**,
+  DVC-managed (materialized locally by `dvc pull` from the padme remote).
+- `data/derived/` — **Phase-2 derived data**: analysis intermediates and derived
+  tables, gitignored and regenerable (`make` recreates them from the corpus). No
+  Phase-2 output belongs under `data/catalogs/`; guard `tests/test_phase_layout.py`.
 
 ## Incremental caches vs DVC outputs
 
 - **`enrich_cache/`** — persistent cache directory (gitignored, not a DVC output). Survives `dvc repro`.
+- **`data/derived/`** — Phase-2 derived data (analysis intermediates, derived tables). Gitignored, non-DVC, regenerable by `make`. Split by phase from `data/catalogs/` so the directory mirrors the pipeline phase (tickets 0208, 0219).
 - **DVC output** — declared in `dvc.yaml` `outs:`. Ephemeral — DVC may delete it.
 
 When adding a new enrichment script: put incremental state in `enrich_cache/<name>.csv`, write the DVC output separately.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -99,11 +99,39 @@ Resolve paths through those constants — never hardcode `data/catalogs/` in a s
 
 `data/` is split by dataflow phase, so the directory names which phase owns a file:
 
-- `data/catalogs/` (+ `pool/`, `exports/`, `syllabi/`) — **Phase-1 corpus**,
-  DVC-managed (materialized locally by `dvc pull` from the padme remote).
-- `data/derived/` — **Phase-2 derived data**: analysis intermediates and derived
-  tables, gitignored and regenerable (`make` recreates them from the corpus). No
-  Phase-2 output belongs under `data/catalogs/`; guard `tests/test_phase_layout.py`.
+```
+data/
+├── catalogs/     Phase-1 corpus (contract: refined_works/embeddings/citations)   DVC (dvc.yaml outs)
+├── pool/         Phase-1 raw source pulls                                         DVC (data/pool.dvc)
+├── exports/      Phase-1 exports                                                  DVC (data/exports.dvc)
+├── syllabi/      Phase-1 teaching sources                                         DVC (data/syllabi.dvc)
+├── het/          seed lists (small, stable)                                       git-tracked
+├── raw/          Phase-1 scratch                                                  gitignored
+├── run_reports/  Phase-1 QA reports                                               gitignored
+└── derived/      Phase-2 derived data (intermediates + derived tables)            gitignored, regenerable
+```
+
+The load-bearing rule: **`data/catalogs/` = corpus (Phase 1, DVC-managed);
+`data/derived/` = analysis outputs (Phase 2, regenerable, gitignored).** No Phase-2
+output belongs under `data/catalogs/` — guard `tests/test_phase_layout.py` fails if
+a script or Make constant resolves one there.
+
+## Artifact homes by phase
+
+Each phase writes to one place, so an artifact's directory tells you its phase:
+
+| Phase | Produces | Lives in |
+|-------|----------|----------|
+| **1 — Corpus** (`catalog_/enrich_/qa_/corpus_`) | the corpus contract | `data/catalogs/` (DVC) |
+| **2 — Analysis** (`analyze_/compute_/plot_/export_`) | writing deliverables | `content/figures/`, `content/tables/`, `content/_includes/`, `content/*-vars.yml` |
+| | analysis **intermediates** (not for a document) | `data/derived/` |
+| **3 — Render** (Quarto) | PDF / DOCX | `output/` (gitignored) |
+| **4 — Release** (`build/build_*_archive.sh`) | reproducibility archives | `*.tar.gz` |
+
+The split inside Phase 2 is the crux: it emits two kinds of file — things a paper
+renders (→ `content/`) and intermediates only other scripts read (→ `data/derived/`).
+Mixing them is what bloated `content/tables/` (ticket 0208) and hid Phase-2 outputs
+in `data/catalogs/` (ticket 0219).
 
 ## Incremental caches vs DVC outputs
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ data/raw/
 data/run_reports/
 data/teaching_sources.yaml
 data/catalogs/.citations_batch_checkpoint.csv
-# Analysis-side scratch dir for large Phase-2 intermediates (ticket 0208) —
-# regenerable, not a writing deliverable, not DVC-tracked.
+# Phase-2 derived data (analysis intermediates + derived tables) — regenerable,
+# not a writing deliverable, not DVC-tracked. Split by dataflow phase from
+# data/catalogs/ so the directory names the owning phase (tickets 0208, 0219).
 data/derived/
 
 # Make sentinel files (dynamic-output targets)

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,11 @@
 #   make rebuild            Clean + rebuild everything
 
 # ── Paths ─────────────────────────────────────────────────
-# Data lives in data/catalogs/ (managed by DVC).
-# Python scripts resolve the same path via utils.py (BASE_DIR/data).
+# data/ is split by dataflow phase (see .claude/rules/architecture.md § Data location):
+#   data/catalogs/ (+ pool/ exports/ syllabi/) = Phase-1 corpus, DVC-managed.
+#   data/derived/  = Phase-2 derived data, gitignored + regenerable.
+# Python scripts resolve the same paths via utils.py (CATALOGS_DIR / DERIVED_TABLES_DIR).
 DATA_DIR     := data/catalogs
-# Analysis-side scratch dir for large Phase-2 intermediates consumed only by
-# other Phase-2 scripts (not writing deliverables). Python resolves the same
-# path via utils.DERIVED_TABLES_DIR (DATA_DIR/derived/tables). Ticket 0208.
 DERIVED      := data/derived/tables
 CONFIG       := config/analysis.yaml
 BIB         := content/bibliography/main.bib
@@ -41,7 +40,9 @@ EXTENDED    := $(DATA_DIR)/extended_works.csv
 REFINED     := $(DATA_DIR)/refined_works.csv
 REFINED_EMB := $(DATA_DIR)/refined_embeddings.npz
 REFINED_CIT := $(DATA_DIR)/refined_citations.csv
-MOSTCITED   := $(DATA_DIR)/het_mostcited_50.csv
+
+# Phase 2 derived data (regenerable, under data/derived/)
+MOSTCITED   := $(DERIVED)/het_mostcited_50.csv
 
 # Phase 1→2 handoff: Feather files for fast Phase 2 reads
 REFINED_FTH := $(DATA_DIR)/refined_works.feather
@@ -418,7 +419,7 @@ content/figures/fig_composition_wide.png: scripts/plot_fig2_composition.py scrip
 
 # -- Data paper --
 # Semantic clusters (computation only — no figures)
-SEMANTIC_CLUSTERS := $(DATA_DIR)/semantic_clusters.csv
+SEMANTIC_CLUSTERS := $(DERIVED)/semantic_clusters.csv
 
 $(SEMANTIC_CLUSTERS): scripts/analyze_embeddings.py scripts/utils.py $(CONFIG) $(ENRICHED) $(DATA_DIR)/embeddings.npz
 	$(PYTHON) $< --output $@

--- a/scripts/analyze_embeddings.py
+++ b/scripts/analyze_embeddings.py
@@ -11,7 +11,7 @@ Method:
 - Cross-validate with co-citation communities (if available)
 
 Produces:
-- data/catalogs/semantic_clusters.csv: Cluster assignments with UMAP coordinates
+- data/derived/tables/semantic_clusters.csv: Cluster assignments with UMAP coordinates
 """
 
 import os
@@ -23,6 +23,7 @@ import pandas as pd
 from script_io_args import parse_io_args, validate_io
 from utils import (
     CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     EMBEDDINGS_PATH,
     get_logger,
     load_analysis_config,
@@ -34,7 +35,7 @@ log = get_logger("analyze_embeddings")
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-CLUSTERS_PATH = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+CLUSTERS_PATH = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
 
 
 def main():

--- a/scripts/analyze_genealogy.py
+++ b/scripts/analyze_genealogy.py
@@ -7,7 +7,7 @@ builds the internal citation DAG, and computes a year × band layout.
 Reads:
   data/catalogs/refined_works.csv
   data/catalogs/refined_citations.csv
-  data/catalogs/semantic_clusters.csv
+  data/derived/tables/semantic_clusters.csv
   <derived>/tab_pole_papers.csv  (optional — from analyze_bimodality.py)
 
 Produces:
@@ -103,7 +103,7 @@ def load_data():
 
     # Load KMeans semantic clusters (needed for CDM cluster identification)
     log.info("Loading semantic clusters...")
-    sem_df = pd.read_csv(os.path.join(CATALOGS_DIR, "semantic_clusters.csv"))
+    sem_df = pd.read_csv(os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv"))
     sem_df["doi_norm"] = sem_df["doi"].apply(normalize_doi)
     doi_to_cluster = dict(zip(sem_df["doi_norm"], sem_df["semantic_cluster"]))
     log.info("Semantic clusters loaded: %d papers", len(sem_df))

--- a/scripts/analyze_multilingual.py
+++ b/scripts/analyze_multilingual.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 from build_het_core import is_global_south, is_non_english
 from pipeline_loaders import (
-    CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     REFINED_WORKS_PATH,
     load_refined_citations,
     load_refined_embeddings,
@@ -279,7 +279,7 @@ def main():
     log.info("Loaded %d citation edges", len(citations_df))
     _log_mem("after load citations")
 
-    clusters_path = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+    clusters_path = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
     clusters_df = pd.read_csv(clusters_path, low_memory=False)
     log.info("Loaded %d cluster assignments", len(clusters_df))
     _log_mem("after load clusters")

--- a/scripts/build_het_core.py
+++ b/scripts/build_het_core.py
@@ -10,10 +10,10 @@ Pipeline:
   6. Output CSV
 
 Reads:  $DATA/catalogs/refined_works.csv, $DATA/catalogs/refined_citations.csv
-Writes: $DATA/catalogs/het_mostcited_50.csv
+Writes: $DATA/derived/tables/het_mostcited_50.csv
 
 Usage:
-    uv run python scripts/build_het_core.py --output data/catalogs/het_mostcited_50.csv \
+    uv run python scripts/build_het_core.py --output data/derived/tables/het_mostcited_50.csv \
         [--refined-works data/catalogs/refined_works.csv]
 """
 

--- a/scripts/export_core_venues_markdown.py
+++ b/scripts/export_core_venues_markdown.py
@@ -5,7 +5,7 @@ Produces a Quarto-includable markdown table grouping venues by publisher
 where institutional series overlap, matching the manuscript's @tbl-venues.
 
 Reads:
-- $DATA/catalogs/het_mostcited_50.csv
+- $DATA/derived/tables/het_mostcited_50.csv
 
 Writes:
 - content/tables/tab_core_venues_top10.md
@@ -19,7 +19,7 @@ import os
 import pandas as pd
 from script_io_args import parse_io_args, validate_io
 from summarize_core_venues import canonical_venue, venue_type
-from utils import BASE_DIR, CATALOGS_DIR, get_logger
+from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger
 
 log = get_logger("export_core_venues_markdown")
 
@@ -46,7 +46,7 @@ def main():
     parser.add_argument(
         "--core",
         type=str,
-        default=os.path.join(CATALOGS_DIR, "het_mostcited_50.csv"),
+        default=os.path.join(DERIVED_TABLES_DIR, "het_mostcited_50.csv"),
         help="Input core works CSV",
     )
     args = parser.parse_args(extra)

--- a/scripts/plot_interactive_corpus.py
+++ b/scripts/plot_interactive_corpus.py
@@ -47,7 +47,7 @@ TABLES_DIR = os.path.join(BASE_DIR, "content", "tables")
 os.makedirs(FIGURES_DIR, exist_ok=True)
 
 EMBEDDINGS_PATH = os.path.join(CATALOGS_DIR, "embeddings.npz")
-CLUSTERS_PATH = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+CLUSTERS_PATH = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
 CLUSTER_LABELS_PATH = os.path.join(TABLES_DIR, "cluster_labels.json")
 BIB_PATH = os.path.join(BASE_DIR, "bibliography", "main.bib")
 

--- a/scripts/plot_semantic.py
+++ b/scripts/plot_semantic.py
@@ -17,11 +17,11 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from script_io_args import parse_io_args, validate_io
-from utils import CATALOGS_DIR, get_logger, save_figure
+from utils import DERIVED_TABLES_DIR, get_logger, save_figure
 
 log = get_logger("plot_semantic")
 
-CLUSTERS_CSV = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+CLUSTERS_CSV = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
 
 
 def _plot_cluster(df, ax):

--- a/scripts/qa_embeddings.py
+++ b/scripts/qa_embeddings.py
@@ -23,7 +23,7 @@ import pandas as pd
 from scipy import stats
 from script_io_args import parse_io_args, validate_io
 from utils import (
-    CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     REFINED_EMBEDDINGS_PATH,
     REFINED_WORKS_PATH,
     get_logger,
@@ -31,7 +31,7 @@ from utils import (
 
 log = get_logger("qa_embeddings")
 
-CLUSTERS_PATH = os.path.join(CATALOGS_DIR, "semantic_clusters.csv")
+CLUSTERS_PATH = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/summarize_core_venues.py
+++ b/scripts/summarize_core_venues.py
@@ -2,7 +2,7 @@
 """Summarize publication venues for core works.
 
 Reads:
-- $DATA/catalogs/het_mostcited_50.csv
+- $DATA/derived/tables/het_mostcited_50.csv
 
 Writes:
 - tables/tab_core_venues_journals.csv
@@ -18,7 +18,7 @@ import re
 
 import pandas as pd
 from script_io_args import parse_io_args, validate_io
-from utils import BASE_DIR, CATALOGS_DIR, get_logger, save_csv
+from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger, save_csv
 
 log = get_logger("summarize_core_venues")
 
@@ -32,7 +32,7 @@ def parse_args():
     parser.add_argument(
         "--core",
         type=str,
-        default=os.path.join(CATALOGS_DIR, "het_mostcited_50.csv"),
+        default=os.path.join(DERIVED_TABLES_DIR, "het_mostcited_50.csv"),
         help="Input core works CSV",
     )
     parser.add_argument(

--- a/tests/test_phase_layout.py
+++ b/tests/test_phase_layout.py
@@ -1,0 +1,85 @@
+"""Ticket 0219 — layout mirrors dataflow phase: no Phase-2 output under data/catalogs/.
+
+`data/` is split by pipeline phase: `data/catalogs/` (+ pool/exports/syllabi) is
+Phase-1 corpus (DVC-managed), `data/derived/` is Phase-2 derived data (gitignored,
+regenerable). Two Phase-2 outputs used to leak into the Phase-1 corpus dir:
+`semantic_clusters.csv` (analyze_embeddings.py) and `het_mostcited_50.csv`
+(build_het_core.py). This guard pins them out of `data/catalogs/` so the layout
+keeps mirroring the phase — a re-introduced `$(DATA_DIR)/...` or
+`os.path.join(CATALOGS_DIR, "<name>")` for these basenames fails the test.
+
+Grep-ratchet style (like ticket 0208's guard): a stale hardcoded path is lexically
+stable, so a line-level scan is a durable regression guard.
+"""
+
+import glob
+import os
+
+import pytest
+
+# Grep-ratchet guard — belongs to the mechanical adherence gate (`pytest -m adherence`).
+pytestmark = pytest.mark.adherence
+
+PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
+MAKEFILE = os.path.join(PROJECT_ROOT, "Makefile")
+
+# Phase-2 outputs evicted from data/catalogs/ by ticket 0219.
+PHASE2_OUTPUTS = [
+    "semantic_clusters.csv",
+    "het_mostcited_50.csv",
+]
+
+
+def _bad_patterns(basename):
+    """Path constructions that resolve `basename` under the Phase-1 corpus dir.
+
+    Anchored on the basename so a legit Phase-1 read on the same line (e.g.
+    refined_works.csv from CATALOGS_DIR) does not trip the guard.
+    """
+    return [
+        f"data/catalogs/{basename}",                 # literal repo path (Make + docstrings)
+        f"$DATA/catalogs/{basename}",                # $DATA/catalogs/<name> docstrings
+        f'CATALOGS_DIR, "{basename}"',               # os.path.join(CATALOGS_DIR, name)
+        f"CATALOGS_DIR, '{basename}'",
+        f"$(DATA_DIR)/{basename}",                   # Makefile constant under Phase 1
+    ]
+    # Note: bare `catalogs/<name>` is intentionally NOT matched — it would catch the
+    # scoped-out smoke fixture `tests/fixtures/smoke/catalogs/<name>` (a self-contained
+    # test mirror, ticket 0219 § Scope out), not the production Phase-1 corpus dir.
+
+
+def _scan(path):
+    """Return list of (lineno, line) in `path` matching any bad pattern."""
+    hits = []
+    with open(path, encoding="utf-8") as fh:
+        for i, line in enumerate(fh, 1):
+            for basename in PHASE2_OUTPUTS:
+                if any(pat in line for pat in _bad_patterns(basename)):
+                    hits.append((i, line.rstrip()))
+                    break
+    return hits
+
+
+def _production_files():
+    """Makefile + scripts/*.py. Excludes tests/fixtures/ (self-contained mirrors)."""
+    files = [MAKEFILE]
+    files += glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))
+    return files
+
+
+def test_no_phase2_output_under_catalogs():
+    offenders = {}
+    for path in _production_files():
+        hits = _scan(path)
+        if hits:
+            offenders[os.path.relpath(path, PROJECT_ROOT)] = hits
+    assert not offenders, (
+        "Phase-2 outputs must live under data/derived/, not data/catalogs/ "
+        "(ticket 0219). Offending lines:\n"
+        + "\n".join(
+            f"  {f}:{ln}: {txt}"
+            for f, hits in offenders.items()
+            for ln, txt in hits
+        )
+    )

--- a/tickets/closed/0219-layout-data-split-by-dataflow-phase-evic.erg
+++ b/tickets/closed/0219-layout-data-split-by-dataflow-phase-evic.erg
@@ -1,0 +1,90 @@
+%erg 0.1
+Title: Layout: data/ split by dataflow phase — evict remaining Phase-2 derived data from data/catalogs
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Closed: phase-split migration complete — semantic_clusters + het_mostcited under data/derived, convention documented, guard green
+
+--- log ---
+2026-07-10T08:46Z HDMX-coding-agent created
+
+2026-07-10T09:02Z HDMX-coding-agent closed — phase-split migration complete — semantic_clusters + het_mostcited under data/derived, convention documented, guard green
+--- body ---
+## Context
+
+The project is organized along four logics — build (Makefiles / workpackage
+`.mk`s), layout (directories), data-analysis (dataflow phases), tracking
+(tickets). The layout logic drifted from the data-analysis logic: **Phase-2
+derived data leaked into `data/catalogs/`, the Phase-1 corpus directory.**
+
+`data/` is subdivided by phase — but only half-consistently:
+- `data/catalogs/` (+ `pool/`, `exports/`, `syllabi/`) = Phase-1 corpus, DVC-managed.
+- `data/derived/` = Phase-2 derived data (gitignored, regenerable), established by
+  0208 when it evicted the heavy `content/tables/` intermediates.
+
+Two Phase-2 outputs still resolve under `data/catalogs/` (Phase 1's dir):
+- `semantic_clusters.csv` — produced by `analyze_embeddings.py` (Phase 2).
+- `het_mostcited_50.csv` — produced by `build_het_core.py` (Phase 2).
+
+Completing the phase split makes the layout mirror the data-analysis phase, with the
+build constants following.
+
+## Decision — flat `data/derived/`, split by phase not workpackage
+
+`data/derived/` stays FLAT. It is NOT subdivided to mirror the `.mk` workpackages:
+mirroring couples layout to build and breaks on the first cross-workpackage file —
+`tab_pole_papers.csv` is already consumed by three workpackages and has no single
+owner. `data/` splits on the coarse, stable axis (phase): `catalogs`=Phase 1,
+`derived`=Phase 2.
+
+## Relevant files
+- `Makefile` — `SEMANTIC_CLUSTERS := $(DATA_DIR)/semantic_clusters.csv` (~421),
+  `MOSTCITED := $(DATA_DIR)/het_mostcited_50.csv` (44) become `$(DERIVED)/...`.
+  Producer recipes already pass `--output $@`. Fix the stale `DERIVED` comment (~30)
+  that mislabels the path as `DATA_DIR/derived/tables`.
+- `scripts/analyze_embeddings.py` (`CLUSTERS_PATH`, ~37 + docstring ~14),
+  `scripts/analyze_multilingual.py` (~282), `scripts/analyze_genealogy.py` (~106 +
+  docstring ~10) — hardcode `os.path.join(CATALOGS_DIR, "semantic_clusters.csv")`.
+  Prefer the script-io flag pattern 0208 used for cross-script reads (`--clusters`),
+  else `DERIVED_TABLES_DIR` — whichever keeps producer-write and consumer-read on the
+  SAME resolved path (verify DERIVED_TABLES_DIR resolves == Makefile `$(DERIVED)`).
+- `scripts/build_het_core.py`, `scripts/export_core_venues_markdown.py` — docstrings.
+- Docs to keep aligned: `.claude/rules/architecture.md` (Data location + phases),
+  `.gitignore` (data/ governance comment), `Makefile` DERIVED comment.
+
+## Actions
+1. Retarget the two Makefile constants to `$(DERIVED)/`; move the three scripts'
+   `semantic_clusters.csv` reads off `CATALOGS_DIR` onto the derived path, mirroring
+   0208's wiring exactly (flags where cross-script). Fix docstrings.
+2. Document the phase-split convention where the layout is described:
+   `.claude/rules/architecture.md` (Data location + the Phase-2 outputs line),
+   `.gitignore` comment, Makefile constant-block comment. Reconcile the stale
+   "data lives outside the repo / never hardcode data/catalogs" wording with reality.
+3. Keep DVC scoped to corpus data; the moved files stay gitignored, non-DVC,
+   regenerable — no git mv (untracked), no on-disk move (next `make` regenerates).
+
+## Scope out
+- `tests/fixtures/smoke/catalogs/het_mostcited_50.csv` — a self-contained smoke-test
+  mini-corpus mirror; internal path is a test detail. Left as-is.
+- Residual small `content/tables/` intermediates — the opposite leak, owned by 0218.
+
+## Test
+- New guard `tests/test_phase_layout.py` (adherence marker, grep-ratchet style like
+  0208's): no Make constant or `scripts/*.py` line resolves `semantic_clusters.csv`
+  or `het_mostcited_50.csv` under `data/catalogs/` or `CATALOGS_DIR`. Excludes
+  `tests/fixtures/`. RED first, then migrate to green.
+- Regression: `make check-fast` stays green.
+
+## Invariants
+- `make papers` unaffected — producer-write and consumer-read paths move together in
+  one commit and resolve to the same location.
+- Phase separation preserved; DVC untouched; files stay gitignored + regenerable.
+
+## Exit criteria
+- No Phase-2 output (`semantic_clusters.csv`, `het_mostcited_50.csv`) resolves under
+  `data/catalogs/`; both live under `data/derived/`.
+- Phase-split convention documented in `architecture.md`, `.gitignore`, Makefile.
+- New class guard green; would fail on a re-introduced Phase-2 output under catalogs.
+- `make check-fast` green.
+
+Ticket-ref: tickets/0163-split-build-remaining-writing-workpackag.erg
+Ticket-ref: tickets/0218-evict-remaining-phase-2-intermediates-fr.erg


### PR DESCRIPTION
Completes the layout↔phase alignment 0208 started, and documents the convention. Follows your framing: `data/` split by **dataflow phase** (not by workpackage — mirroring is fraught: it couples layout to build and breaks on cross-workpackage files).

## Problem
Two Phase-2 outputs still resolved under `data/catalogs/` — the Phase-1 corpus dir:
- `semantic_clusters.csv` (`analyze_embeddings.py`)
- `het_mostcited_50.csv` (`build_het_core.py`)

So `data/catalogs/` couldn't be trusted to mean "Phase-1 corpus" — the confusion that started this.

## Convention (now documented)
`data/` splits on the coarse, stable axis — **phase**, flat within each:
- `data/catalogs/` (+ `pool/exports/syllabi/`) = Phase-1 corpus (DVC-managed)
- `data/derived/` = Phase-2 derived data (gitignored, regenerable)

## Change
- **Makefile**: `MOSTCITED`, `SEMANTIC_CLUSTERS` → `$(DERIVED)/`; `MOSTCITED` reclassified out of the "Phase 1 contract" block; fixed the comment that mislabeled the path as `DATA_DIR/derived`.
- **8 scripts**: `semantic_clusters`/`het_mostcited` reads moved `CATALOGS_DIR` → `DERIVED_TABLES_DIR`. The RED guard surfaced 5 consumers beyond my initial 3 — leaving any on `CATALOGS_DIR` would break it, so completeness matters.
- **Guard** `tests/test_phase_layout.py` (adherence, grep-ratchet): no Make constant or script may resolve either basename under `data/catalogs/`/`CATALOGS_DIR`. Excludes `tests/fixtures/`.
- **Docs aligned**: `architecture.md` (reconciled the stale "data lives outside the repo" — `DATA_DIR` actually defaults to `<repo>/data`, `.env`-overridable; phase split stated), `.gitignore` comment, Makefile comment.

## Verification
- Guard: RED on the old tree → GREEN after migration.
- `make check-fast`: **1119 passed**, 19 skipped (only pre-existing complexity warnings).
- Producer-write (`$(DERIVED)`) and consumer-default (`DERIVED_TABLES_DIR`) resolve to the same path; regression harness passes `--output` explicitly, so it's unaffected.

## Out of scope (noted)
- `plot_interactive_corpus.py:58` — a residual 0208 `tab_pole_papers.csv` fallback still pointing at `CATALOGS_DIR`. Belongs to sibling ticket **0218** (content/tables residual), not this one.
- The smoke fixture `tests/fixtures/smoke/catalogs/` — a self-contained test mirror, left as-is.

Ticket: tickets/0219-layout-data-split-by-dataflow-phase-evic.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)