### PR TITLE
ticket(0218,0231): record raid scoping findings; split sub-Makefile eviction

### DIFF
--- a/tickets/0218-evict-remaining-phase-2-intermediates-fr.erg
+++ b/tickets/0218-evict-remaining-phase-2-intermediates-fr.erg
@@ -8,6 +8,8 @@ Author: HDMX-coding-agent
 
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T10:11Z HDMX-coding-agent unlabel deferred
+2026-07-10T10:57Z note raid 2026-07-10: execute attempt FAILED — no commits landed. Root cause: the execute prompt hardcoded primary-checkout absolute paths, so the agent edited the shared main checkout instead of its worktree; a parallel session's reset wiped the leaked edits. Re-scope required (see body: Scoping findings). Sub-Makefile subsystems split to 0231.
+2026-07-10T10:57Z note scoper correction: '~15 intermediates' undercounts by 4-5x; the generalized guard must scan the TOP-LEVEL Makefile ONLY (sub-Makefile ~70 targets → 0231) or it false-positive-storms.
 --- body ---
 ## Context
 
@@ -53,6 +55,38 @@ Defer freely behind deadline work.
   `.gitignore` negation block) OR resolve under `$(DERIVED)`. A new intermediate
   landing in `content/tables/` fails the test. Write this ratchet RED first.
 - Regression: `make papers` builds all six PDFs; manuscript clean-room build passes.
+
+## Scoping findings (raid 2026-07-10 — read before re-executing)
+
+A read-only scoping pass produced the keep/evict classification and two
+corrections the first execute attempt lacked:
+
+1. **Scope is the top-level `Makefile` literal set only.** 17 literal-path
+   `content/tables/tab_*` targets are in scope (bimodality[_core], axis_detection
+   [_core], breakpoints[_core,_censor2], breakpoint_robustness[_core,_censor2],
+   alluvial[_core], cluster_labels[_core].json, core_shares, lineages,
+   k_sensitivity). The `tab_axis_detection_core.csv` output is **dead** (no
+   consumer). KEEP in `content/tables/`: the `.md` `{{< include >}}` deliverables,
+   the `.gitignore`-whitelisted pinned `.csv` (tab_null_separation_pre2007,
+   tab_pre2007_coverage), and `tab_corpus_sources.csv` (grouped with its `.md`,
+   no separate consumer).
+2. **Guard scans the top-level `Makefile` ONLY.** Four sub-Makefiles
+   (`divergence.mk`/`zoo.mk`/`multilayer-detection.mk`/`venues.mk`) route ~70 more
+   `tab_*` targets to `content/tables/` via a `*_TABLES` dir variable. A guard that
+   scans `*.mk` would go RED on all ~70 pre-existing targets — a false-positive
+   storm, not a regression. Scope the scan to `Makefile`; document the boundary in
+   the guard docstring. The sub-Makefile subsystems are **ticket 0231** (blocked-by
+   this one), which later widens the guard.
+
+Archive coupling to update (5 entries move): `ANALYSIS_OUTPUTS` (Makefile ~701-706),
+`build/build_analysis_archive.sh:25-30`, `build/templates/Makefile.analysis-manuscript:30-32`,
+`tests/test_archive_checksums.py` `EXPECTED_OUTPUTS`. Also fix
+`scripts/plot_interactive_corpus.py:57-58` — drop the legacy `CATALOGS_DIR`
+fallback for `tab_pole_papers.csv`.
+
+**Execution note:** the next run MUST edit files at **worktree-rooted paths**, not
+the primary-checkout absolute path — the failed attempt's prompt hardcoded the
+latter and the agent edited the shared main checkout (see log).
 
 ## Invariants
 - `make papers` unaffected; every writing deliverable stays in `content/tables/`.

