### PR TITLE
ticket(0220): close — migrated to ImperialDragonHarness 0269

### DIFF
--- a/tickets/closed/0220-update-global-coding-python-md-marker-ta.erg
+++ b/tickets/closed/0220-update-global-coding-python-md-marker-ta.erg
@@ -2,10 +2,13 @@
 Title: Update global coding-python.md marker table to cost-based tiers
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: migrated-to-idh-0269
 
 --- log ---
 2026-07-10T08:51Z HDMX-coding-agent created
 
+2026-07-10T09:59Z Migrated to ImperialDragonHarness ticket 0269 (the repo that owns rules/coding-python.md). Filed there via IDH PR #446. Closing here — wrong-repo ticket.
+2026-07-10T09:59Z HDMX-coding-agent closed — migrated-to-idh-0269
 --- body ---
 ## Context
 Follow-up from 0214 (test-tiers rethink, tracker 0213). The project marker table


### PR DESCRIPTION
0220 was a **wrong-repo ticket**: it targeted the global harness `rules/coding-python.md`, which lives in the **ImperialDragonHarness** repo, not this project — a dangling cross-repo reference invisible to anyone working in the harness.

Re-filed where the work happens: **IDH ticket 0269** (IDH PR #446). Closing 0220 here as migrated.

**Ticket:** tickets/0220-update-global-coding-python-md-marker-ta.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)