### PR TITLE
build(0211): wire openalex-corpus package suite + installability guard into host CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
+.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-package check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
 
 .DEFAULT_GOAL := manuscript
 
@@ -740,13 +740,19 @@ venv-canonicalize:
 	fi
 
 # ── All checks (tests) ───────────────────────────────────
-check: | venv-canonicalize
+# The libs/openalex-corpus path package ships its own 25-test suite that root
+# `pytest tests/` never collects (norecursedirs=["libs"]). Run it explicitly so
+# host CI gates it. Pure-logic / mocked-HTTP — belongs in the fast tier too.
+check-package: | venv-canonicalize
+	$(PYTHON) -m pytest libs/openalex-corpus/tests -v --tb=short
+
+check: check-package | venv-canonicalize
 	$(PYTHON) -m pytest tests/ -v --tb=short -n 4
 
 # Fast inner loop: pure-Python logic only. Deselects slow (network / real data /
 # heavy numerical dep / heavy compute), integration (subprocess / sleep), and
 # adherence (lint — ruff/mypy/hygiene, run via `make lint`). Ticket 0214.
-check-fast: | venv-canonicalize
+check-fast: check-package | venv-canonicalize
 	$(PYTHON) -m pytest tests/ -v --tb=short -m "not slow and not integration and not adherence" -n 4
 
 # Lint / rule-enforcement tier (ruff, mypy, hygiene, contracts). Run alongside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,11 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-# libs/openalex-corpus is a separate installed package with its own test suite
