### PR TITLE
ticket(0216): fast-path tier guards — heavy-import auto-mark + duration ratchet

### DIFF
--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -40,6 +40,11 @@ Markers gate which `make` target runs a test. Pick the tier by **cost**, not by 
 
 `make check-fast` = `-m "not slow and not integration and not adherence"` (the inner loop — must stay pure logic). `make lint` = `-m adherence`. `make check` runs everything. No coverage is lost by moving a test to a slower tier — `make check` still runs it before every PR.
 
+Two guards keep the fast tier honest (ticket 0216, owned by `tests/test_fast_path_budget.py` + `tests/conftest.py`):
+
+- **Auto-mark** — a collection hook marks any test whose module imports a heavy dependency (dcor/torch/ot/sentence_transformers/matplotlib) `slow` automatically, so you rarely mark those by hand. `import dcor` alone costs ~7s (numba JIT), so this is the deterministic fix for the per-worker import tax.
+- **Ratchet** — an `adherence` test fails if any fast-path test on the last recorded run exceeds the budget in `[tool.fast_path_ratchet]` (pyproject). Heavy *compute* that no heavy *import* reveals lands here: give it `slow` (heavy compute / real data) or `integration` (subprocess). Refresh timings with `make test-durations` (serial, so the budget measures true cost, not xdist contention).
+
 ## Testing
 
 - Acceptance tests (e.g., `make corpus-validate`) are the top-level contract — never weaken without discussion.

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
+# Per-test durations recorded by the fast-path ratchet (ticket 0216) — a
+# machine/run-specific artifact regenerated on every `make check`.
+.test_durations.json
 .cache/
 
 # Replication archive

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-fast lint venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
+.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
 
 .DEFAULT_GOAL := manuscript
 
@@ -753,6 +753,18 @@ check-fast: | venv-canonicalize
 # tests, not inside the inner loop — a warm mypy cache makes it ~1s. Ticket 0214.
 lint: | venv-canonicalize
 	$(PYTHON) -m pytest tests/ --tb=short -m adherence -n 4
+
+# Record per-test durations for the fast-path ratchet (ticket 0216) into the
+# gitignored .test_durations.json. Serial (-n0) and opt-in so timings reflect
+# true per-test cost, not xdist contention. Run this to refresh the data the
+# ratchet (test_fast_path_budget.py, adherence tier) checks on the next run.
+# --continue-on-collection-errors: a base (non-corpus) env may lack an optional
+# dep (e.g. bibtexparser), which hard-stops collection of one module; the
+# recorder is best-effort and should still time every collectable fast-path test.
+test-durations: | venv-canonicalize
+	RECORD_TEST_DURATIONS=1 $(PYTHON) -m pytest tests/ --tb=short \
+		-m "not slow and not integration and not adherence" \
+		-p no:xdist -q --continue-on-collection-errors
 
 # PDF content audit: does each docs/articles/*.pdf match its bib title?
 # Author-run, human-verified — NOT wired into check/check-fast: scanned PDFs have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,17 @@ markers = [
     "adherence: project rule enforcement (hygiene/discipline/contracts)",
 ]
 
