### PR TITLE
test(0121): standing dispatcher-contract guard on empty corpus

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,15 +114,24 @@ def smoke_env():
     }
 
 
-def run_compute(method, output_path, timeout=300):
-    """Run compute_divergence.py --method M --output P."""
+def run_compute(method, output_path, timeout=300, input_paths=None):
+    """Run compute_divergence.py --method M --output P.
+
+    input_paths : list[str] | None
+        When provided, forwarded as ``--input <path...>`` so the method reads
+        the given fixture files instead of the smoke corpus. Default (None)
+        leaves the smoke-env corpus in place — existing call sites unchanged.
+    """
+    cmd = [
+        sys.executable,
+        os.path.join(SCRIPTS_DIR, "compute_divergence.py"),
+        "--method", method,
+        "--output", str(output_path),
+    ]
+    if input_paths:
+        cmd += ["--input", *[str(p) for p in input_paths]]
     return subprocess.run(
-        [
-            sys.executable,
-            os.path.join(SCRIPTS_DIR, "compute_divergence.py"),
-            "--method", method,
-            "--output", str(output_path),
-        ],
+        cmd,
         env=smoke_env(),
         capture_output=True,
         text=True,

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -1068,3 +1068,91 @@ class TestEmptyResultsGuard:
         assert isinstance(result, pd.DataFrame)
         assert {"year", "window", "hyperparams", "value"}.issubset(result.columns)
         assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher contract on a tiny/empty corpus (ticket 0121)
+# ---------------------------------------------------------------------------
+#
+# The pre-0118 bug class: a compute_* function returning pd.DataFrame([]) (0
+# columns) which the dispatcher turns into a 1-column ['channel'] frame that
+# fails DivergenceSchema.validate. TestEmptyResultsGuard covers 4/18 methods
+# by *direct* calls; this class exercises all 18 through the actual dispatcher
+# subprocess on a single-year corpus that forces every empty-window path.
+#
+# Non-C2ST methods emit the DivergenceSchema columns; C2ST methods carry the
+# extra CV-variance columns (schemas.C2STDivergenceSchema).
+
+from compute_divergence import METHODS as _DISPATCH_METHODS
+
+_DISPATCH_METHOD_KEYS = list(_DISPATCH_METHODS.keys())
+
+_DISPATCH_BASE_COLS = {"year", "channel", "window", "hyperparams", "value"}
+# empty_divergence_df columns + channel (added by the dispatcher) plus the
+# C2ST CV-variance columns (_divergence_c2st._C2ST_COLUMNS).
+_DISPATCH_C2ST_COLS = _DISPATCH_BASE_COLS | {
+    "auc_std",
+    "auc_q025",
+    "auc_q975",
+    "n_folds",
+    "p_value_vs_chance",
+}
+
+
+def _write_tiny_corpus(tmp_path):
+    """Build a single-year (all year=2015) corpus that forces empty windows.
+
+    Returns (works_csv, embeddings_npz, citations_csv). Every sliding method's
+    per_window_year_ranges is empty; every citation method sees no internal
+    edges. The dispatcher must still emit a valid-schema CSV.
+    """
+    works = tmp_path / "works.csv"
+    pd.DataFrame(
+        {
+            "doi": ["10.1/a", "10.1/b"],
+            "year": [2015, 2015],
+            "cited_by_count": [0, 0],
+            "abstract": ["carbon finance mechanism", "climate adaptation fund"],
+        }
+    ).to_csv(works, index=False)
+
+    emb = tmp_path / "refined_embeddings.npz"
+    vectors = np.random.RandomState(0).randn(2, 16).astype(np.float32)
+    np.savez(emb, vectors=vectors)
+
+    citations = tmp_path / "citations.csv"
+    pd.DataFrame(columns=["source_doi", "ref_doi", "ref_year"]).to_csv(
+        citations, index=False
+    )
+    return works, emb, citations
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestDispatcherEmptyCorpusContract:
+    """Every METHOD emits a schema-valid CSV through the dispatcher on an
+    empty-window corpus — never a bare 1-column ['channel'] frame."""
+
+    @pytest.mark.parametrize("method", _DISPATCH_METHOD_KEYS)
+    def test_dispatcher_result_columns_on_empty_corpus(self, method, tmp_path):
+        from compute_divergence import METHODS
+
+        _, _, _, needs_emb, needs_cit = METHODS[method]
+        works, emb, citations = _write_tiny_corpus(tmp_path)
+        if needs_emb:
+            inputs = [works, emb]
+        elif needs_cit:
+            inputs = [works, citations]
+        else:
+            inputs = [works]
+
+        out = tmp_path / f"tab_div_{method}.csv"
+        result = _run_compute(method, out, input_paths=inputs)
+        assert result.returncode == 0, f"{method} crashed:\n{result.stderr}"
+        assert out.exists(), f"{method}: no output written"
+
+        df = pd.read_csv(out)
+        expected = (
+            _DISPATCH_C2ST_COLS if method.startswith("C2ST_") else _DISPATCH_BASE_COLS
+        )
+        assert set(df.columns) == expected, f"{method}: got {set(df.columns)}"

--- a/tickets/closed/0121-test-empty-corpus-dispatcher-guard.erg
+++ b/tickets/closed/0121-test-empty-corpus-dispatcher-guard.erg
@@ -2,6 +2,7 @@
 Title: Standing regression test — dispatcher must never emit 1-column DataFrame on empty corpus
 Created: 2026-04-25
 Author: claude
+Closed: dispatcher empty-corpus contract guard added (18 methods, RED-proven)
 
 --- log ---
 2026-04-25T23:55Z claude created — follow-up from 0118/0120 sweep; guards the class, not just instances
@@ -12,6 +13,7 @@ Author: claude
 2026-07-09T13:27Z HDMX-coding-agent label deferred
 2026-07-10T09:49Z HDMX-coding-agent unlabel deferred
 2026-07-10T09:49Z note audit 2026-07-10: undeferred — cited blocker (S4_frechet, ticket 0118/PR#773) now closed+archived; ripe, ~30min regression test
+2026-07-10T10:46Z HDMX-coding-agent closed — dispatcher empty-corpus contract guard added (18 methods, RED-proven)
 --- body ---
 ## Context
 
@@ -57,9 +59,9 @@ PASS; a SchemaError or a 1-column `['channel']` CSV is a FAIL.
 
 ## Exit criteria
 
-- [ ] Test exists and passes for all methods in `METHODS.keys()`
-- [ ] Test is marked `@pytest.mark.slow` (excluded from check-fast)
-- [ ] `make check-fast` clean
+- [x] Test exists and passes for all methods in `METHODS.keys()`
+- [x] Test is marked `@pytest.mark.slow` (excluded from check-fast)
+- [x] `make check-fast` clean
 
 ## Picker assessment 2026-04-26T22:06Z
 **Decision:** not picked


### PR DESCRIPTION
## What

Parametrized regression test running **all 18** `compute_divergence.METHODS`
through the actual dispatcher subprocess on a tiny single-year corpus (both
works `year=2015`, empty-but-headered citations, random 2×16 embeddings). Each
method must emit a DataFrame whose columns match `DivergenceSchema`
(`year, channel, window, hyperparams, value`) — or, for the two C2ST methods,
that set plus the CV-variance columns (`auc_std, auc_q025, auc_q975, n_folds,
p_value_vs_chance`). Never the pre-0118 bare 1-column `['channel']` frame.

`conftest.run_compute` gains an optional `input_paths=` param forwarded as
`--input <path...>`; existing call sites are unchanged (default `None`).

## Why

The bug class (tickets 0118/0120) is the dispatcher's `result["channel"] = channel`
turning a 0-column `pd.DataFrame([])` into a `['channel']`-only frame that fails
schema validation. The existing `TestEmptyResultsGuard` covers only 4/18 methods
by calling the compute_s* functions **directly** — it does not exercise the
dispatch layer where the defect actually manifests. This test guards the class at
the dispatch boundary.

## RED-proof evidence

Removing the guard `if not results: return empty_divergence_df()` in
`scripts/_citation_methods.py` `_sliding_abs_diff` made the 4 methods routing
through it (G2/G5/G6/G8) fail:

```
pandera.errors.SchemaError: column 'year' not in dataframe. Columns in dataframe: ['channel']
4 failed, 70 deselected
```

— the exact pre-0118 defect. Guard restored (no source change in this PR), all
18 GREEN in ~47s.

## Residual gap (in scope as written)

G3/G4/G7 route through `_dict_to_df` and don't stress the 0-column path on a
single-year corpus; they still pass the schema-column assertion, so the test
holds the contract for them but doesn't specifically probe their empty branch.

## Tiers

`@pytest.mark.slow` + `@pytest.mark.integration` (subprocess + torch), excluded
from `check-fast`. `make check-fast` clean (926 passed; one pre-existing
collection error in `test_bib_doi_title.py` from a missing `bibtexparser` in the
shared env — unrelated to this change).

**Ticket:** tickets/0121-test-empty-corpus-dispatcher-guard.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)