--- a/tickets/0231-evict-phase-2-intermediates-routed-via-s.erg
+++ b/tickets/0231-evict-phase-2-intermediates-routed-via-s.erg
@@ -1,0 +1,74 @@
+%erg 0.1
+Title: Evict Phase-2 intermediates routed via sub-Makefile *_TABLES dir vars (divergence/zoo/multilayer/venues)
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0218
+
+--- log ---
+2026-07-10T10:57Z HDMX-coding-agent created
+2026-07-10T11:00Z note spun out of the 0218 raid scoping pass (2026-07-10): the scoper found 0218's "~15 intermediates" undercounts the class 4-5x once sub-Makefiles are included. Different risk profile (~70 targets), own ticket. Blocked-by 0218 so the top-level Makefile eviction + generalized guard land first.
+
+--- body ---
+## Context
+
+Spun out of ticket 0218's raid scoping pass (2026-07-10). 0218 evicts the
+residual Phase-2 intermediate `.csv` files that sit in `content/tables/` as
+**hardcoded-literal** Make targets in the top-level `Makefile`. The scoper found
+that four `-include`d sub-Makefiles route a much larger population of `tab_*`
+targets to `content/tables/` via a shared **directory variable**, not literals:
+
+- `divergence.mk`: `DIV_TABLES := content/tables` (line 23) — ~51 targets
+  (`tab_div_*`, `tab_null_*`, `tab_boot_*`, `tab_subsample_*`, `tab_summary_*`,
+  `tab_sens_pca/jl_*`, `tab_changepoints.csv`, `tab_convergence.csv`).
+- `zoo.mk`: `ZOO_TABLES := content/tables` (line 15) — `tab_crossyear_*`,
+  `tab_analytical_null_*`, `tab_div_biased_*`.
+- `multilayer-detection.mk`: `COMP_TABLES := content/tables` (line 18) +
+  `_companion_plot_utils.py:22` `DEFAULT_TABLES_DIR` — `tab_sensitivity_grid.csv`.
+- `venues.mk`: `VENUE_TABLE := content/tables/tab_venue_concentration.csv` (line 12).
+
+All are Phase-2-script-only intermediates by the same classification rule 0218
+uses (none is `{{< include >}}`'d by a `.qmd`). Blast radius ~70+ derived files
+and dozens of consumer scripts — a different risk profile from 0218's literal
+set, which is why it is its own ticket.
+
+## Why blocked by 0218
+
+0218 lands the top-level `content/tables/` eviction AND generalizes the guard
+`tests/test_evict_analysis_intermediates.py` to the class — but, per the scoper,
+scoped to the **top-level Makefile only** (else the guard goes RED on these ~70
+pre-existing sub-Makefile targets: a false-positive storm, not a regression
+signal). This ticket then (a) migrates the sub-Makefile subsystems by flipping
+each `*_TABLES` variable from `content/tables` to `$(DERIVED)`, and (b) widens
+the guard's scan to include the `.mk` files once their targets resolve under
+`$(DERIVED)`.
+
+## Actions
+1. Flip `DIV_TABLES`, `ZOO_TABLES`, `COMP_TABLES` from `content/tables` to
+   `$(DERIVED)` (data/derived/tables/); repoint `VENUE_TABLE`. Update
+   `_companion_plot_utils.py:22 DEFAULT_TABLES_DIR`.
+2. Rewire every consumer (grep each `tab_*` basename). Most producer scripts
+   derive sibling paths from `os.path.dirname(io_args.output)`, so only the
+   Makefile `--output` argument moves — confirm per script.
+3. Update archive coupling if any of these appear in `ANALYSIS_OUTPUTS` /
+   `build/build_analysis_archive.sh` / `tests/test_archive_checksums.py`.
+4. Widen the class guard's Makefile scan to the `.mk` files (remove the
+   top-level-only boundary 0218 documented) once the subsystems resolve under
+   `$(DERIVED)`.
+
+## Test
+- Guard (post-widening): every `content/tables/tab_*.csv` that is a Make target
+  in `Makefile` OR any `.mk` must be whitelisted-deliverable or resolve under
+  `$(DERIVED)`. RED on a fabricated sub-Makefile intermediate.
+- Regression: `make papers` builds all six PDFs; manuscript clean-room build
+  passes (HUMAN-run — long build).
+
+## Invariants
+- `make papers` unaffected; no Phase-1 trigger; DVC untouched.
+
+## Exit criteria
+- Every sub-Makefile Phase-2 `tab_*` intermediate resolves under `$(DERIVED)`.
+- The class guard covers `.mk` targets (top-level-only boundary removed).
+- `make papers` + clean-room build pass (human gate).
+
+Ticket-ref: tickets/0218-evict-remaining-phase-2-intermediates-fr.erg
+Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg


### PR DESCRIPTION
Records the read-only scoping findings from the 2026-07-10 raid so they aren't lost, and splits the sub-Makefile subsystem eviction into its own ticket.

## What happened
The 0218 execute attempt in the raid landed **nothing**. Root cause: the execute prompt hardcoded primary-checkout absolute paths, so the worktree-isolated agent edited the **shared main checkout** instead of its own worktree; a parallel session's reset then wiped the leaked edits. No commits, no corruption on `origin/main`.

## What this PR does (tickets only — no code)
- **0218**: adds a "Scoping findings" section with the keep/evict classification (17 top-level literal targets, `tab_axis_detection_core` dead), the guard-scoping fix (**scan top-level `Makefile` only**, else false-positive storm on ~70 sub-Makefile targets), archive-coupling map, and an execution note to use worktree-rooted paths next time. Two diagnosis log entries.
- **0231** (new, Blocked-by 0218): evict the ~70 Phase-2 intermediates routed via the `DIV_TABLES`/`ZOO_TABLES`/`COMP_TABLES`/`VENUE_TABLE` sub-Makefile dir variables; widens the guard to `.mk` afterward.

0218 stays open (still a child of tracker 0221); 0231 is its follow-up.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)