+[tool.fast_path_ratchet]
+# Duration-ratchet guard (ticket 0216): fail if any fast-path test
+# (`-m "not slow and not integration and not adherence"`) on the last recorded
+# run exceeds this budget. Enforced by tests/test_fast_path_budget.py; timings
+# are recorded by the conftest.py hooks into durations_file (gitignored).
+# Start generous — the ~7s dcor import tax is gone via the collection-time
+# auto-mark, so the residual heavy-compute tail sets the floor. Tighten as the
+# fast path gets leaner.
+budget_seconds = 5.0
+durations_file = ".test_durations.json"
+
 [tool.uv]
 conflicts = [
     [{ extra = "cpu" }, { extra = "cu130" }],

--- a/tests/_tier_autoscan.py
+++ b/tests/_tier_autoscan.py
@@ -1,0 +1,117 @@
+"""Shared logic for the fast-path tier guards (ticket 0216).
+
+Two consumers import from here:
+
+- ``conftest.py`` — the collection-time auto-mark hook (heavy-import detection)
+  and the duration-recording hooks (config lookup, durations-file path).
+- ``tests/test_fast_path_budget.py`` — the ratchet meta-test and its unit tests.
+
+Keeping the pure functions here (not in ``conftest.py``) makes them importable
+and unit-testable without triggering a real pytest collection, and gives the two
+consumers a single source of truth.
+
+The module name is underscore-prefixed so pytest never collects it as a test.
+"""
+
+import os
+import re
+from functools import lru_cache
+
+import tomllib
+
+# Heavy dependencies whose import dominates a test's wall time. ``import dcor``
+# alone costs ~7s (numba JIT compiled at import, no on-disk cache). A module that
+# imports any of these — at top level OR lazily inside a function body — has no
+# place on the fast inner loop.
+HEAVY_MODULES = ("dcor", "torch", "ot", "sentence_transformers", "matplotlib")
+
+# Match `import <mod>` / `from <mod> import ...` at any indentation (lazy imports
+# inside function bodies count). The trailing \b keeps `ot` from matching inside
+# `other`, and `torch` from matching inside `torchvision`. A static source scan
+# is deliberate — it mirrors the existing convention in
+# test_script_hygiene.py::test_no_slow_in_subprocess_files (substring match) and
+# never imports the heavy module just to classify it.
+_HEAVY_RE = re.compile(
+    r"^\s*(?:from|import)\s+(" + "|".join(HEAVY_MODULES) + r")\b",
+    re.MULTILINE,
+)
+
+# Markers that remove a test from the fast inner loop
+# (`-m "not slow and not integration and not adherence"`).
+NON_FAST_MARKERS = frozenset({"slow", "integration", "adherence"})
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def heavy_imports_in_source(source: str) -> set[str]:
+    """Return the set of heavy modules imported anywhere in ``source``."""
+    return set(_HEAVY_RE.findall(source))
+
+
+@lru_cache(maxsize=None)
+def file_has_heavy_import(path: str) -> bool:
+    """True if the Python file at ``path`` imports a heavy dependency.
+
+    Cached per path — the auto-mark hook calls this once per collected item, but
+    many items share one module file. Missing/unreadable files are treated as
+    not-heavy (fail open; the ratchet backstops anything that slips through).
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except OSError:
+        return False
+    return bool(heavy_imports_in_source(source))
+
+
+def is_fast_path(markers) -> bool:
+    """True if a test carrying ``markers`` runs on the fast inner loop."""
+    return not (NON_FAST_MARKERS & set(markers))
+
+
+def fast_path_violations(records, budget: float) -> list[tuple[str, float]]:
+    """Return (nodeid, duration) for each fast-path test exceeding ``budget``.
+
+    ``records`` is a list of ``{"nodeid", "duration", "markers"}`` dicts. A test
+    counts as fast-path only when it carries none of the non-fast markers.
+    Sorted slowest first so the message leads with the worst offender.
+    """
+    violations = [
+        (r["nodeid"], float(r["duration"]))
+        for r in records
+        if is_fast_path(r.get("markers", [])) and float(r["duration"]) > budget
+    ]
+    violations.sort(key=lambda t: t[1], reverse=True)
+    return violations
+
+
+def load_ratchet_config() -> dict:
+    """Read the ratchet budget and durations-file path from pyproject.toml.
+
+    The threshold lives in config (``[tool.fast_path_ratchet]``), never hardcoded
+    — see the ticket 0216 invariant. Defaults keep the guard functional even if
+    the table is absent.
+    """
+    with open(os.path.join(_REPO, "pyproject.toml"), "rb") as f:
+        data = tomllib.load(f)
+    cfg = data.get("tool", {}).get("fast_path_ratchet", {})
+    return {
+        "budget_seconds": float(cfg.get("budget_seconds", 5.0)),
+        "durations_file": cfg.get("durations_file", ".test_durations.json"),
+    }
+
+
+def durations_path() -> str:
+    """Absolute path to the recorded-durations JSON file."""
+    return os.path.join(_REPO, load_ratchet_config()["durations_file"])
+
+
+def load_durations() -> dict | None:
+    """Load the recorded durations, or None if no run has recorded any yet."""
+    import json
+
+    path = durations_path()
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,107 @@
-"""Shared test helpers for the divergence pipeline tests."""
+"""Shared test helpers for the divergence pipeline tests.
 
+Also wires the fast-path tier guards (ticket 0216):
+
+- ``pytest_collection_modifyitems`` auto-marks any test whose module statically
+  imports a heavy dependency (dcor/torch/ot/sentence_transformers/matplotlib)
+  ``slow`` — deterministically keeping the ~7s dcor import tax off the fast loop.
+- ``pytest_runtest_logreport`` + ``pytest_sessionfinish`` record per-test
+  durations (with tier markers) to a gitignored JSON file, which the ratchet in
+  ``tests/test_fast_path_budget.py`` reads on the next run.
+"""
+
+import json
 import os
 import subprocess
 import sys
+
+import pytest
+from _tier_autoscan import (
+    NON_FAST_MARKERS,
+    durations_path,
+    file_has_heavy_import,
+)
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "smoke")
 GOLDEN_DIR = os.path.join(FIXTURES_DIR, "golden")
 
 sys.path.insert(0, SCRIPTS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Fast-path tier guards (ticket 0216)
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark heavy-import test modules ``slow``.
+
+    Runs before pytest's built-in ``-m`` deselection (user conftest hooks fire
+    before internal plugin hooks), so an auto-added ``slow`` mark correctly
+    removes the test from ``make check-fast``. Idempotent: never touches a test
+    that already carries slow / integration / adherence.
+    """
+    for item in items:
+        if any(item.get_closest_marker(m) for m in NON_FAST_MARKERS):
+            continue
+        path = str(getattr(item, "path", None) or item.fspath)
+        if file_has_heavy_import(path):
+            item.add_marker(pytest.mark.slow)
+
+
+# nodeid -> {"duration": float (summed over phases), "markers": list[str]}
+_RECORDED_DURATIONS: dict[str, dict] = {}
+
+
+def pytest_runtest_logreport(report):
+    """Accumulate per-test wall time and tier markers.
+
+    ``report.keywords`` carries the marker names — including any auto-added
+    ``slow`` — so the ratchet sees the effective tier, not the source-declared
+    one. Durations are summed across setup/call/teardown for an honest per-test
+    total.
+    """
+    entry = _RECORDED_DURATIONS.setdefault(
+        report.nodeid, {"duration": 0.0, "markers": []}
+    )
+    entry["duration"] += float(getattr(report, "duration", 0.0) or 0.0)
+    marks = [m for m in NON_FAST_MARKERS if report.keywords.get(m)]
+    if marks:
+        entry["markers"] = sorted(set(entry["markers"]) | set(marks))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write recorded durations, but only for an opt-in *serial* run.
+
+    ``report.duration`` is wall time; under ``-n N`` xdist oversubscription it
+    inflates 3-5x (CPU contention), which would make a per-test budget fire on
+    scheduling noise rather than true cost. So recording is gated two ways:
+
+    - ``RECORD_TEST_DURATIONS`` must be set (avoids a stray single-file serial
+      run clobbering the file with a partial record), and
+    - the run must be serial (no active xdist workers).
+
+    ``make test-durations`` sets both. The ratchet then reflects the last such
+    run; a fresh checkout has no file and the guard skips (cold-start).
+    """
+    if not os.environ.get("RECORD_TEST_DURATIONS"):
+        return
+    if hasattr(session.config, "workerinput"):
+        return  # xdist worker
+    if session.config.getoption("numprocesses", None):
+        return  # distributed controller — durations would be contention-inflated
+    if not _RECORDED_DURATIONS:
+        return
+    records = [
+        {"nodeid": nodeid, "duration": entry["duration"], "markers": entry["markers"]}
+        for nodeid, entry in sorted(_RECORDED_DURATIONS.items())
+    ]
+    try:
+        with open(durations_path(), "w", encoding="utf-8") as f:
+            json.dump({"records": records}, f, indent=1)
+    except OSError:
+        pass  # never fail a run over a bookkeeping write.
 
 
 def smoke_env():

--- a/tests/test_c2st.py
+++ b/tests/test_c2st.py
@@ -162,6 +162,11 @@ class TestC2STCore:
 # ---------------------------------------------------------------------------
 
 
+# Heavy compute: computing a real C2ST output pulls the classifier/embedding
+# stack, and the first schema class to run pays that import (~5s). Marking the
+# class — not the one test that happened to run first — is the robust fix
+# (ticket 0216, same whack-a-mole shape as the dcor import tax).
+@pytest.mark.slow
 class TestC2STEmbeddingSchema:
     """Output of compute_c2st_embedding matches C2STDivergenceSchema."""
 
@@ -196,6 +201,7 @@ class TestC2STEmbeddingSchema:
             assert col in result.columns, f"{col} missing from C2ST output"
 
 
+@pytest.mark.slow
 class TestC2STLexicalSchema:
     """Output of compute_c2st_lexical matches C2STDivergenceSchema."""
 

--- a/tests/test_fast_path_budget.py
+++ b/tests/test_fast_path_budget.py
@@ -1,0 +1,181 @@
+"""Duration-ratchet guard + heavy-import auto-mark (ticket 0216).
+
+Two enforcement layers keep heavy tests off the fast inner loop
+(`make check-fast` = `-m "not slow and not integration and not adherence"`):
+
+1. **Auto-mark** — a collection-time hook (in ``conftest.py``) marks every test
+   whose module statically imports a heavy dependency (dcor / torch / ot /
+   sentence_transformers / matplotlib) with ``slow``. This is the robust fix for
+   the dcor import tax: ``import dcor`` costs ~7s (numba JIT, no disk cache) and
+   is paid once per xdist worker, attaching to whichever dcor test runs first —
+   so per-test marking is whack-a-mole. Marking every dcor-importing module in
+   one stroke is deterministic.
+
+2. **Ratchet** — this file's ``adherence`` test reads the per-test durations
+   recorded on the last run and fails if any *fast-path* test (one carrying none
+   of slow/integration/adherence) exceeds the budget. This backstops heavy
+   *compute* that no heavy *import* reveals.
+
+The pure detection/selection logic lives in ``tests/_tier_autoscan.py`` so both
+this test and ``conftest.py`` share one implementation, and so the logic is unit
+-testable without spinning a real collection.
+"""
+
+import os
+
+import pytest
+from _tier_autoscan import (
+    HEAVY_MODULES,
+    fast_path_violations,
+    file_has_heavy_import,
+    heavy_imports_in_source,
+    load_durations,
+    load_ratchet_config,
+)
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — heavy-import detection (pure, fast tier)
+# ---------------------------------------------------------------------------
+
+
+class TestHeavyImportDetection:
+    def test_detects_plain_import(self):
+        assert heavy_imports_in_source("import dcor") == {"dcor"}
+
+    def test_detects_from_import(self):
+        assert heavy_imports_in_source("from matplotlib import pyplot") == {
+            "matplotlib"
+        }
+
+    def test_detects_dotted_import(self):
+        assert heavy_imports_in_source("import matplotlib.pyplot as plt") == {
+            "matplotlib"
+        }
+
+    def test_detects_lazy_import_in_function_body(self):
+        src = "def f():\n    import torch\n    return torch\n"
+        assert heavy_imports_in_source(src) == {"torch"}
+
+    def test_ot_word_boundary_no_false_positive(self):
+        # `ot` must not match inside another module name.
+        assert heavy_imports_in_source("import other_module") == set()
+        assert heavy_imports_in_source("from otherpkg import x") == set()
+
+    def test_ot_matches_exact(self):
+        assert heavy_imports_in_source("import ot") == {"ot"}
+
+    def test_torch_word_boundary(self):
+        # `import torchvision` must not be read as `torch`.
+        assert heavy_imports_in_source("import torchvision") == set()
+
+    def test_pure_source_has_no_heavy_import(self):
+        assert heavy_imports_in_source("import os\nimport numpy as np\n") == set()
+
+    def test_all_heavy_modules_named(self):
+        # Guard the canonical list against silent shrinkage.
+        assert set(HEAVY_MODULES) == {
+            "dcor",
+            "torch",
+            "ot",
+            "sentence_transformers",
+            "matplotlib",
+        }
+
+    def test_real_dcor_test_file_flagged(self):
+        # test_divergence.py lazy-imports dcor inside test bodies.
+        assert file_has_heavy_import(os.path.join(TESTS_DIR, "test_divergence.py"))
+
+    def test_this_file_not_flagged(self):
+        # This ratchet file imports nothing heavy — it must stay on the fast path.
+        assert not file_has_heavy_import(os.path.abspath(__file__))
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — ratchet selection logic (pure, fast tier)
+# ---------------------------------------------------------------------------
+
+
+class TestRatchetLogic:
+    def test_flags_unmarked_fast_path_test_over_budget(self):
+        records = [
+            {"nodeid": "tests/test_x.py::test_heavy", "duration": 10.0, "markers": []},
+            {"nodeid": "tests/test_x.py::test_light", "duration": 0.5, "markers": []},
+        ]
+        violations = fast_path_violations(records, budget=5.0)
+        assert [nodeid for nodeid, _ in violations] == [
+            "tests/test_x.py::test_heavy"
+        ]
+        assert violations[0][1] == 10.0
+
+    def test_passes_when_over_budget_test_is_slow(self):
+        records = [
+            {
+                "nodeid": "tests/test_x.py::test_heavy",
+                "duration": 10.0,
+                "markers": ["slow"],
+            }
+        ]
+        assert fast_path_violations(records, budget=5.0) == []
+
+    def test_passes_when_over_budget_test_is_integration(self):
+        records = [
+            {"nodeid": "n", "duration": 10.0, "markers": ["integration"]},
+        ]
+        assert fast_path_violations(records, budget=5.0) == []
+
+    def test_passes_when_over_budget_test_is_adherence(self):
+        records = [
+            {"nodeid": "n", "duration": 10.0, "markers": ["adherence"]},
+        ]
+        assert fast_path_violations(records, budget=5.0) == []
+
+    def test_under_budget_never_flags(self):
+        records = [
+            {"nodeid": "n", "duration": 4.9, "markers": []},
+        ]
+        assert fast_path_violations(records, budget=5.0) == []
+
+
+class TestRatchetConfig:
+    def test_budget_from_config_is_positive_float(self):
+        cfg = load_ratchet_config()
+        assert isinstance(cfg["budget_seconds"], float)
+        assert cfg["budget_seconds"] > 0
+        assert cfg["durations_file"]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — the live ratchet (adherence tier)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.adherence
+def test_fast_path_within_budget():
+    """Fail if any fast-path test on the last recorded run exceeded the budget.
+
+    Cold-start: skip (never error) when no durations file exists yet — the guard
+    activates only once `make test-durations` has recorded timings.
+    """
+    cfg = load_ratchet_config()
+    budget = cfg["budget_seconds"]
+    data = load_durations()
+    if data is None:
+        pytest.skip(
+            f"no durations file ({cfg['durations_file']}) yet — "
+            "run `make test-durations` to record fast-path timings"
+        )
+    violations = fast_path_violations(data["records"], budget=budget)
+    if violations:
+        lines = "\n".join(
+            f"  {nodeid}  ({dur:.2f}s)" for nodeid, dur in violations
+        )
+        pytest.fail(
+            f"{len(violations)} fast-path test(s) exceed the {budget:.1f}s budget.\n"
+            f"{lines}\n"
+            "Fix: give each a slower tier — `@pytest.mark.slow` (heavy compute / "
+            "real data / heavy dep) or `@pytest.mark.integration` (spawns a "
+            "subprocess). A heavy *import* is auto-marked; this is heavy *compute*."
+        )

--- a/tests/test_multilayer_detection_figures.py
+++ b/tests/test_multilayer_detection_figures.py
@@ -25,6 +25,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+# Every test here drives a figure script through subprocess (`_run`), so the
+# whole module is the integration tier (ticket 0216 — surfaced by the fast-path
+# ratchet as unmarked subprocess tests taxing the inner loop at 5-6s each).
+pytestmark = pytest.mark.integration
+
 REPO = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCRIPTS_DIR = REPO / "scripts"
 

--- a/tests/test_null_model_c2st.py
+++ b/tests/test_null_model_c2st.py
@@ -90,6 +90,11 @@ def _base_cfg(n_perm=20):
 # ---------------------------------------------------------------------------
 
 
+# Heavy compute: a real C2ST permutation run pulls the classifier stack, and the
+# first NullModel class to run pays that import (~5-8s). Marking the class is the
+# robust fix (ticket 0216); the file also has an integration smoke class, so it
+# is listed in TestMarkerDiscipline.EXCEPTIONS.
+@pytest.mark.slow
 class TestC2STEmbeddingNullModel:
     """Unit tests for _run_c2st_embedding_permutations."""
 
@@ -193,6 +198,7 @@ class TestC2STEmbeddingNullModel:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestC2STLexicalNullModel:
     """Unit tests for _run_c2st_lexical_permutations."""
 

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -820,6 +820,9 @@ class TestMarkerDiscipline:
     EXCEPTIONS = {
         # @integration subprocess tests + @slow TestPCABreakPreservation (dcor).
         "test_embedding_sensitivity.py",
+        # @integration smoke class (subprocess) + @slow C2ST NullModel classes
+        # (classifier-stack import ~5-8s). Different tests, not a mislabel (0216).
+        "test_null_model_c2st.py",
     }
 
     def test_no_slow_in_subprocess_files(self):

--- a/tickets/closed/0216-duration-ratchet-guard-fast-path-budget.erg
+++ b/tickets/closed/0216-duration-ratchet-guard-fast-path-budget.erg
@@ -2,10 +2,12 @@
 Title: Duration-ratchet guard: fail a fast-path test that exceeds budget
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: done
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T09:33Z HDMX-coding-agent closed — done
 --- body ---
 ## Context
 Part of tracker 0213. This is the enforcement that converts "whack-a-mole


### PR DESCRIPTION
## What

Two enforcement layers keep heavy tests off the fast inner loop (`make check-fast` = `-m "not slow and not integration and not adherence"`), closing the "whack-a-mole forever" gap left open by ticket 0214:

1. **Auto-mark (the real fix).** A `pytest_collection_modifyitems` hook in `tests/conftest.py` marks every test whose module statically imports a heavy dependency (dcor / torch / ot / sentence_transformers / matplotlib) `slow` — unless it already carries slow/integration/adherence. Detection is a static source scan (`tests/_tier_autoscan.py`), mirroring the existing `test_no_slow_in_subprocess_files` convention; it catches lazy imports inside function bodies and never imports the heavy module to classify it.

2. **Ratchet (backstop for heavy compute without heavy imports).** An `adherence` meta-test (`tests/test_fast_path_budget.py`) reads recorded per-test durations and fails if any fast-path test exceeds the budget in `[tool.fast_path_ratchet]` (pyproject, **5.0s**), naming the offender and the tier it should join. Cold-start **skips** (never errors) when no durations file exists.

## Why the auto-mark, not per-test marking

`import dcor` costs ~7s (numba JIT at import, no disk cache) and is paid **once per xdist worker**, attaching to whichever dcor test runs first on that worker. So marking individual dcor tests `slow` is whack-a-mole: the 7s tax jumps to the next dcor test, nondeterministically per run — a pure per-test ratchet would flag a different test each run and never converge. A collection-time auto-mark on heavy-import **modules** removes all such cost in one deterministic stroke (all 7 dcor/torch/matplotlib-importing test files leave the fast path at once).

## Durations recorded serially, on purpose

`report.duration` is wall time; under `-n N` xdist oversubscription it inflates 3-5x from CPU contention (measured: a 1.9s test showed 8.9s under `-n4`), which would make a per-test budget fire on scheduling noise. So recording is **serial and opt-in** via `make test-durations` (`RECORD_TEST_DURATIONS=1`, `-p no:xdist`), giving budget >> noise. The `.test_durations.json` file is gitignored (machine/run-specific); a fresh checkout cold-starts the ratchet into skip.

## Re-tiering surfaced by the ratchet

The ratchet flagged 6 genuinely-heavy fast-path tests whose cost is heavy compute / **transitive** import the static scanner can't see (classifier + embedding + matplotlib pulled via the script modules they exercise). Re-tiered by cost:

- `test_multilayer_detection_figures.py` → module-level `integration` (all 8 tests drive a figure script via subprocess — a prior marker-discipline miss).
- `test_c2st.py` → `slow` on the two heavy C2ST schema classes (class-level, since the first to run pays the import — same shape as dcor); light `TestC2STCore` stays fast.
- `test_null_model_c2st.py` → `slow` on the two C2ST NullModel classes; file joins `TestMarkerDiscipline.EXCEPTIONS` (it also has an `integration` subprocess smoke class — slow + subprocess coexist by design).

## Before / after fast-path timing (`-n 4`, doudou)

| | Wall time | Max single fast-path test |
|---|---|---|
| before | ~84s | 5.5s (+ nondeterministic 7s dcor tax) |
| after | **~16s** | **1.6s** |

Serial fast-path max dropped 7.86s → **1.30s** (budget 5.0s → ~3.8x headroom), so the ratchet ships green and only trips on a genuine new regression. No coverage lost — `make check` still runs every tier.

## Notes

- Design diverges from the ticket's original ratchet-only framing: the **auto-mark is the refinement** (the ticket's own body predicted per-test marking would be whack-a-mole and pointed here). Both layers are implemented.
- Residual heavy tests left on the fast path: **none** over budget. The pre-existing `test_bib_doi_title.py` collection error (`bibtexparser`, an optional corpus-env dep) is unrelated environment drift; `make test-durations` uses `--continue-on-collection-errors` to stay best-effort under it.

TDD: pure-logic unit tests (heavy-import detection; ratchet selection incl. synthetic 10s red/green fixtures) were red on the missing module, green after implementation.

**Ticket:** tickets/0216-duration-ratchet-guard-fast-path-budget.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)