### PR TITLE
ticket(0221,0222): layout-reorg tracker + data/catalogs completion child

### DIFF
--- a/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
+++ b/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
@@ -1,0 +1,84 @@
+%erg 0.1
+Title: Tracking: reorganize the repo so layout mirrors dataflow phase
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T09:19Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Retroactive tracker. A design conversation (2026-07-10) settled how the repo is
+organized and produced a reorganization, but the pieces were executed as
+individual tickets without an owning tracker — so the "tracking logic" (below) was
+the one logic left incomplete, and the reorg shipped partial: a per-file guard let
+a third leak (`communities.csv`) slip through unnoticed. This ticket records the
+decision and tracks the reorg to completion.
+
+## The decision — four logics, layout mirrors phase
+
+The repo is organized along four logics that must each be coherent and must not
+bleed into one another:
+
+- **build** — Makefiles / workpackage `.mk`s.
+- **layout** — directories.
+- **data-analysis** — dataflow phases (1 corpus → 2 analysis → 3 render → 4 release).
+- **tracking** — tickets.
+
+Settled rules:
+1. **Layout mirrors the data-analysis phase**, on the coarse, stable axis. A file's
+   directory names its phase. Documented in `.claude/rules/architecture.md`
+   (§ Data location, § Artifact homes by phase).
+2. **Flat by phase, NOT by workpackage.** Mirroring the `.mk` workpackages into the
+   layout couples layout to build and breaks on cross-workpackage files
+   (`tab_pole_papers.csv` has three consumers, no single owner). `data/catalogs`=
+   Phase 1, `data/derived`=Phase 2.
+3. **Build: clean-room vs live.** In-repo clean-room freeze == the paper being
+   (re)submitted from the repo (the manuscript R&R); everything else builds live.
+   An already-submitted paper's frozen form is its external deposit, not an in-repo
+   copy (0163/0207).
+
+## Children
+
+Done:
+- **0208** (merged #969) — evict the heavy Phase-2 intermediates out of
+  `content/tables/` → `data/derived/`.
+- **0219** (merged #974) — evict `semantic_clusters.csv` + `het_mostcited_50.csv`
+  out of `data/catalogs/` → `data/derived/`; document the phase-split convention;
+  add the (per-file) guard `tests/test_phase_layout.py`.
+- **0163 / 0207** (closed #970) — build clean-room-vs-live architecture documented;
+  premise-falsified `.mk`-per-paper scope retired.
+
+Open:
+- **0218** — residual small Phase-2 intermediates still in `content/tables/`, plus
+  the `plot_interactive_corpus.py:58` `tab_pole_papers` fallback still pointing at
+  `CATALOGS_DIR`.
+- **0222** — complete the `data/catalogs/` eviction (`communities.csv` + sweep) and
+  generalize the per-file guard to the class (see Remaining).
+
+## Remaining (the incompleteness this tracker exists to close)
+
+1. **Audit `data/catalogs/` for ALL Phase-2 outputs, not the two 0219 named.**
+   Confirmed leak: `COMMUNITIES := data/catalogs/communities.csv` (Makefile:570),
+   produced by `analyze_cocitation.py` (Phase 2) — evict to `data/derived/` and
+   rewire its consumers (`analyze_embeddings.py:156`, `plot_cocitation.py`). Sweep
+   for any others (every `$(DATA_DIR)/…` or `CATALOGS_DIR`-joined path whose
+   producer is an `analyze_/compute_/plot_/export_/summarize_/build_het` script).
+2. **Generalize the guard from per-file to per-CLASS.** `tests/test_phase_layout.py`
+   currently pins two basenames. Replace with: any Make target produced by a Phase-2
+   script must resolve under `data/derived/`, detected by producer-script prefix —
+   so a NEW Phase-2 output under `data/catalogs/` fails without editing the test.
+3. **Classify the ambiguous subtrees.** `data/het/` (git-tracked seeds) and
+   `data/run_reports/` — confirm each sits in the right phase bucket or document why.
+
+## Exit criteria (tracker closes when)
+- No Phase-2 output resolves under `data/catalogs/` (class-level, guard-enforced).
+- 0218 closed (content/tables residual + pole-papers fallback).
+- The four-logics decision + phase-mirror rule documented (DONE — architecture.md).
+- A short completeness re-read confirms `make papers` still builds all six.
+
+Ticket-ref: tickets/0218-evict-remaining-phase-2-intermediates-fr.erg
+Ticket-ref: tickets/0219-layout-data-split-by-dataflow-phase-evic.erg
+Ticket-ref: tickets/0222-complete-data-catalogs-phase-2-eviction.erg
+Ticket-ref: tickets/0163-split-build-remaining-writing-workpackag.erg

--- a/tickets/0222-complete-data-catalogs-phase-2-eviction.erg
+++ b/tickets/0222-complete-data-catalogs-phase-2-eviction.erg
@@ -1,0 +1,58 @@
+%erg 0.1
+Title: Complete data/catalogs Phase-2 eviction + generalize the phase-layout guard to the class
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T09:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Child of tracker 0221. Ticket 0219 evicted two named Phase-2 outputs
+(`semantic_clusters.csv`, `het_mostcited_50.csv`) from `data/catalogs/` and added a
+**per-file** guard. Because the guard pins basenames, it missed a third leak:
+`COMMUNITIES := data/catalogs/communities.csv` (Makefile:570), produced by
+`analyze_cocitation.py` (Phase 2). This ticket finishes the class and hardens the
+guard so completeness no longer depends on remembering to name each file.
+
+## Relevant files
+- `Makefile` — `COMMUNITIES := data/catalogs/communities.csv` (~570), producer
+  `$(COMMUNITIES): scripts/analyze_cocitation.py …` (~571), consumer
+  `content/figures/fig_communities.png: … $(COMMUNITIES)` and `analyze_embeddings.py:156`.
+- `scripts/analyze_cocitation.py` (producer default), `scripts/analyze_embeddings.py`
+  (~156 reads `os.path.join(CATALOGS_DIR, "communities.csv")`), `scripts/plot_cocitation.py`.
+- `tests/test_phase_layout.py` — the per-file guard from 0219, to be generalized.
+
+## Actions
+1. **Sweep** `data/catalogs/` for every Make target/constant whose producer is a
+   Phase-2 script (`analyze_/compute_/plot_/export_/summarize_/build_het`). Known:
+   `communities.csv`. List and evict each to `data/derived/` exactly as 0219 did —
+   Makefile constant → `$(DERIVED)/`, script `CATALOGS_DIR` reads → `DERIVED_TABLES_DIR`,
+   docstrings; producer-write and consumer-read move together.
+2. **Generalize the guard** (`tests/test_phase_layout.py`): replace the two-basename
+   whitelist with a class rule — parse the Makefile for targets under `$(DATA_DIR)`/
+   `data/catalogs/` whose recipe/prereq is a Phase-2 script, and fail if any exist.
+   A NEW Phase-2 output under `data/catalogs/` must fail the test WITHOUT editing it.
+3. **Classify the ambiguous subtrees** (0221 remaining item 3): `data/het/`
+   (git-tracked seeds) and `data/run_reports/` — confirm each is in the right phase
+   bucket, or document the exception in `architecture.md`.
+
+## Test
+- RED: the generalized guard fails on today's tree (catches `communities.csv`).
+- GREEN after eviction. Add a synthetic-fixture assertion that a fabricated
+  `data/catalogs/foo.csv` produced by an `analyze_*` target trips the guard.
+- Regression: `make check-fast` green.
+
+## Invariants
+- `make papers` unaffected; producer-write and consumer-read resolve to one path.
+- Phase separation preserved; DVC untouched; moved files stay gitignored, regenerable.
+
+## Exit criteria
+- No Phase-2 output resolves under `data/catalogs/` (verified by the generalized,
+  class-level guard, not a basename list).
+- `data/het/` and `data/run_reports/` classified/documented.
+- `make check-fast` green.
+
+Parent tracker: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
+Ticket-ref: tickets/0219-layout-data-split-by-dataflow-phase-evic.erg


### PR DESCRIPTION
Files the tracking ticket the reorganization should have had from the start, and the concrete child that closes the incompleteness it exposed. Ticket-only PR — no code.

## Why
We decided how the repo is organized (four logics — build / layout / data-analysis / tracking — with **layout mirroring dataflow phase**, flat not by-workpackage) and executed it across 0208 / 0219 / 0163 / 0207 — but never opened a tracker. The **tracking** logic was the one of the four we left incomplete, and it bit: 0219's guard is per-file, so it missed a third Phase-2 leak — `data/catalogs/communities.csv` (produced by `analyze_cocitation.py`, Phase 2).

## What this adds
- **0221 (tracker)** — records the decision + phase-mirror rule (already documented in `architecture.md`), links the done children (0208/0219/0163/0207) and open ones (0218, 0222), and stays open until no Phase-2 output resolves under `data/catalogs/`, class-enforced.
- **0222 (child)** — evict `communities.csv` (+ sweep for any others), and **generalize the guard** from a two-basename whitelist to a class rule keyed on producer phase, so a new Phase-2 output under `data/catalogs/` fails the test without editing it.

Ticket: none
Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
Ticket-ref: tickets/0222-complete-data-catalogs-phase-2-eviction.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)