### PR TITLE
ticket(0222): evict communities.csv from data/catalogs; generalize phase-layout guard to the class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ content/figures/fig_traditions.png: scripts/plot_fig_traditions.py scripts/plot_
 	$(PYTHON) $< --output $@
 
 # Co-citation communities (compute: community assignments + summary table)
-COMMUNITIES := data/catalogs/communities.csv
+COMMUNITIES := $(DERIVED)/communities.csv
 $(COMMUNITIES): scripts/analyze_cocitation.py scripts/utils.py $(REFINED_CIT)
 	$(PYTHON) $< --output $@
 

--- a/scripts/analyze_cocitation.py
+++ b/scripts/analyze_cocitation.py
@@ -6,7 +6,7 @@ Method (Small 1973, White & Griffith 1981):
   communities using the Louvain algorithm.
 
 Produces:
-- data/catalogs/communities.csv: Community assignments for top-cited works
+- data/derived/tables/communities.csv: Community assignments for top-cited works
 
 Options:
   --robustness    Louvain resolution sensitivity (logged, no file output)

--- a/scripts/analyze_embeddings.py
+++ b/scripts/analyze_embeddings.py
@@ -154,7 +154,7 @@ def main():
     # Step 4: Cross-validate with co-citation communities
     # ============================================================
 
-    cocit_path = os.path.join(CATALOGS_DIR, "communities.csv")
+    cocit_path = os.path.join(DERIVED_TABLES_DIR, "communities.csv")
     if os.path.exists(cocit_path):
         log.info("=== Cross-validation with co-citation communities ===")
         cocit = pd.read_csv(cocit_path)

--- a/scripts/compute_clusters.py
+++ b/scripts/compute_clusters.py
@@ -27,13 +27,13 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from script_io_args import parse_io_args, validate_io
 from sklearn.cluster import KMeans
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import adjusted_rand_score
-from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
-    CATALOGS_DIR,
+    DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_config,
     load_analysis_corpus,
@@ -270,7 +270,7 @@ def _save_core_shares(df, alluvial_data, period_labels, cite_threshold, suffix, 
 
 def _check_ari_alignment(df):
     """Check KMeans/Louvain alignment via Adjusted Rand Index."""
-    cocit_path = os.path.join(CATALOGS_DIR, "communities.csv")
+    cocit_path = os.path.join(DERIVED_TABLES_DIR, "communities.csv")
     if not os.path.exists(cocit_path):
         log.warning("communities.csv not found, skipping ARI alignment check.")
         return

--- a/tests/test_phase_layout.py
+++ b/tests/test_phase_layout.py
@@ -1,85 +1,95 @@
-"""Ticket 0219 — layout mirrors dataflow phase: no Phase-2 output under data/catalogs/.
+"""Tickets 0219 / 0222 — layout mirrors dataflow phase: no Phase-2 output under data/catalogs/.
 
 `data/` is split by pipeline phase: `data/catalogs/` (+ pool/exports/syllabi) is
 Phase-1 corpus (DVC-managed), `data/derived/` is Phase-2 derived data (gitignored,
-regenerable). Two Phase-2 outputs used to leak into the Phase-1 corpus dir:
-`semantic_clusters.csv` (analyze_embeddings.py) and `het_mostcited_50.csv`
-(build_het_core.py). This guard pins them out of `data/catalogs/` so the layout
-keeps mirroring the phase — a re-introduced `$(DATA_DIR)/...` or
-`os.path.join(CATALOGS_DIR, "<name>")` for these basenames fails the test.
+regenerable). A Phase-2 output living in the Phase-1 corpus dir breaks that mirror.
 
