### PR TITLE
ticket(0230,0232): split ruff work into cleanup + guard

### DIFF
--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -46,8 +46,16 @@ Two facts found while scoping:
 1. Add `ruff>=0.11.12,<0.12` to `[dependency-groups] dev` in `pyproject.toml`
    (upper bound so a minor bump can't silently add rules); `uv lock` pins the
    exact version. `uv run ruff` then resolves the pinned build, not system PATH.
-2. Add `tests/test_ruff.py`: an `@pytest.mark.adherence` test that shells
-   `uv run ruff check .` and asserts returncode 0 (per the harness snippet).
+2. Add `tests/test_ruff.py`: an `@pytest.mark.adherence` test that runs ruff and
+   asserts returncode 0. Resolve the binary with `shutil.which("ruff")`, NOT a
+   nested `uv run ruff`. Rationale: pytest already runs inside the project venv
+   (via `make lint` → `uv run … pytest`), so the pinned ruff is on that venv's
+   PATH — `which` finds it directly. A nested `uv run` re-enters uv from inside
+   uv, forcing an extra lockfile/sync check per call and breaking under
+   `UV_NO_SYNC`; in a clean CI/cloud container that nested resolution is the
+   fragile path. The harness snippet writes `uv run ruff` for brevity; the
+   container-robust form is `shutil.which`. Assert `which` is non-None (fail
+   loudly if ruff is undeclared/uninstalled — not a silent skip).
 3. Confirm `make lint` runs it and `make check-fast` deselects it (adherence
    marker is already excluded from the fast tier).
 4. Scope note: one repo-wide test covers `libs/` too — ruff config discovery
@@ -55,16 +63,18 @@ Two facts found while scoping:
    `libs/openalex-corpus/` under the same rules. No package-local test needed.
 
 ## Test
-Write first (red): `tests/test_ruff.py` shells `uv run ruff check .` and asserts
-returncode 0. Red today (171 violations); green once 0232 lands. Prove teeth by
-introducing a deliberate lint error and seeing it fail.
+Write first (red): `tests/test_ruff.py` resolves ruff via `shutil.which("ruff")`
+and runs `[ruff, "check", "."]`, asserting returncode 0. Red today (171
+violations); green once 0232 lands. Prove teeth by introducing a deliberate lint
+error and seeing it fail.
 
 ## Verification
 - [ ] `make lint` runs the ruff adherence test.
 - [ ] The test is in the `adherence` marker tier (out of `check-fast`).
 - [ ] A deliberately-introduced lint error makes it fail.
-- [ ] `uv run ruff --version` resolves the lockfile-pinned build, not
-      `~/.local/bin/ruff` — the verdict is version-stable across machines.
+- [ ] `shutil.which("ruff")` resolves the venv-local pinned build (not
+      `~/.local/bin/ruff`) when run under `make lint` — verdict is version-stable
+      and portable to a clean CI/cloud container.
 
 ## Invariants
 - Do not add ruff to the fast inner loop (`check-fast`) — adherence tier only.

--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -9,7 +9,7 @@ Blocked-by: 0232
 
 2026-07-10T10:52Z HDMX-coding-agent note blocker 0211 closed — Blocked-by removed.
 
-2026-07-10T00:00Z HDMX-coding-agent note rescoped to guard-only; cleanup split to 0232 (171 live violations would keep the guard red). Blocked-by 0232. Added cold-codebase requirement: ruff is not a declared dep today.
+2026-07-10T00:00Z HDMX-coding-agent note rescoped to guard-only; cleanup split to 0232 (171 live violations would keep the guard red). Blocked-by 0232. Added requirement to declare a lockfile-pinned ruff dev dep (today uv run resolves system ruff, so the verdict is version-unstable across machines).
 --- body ---
 ## Context
 Multiple /gaze reviewers (#956/#958/#960) noted the repo has no `def test_ruff`
@@ -26,10 +26,14 @@ Two facts found while scoping:
 - The ping-pong the author hit earlier came from ruff in the *inner* loop. This
   guard lives in the `adherence` tier (`make lint`), out of `check-fast`, so it
   cannot ping-pong the inner loop (invariant below).
-- **ruff is not a declared dependency** anywhere in `pyproject.toml` (only
-  `[tool.ruff]` config). `make lint` relies on ambient ruff today. For the guard
-  to run on a **cold codebase** (fresh clone → `uv sync` → `make lint`), ruff
-  must be added to the `dev` dependency-group.
+- **ruff is not a declared dependency.** `uv run ruff` resolves to the system
+  binary (`~/.local/bin/ruff`, 0.11.12 on doudou) — the venv has no ruff. So the
+  guard's verdict rides on whatever ruff version is on PATH, which can differ
+  across machines (doudou vs padme) and drift on a global upgrade. An adherence
+  guard must give a machine-independent pass/fail. Declare `ruff` in the `dev`
+  group so `uv run ruff` resolves a lockfile-pinned version everywhere, bumped
+  deliberately by PR. (There is no CI to normalise versions, so the lockfile is
+  the only thing that can — see reference_repo_no_ci.)
 
 ## Relevant files
 - `tests/` — a `test_ruff.py` marked `@pytest.mark.adherence`.
@@ -39,8 +43,9 @@ Two facts found while scoping:
 - `~/.claude/rules/coding-python.md` — canonical adherence-test snippet.
 
 ## Actions
-1. Add `ruff>=<pin>` to `[dependency-groups] dev` in `pyproject.toml` so a cold
-   `uv sync` installs it. `uv lock`.
+1. Add `ruff>=0.11.12,<0.12` to `[dependency-groups] dev` in `pyproject.toml`
+   (upper bound so a minor bump can't silently add rules); `uv lock` pins the
+   exact version. `uv run ruff` then resolves the pinned build, not system PATH.
 2. Add `tests/test_ruff.py`: an `@pytest.mark.adherence` test that shells
    `uv run ruff check .` and asserts returncode 0 (per the harness snippet).
 3. Confirm `make lint` runs it and `make check-fast` deselects it (adherence
@@ -58,8 +63,8 @@ introducing a deliberate lint error and seeing it fail.
 - [ ] `make lint` runs the ruff adherence test.
 - [ ] The test is in the `adherence` marker tier (out of `check-fast`).
 - [ ] A deliberately-introduced lint error makes it fail.
-- [ ] Cold codebase: a fresh clone with only `uv sync` (dev group) can run
-      `make lint` — ruff is installed from declared deps, not ambient.
+- [ ] `uv run ruff --version` resolves the lockfile-pinned build, not
+      `~/.local/bin/ruff` — the verdict is version-stable across machines.
 
 ## Invariants
 - Do not add ruff to the fast inner loop (`check-fast`) — adherence tier only.
@@ -67,5 +72,5 @@ introducing a deliberate lint error and seeing it fail.
 
 ## Exit criteria
 - A ruff adherence test gates the whole repo (including `libs/openalex-corpus`)
-  so lint failures are caught locally before review, and it runs on a cold
-  checkout via declared dev deps.
+  so lint failures are caught locally before review, using a lockfile-pinned
+  ruff so the verdict is machine-independent.

--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -2,47 +2,70 @@
 Title: Add a repo-wide ruff adherence test
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Blocked-by: 0232
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
 2026-07-10T10:52Z HDMX-coding-agent note blocker 0211 closed — Blocked-by removed.
+
+2026-07-10T00:00Z HDMX-coding-agent note rescoped to guard-only; cleanup split to 0232 (171 live violations would keep the guard red). Blocked-by 0232. Added cold-codebase requirement: ruff is not a declared dep today.
 --- body ---
 ## Context
 Multiple /gaze reviewers (#956/#958/#960) noted the repo has no `def test_ruff`
 anywhere — lint drift is only caught in CI-less `make lint`, never as a pinned
 pytest adherence guard. The harness Python rule requires every project to carry
 a ruff adherence test so lint failures surface locally before review. Spun out
-of ticket 0211 action 3, which the 0211 scoper deferred as out-of-scope
-(0211 wired the package suite + installability guards; a repo-wide ruff test is
-a separable concern, YAGNI at that point).
+of ticket 0211 action 3, which the 0211 scoper deferred as out-of-scope.
+
+Rescoped 2026-07-10: this ticket is the **guard only**. The repo has 171 live
+ruff violations, so cleaning the tree is a separate validation unit — split to
+0232, which this is Blocked-by. The guard can only go green on a clean tree.
+
+Two facts found while scoping:
+- The ping-pong the author hit earlier came from ruff in the *inner* loop. This
+  guard lives in the `adherence` tier (`make lint`), out of `check-fast`, so it
+  cannot ping-pong the inner loop (invariant below).
+- **ruff is not a declared dependency** anywhere in `pyproject.toml` (only
+  `[tool.ruff]` config). `make lint` relies on ambient ruff today. For the guard
+  to run on a **cold codebase** (fresh clone → `uv sync` → `make lint`), ruff
+  must be added to the `dev` dependency-group.
 
 ## Relevant files
-- `tests/` — where a `test_ruff.py` (or a case in an existing adherence module)
-  would live; mark `@pytest.mark.adherence` so it lands in the `make lint` tier.
-- `libs/openalex-corpus/` — decide whether the repo-wide test also covers the
-  path package or the package carries its own.
+- `tests/` — a `test_ruff.py` marked `@pytest.mark.adherence`.
+- `pyproject.toml` — add `ruff` to `[dependency-groups] dev`; the test is picked
+  up by the existing `make lint` (`pytest -m adherence`).
+- `Makefile` — `lint` target (already `-m adherence`); confirm no change needed.
 - `~/.claude/rules/coding-python.md` — canonical adherence-test snippet.
 
 ## Actions
-1. Add an `@pytest.mark.adherence` test that runs `uv run ruff check .` and
-   asserts returncode 0 (per the harness snippet).
-2. Decide scope: whole repo (including `libs/`) vs a package-local test. Prefer
-   one repo-wide test if ruff config already reaches `libs/`.
-3. Confirm `make lint` picks it up and it is deselected from `check-fast`.
+1. Add `ruff>=<pin>` to `[dependency-groups] dev` in `pyproject.toml` so a cold
+   `uv sync` installs it. `uv lock`.
+2. Add `tests/test_ruff.py`: an `@pytest.mark.adherence` test that shells
+   `uv run ruff check .` and asserts returncode 0 (per the harness snippet).
+3. Confirm `make lint` runs it and `make check-fast` deselects it (adherence
+   marker is already excluded from the fast tier).
+4. Scope note: one repo-wide test covers `libs/` too — ruff config discovery
+   walks up to the root `[tool.ruff]`, so `ruff check .` from the root lints
+   `libs/openalex-corpus/` under the same rules. No package-local test needed.
 
 ## Test
-Write first (red): a test that shells `uv run ruff check .` and asserts
-returncode 0. It goes red the moment any tracked file has a lint violation.
+Write first (red): `tests/test_ruff.py` shells `uv run ruff check .` and asserts
+returncode 0. Red today (171 violations); green once 0232 lands. Prove teeth by
+introducing a deliberate lint error and seeing it fail.
 
 ## Verification
 - [ ] `make lint` runs the ruff adherence test.
 - [ ] The test is in the `adherence` marker tier (out of `check-fast`).
 - [ ] A deliberately-introduced lint error makes it fail.
+- [ ] Cold codebase: a fresh clone with only `uv sync` (dev group) can run
+      `make lint` — ruff is installed from declared deps, not ambient.
 
 ## Invariants
 - Do not add ruff to the fast inner loop (`check-fast`) — adherence tier only.
+- Depends on a clean tree (0232); do not merge this before 0232.
 
 ## Exit criteria
-- A ruff adherence test gates the repo (and the openalex-corpus package) so lint
-  failures are caught locally before review.
+- A ruff adherence test gates the whole repo (including `libs/openalex-corpus`)
+  so lint failures are caught locally before review, and it runs on a cold
+  checkout via declared dev deps.

--- a/tickets/0232-make-repo-ruff-clean.erg
+++ b/tickets/0232-make-repo-ruff-clean.erg
@@ -1,0 +1,67 @@
+%erg 0.1
+Title: Make the repo ruff-clean
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0218
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Split out of 0230. Adding a repo-wide ruff adherence guard (0230) is blocked by
+the tree not being clean: `uv run ruff check .` reports **171 violations** today
+across `scripts/` (83) and `tests/` (88). A guard asserting returncode 0 would be
+red from its first commit, so the tree must be cleaned first — as its own
+reviewable unit, separate from wiring the guard.
+
+Blocked-by 0218: that raid (`t218-evict-phase2-intermediates`) is live and
+touches many `scripts/`/`tests/` files. A repo-wide `ruff --fix` sweep run
+concurrently would collide (import-reorder diffs conflict with almost any edit,
+and a non-conflicting silent drop is worse — see rules/git.md multi-PR wave).
+Run this only once 0218 has merged and `origin/main` is quiet.
+
+## Relevant files
+- `scripts/*.py` — 83 violations
+- `tests/*.py` — 88 violations
+- `libs/openalex-corpus/src/**` — confirm ruff reaches it (config discovery walks
+  up to the root `[tool.ruff]`; verify no residual violations there)
+- `pyproject.toml` — `[tool.ruff.lint] select` and `per-file-ignores`
+
+## Violation profile (as of 2026-07-10, `ruff check . --statistics`)
+- 144 auto-fixable via `ruff check . --fix`:
+  - F401 unused-import (72), I001 unsorted-imports (58), RUF100 unused-noqa (10),
+    D413 missing-blank-line-after-last-section (5), F541 f-string-no-placeholder (1)
+- ~27 need a hand decision (NOT auto-fixed):
+  - F841 unused-variable (15) — delete or use
+  - C901 complex-structure (3), PLR0912 too-many-branches (2),
+    PLR0915 too-many-statements (1) — refactor OR `# noqa` with a one-line reason
+  - D417 undocumented-param (3) — add param docs
+  - PERF102 incorrect-dict-iterator (1)
+
+## Actions
+1. Fetch origin; confirm 0218 is merged and no sibling session is mid-sweep on
+   `scripts/`/`tests/` before starting (rules/workflow.md sync gate).
+2. `uv run ruff check . --fix` for the 144 mechanical fixes. Review the diff.
+3. Hand-resolve the ~27 remainder. Prefer a real fix; for the complexity rules,
+   a `# noqa: C901  # <reason>` is acceptable on legitimately-branchy analysis
+   code rather than a risk-bearing refactor of working numerics.
+4. `uv run ruff check .` returns 0. `make check` still green.
+
+## Test
+Not a code-behaviour change — verification is `uv run ruff check .` returncode 0
+plus a green `make check` (no regression from the import edits). The pinned guard
+itself lands in 0230, on top of this clean tree.
+
+## Verification
+- [ ] `uv run ruff check .` returns 0 across the whole repo (incl. `libs/`).
+- [ ] `make check` passes (no behaviour regression from unused-import deletion or
+      import reordering).
+
+## Invariants
+- No behaviour change: `--fix` may delete genuinely-used-via-side-effect imports;
+  re-run the suite after fixing. Do not touch analysis numerics to satisfy a
+  complexity rule — `# noqa` with reason instead.
+
+## Exit criteria
+- The tree is ruff-clean, unblocking 0230's guard.

--- a/tickets/0232-make-repo-ruff-clean.erg
+++ b/tickets/0232-make-repo-ruff-clean.erg
@@ -15,11 +15,13 @@ across `scripts/` (83) and `tests/` (88). A guard asserting returncode 0 would b
 red from its first commit, so the tree must be cleaned first — as its own
 reviewable unit, separate from wiring the guard.
 
-Blocked-by 0218: that raid (`t218-evict-phase2-intermediates`) is live and
-touches many `scripts/`/`tests/` files. A repo-wide `ruff --fix` sweep run
-concurrently would collide (import-reorder diffs conflict with almost any edit,
-and a non-conflicting silent drop is worse — see rules/git.md multi-PR wave).
-Run this only once 0218 has merged and `origin/main` is quiet.
+Run only against a quiet tree — no concurrent session touching the code. A
+repo-wide `ruff --fix` sweep rewrites imports across ~171 sites in `scripts/`
+and `tests/`; run against a moving tree it collides (import-reorder diffs
+conflict with almost any edit, and a non-conflicting silent drop is worse — see
+rules/git.md multi-PR wave). Blocked-by 0218 because that raid
+(`t218-evict-phase2-intermediates`) is live on exactly those directories; do the
+sweep only once 0218 has merged and `origin/main` is quiet.
 
 ## Relevant files
 - `scripts/*.py` — 83 violations
@@ -40,8 +42,8 @@ Run this only once 0218 has merged and `origin/main` is quiet.
   - PERF102 incorrect-dict-iterator (1)
 
 ## Actions
-1. Fetch origin; confirm 0218 is merged and no sibling session is mid-sweep on
-   `scripts/`/`tests/` before starting (rules/workflow.md sync gate).
+1. Confirm the tree is quiet: fetch origin, 0218 merged, and no sibling session
+   mid-sweep on `scripts/`/`tests/` (rules/workflow.md sync gate).
 2. `uv run ruff check . --fix` for the 144 mechanical fixes. Review the diff.
 3. Hand-resolve the ~27 remainder. Prefer a real fix; for the complexity rules,
    a `# noqa: C901  # <reason>` is acceptable on legitimately-branchy analysis


### PR DESCRIPTION
## What

Scoping ticket 0230 (add a repo-wide ruff adherence test) surfaced that the premise was false: **the repo has 171 live ruff violations today** (`ruff check .` → rc 1). A guard asserting returncode 0 would be red from its first commit. This PR splits the work into the two atomic validation units it actually is — no code touched, tickets only.

## Tickets

- **0232 (new)** — *Make the repo ruff-clean.* Fix the 171 (144 auto-fixable via `--fix`, ~27 hand). `Blocked-by: 0218` — run the `--fix` sweep only against a **quiet tree** (no concurrent session); that raid is live on `scripts/`/`tests/` and would collide (import-reorder diffs, silent-drop risk).
- **0230 (rescoped)** — *guard only.* `Blocked-by: 0232`. Records two scoping findings:
  - the inner-loop **ping-pong** the author hit was ruff in `check-fast`; this guard is `adherence`-tier only, out of the fast loop.
  - `uv run ruff` resolves the **system** binary (`~/.local/bin/ruff` 0.11.12), not the venv — so the verdict is version-unstable across machines. Declare a **lockfile-pinned** `ruff` dev dep so the pass/fail is machine-independent (no CI to normalise versions).

## Dependency order

0218 → 0232 (cleanup) → 0230 (guard). Neither ticket is worked in this PR.

Ticket-ref: tickets/0230-repo-wide-ruff-adherence-test.erg
Ticket-ref: tickets/0232-make-repo-ruff-clean.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)