### PR TITLE
fix(0233): DERIVED producers makedirs before validate_io + class guard

### DIFF
--- a/scripts/analyze_cocitation.py
+++ b/scripts/analyze_cocitation.py
@@ -210,6 +210,9 @@ def run_robustness(G):
 
 def main():
     io_args, extra = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     parser = argparse.ArgumentParser()

--- a/scripts/analyze_embeddings.py
+++ b/scripts/analyze_embeddings.py
@@ -40,6 +40,9 @@ CLUSTERS_PATH = os.path.join(DERIVED_TABLES_DIR, "semantic_clusters.csv")
 
 def main():
     io_args, extra = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     global FIGURES_DIR

--- a/scripts/build_het_core.py
+++ b/scripts/build_het_core.py
@@ -379,6 +379,9 @@ def _select_with_quotas(s2):
 
 def main():
     io_args, extra = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     parser = argparse.ArgumentParser(description=__doc__)

--- a/scripts/compute_analytical_null.py
+++ b/scripts/compute_analytical_null.py
@@ -28,6 +28,7 @@ null distribution parameters, not the observed statistic).
 
 import argparse
 import math
+import os
 import sys
 
 import pandas as pd
@@ -156,6 +157,9 @@ def main() -> None:
     args = parser.parse_args(extra)
     method = args.method
 
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     cfg = load_analysis_config()

--- a/scripts/compute_crossyear_zscore.py
+++ b/scripts/compute_crossyear_zscore.py
@@ -19,6 +19,7 @@ Usage::
 """
 
 import argparse
+import os
 import re
 import sys
 
@@ -191,6 +192,9 @@ def main() -> None:
         else f"{DERIVED_TABLES_DIR}/tab_div_{method}.csv"
     )
 
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output, inputs=io_args.input)
 
     log.info("Reading %s", input_path)

--- a/scripts/compute_lexical.py
+++ b/scripts/compute_lexical.py
@@ -48,6 +48,9 @@ if __name__ == "__main__":
     from utils import load_analysis_corpus
 
     io_args, extra = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     os.makedirs(os.path.dirname(io_args.output) or TABLES_DIR, exist_ok=True)

--- a/scripts/compute_lexical.py
+++ b/scripts/compute_lexical.py
@@ -12,11 +12,9 @@ Exports (for import by plot_fig_lexical_tfidf.py):
 
 import os
 
-from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger
+from utils import DERIVED_TABLES_DIR, get_logger
 
 log = get_logger("compute_lexical")
-
-TABLES_DIR = os.path.join(BASE_DIR, "content", "tables")
 
 # --- Shared lexical denoising constants (imported by plot_fig_lexical_tfidf.py) ---
 MIN_PERIOD_DF = 3
@@ -52,8 +50,6 @@ if __name__ == "__main__":
     # create it so validate_io's dir check passes on a clean tree.
     os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
-
-    os.makedirs(os.path.dirname(io_args.output) or TABLES_DIR, exist_ok=True)
 
     # --- Args ---
     parser = argparse.ArgumentParser(description="Compute lexical TF-IDF table at break years")

--- a/scripts/compute_sensitivity_grid.py
+++ b/scripts/compute_sensitivity_grid.py
@@ -12,6 +12,7 @@ target companion-sensitivity is the intended entry point.
 """
 
 import copy
+import os
 import sys
 
 import pandas as pd
@@ -215,6 +216,9 @@ def compute_grid(df, emb, cfg):
 
 def main():
     io_args, _ = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     cfg = load_analysis_config()

