### PR TITLE
docs(0227): document phase-layout guard blind spots

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -133,6 +133,25 @@ renders (→ `content/`) and intermediates only other scripts read (→ `data/de
 Mixing them is what bloated `content/tables/` (ticket 0208) and hid Phase-2 outputs
 in `data/catalogs/` (ticket 0219).
 
+### Phase is semantic, not a filename prefix (ticket 0227)
+
+The prefix table above is a heuristic. A script's phase is what it *does*, not the
+letters that start its name. Known exceptions:
+
+- `compute_reranker_calibration.py` — `compute_` prefix, but Phase-1: it scores
+  corpus relevance and writes `reranker_calibration.csv` / `reranker_hitl_review.csv`
+  to `CATALOGS_DIR`. Correctly a Phase-1 corpus artifact.
+- `qa_embeddings.py`, `qa_detect_type.py` — `qa_` prefix (a Phase-1 corpus prefix in
+  the table), but their derived outputs are Phase-2: they write to
+  `DERIVED_TABLES_DIR` (`semantic_clusters.csv`, `qa_type_report.csv`).
+
+Guard coverage boundary: `tests/test_phase_layout.py` reads the Makefile and checks
+only Makefile-wired targets. A script that writes to a hardcoded `CATALOGS_DIR`
+default with no Make target is invisible to it — `compute_reranker_calibration.py`
+is exactly that case. The guard is a net for wired producers, not a complete phase
+audit; the ~20-basename allowlist an exhaustive scanner would need was judged not
+worth the upkeep against a low leak probability.
+
 ## Incremental caches vs DVC outputs
 
 - **`enrich_cache/`** — persistent cache directory (gitignored, not a DVC output). Survives `dvc repro`.

--- a/tests/test_phase_layout.py
+++ b/tests/test_phase_layout.py
@@ -25,6 +25,18 @@ MAKEFILE = os.path.join(PROJECT_ROOT, "Makefile")
 SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 
 # A Make prerequisite naming one of these script prefixes marks a Phase-2 producer.
+#
+# Two blind spots, documented in .claude/rules/architecture.md
+# ("Phase is semantic, not a filename prefix"):
+#   1. Only Makefile-wired targets are checked. A script writing to a hardcoded
+#      CATALOGS_DIR default with no Make target is invisible here — e.g.
+#      compute_reranker_calibration.py (Phase-1 corpus scoring, correctly under
+#      data/catalogs/, no Make target).
+#   2. The prefix is a heuristic, not the semantic phase: compute_reranker_calibration
+#      has a compute_ prefix but is Phase-1; qa_embeddings / qa_detect_type have a
+#      qa_ prefix but write Phase-2 outputs to DERIVED_TABLES_DIR.
+# Extending the guard to close these (a ~20-basename allowlist) was declined (0227):
+# low leak probability, upkeep not worth it.
 PHASE2_PRODUCER = re.compile(r"scripts/(analyze_|compute_|plot_|export_|summarize_|build_het)")
 CATALOGS = "data/catalogs/"
 DERIVED = "data/derived/"

--- a/tickets/closed/0227-harden-phase-layout-guard-non-make-wired.erg
+++ b/tickets/closed/0227-harden-phase-layout-guard-non-make-wired.erg
@@ -2,10 +2,12 @@
 Title: Harden phase-layout guard: non-Make-wired outputs + phase-by-prefix exceptions
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #985
 
 --- log ---
 2026-07-10T09:46Z HDMX-coding-agent created
 
+2026-07-10T10:51Z HDMX-coding-agent closed — autoclosed — PR #985
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0227-harden-phase-layout-guard-non-make-wired.erg

Child of tracker 0221.

## What
Document the two blind spots of the phase-layout guard (`tests/test_phase_layout.py`, 0222) rather than extend it:
- New subsection in `.claude/rules/architecture.md` ("Phase is semantic, not a filename prefix") listing the prefix exceptions (`compute_reranker_calibration.py` = Phase-1 despite `compute_`; `qa_embeddings.py` / `qa_detect_type.py` = Phase-2 despite `qa_`) and the guard's coverage boundary (only Makefile-wired targets checked).
- Cross-referenced comment at the guard's `PHASE2_PRODUCER` / `CATALOGS` constants naming both blind spots.

## Why doc + comment over an allowlist scanner
Closing the blind spots needs a ~20-basename allowlist whose upkeep outweighs a low leak probability (Option 2 declined). No logic change — the guard test still passes (2 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)