### PR TITLE
ticket(0213): close tracker — test-tiers rethink complete

### DIFF
--- a/tickets/0228-harden-fast-path-auto-mark-pin-hook-orde.erg
+++ b/tickets/0228-harden-fast-path-auto-mark-pin-hook-orde.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Harden fast-path auto-mark: pin hook-ordering + quantify over-sweep
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T09:49Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Follow-up from 0216 (fast-path tier guards, PR #978, tracker 0213). The
+collection-time auto-mark works (verified live: check-fast ~93s → ~24s, no
+dcor/heavy test on the fast path). Two non-blocking robustness gaps surfaced in
+the /gaze review of #978:
+
+1. **Hook-ordering assumption is unpinned.** The auto-mark relies on
+   `pytest_collection_modifyitems` (conftest) running before pytest's core `-m`
+   mark-filter. Verified to hold under pytest 9.0.2, but no regression test locks
+   it — a future pytest hook-ordering change could silently defeat the auto-mark
+   with no test failure. (built-in reviewer, #978)
+2. **Module-granularity over-sweeps.** The scanner marks a whole file `slow` when
+   its source contains a heavy import, even a lazy one fired by only a few tests.
+   Concrete: `tests/test_null_model.py` imports torch only inside two
+   CUDA-skip-guarded methods, yet all 37 tests (34 unrelated to torch) leave the
+   fast path. Safe direction (they still run in `make check`) and intentional per
+   0216, but the scale of lost fast-path coverage is under-quantified. (panel
+   reviewer, #978)
+
+## Relevant files
+- `tests/conftest.py` — `pytest_collection_modifyitems` auto-mark hook
+- `tests/_tier_autoscan.py` — static heavy-import scanner
+- `tests/test_fast_path_budget.py` — ratchet + unit tests for the scanner
+
+## Actions
+1. Add a `pytester`/`testdir`-based regression test (integration tier) that
+   spins a real collection with a synthetic heavy-import module and asserts it is
+   deselected under `-m "not slow and not integration and not adherence"` and
+   selected under `-m slow` — pinning the hook-ordering behaviour.
+2. Quantify the over-sweep: count tests moved off the fast path whose module's
+   heavy import is lazy and never fired by that test. Decide whether per-test
+   refinement (e.g. only auto-mark tests whose own body/callees reach the import)
+   is worth the added fragility, or whether module-granularity is the right
+   conservative default (document the decision either way).
+
+## Test
+Write first (red): the pytester regression test from action 1 (fails if the hook
+ordering ever stops deselecting the synthetic heavy-import test).
+
+## Exit criteria
+- Hook-ordering pinned by a regression test.
+- Over-sweep quantified; a documented decision on module- vs per-test granularity.

--- a/tickets/closed/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
+++ b/tickets/closed/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
@@ -2,11 +2,14 @@
 Title: Test-suite rethink: classify by cost, enforce by ratchet (tracking)
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: done
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
 2026-07-10T08:04Z MinhHaDuong approved the inner-loop trade-off (see 0214 log): numerical-kernel tests move off the fast path. Load-bearing design decision resolved; children unblocked pending ticket review.
+2026-07-10T09:49Z All children merged: 0214 (#973 gates+make lint), 0215 (#972 adherence tier), 0216 (#978 auto-mark+ratchet), 0217 (#977 testmon REJECT). Integration verified on merged main: check-fast ~93s->24s, 926 tests, no dcor/heavy test on fast path, ratchet green. Follow-ups open: 0220 (global rule table, cross-repo), 0228 (harden auto-mark: pin hook-ordering + quantify over-sweep).
+2026-07-10T09:49Z HDMX-coding-agent closed — done
 --- body ---
 ## Context
 `make check-fast` (contract: unit tests + lint, <30s inner loop) had drifted to


### PR DESCRIPTION
Closes tracker **0213**. All four children merged and the tier system is verified end-to-end on main.

## The result

`make check-fast` (the inner loop): **~93s → ~24s wall** (926 tests), and every fast-path test is now ~1-2s — no dcor/torch/matplotlib import tax, no cold-mypy. Achieved structurally, not by mole-whacking.

## What landed

| Child | PR | Delivered |
|-------|-----|-----------|
| 0215 | #972 | `adherence` tier applied consistently + regression guard |
| 0214 | #973 | cost-based gates: check-fast excludes adherence; `make lint`; broadened `slow` |
| 0216 | #978 | collection-time **auto-mark** (heavy-import modules → `slow`) + **duration ratchet** (5s budget) |
| 0217 | #977 | testmon evaluated → **REJECT** (pytest-9 incompat, no xdist support, dependency-topology makes core edits slower than check-fast) |

The key insight that made it work: the ~7s `dcor` import is paid **per xdist worker** and lands on whichever dcor test runs first, so per-test `slow` marking never converges. The **collection-time auto-mark** dissolves it deterministically in one hook.

## Integration verification

On merged main: `-m "not slow and not integration and not adherence" -n 4` → **926 passed, 24.6s**, max fast-path test ~2.3s. The one collection error (`bibtexparser` in `test_bib_doi_title.py`) is pre-existing env drift, unrelated (confirmed by every reviewer).

## Follow-ups (open)

- **0228** (filed here) — harden the auto-mark: pin the pytest hook-ordering with a `pytester` regression test; quantify the module-granularity over-sweep (e.g. 34 non-torch tests in `test_null_model.py` leave the fast path). From the #978 gaze review.
- **0220** — update the global harness `coding-python.md` marker table (cross-repo, linter-protected here).
- Idea worth a ticket (from 0217): check-fast is still ~24s; a lighter keystroke loop than testmon is explicit path/`-k` scoping under `ptw` (keeps `-n 4`, no coverage fingerprint).

**Ticket:** tickets/0213-test-tiers-classify-by-cost-enforce-ratchet.erg
Related follow-up: tickets/0228-harden-fast-path-auto-mark-pin-hook-orde.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)