-# (run standalone / on install); the host suite never collects it, so an
-# unscoped root `pytest` does not choke on `import openalex_corpus`.
+# libs/openalex-corpus is a separate installed package with its own test suite.
+# This guards *implicit* discovery only: a bare `pytest` (no path) does not
+# descend into libs/, so an unscoped root run never chokes on `import
+# openalex_corpus`. The host `make check`/`check-fast` still gate the package —
+# they collect it explicitly via the `check-package` target.
 norecursedirs = ["libs"]
 markers = [
     "slow: network access, external/real data, a heavy numerical dependency (dcor/torch/ot/sentence_transformers), matplotlib rendering, or heavy compute (deselect with '-m \"not slow\"')",

--- a/tests/test_openalex_corpus_installability.py
+++ b/tests/test_openalex_corpus_installability.py
@@ -1,0 +1,128 @@
+"""Installability guards for the ``openalex-corpus`` path package.
+
+Ticket 0211. The package's 25-test suite ran only standalone, so a clean-install
+defect shipped to review: the package declared only ``pandas`` while
+``crawl.py`` imports ``requests``. The shared dev env already had ``requests``,
+so "green" masked a broken install (fixed in #956).
+
+These two tests close that gap in a way a shared warm env cannot:
+
+1. ``test_installs_cleanly_with_declared_deps`` — install the real package into
+   a throwaway venv and exercise the HTTP layer. Regression guard: proves #956
+   holds (all runtime imports are covered by declared deps).
+2. ``test_installability_guard_catches_undeclared_dep`` — install a COPY whose
+   ``requests`` dependency has been stripped, then import the submodule that
+   needs it. Mutation-proof by construction: it reproduces the historical defect
+   every run, so it can never rot into a tautology. It imports
+   ``openalex_corpus.crawl`` (not bare ``openalex_corpus``): PEP 562 lazy
+   ``__init__`` lets the bare import succeed without ``requests``; only the lazy
+   submodule import surfaces the missing dependency.
+
+Both spawn ``uv``/``python`` subprocesses against a ``tmp_path`` venv. They read
+the shared uv cache read-only and never touch the project ``.venv`` or the
+shared ``/data`` env — no ``uv sync``, nothing lands in git status.
+See memory ``feedback_isolated_venv_proves_installability``.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG_DIR = Path(__file__).resolve().parent.parent / "libs" / "openalex-corpus"
+
+pytestmark = pytest.mark.integration
+
+
+def _uv() -> str:
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv not on PATH")
+    return uv
+
+
+def _make_venv(uv: str, root: Path) -> Path:
+    """Create an isolated venv under ``root`` and return its python interpreter."""
+    venv = root / ".venv-check"
+    subprocess.run([uv, "venv", str(venv)], check=True,
+                   capture_output=True, text=True)
+    py = venv / "bin" / "python"
+    assert py.exists(), f"venv python missing: {py}"
+    return py
+
+
+def _install(uv: str, py: Path, pkg_dir: Path) -> subprocess.CompletedProcess:
+    """Non-editable install of ``pkg_dir`` into the venv at ``py``."""
+    return subprocess.run(
+        [uv, "pip", "install", "--python", str(py), str(pkg_dir)],
+        capture_output=True, text=True)
+
+
+def _run_import(py: Path, code: str) -> subprocess.CompletedProcess:
+    return subprocess.run([str(py), "-c", code], capture_output=True, text=True)
+
+
+def test_installs_cleanly_with_declared_deps(tmp_path):
+    """The real package installs into a fresh venv and its HTTP layer imports."""
+    uv = _uv()
+    py = _make_venv(uv, tmp_path)
+    install = _install(uv, py, _PKG_DIR)
+    assert install.returncode == 0, f"install failed:\n{install.stderr}"
+
+    # Exercise the lazy submodules that pull the third-party deps: crawl needs
+    # requests, embedding path needs pandas via text/embedding conventions.
+    check = _run_import(
+        py,
+        "import openalex_corpus; "
+        "from openalex_corpus import retry_get, build_text, normalize_doi; "
+        "import openalex_corpus.crawl; "
+        "assert callable(retry_get)",
+    )
+    assert check.returncode == 0, (
+        f"clean-install import failed:\n{check.stderr}")
+
+
+def test_installability_guard_catches_undeclared_dep(tmp_path):
+    """Stripping a declared runtime dep makes the dependent import fail.
+
+    This is the mutation the guard must catch. If a future edit imports a new
+    third-party module without declaring it, a clean install omits the module
+    and this failure mode reproduces — surfaced by importing the submodule, not
+    the lazy top-level package.
+    """
+    uv = _uv()
+
+    # Copy the package and strip `requests` from its declared dependencies.
+    pkg_copy = tmp_path / "pkg"
+    shutil.copytree(_PKG_DIR, pkg_copy)
+    manifest = pkg_copy / "pyproject.toml"
+    text = manifest.read_text()
+    stripped = text.replace('    "requests",\n', "")
+    assert stripped != text, "expected to strip a `requests` dependency line"
+    manifest.write_text(stripped)
+
+    py = _make_venv(uv, tmp_path)
+    install = _install(uv, py, pkg_copy)
+    assert install.returncode == 0, f"stripped install failed:\n{install.stderr}"
+
+    # Bare import stays lazy (PEP 562) and would succeed without requests; the
+    # submodule import is what surfaces the undeclared dependency.
+    submodule = _run_import(py, "import openalex_corpus.crawl")
+    assert submodule.returncode != 0, (
+        "guard is toothless: importing openalex_corpus.crawl succeeded even "
+        "though requests was undeclared and uninstalled")
+    assert "ModuleNotFoundError" in submodule.stderr or \
+           "No module named 'requests'" in submodule.stderr, (
+        f"expected a missing-requests failure, got:\n{submodule.stderr}")
+
+    # Sanity: the bare package import DOES survive (proves the guard needs the
+    # submodule import, not that the whole package is uninstallable).
+    bare = _run_import(py, "import openalex_corpus")
+    assert bare.returncode == 0, (
+        f"bare import should stay lazy-safe without requests:\n{bare.stderr}")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -2,11 +2,11 @@
 Title: Add a repo-wide ruff adherence test
 Created: 2026-07-10
 Author: HDMX-coding-agent
-Blocked-by: 0211
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T10:52Z HDMX-coding-agent note blocker 0211 closed — Blocked-by removed.
 --- body ---
 ## Context
 Multiple /gaze reviewers (#956/#958/#960) noted the repo has no `def test_ruff`

--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -1,0 +1,48 @@
+%erg 0.1
+Title: Add a repo-wide ruff adherence test
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0211
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Multiple /gaze reviewers (#956/#958/#960) noted the repo has no `def test_ruff`
+anywhere — lint drift is only caught in CI-less `make lint`, never as a pinned
+pytest adherence guard. The harness Python rule requires every project to carry
+a ruff adherence test so lint failures surface locally before review. Spun out
+of ticket 0211 action 3, which the 0211 scoper deferred as out-of-scope
+(0211 wired the package suite + installability guards; a repo-wide ruff test is
+a separable concern, YAGNI at that point).
+
+## Relevant files
+- `tests/` — where a `test_ruff.py` (or a case in an existing adherence module)
+  would live; mark `@pytest.mark.adherence` so it lands in the `make lint` tier.
+- `libs/openalex-corpus/` — decide whether the repo-wide test also covers the
+  path package or the package carries its own.
+- `~/.claude/rules/coding-python.md` — canonical adherence-test snippet.
+
+## Actions
+1. Add an `@pytest.mark.adherence` test that runs `uv run ruff check .` and
+   asserts returncode 0 (per the harness snippet).
+2. Decide scope: whole repo (including `libs/`) vs a package-local test. Prefer
+   one repo-wide test if ruff config already reaches `libs/`.
+3. Confirm `make lint` picks it up and it is deselected from `check-fast`.
+
+## Test
+Write first (red): a test that shells `uv run ruff check .` and asserts
+returncode 0. It goes red the moment any tracked file has a lint violation.
+
+## Verification
+- [ ] `make lint` runs the ruff adherence test.
+- [ ] The test is in the `adherence` marker tier (out of `check-fast`).
+- [ ] A deliberately-introduced lint error makes it fail.
+
+## Invariants
+- Do not add ruff to the fast inner loop (`check-fast`) — adherence tier only.
+
+## Exit criteria
+- A ruff adherence test gates the repo (and the openalex-corpus package) so lint
+  failures are caught locally before review.

--- a/tickets/closed/0211-wire-openalex-corpus-package-tests-insta.erg
+++ b/tickets/closed/0211-wire-openalex-corpus-package-tests-insta.erg
@@ -2,10 +2,12 @@
 Title: Wire openalex-corpus package tests + installability guard into host CI
 Created: 2026-07-09
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #986
 
 --- log ---
 2026-07-09T22:26Z HDMX-coding-agent created
 
+2026-07-10T10:52Z HDMX-coding-agent closed — autoclosed — PR #986
 --- body ---
 ## Context
 Ticket 0170 added the `libs/openalex-corpus/` path package and rewired the host


### PR DESCRIPTION
**Ticket:** tickets/0211-wire-openalex-corpus-package-tests-insta.erg
Related follow-up: tickets/0230-repo-wide-ruff-adherence-test.erg

## What
- New `check-package` Makefile target runs `libs/openalex-corpus/`'s own 25-test suite; made a prerequisite of both `check` and `check-fast` (pure-logic / mocked-HTTP → fast tier). Added to `.PHONY`.
- New `tests/test_openalex_corpus_installability.py` — two `@pytest.mark.integration` guards using isolated `tmp_path` venvs (read shared uv cache read-only; never touch the project `.venv` / shared `/data` env; no `uv sync`):
  1. `test_installs_cleanly_with_declared_deps` — regression guard proving #956 holds.
  2. `test_installability_guard_catches_undeclared_dep` — mutation-proof: installs a copy with `requests` stripped, then imports `openalex_corpus.crawl` (the lazy submodule, since PEP 562 `__init__` lets bare import succeed without requests) and asserts it fails.
- Reworded the stale `norecursedirs` comment in root `pyproject.toml`: it guards *implicit* bare-`pytest` discovery only; host targets now collect the package explicitly.

## Why
`make check`/`check-fast` ran only `pytest tests/` (never descending into `libs/`), so the package's suite was ungated. That let the #956 clean-install defect ship (crawl.py imports `requests`; package declared only `pandas`; warm shared env masked it). The installability guard reproduces that defect class every run.

## Verification
- `make check-package` → 25 passed.
- Both new integration tests pass; the regression guard proven RED by temporarily stripping `requests` from the real package pyproject (fails with the exact #956 `ModuleNotFoundError`, reverted).
- `make check-fast` clean w.r.t. this change (one unrelated pre-existing env-drift error: `test_bib_doi_title.py` — `bibtexparser` absent from the shared env).

## Coordination
Sibling ticket 0218 also appends to the same `.PHONY` line — additive, trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)