-Grep-ratchet style (like ticket 0208's guard): a stale hardcoded path is lexically
-stable, so a line-level scan is a durable regression guard.
+This is a **class** guard (0222 generalized 0219's two-basename whitelist): it reads
+the Makefile as the source of truth and fails if *any* target produced by a Phase-2
+script resolves under `data/catalogs/`, or if any script reads a `data/derived`
+output from `CATALOGS_DIR`. A newly-introduced Phase-2 output under `data/catalogs/`
+fails the test with no edit to this file.
 """
 
 import glob
 import os
+import re
 
 import pytest
 
-# Grep-ratchet guard — belongs to the mechanical adherence gate (`pytest -m adherence`).
+# Mechanical adherence gate (`make lint` / `pytest -m adherence`).
 pytestmark = pytest.mark.adherence
 
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
-SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 MAKEFILE = os.path.join(PROJECT_ROOT, "Makefile")
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 
-# Phase-2 outputs evicted from data/catalogs/ by ticket 0219.
-PHASE2_OUTPUTS = [
-    "semantic_clusters.csv",
-    "het_mostcited_50.csv",
-]
-
-
-def _bad_patterns(basename):
-    """Path constructions that resolve `basename` under the Phase-1 corpus dir.
-
-    Anchored on the basename so a legit Phase-1 read on the same line (e.g.
-    refined_works.csv from CATALOGS_DIR) does not trip the guard.
-    """
-    return [
-        f"data/catalogs/{basename}",                 # literal repo path (Make + docstrings)
-        f"$DATA/catalogs/{basename}",                # $DATA/catalogs/<name> docstrings
-        f'CATALOGS_DIR, "{basename}"',               # os.path.join(CATALOGS_DIR, name)
-        f"CATALOGS_DIR, '{basename}'",
-        f"$(DATA_DIR)/{basename}",                   # Makefile constant under Phase 1
-    ]
-    # Note: bare `catalogs/<name>` is intentionally NOT matched — it would catch the
-    # scoped-out smoke fixture `tests/fixtures/smoke/catalogs/<name>` (a self-contained
-    # test mirror, ticket 0219 § Scope out), not the production Phase-1 corpus dir.
+# A Make prerequisite naming one of these script prefixes marks a Phase-2 producer.
+PHASE2_PRODUCER = re.compile(r"scripts/(analyze_|compute_|plot_|export_|summarize_|build_het)")
+CATALOGS = "data/catalogs/"
+DERIVED = "data/derived/"
+_MAKE_VAR = re.compile(r"\$\(([A-Z_][A-Z0-9_]*)\)")
 
 
-def _scan(path):
-    """Return list of (lineno, line) in `path` matching any bad pattern."""
-    hits = []
-    with open(path, encoding="utf-8") as fh:
+def _makefile_constants():
+    """Parse `NAME := value` assignments and fully expand nested $(REF) references."""
+    raw = {}
+    with open(MAKEFILE, encoding="utf-8") as fh:
+        for line in fh:
+            m = re.match(r"^([A-Z_][A-Z0-9_]*)\s*:=\s*(.+?)\s*$", line)
+            if m:
+                raw[m.group(1)] = m.group(2)
+
+    def expand(value, seen):
+        def repl(mm):
+            name = mm.group(1)
+            if name in raw and name not in seen:
+                return expand(raw[name], seen | {name})
+            return mm.group(0)
+        return _MAKE_VAR.sub(repl, value)
+
+    return {k: expand(v, {k}) for k, v in raw.items()}
+
+
+def _resolve(token, consts):
+    return _MAKE_VAR.sub(lambda m: consts.get(m.group(1), m.group(0)), token)
+
+
+def test_no_phase2_target_under_catalogs():
+    """Producer side: no target built by a Phase-2 script resolves under data/catalogs/."""
+    consts = _makefile_constants()
+    offenders = []
+    with open(MAKEFILE, encoding="utf-8") as fh:
         for i, line in enumerate(fh, 1):
-            for basename in PHASE2_OUTPUTS:
-                if any(pat in line for pat in _bad_patterns(basename)):
-                    hits.append((i, line.rstrip()))
-                    break
-    return hits
-
-
-def _production_files():
-    """Makefile + scripts/*.py. Excludes tests/fixtures/ (self-contained mirrors)."""
-    files = [MAKEFILE]
-    files += glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))
-    return files
-
-
-def test_no_phase2_output_under_catalogs():
-    offenders = {}
-    for path in _production_files():
-        hits = _scan(path)
-        if hits:
-            offenders[os.path.relpath(path, PROJECT_ROOT)] = hits
+            # A rule line "target[ target…]: prereqs" (not a ":=" assignment, not a recipe).
+            m = re.match(r"^([^\s#][^:=]*):\s+(\S.*)$", line)
+            if not m or not PHASE2_PRODUCER.search(m.group(2)):
+                continue
+            for tok in m.group(1).split():
+                if CATALOGS in _resolve(tok, consts):
+                    offenders.append(f"Makefile:{i}: {tok} -> {_resolve(tok, consts)}")
     assert not offenders, (
-        "Phase-2 outputs must live under data/derived/, not data/catalogs/ "
-        "(ticket 0219). Offending lines:\n"
-        + "\n".join(
-            f"  {f}:{ln}: {txt}"
-            for f, hits in offenders.items()
-            for ln, txt in hits
-        )
+        "Phase-2 outputs must resolve under data/derived/, not data/catalogs/ "
+        "(ticket 0219/0222). A Phase-2-produced Make target still lands in the "
+        "Phase-1 corpus dir:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_script_reads_derived_output_from_catalogs():
+    """Consumer side: no script reads a data/derived output via CATALOGS_DIR."""
+    consts = _makefile_constants()
+    derived_names = {
+        os.path.basename(v) for v in consts.values() if DERIVED in v and v.endswith((".csv", ".json", ".npz"))
+    }
+    offenders = []
+    for path in glob.glob(os.path.join(SCRIPTS_DIR, "*.py")):
+        with open(path, encoding="utf-8") as fh:
+            for i, line in enumerate(fh, 1):
+                for name in derived_names:
+                    if f'CATALOGS_DIR, "{name}"' in line or f"CATALOGS_DIR, '{name}'" in line:
+                        rel = os.path.relpath(path, PROJECT_ROOT)
+                        offenders.append(f"{rel}:{i}: reads {name} from CATALOGS_DIR")
+    assert not offenders, (
+        "A Phase-2 derived output is read from CATALOGS_DIR — use DERIVED_TABLES_DIR "
+        "(ticket 0219/0222):\n  " + "\n  ".join(offenders)
     )

--- a/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
+++ b/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-10T09:19Z HDMX-coding-agent created
+2026-07-10T10:00Z note 0222 landed: communities.csv evicted to data/derived/, and the phase-layout guard generalized from a two-basename whitelist to a producer-phase CLASS rule (any Phase-2-produced Make target under data/catalogs/ now fails without editing the test; consumer-side CATALOGS_DIR reads of derived outputs also caught). data/het/ + data/run_reports/ classified in the architecture.md tree. Remaining before this tracker closes: 0218 (content/tables residual + pole-papers fallback).
 
 --- body ---
 ## Context

--- a/tickets/closed/0222-complete-data-catalogs-phase-2-eviction.erg
+++ b/tickets/closed/0222-complete-data-catalogs-phase-2-eviction.erg
@@ -2,10 +2,12 @@
 Title: Complete data/catalogs Phase-2 eviction + generalize the phase-layout guard to the class
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: communities.csv evicted to data/derived; guard generalized to producer-phase class rule
 
 --- log ---
 2026-07-10T09:20Z HDMX-coding-agent created
 
+2026-07-10T09:40Z HDMX-coding-agent closed — communities.csv evicted to data/derived; guard generalized to producer-phase class rule
 --- body ---
 ## Context
 


### PR DESCRIPTION
Completes the `data/catalogs/` Phase-2 eviction (tracker 0221) and hardens the guard so completeness no longer rides on a hand-maintained list.

## The leak
`communities.csv` (produced by `analyze_cocitation.py`, Phase 2) was the **third** Phase-2 output under `data/catalogs/` — 0219's per-file guard pinned only two basenames, so it sailed past. Exactly the incompleteness the missing tracker (0221) let through.

## Change
- **Makefile**: `COMMUNITIES` → `$(DERIVED)/communities.csv`.
- **Consumers** `compute_clusters.py`, `analyze_embeddings.py`: `CATALOGS_DIR` → `DERIVED_TABLES_DIR`; producer docstring. `plot_cocitation.py` already gets `--input` explicitly.
- **Guard generalized** (`tests/test_phase_layout.py`): the two-basename whitelist is replaced by a **class rule** — it parses the Makefile and fails if *any* target produced by a Phase-2 script (`analyze_/compute_/plot_/export_/summarize_/build_het`) resolves under `data/catalogs/`, plus a consumer-side check that no script reads a `data/derived` output from `CATALOGS_DIR`. **A new leak fails the test without editing it.**

## Verification
- Guard GREEN post-fix; **RED-proven by class**: reverting the constant re-fails on `communities.csv` detected as `$(COMMUNITIES) -> data/catalogs/communities.csv` — by producer-phase, not by name.
- `make check-fast`: 992 passed. The 2 failures (`test_bib_doi_title` missing `bibtexparser`; a robustness fixture path) reproduce on clean `origin/main` and don't reference any changed file — pre-existing/environmental.
- `data/het/` + `data/run_reports/` classified in the `architecture.md` tree (0222 action 3).

Tracker 0221 stays open on its last child — **0218** (content/tables residual).

Ticket: tickets/0222-complete-data-catalogs-phase-2-eviction.erg
Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)