### PR TITLE
test(hygiene): skip test_bib_doi_title when bibtexparser absent

### DIFF
--- a/tests/test_bib_doi_title.py
+++ b/tests/test_bib_doi_title.py
@@ -22,6 +22,11 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+# qa_bib_doi imports bibtexparser, which lives in the Phase-1 `corpus`
+# dependency-group (not installed on Phase-2/3 hosts like doudou). Skip the whole
+# module cleanly there instead of erroring collection.
+pytest.importorskip("bibtexparser")
+
 from qa_bib_doi import (
     author_mismatch,
     first_author_surname,


### PR DESCRIPTION
## Problem
`tests/test_bib_doi_title.py` imports `qa_bib_doi`, which imports `bibtexparser` — a package in the Phase-1 `corpus` dependency-group that Phase-2/3 hosts (doudou) don't install. The unguarded module-level import **errored pytest collection** on those hosts (1 error on every `make check-fast`/`make lint`), instead of skipping. Surfaced during a `uv sync` after the raid.

The fast-tier auto-mark hook only catches `dcor/torch/ot/sentence_transformers/matplotlib`, so `bibtexparser` slipped through.

## Fix
`pytest.importorskip("bibtexparser")` before the `qa_bib_doi` import → the module skips cleanly when the `corpus` group is absent, and collects normally on a corpus-equipped host (padme).

## Sweep
Grepped `tests/` for module-level imports (direct + via a `scripts/` module) of every `corpus`-group dep (`bibtexparser/dvc/sentence_transformers/umap/community/bs4/pdfplumber/ddgs`). `qa_bib_doi` (in `test_bib_doi_title.py`) is the **only** one imported at a test module's top level — no other collection error exists. The other corpus-dep scripts are reached only through subprocess `@slow` tests, never imported at collection time.

## Verification
- Full `tests/` collection: **1402 tests, 0 errors** (was 1 error).
- `test_bib_doi_title.py` alone: skipped (0 collected), no error.
- `ruff check tests/test_bib_doi_title.py`: clean.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)