--- a/scripts/compute_venue_concentration.py
+++ b/scripts/compute_venue_concentration.py
@@ -14,6 +14,8 @@ Usage:
     uv run python scripts/compute_venue_concentration.py --output content/tables/tab_venue_concentration.csv
 """
 
+import os
+
 import numpy as np
 import pandas as pd
 from pipeline_io import save_csv
@@ -87,6 +89,9 @@ def compute_concentration(df: pd.DataFrame) -> pd.DataFrame:
 
 def main():
     io_args, _extra = parse_io_args()
+    # Output lands under data/derived/tables/ (gitignored, regenerable — ticket 0233);
+    # create it so validate_io's dir check passes on a clean tree.
+    os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)
     validate_io(output=io_args.output)
 
     if io_args.input:

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -251,3 +251,129 @@ class TestComputeBreakpointsOneOutput:
             "compute_breakpoints.py should use mutually exclusive argument "
             "group for --robustness and --k-sensitivity"
         )
+
+
+# ---------------------------------------------------------------------------
+# $(DERIVED) producers create their output dir before validate_io (ticket 0233)
+# ---------------------------------------------------------------------------
+#
+# `validate_io` only *checks* the output dir exists (it raises on a missing
+# dir; that raise is pinned by test_validate_io_checks_output_dir). It does not
+# create it. `content/tables/` is git-tracked and always present, but
+# `data/derived/` (= $(DERIVED)) is gitignored and regenerable — absent on a
+# clean tree. So every producer whose Make target writes under $(DERIVED) must
+# `os.makedirs(...)` before `validate_io`, or an isolated / `make -jN` build on
+# a clean tree fails depending on which producer runs first (ticket 0218 fixed
+# four; 0233 finishes the class and adds this standing guard).
+#
+# The guard is Makefile-driven, not a hardcoded script list: it discovers every
+# $(DERIVED)-valued producer target from the Makefile, so a NEW producer that
+# forgets the bootstrap is caught automatically.
+
+
+def _makefile_text():
+    """Concatenate the main Makefile and every included *.mk."""
+    root = os.path.join(os.path.dirname(__file__), "..")
+    text = ""
+    for name in ["Makefile"] + sorted(
+        f for f in os.listdir(root) if f.endswith(".mk")
+    ):
+        with open(os.path.join(root, name)) as f:
+            text += f"\n# === {name} ===\n" + f.read()
+    return text
+
+
+def _derived_producer_scripts():
+    """Scripts wired to a Make target whose output resolves under data/derived.
+
+    Two-pass Make variable resolution scoped to $(DERIVED)-valued variables,
+    then scan target lines for a `scripts/*.py` prerequisite.
+    """
+    import re
+
+    text = _makefile_text()
+
+    # Join `\`-continuation lines so a recipe target and its prerequisites
+    # (often wrapped) are scanned as one logical line.
+    text = re.sub(r"\\\n\s*", " ", text)
+
+    # Pass 1: collect variables whose value expands under data/derived.
+    assign = re.compile(r"^([A-Z][A-Z0-9_]*)\s*:?=\s*(.+?)\s*$", re.MULTILINE)
+    values = {m.group(1): m.group(2) for m in assign.finditer(text)}
+
+    def expands_to_derived(val, depth=0):
+        if depth > 10:
+            return False
+        val = val.strip()
+        if val.startswith("data/derived"):
+            return True
+        m = re.match(r"^\$\(([A-Z][A-Z0-9_]*)\)", val)
+        if m and m.group(1) in values:
+            return expands_to_derived(values[m.group(1)], depth + 1)
+        return False
+
+    derived_vars = {v for v, val in values.items() if expands_to_derived(val)}
+
+    # Pass 2: target lines whose LHS resolves under data/derived. LHS forms:
+    #   $(VAR):                  bare derived var  (e.g. $(SEMANTIC_CLUSTERS))
+    #   $(DERIVEDVAR)/literal:   var + suffix      (e.g. $(DERIVED)/tab_x.csv)
+    #   data/derived/literal:    literal path
+    producers = {}
+    target = re.compile(r"^(?!\t)(\S.*?):(?!=)\s*(.*)$")
+    for line in text.splitlines():
+        m = target.match(line)
+        if not m:
+            continue
+        lhs = m.group(1).strip()
+        var = re.match(r"^\$\(([A-Z][A-Z0-9_]*)\)", lhs)
+        is_derived = (
+            lhs.startswith("data/derived")
+            or (var is not None and var.group(1) in derived_vars)
+        )
+        if not is_derived:
+            continue
+        script = re.search(r"scripts/(\S+\.py)", m.group(2))
+        if script:
+            producers[script.group(1)] = lhs
+    return producers
+
+
+class TestDerivedProducersMakedirs:
+    """Every $(DERIVED)-writing producer creates its output dir before validate_io.
+
+    Source inspection (adherence tier) — cheap, deterministic, no subprocess.
+    Ticket 0233; the class the ticket 0218 fix belongs to.
+    """
+
+    pytestmark = pytest.mark.adherence
+
+    PRODUCERS = _derived_producer_scripts()
+
+    def test_discovery_nonempty(self):
+        """Sanity: the Makefile scan must find the known $(DERIVED) producers."""
+        found = set(self.PRODUCERS)
+        expected = {
+            "analyze_embeddings.py",
+            "analyze_cocitation.py",
+            "build_het_core.py",
+        }
+        missing = expected - found
+        assert not missing, (
+            f"Makefile scan lost known $(DERIVED) producers: {sorted(missing)}"
+        )
+
+    @pytest.mark.parametrize("script", sorted(_derived_producer_scripts()))
+    def test_makedirs_before_validate_io(self, script):
+        with open(os.path.join(SCRIPTS_DIR, script)) as f:
+            source = f.read()
+        if "validate_io(" not in source:
+            pytest.skip(f"{script} does not use validate_io")
+        vi = source.index("validate_io(")
+        md = source.find("os.makedirs(")
+        assert md != -1 and md < vi, (
+            f"{script} writes under $(DERIVED) but does not os.makedirs() its "
+            f"output dir before validate_io — an isolated/clean-tree build "
+            f"(no data/derived/) will fail. Add "
+            f"os.makedirs(os.path.dirname(io_args.output) or '.', exist_ok=True) "
+            f"before validate_io (ticket 0233)."
+        )

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -350,12 +350,27 @@ class TestDerivedProducersMakedirs:
     PRODUCERS = _derived_producer_scripts()
 
     def test_discovery_nonempty(self):
-        """Sanity: the Makefile scan must find the known $(DERIVED) producers."""
+        """The Makefile scan must find every known $(DERIVED) producer.
+
+        Pinning the full known set (not just a sample) means a discovery
+        regression that silently drops a producer — leaving it unguarded —
+        fails here instead of passing vacuously.
+        """
         found = set(self.PRODUCERS)
         expected = {
             "analyze_embeddings.py",
             "analyze_cocitation.py",
             "build_het_core.py",
+            "compute_lexical.py",
+            "compute_analytical_null.py",
+            "compute_crossyear_zscore.py",
+            "compute_sensitivity_grid.py",
+            "compute_venue_concentration.py",
+            # 0218's four (already fixed) — the guard must keep covering them.
+            "compute_breakpoints.py",
+            "compute_clusters.py",
+            "analyze_bimodality.py",
+            "analyze_genealogy.py",
         }
         missing = expected - found
         assert not missing, (
@@ -368,12 +383,20 @@ class TestDerivedProducersMakedirs:
             source = f.read()
         if "validate_io(" not in source:
             pytest.skip(f"{script} does not use validate_io")
+        # The makedirs must (a) target the output path — os.path.dirname of the
+        # parsed output — and (b) sit in the main() prologue, between
+        # parse_io_args() and validate_io(). Anchoring both defeats a decoy: an
+        # unrelated makedirs elsewhere (e.g. analyze_genealogy's module-level
+        # makedirs(TABLES_DIR), analyze_bimodality's makedirs(pole_dir)) must
+        # NOT satisfy the guard, so deleting the real fix turns it RED.
         vi = source.index("validate_io(")
-        md = source.find("os.makedirs(")
-        assert md != -1 and md < vi, (
-            f"{script} writes under $(DERIVED) but does not os.makedirs() its "
-            f"output dir before validate_io — an isolated/clean-tree build "
+        pio = source.rfind("parse_io_args()", 0, vi)
+        prologue = source[pio:vi] if pio != -1 else source[:vi]
+        assert "os.makedirs(os.path.dirname(io_args.output)" in prologue, (
+            f"{script} writes under $(DERIVED) but does not "
+            f"os.makedirs(os.path.dirname(io_args.output) ...) between "
+            f"parse_io_args() and validate_io — an isolated/clean-tree build "
             f"(no data/derived/) will fail. Add "
             f"os.makedirs(os.path.dirname(io_args.output) or '.', exist_ok=True) "
-            f"before validate_io (ticket 0233)."
+            f"immediately before validate_io (ticket 0233)."
         )

--- a/tickets/0233-derived-producers-makedirs-bootstrap.erg
+++ b/tickets/0233-derived-producers-makedirs-bootstrap.erg
@@ -1,0 +1,72 @@
+%erg 0.1
+Title: $(DERIVED) producers must create their output dir before validate_io (bootstrap the class)
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T13:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Ticket 0218 evicted 17 Phase-2 intermediates from `content/tables/` (git-tracked,
+always present) to `data/derived/tables/` (`$(DERIVED)`, gitignored, regenerable).
+That surfaced a latent fragility: producers that write via
+`script_io_args.validate_io()` only *check* the output dir exists — they
+`raise FileNotFoundError("Output directory does not exist")` if it is absent —
+they do not create it. `content/tables/` existed for free; `$(DERIVED)` does not.
+
+0218 fixed the four producers it touched (`compute_breakpoints`, `compute_clusters`,
+`analyze_bimodality`, `analyze_genealogy`) by adding
+`os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)` before
+`validate_io`. A roar sweep found **three pre-existing producers with the same gap**
+— they already write to `$(DERIVED)` via `validate_io` without a makedirs bootstrap:
+
+- `scripts/analyze_embeddings.py` -> `$(DERIVED)/semantic_clusters.csv` (`main()` ~L43 validate_io, no makedirs)
+- `scripts/analyze_cocitation.py` -> `$(DERIVED)/communities.csv` (`main()` ~L215 validate_io, no makedirs)
+- `scripts/build_het_core.py` -> `$(DERIVED)/het_mostcited_50.csv` (MOSTCITED; `main()` ~L382 validate_io, no makedirs)
+
+They "work" today only because a full `make figures`/`make papers` happens to run a
+makedirs-producer (e.g. `analyze_bimodality`) first, which creates `$(DERIVED)` as a
+side effect. Under `make -jN` or an isolated target build on a clean tree (no
+`data/derived/`), whichever of these runs first fails. This is order-dependent
+fragility, not correctness — the same class 0218 fixed for its four producers.
+
+## Relevant files
+- `scripts/analyze_embeddings.py`, `scripts/analyze_cocitation.py`,
+  `scripts/build_het_core.py` — add the makedirs bootstrap before `validate_io`.
+- `scripts/script_io_args.py` — `validate_io` (do NOT change; its raise-on-missing-dir
+  is pinned by `tests/test_io_discipline.py`).
+- `tests/test_evict_analysis_intermediates.py` / `tests/test_io_discipline.py` —
+  home for the class regression guard.
+
+## Actions
+1. In each of the three producers' `main()`, insert
+   `os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)` immediately
+   before `validate_io(output=io_args.output)`. Confirm each has `import os`.
+2. Add a class regression guard (see Test) so a NEW `$(DERIVED)`-writing producer
+   that forgets the bootstrap is caught — a standing test, not a per-PR gate.
+
+## Test
+- RED-first: a guard that, for every top-level Makefile target whose output is under
+  `$(DERIVED)` and whose recipe runs a `scripts/*.py` using `validate_io`, asserts the
+  script creates its output dir. Two viable forms: source inspection (grep the script
+  body for `os.makedirs` alongside `validate_io`) marked `adherence`, or behavioural
+  (in a tmp CWD with no `data/derived/`, invoke the script with
+  `--output data/derived/tables/x.csv` and assert it does not raise "Output directory
+  does not exist") marked `integration`.
+- Prove teeth: reverting the makedirs on one producer turns the guard RED.
+
+## Invariants
+- `validate_io` behaviour unchanged (unit test still sees the raise).
+- No Phase-1 trigger; DVC untouched. Behaviour of the three producers unchanged
+  except the output dir is now auto-created.
+
+## Exit criteria
+- The three producers create their output dir before `validate_io`.
+- A clean tree (`rm -r data/derived`) build of each affected `$(DERIVED)` target
+  (`make $(DERIVED)/semantic_clusters.csv`, `.../communities.csv`,
+  `.../het_mostcited_50.csv`) succeeds without pre-creating the dir.
+- The class regression guard is green and would fail on a re-introduced gap.
+
+Ticket-ref: tickets/closed/0218-evict-remaining-phase-2-intermediates-fr.erg

--- a/tickets/closed/0233-derived-producers-makedirs-bootstrap.erg
+++ b/tickets/closed/0233-derived-producers-makedirs-bootstrap.erg
@@ -2,10 +2,12 @@
 Title: $(DERIVED) producers must create their output dir before validate_io (bootstrap the class)
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #992
 
 --- log ---
 2026-07-10T13:20Z HDMX-coding-agent created
 
+2026-07-10T15:26Z HDMX-coding-agent closed — autoclosed — PR #992
 --- body ---
 ## Context
 


### PR DESCRIPTION
Finishes the `$(DERIVED)`-producer makedirs class that ticket 0218 started, and adds a standing guard so the class stays closed.

## Problem
`validate_io()` only *checks* the output dir exists (it raises if absent) — it does not create it. `content/tables/` is git-tracked and always present, but `$(DERIVED)`=`data/derived/tables` is gitignored and regenerable, so it is absent on a clean tree. A producer that writes there without `os.makedirs` fails under `make -jN` / an isolated target build depending on which producer runs first (0218 fixed four; the roar sweep that filed this ticket found more).

## Change
- **8 producers** get `os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)` before `validate_io`:
  - the 3 named by the ticket: `analyze_embeddings`, `analyze_cocitation`, `build_het_core`
  - `compute_lexical` — a 4th the guard's auto-discovery surfaced that the manual sweep missed
  - `compute_analytical_null`, `compute_crossyear_zscore`, `compute_sensitivity_grid`, `compute_venue_concentration` — 4 more brought in by rebasing onto 0231's eviction work; the guard caught them going RED
- **Standing guard** `TestDerivedProducersMakedirs` (adherence tier): Makefile-driven auto-discovery of every target whose output resolves under `data/derived`, asserting the producing script calls `os.makedirs(os.path.dirname(io_args.output) ...)` **in the main() prologue** (between `parse_io_args()` and `validate_io`). Not a hardcoded list — a future `$(DERIVED)` producer that forgets the bootstrap is caught automatically. The prologue+output-target anchoring means a decoy `makedirs` elsewhere (e.g. `analyze_genealogy`'s module-level `makedirs(TABLES_DIR)`) can't mask a deleted real fix. `test_discovery_nonempty` pins all 12 known producers so a scan regression that drops one fails loudly. Green now; was RED for every offender, and mutation-verified: deleting any producer's real fix turns it RED.
- `simplify` cleanup in `compute_lexical.py`: dropped a now-redundant post-`validate_io` `makedirs` and its dead `TABLES_DIR` / `BASE_DIR` import.

## Verification
- `TestDerivedProducersMakedirs`: 13 passed, 3 skipped (skips write via `save_csv`, not `validate_io`).
- Adherence tier: 132 passed. Ruff: clean on all touched files.
- Teeth proven: reverting any producer's makedirs turns the guard RED.
- `validate_io`'s raise-on-missing-dir behaviour is unchanged (still pinned by `test_validate_io_checks_output_dir`). No Phase-1 trigger; DVC untouched.
- Out of scope / pre-existing (not caused by this diff): 3 `qa_*` subprocess tests fail in this worktree on a missing `corpus`-extra dep (`bibtexparser`); they pass in the corpus env.

**Ticket:** tickets/0233-derived-producers-makedirs-bootstrap.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
