### PR TITLE
ticket(0232): make the repo ruff-clean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,8 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 # Re-export facades: imports are public API, not unused
 "scripts/utils.py" = ["F401", "E402"]
-"scripts/collect_syllabi.py" = ["F401"]
-"scripts/compare_clustering.py" = ["F401"]
+"scripts/catalog_syllabi.py" = ["F401"]
+"scripts/compute_clustering_comparison.py" = ["F401"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/scripts/_citation_methods.py
+++ b/scripts/_citation_methods.py
@@ -236,6 +236,12 @@ def _sliding_abs_diff(works, internal_edges, cfg, metric_fn, label):
 
     Parameters
     ----------
+    works : pd.DataFrame
+        Corpus works (graph nodes) with year metadata.
+    internal_edges : pd.DataFrame
+        Intra-corpus citation edges used to build each window graph.
+    cfg : dict
+        Analysis configuration (sliding-window and gap parameters).
     metric_fn : callable(G) -> float
         Graph metric to compare. Should return np.nan on failure.
     label : str

--- a/scripts/_permutation_citation.py
+++ b/scripts/_permutation_citation.py
@@ -113,6 +113,16 @@ def _run_abs_diff_permutations(
         Method label for logging (e.g. "G6").
     metric_fn : callable(G) -> float
         Graph scalar metric.
+    works : pd.DataFrame
+        Corpus works (graph nodes) with year metadata.
+    internal_edges : pd.DataFrame
+        Intra-corpus citation edges used to build each window graph.
+    div_df : pd.DataFrame
+        Per-window divergence observations driving the null.
+    cfg : dict
+        Analysis configuration (sliding-window and gap parameters).
+    n_jobs : int
+        Number of parallel workers.  1 = sequential, -1 = all cores.
     n_perm_override : int or None
         If set, caps n_perm to this value (used by G8 for tractability).
 

--- a/scripts/_permutation_io.py
+++ b/scripts/_permutation_io.py
@@ -122,6 +122,12 @@ def _collect_permutation_rows(window_iter, statistic_fn, n_perm, n_jobs=1):
 
     Parameters
     ----------
+    window_iter : iterable
+        Yields per-window tuples ``(y, w, X, Y, perm_rng)`` to test.
+    statistic_fn : callable
+        Computes the observed/null statistic for one window.
+    n_perm : int
+        Number of permutations per window.
     n_jobs : int
         Number of parallel workers.  1 = sequential (original path),
         -1 = all available cores.

--- a/scripts/analyze_bimodality.py
+++ b/scripts/analyze_bimodality.py
@@ -23,12 +23,11 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from script_io_args import parse_io_args, validate_io
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.mixture import GaussianMixture
-from script_io_args import parse_io_args, validate_io
 from utils import (
-    BASE_DIR,
     CATALOGS_DIR,
     DERIVED_TABLES_DIR,
     get_logger,

--- a/scripts/analyze_cocitation.py
+++ b/scripts/analyze_cocitation.py
@@ -22,7 +22,6 @@ import pandas as pd
 from scipy.sparse import lil_matrix
 from script_io_args import parse_io_args, validate_io
 from utils import (
-    BASE_DIR,
     CATALOGS_DIR,
     get_logger,
     load_refined_citations,
@@ -194,7 +193,6 @@ def run_robustness(G):
                 row[col] = partitions[gamma].get(doi, -1)
             sens_rows.append(row)
 
-        sens_df = pd.DataFrame(sens_rows)
 
         # ARI between resolution levels
         log.info("  Pairwise ARI:")

--- a/scripts/analyze_genealogy.py
+++ b/scripts/analyze_genealogy.py
@@ -14,7 +14,6 @@ Produces:
   data/derived/tables/tab_lineages.csv — backbone papers with lineage, position, metadata
 """
 
-import argparse
 import os
 import warnings
 from collections import defaultdict
@@ -28,7 +27,6 @@ from utils import (
     DERIVED_TABLES_DIR,
     get_logger,
     load_analysis_config,
-    load_analysis_periods,
     load_refined_citations,
     normalize_doi,
 )

--- a/scripts/archive/analyze_space_interactions.py
+++ b/scripts/archive/analyze_space_interactions.py
@@ -2,18 +2,18 @@
 Analyze interactions between time, semantic, lexical, and citation clustering spaces.
 """
 
-import sys
 import os
+import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import svds
-from sklearn.preprocessing import normalize
 from sklearn.cluster import KMeans
-from sklearn.metrics import adjusted_rand_score, silhouette_score
 from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics import adjusted_rand_score, silhouette_score
 
 SEED = 42
 K = 6
@@ -152,7 +152,7 @@ def print_separator(char="=", width=70):
 # Main analysis
 # ──────────────────────────────────────────────────────────────────────────────
 
-def main():
+def main():  # noqa: C901, PLR0912, PLR0915  # archived exploratory script, not refactored
     works, embeddings, citations = load_data()
     works, embeddings, _ = filter_works(works, embeddings)
 

--- a/scripts/build_smoke_fixture.py
+++ b/scripts/build_smoke_fixture.py
@@ -17,7 +17,6 @@ import sys
 
 import numpy as np
 import pandas as pd
-
 from utils import get_logger
 
 log = get_logger("build_smoke_fixture")

--- a/scripts/catalog_openalex.py
+++ b/scripts/catalog_openalex.py
@@ -35,19 +35,14 @@ import pandas as pd
 import yaml
 from openalex_pool import (
     OA_API,
-    LAST_RUN_PATH,
-    SIDECAR_PATH,
-    build_filter,
+    _download_tiers,
     budget_exhausted,
+    build_filter,  # noqa: F401 -- re-exported through this module for tests
     capture_budget,
-    dry_run_query,
-    fetch_query,
+    fetch_query,  # noqa: F401 -- re-exported through this module for tests
     load_query_dates,
     query_slug,
-    read_last_run_date,
-    save_query_dates,
     write_last_run_date,
-    _download_tiers,
 )
 from utils import (
     CATALOGS_DIR,

--- a/scripts/compute_breakpoints.py
+++ b/scripts/compute_breakpoints.py
@@ -28,8 +28,8 @@ import numpy as np
 import pandas as pd
 from scipy.spatial.distance import cosine as cosine_dist
 from scipy.stats import pearsonr
-from sklearn.cluster import KMeans
 from script_io_args import parse_io_args, validate_io
+from sklearn.cluster import KMeans
 from utils import get_logger, load_analysis_corpus
 
 log = get_logger("compute_breakpoints")

--- a/scripts/compute_regression_history.py
+++ b/scripts/compute_regression_history.py
@@ -12,14 +12,13 @@ Usage:
 Output: prints a table of (commit, script, output, hash) and flags changes.
 """
 
-import hashlib
 import csv
+import hashlib
 import io
 import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 

--- a/scripts/corpus_filter.py
+++ b/scripts/corpus_filter.py
@@ -20,7 +20,6 @@ import os
 
 import numpy as np
 import pandas as pd
-from qa_near_duplicates import detect_near_duplicate_groups
 from filter_flags import (
     _load_config,
     compute_protection,
@@ -31,6 +30,7 @@ from filter_flags import (
     flag_semantic_outlier,
     flag_title_blacklist,
 )
+from qa_near_duplicates import detect_near_duplicate_groups
 from utils import (
     CATALOGS_DIR,
     CONFIG_DIR,

--- a/scripts/corpus_parse_citations_grobid.py
+++ b/scripts/corpus_parse_citations_grobid.py
@@ -29,7 +29,6 @@ from utils import (
     REFS_COLUMNS,
     get_logger,
     make_run_id,
-    normalize_doi,
     save_run_report,
 )
 

--- a/scripts/corpus_ref_match.py
+++ b/scripts/corpus_ref_match.py
@@ -25,9 +25,8 @@ import os
 import time
 
 import pandas as pd
-from rapidfuzz import fuzz, process
-
 from pipeline_text import normalize_title
+from rapidfuzz import fuzz, process
 from utils import CATALOGS_DIR, REFS_COLUMNS, get_logger, save_csv
 
 log = get_logger("ref_match_corpus")
@@ -51,6 +50,7 @@ def _build_corpus_index(
     Returns:
         year_choices: year -> [normalized_titles] for extractOne
         title_to_doi: normalized_title -> doi for result lookup
+
     """
     corpus = pd.read_csv(corpus_path, dtype=str, keep_default_na=False)
     year_choices: dict[str, list[str]] = {}
@@ -160,6 +160,7 @@ def match_refs_to_corpus(
 
     Returns:
         Number of matched rows written.
+
     """
     year_choices, title_to_doi = _build_corpus_index(corpus_path)
     total_entries = sum(len(v) for v in year_choices.values())

--- a/scripts/filter_flags.py
+++ b/scripts/filter_flags.py
@@ -14,7 +14,7 @@ import re
 import numpy as np
 import pandas as pd
 import yaml
-from utils import CATALOGS_DIR, CONFIG_DIR, get_logger, normalize_doi_safe
+from utils import CONFIG_DIR, get_logger, normalize_doi_safe
 
 log = get_logger("filter_flags")
 
@@ -234,12 +234,11 @@ def flag_semantic_outlier(df, config, *, embeddings, emb_df):
 # ============================================================
 
 # Re-export for backward compatibility — corpus_filter.py and tests import from here
-from filter_flags_llm import (  # noqa: E402, F401
+from filter_flags_llm import (  # noqa: F401
     _cache_key,
     flag_llm_irrelevant,
     flag_llm_irrelevant_streaming,
 )
-
 
 # ============================================================
 # Protection

--- a/scripts/pipeline_progress.py
+++ b/scripts/pipeline_progress.py
@@ -12,18 +12,16 @@ sort_dois_by_priority
     Sort a list of DOIs by descending priority score.
 """
 
-from typing import Any
-
 import logging
 import signal
 import subprocess
 import threading
 import time
 from collections.abc import Callable
+from types import TracebackType
+from typing import Any
 
 import pandas as pd
-from types import TracebackType
-
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,

--- a/scripts/plot_alluvial_html.py
+++ b/scripts/plot_alluvial_html.py
@@ -147,7 +147,7 @@ def collect_top_papers(df, period_labels, n_clusters):
     return top_papers
 
 
-def render_html(alluvial_data, cluster_labels, period_stacks, top_papers, output_path):
+def render_html(alluvial_data, cluster_labels, period_stacks, top_papers, output_path):  # noqa: C901  # sequential figure-assembly steps, splitting adds no clarity
     """Render the interactive HTML/SVG alluvial diagram."""
     import matplotlib.pyplot as plt
 

--- a/scripts/plot_bimodality.py
+++ b/scripts/plot_bimodality.py
@@ -15,8 +15,8 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from scipy.stats import gaussian_kde
-from sklearn.mixture import GaussianMixture
 from script_io_args import parse_io_args, validate_io
+from sklearn.mixture import GaussianMixture
 from utils import (
     BASE_DIR,
     DERIVED_TABLES_DIR,

--- a/scripts/plot_cocitation.py
+++ b/scripts/plot_cocitation.py
@@ -23,7 +23,7 @@ log = get_logger("plot_cocitation")
 DPI = 150
 
 
-def main():
+def main():  # noqa: C901  # linear CLI+plot flow
     io_args, extra = parse_io_args()
     validate_io(output=io_args.output)
 
@@ -51,7 +51,7 @@ def main():
     # However, to preserve visual fidelity with the original, we read the
     # citation data and rebuild edges the same way the analyze script does.
     from scipy.sparse import lil_matrix
-    from utils import CATALOGS_DIR, load_refined_citations, normalize_doi
+    from utils import load_refined_citations, normalize_doi
 
     cit = load_refined_citations()
     cit["source_doi"] = cit["source_doi"].apply(normalize_doi)

--- a/scripts/plot_fig_traditions.py
+++ b/scripts/plot_fig_traditions.py
@@ -23,7 +23,6 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import pandas as pd
-
 from pipeline_io import save_figure
 from pipeline_loaders import (
     load_analysis_config,
@@ -34,7 +33,6 @@ from plot_style import DARK, DPI, FIGWIDTH, apply_style
 from scipy.sparse import lil_matrix
 from script_io_args import parse_io_args, validate_io
 from utils import (
-    BASE_DIR,
     get_logger,
     load_refined_citations,
     normalize_doi,
@@ -279,7 +277,7 @@ def _render_traditions(G, partition, pos, comm_to_tradition,
 def _draw_labels(ax, G, pos, trad_to_comm, comm_to_nodes, ref_counts):
     """Draw node labels for top-cited nodes per tradition."""
     label_nodes = set()
-    for trad, c in trad_to_comm.items():
+    for c in trad_to_comm.values():
         nodes_sorted = sorted(
             comm_to_nodes[c], key=lambda d: -ref_counts.get(d, 0))
         label_nodes.update(nodes_sorted[:5])

--- a/scripts/plot_ncc_bimodality.py
+++ b/scripts/plot_ncc_bimodality.py
@@ -23,8 +23,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.stats import gaussian_kde, norm
-from sklearn.mixture import GaussianMixture
 from script_io_args import parse_io_args, validate_io
+from sklearn.mixture import GaussianMixture
 from utils import (
     BASE_DIR,
     DERIVED_TABLES_DIR,

--- a/scripts/plot_schematic_G4_cross_tradition.py
+++ b/scripts/plot_schematic_G4_cross_tradition.py
@@ -175,7 +175,6 @@ def _draw_diagram(ax, flows, using_real):
     """Draw the 3-tradition flow diagram."""
     total = flows.sum()
     c_cross = flows.sum() - np.trace(flows)
-    c_within = np.trace(flows)
     g4 = c_cross / total if total > 0 else 0.0
 
     # --- Draw arrows ---

--- a/scripts/plot_schematic_G5_pref_attachment.py
+++ b/scripts/plot_schematic_G5_pref_attachment.py
@@ -297,7 +297,6 @@ def main():
     )
 
     # ΔY annotation
-    x_ann = ax.get_xlim()[1] * 0.55 if ax.get_xscale() == "linear" else 1.5
     ax.annotate(
         rf"$\Delta\gamma$ = {delta_gamma:.2f}",
         xy=(0.62, 0.47),

--- a/scripts/plot_schematic_L1_js.py
+++ b/scripts/plot_schematic_L1_js.py
@@ -134,7 +134,7 @@ def main() -> None:
     x = np.arange(TOP_N)
     bar_width = 0.32
 
-    bars_p = ax.bar(
+    ax.bar(
         x - bar_width / 2,
         p_top,
         width=bar_width,
@@ -143,7 +143,7 @@ def main() -> None:
         label=f"P  ({BEFORE_YEARS[0]}–{BEFORE_YEARS[1]})",
         zorder=3,
     )
-    bars_q = ax.bar(
+    ax.bar(
         x + bar_width / 2,
         q_top,
         width=bar_width,
@@ -188,7 +188,7 @@ def main() -> None:
     )
 
     # JS formula + value in legend
-    leg = ax.legend(
+    ax.legend(
         loc="upper right",
         fontsize=6.5,
         frameon=True,

--- a/scripts/plot_schematic_L2_ntr.py
+++ b/scripts/plot_schematic_L2_ntr.py
@@ -167,7 +167,7 @@ def main() -> None:
     ax2 = ax_bot
     width = 0.38
 
-    bars_high = ax2.bar(
+    ax2.bar(
         _years - width / 2,
         _high_res,
         width=width,
@@ -175,7 +175,7 @@ def main() -> None:
         alpha=0.75,
         label="High resonance (term persists)",
     )
-    bars_low = ax2.bar(
+    ax2.bar(
         _years + width / 2,
         _low_res,
         width=width,

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -155,7 +155,7 @@ def _compute_null_z_threshold(df: pd.DataFrame, null_df: pd.DataFrame) -> pd.Dat
     return null_df
 
 
-def _plot(
+def _plot(  # noqa: PLR0912  # per-panel plotting branches
     df: pd.DataFrame,
     method: str,
     output_stem: str,

--- a/scripts/script_io_args.py
+++ b/scripts/script_io_args.py
@@ -32,6 +32,7 @@ def parse_io_args(argv=None):
         args.output : str (required)
         args.input : list[str] | None (optional, nargs="+")
         extra : list[str] — remaining args for script-specific parsing
+
     """
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
@@ -59,6 +60,7 @@ def validate_io(output, inputs=None):
     ------
     FileNotFoundError
         If output directory or any input file is missing.
+
     """
     out_dir = os.path.dirname(output)
     if out_dir and not os.path.isdir(out_dir):

--- a/tests/test_archive_checksums.py
+++ b/tests/test_archive_checksums.py
@@ -149,7 +149,7 @@ class TestDockerfileAnalysis:
 
     def test_cmd_targets_exist_in_analysis_makefile(self):
         """Every make target in Dockerfile CMD must exist in Makefile.analysis-manuscript."""
-        df = _read_dockerfile()
+        _read_dockerfile()
         mk_analysis = _read_makefile_analysis()
         # Extract targets from CMD line: expect "make" and "make verify"
         # Verify that 'figures' (default goal) and 'verify' targets exist

--- a/tests/test_catalog_merge.py
+++ b/tests/test_catalog_merge.py
@@ -11,13 +11,12 @@ import sys
 import tempfile
 
 import pandas as pd
-import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
-from catalog_merge import _dedup_vectorized, _load_and_tag  # noqa: E402
-from utils import FROM_COLS, WORKS_COLUMNS  # noqa: E402
+from catalog_merge import _dedup_vectorized, _load_and_tag
+from utils import FROM_COLS, WORKS_COLUMNS
 
 
 def _make_catalog(rows, source_name):

--- a/tests/test_circuit_breaker_non_openalex.py
+++ b/tests/test_circuit_breaker_non_openalex.py
@@ -13,8 +13,7 @@ import pytest
 # Ensure scripts/ is importable
 sys.path.insert(0, "scripts")
 
-from pipeline_io import CONSECUTIVE_FAIL_LIMIT, RateLimitExhausted  # noqa: E402
-
+from pipeline_io import CONSECUTIVE_FAIL_LIMIT, RateLimitExhausted
 
 # ---------------------------------------------------------------------------
 # catalog_istex: fetch_istex_api should abort on consecutive 429s

--- a/tests/test_citations_cache.py
+++ b/tests/test_citations_cache.py
@@ -52,7 +52,7 @@ class TestCacheIsData:
 
     def test_load_done_includes_sentinels(self, tmp_catalogs):
         """DOIs with sentinel ref_doi (__NO_REFS__) are also counted as done."""
-        from enrich_citations_batch import load_done_dois, SENTINEL_REF_DOI
+        from enrich_citations_batch import SENTINEL_REF_DOI, load_done_dois
         from utils import REFS_COLUMNS
 
         cache_path = tmp_catalogs / "enrich_cache" / "crossref_refs.csv"

--- a/tests/test_citations_merge.py
+++ b/tests/test_citations_merge.py
@@ -16,7 +16,7 @@ import pytest
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
-from utils import REFS_COLUMNS  # noqa: E402
+from utils import REFS_COLUMNS
 
 
 @pytest.fixture

--- a/tests/test_classify_type.py
+++ b/tests/test_classify_type.py
@@ -4,13 +4,12 @@ Ensures the refactored function produces identical output to the original
 for representative inputs covering all code paths.
 """
 
-import sys
 import os
+import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from qa_detect_type import classify_type
-
 
 # Each tuple: (description, row_dict, expected_type)
 CASES = [

--- a/tests/test_collect_config.py
+++ b/tests/test_collect_config.py
@@ -15,7 +15,6 @@ Covers:
 import os
 import sys
 
-import pytest
 import yaml
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")

--- a/tests/test_compare_clustering.py
+++ b/tests/test_compare_clustering.py
@@ -79,7 +79,11 @@ class TestClusterMethods:
 
     def test_all_methods_agree_on_well_separated(self, synthetic_embeddings):
         """On trivially separable data, all methods should mostly agree."""
-        from compute_clustering_comparison import cluster_kmeans, cluster_hdbscan, cluster_spectral
+        from compute_clustering_comparison import (
+            cluster_hdbscan,
+            cluster_kmeans,
+            cluster_spectral,
+        )
         from sklearn.metrics import adjusted_rand_score
 
         X, true = synthetic_embeddings
@@ -250,12 +254,12 @@ class TestClusteringArchitectureSplit:
     def test_clustering_methods_has_algorithm_functions(self):
         """Core algorithm functions must be importable from clustering_methods."""
         from clustering_methods import (
-            cluster_kmeans,
             cluster_hdbscan,
+            cluster_kmeans,
             cluster_spectral,
-            silhouette_sweep,
             hdbscan_sweep,
             perturbation_stability,
+            silhouette_sweep,
         )
         assert all(callable(f) for f in [
             cluster_kmeans, cluster_hdbscan, cluster_spectral,

--- a/tests/test_corpus_acceptance.py
+++ b/tests/test_corpus_acceptance.py
@@ -29,11 +29,9 @@ from utils import (
     FROM_COLS,
     REFINED_CITATIONS_PATH,
     REFINED_EMBEDDINGS_PATH,
-    WORKS_COLUMNS,
-    normalize_doi,
     load_analysis_config,
+    normalize_doi,
 )
-
 
 # ── Paths ────────────────────────────────────────────────────
 
@@ -770,7 +768,6 @@ class TestBlacklistValidation:
     def test_blacklist_summary(self, audit, filter_config, capsys):
         """Print blacklist coverage summary (always passes)."""
         noise_title = filter_config["noise_title"]
-        safe_title = filter_config["safe_title"]
 
         lines = ["\n  Blacklist coverage:"]
         for term in noise_title:

--- a/tests/test_corpus_filter.py
+++ b/tests/test_corpus_filter.py
@@ -15,7 +15,6 @@ Extend/filter mode tests that run corpus_filter via subprocess are marked @integ
 import os
 import subprocess
 import sys
-import tempfile
 
 import pandas as pd
 import pytest

--- a/tests/test_doc_contract_consistency.py
+++ b/tests/test_doc_contract_consistency.py
@@ -16,8 +16,6 @@ Docs must:
 import os
 import re
 
-import pytest
-
 ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 AGENTS_MD = os.path.join(ROOT, "AGENTS.md")

--- a/tests/test_doc_vars_completeness.py
+++ b/tests/test_doc_vars_completeness.py
@@ -14,7 +14,7 @@ import pytest
 
 # Allow importing from scripts/
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-from compute_vars import DOC_VARS  # noqa: E402
+from compute_vars import DOC_VARS
 
 CONTENT_DIR = os.path.join(os.path.dirname(__file__), "..", "content")
 

--- a/tests/test_embeddings_cache.py
+++ b/tests/test_embeddings_cache.py
@@ -15,8 +15,8 @@ import ast
 import os
 import sys
 
-import yaml
 import pytest
+import yaml
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 DVC_YAML = os.path.join(os.path.dirname(__file__), "..", "dvc.yaml")

--- a/tests/test_enrich_embeddings.py
+++ b/tests/test_enrich_embeddings.py
@@ -7,8 +7,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 import pandas as pd
 import pytest
-
-from enrich_embeddings import is_boilerplate_abstract, build_text
+from enrich_embeddings import build_text, is_boilerplate_abstract
 
 
 class TestIsBoilerplateAbstract:

--- a/tests/test_enrich_language.py
+++ b/tests/test_enrich_language.py
@@ -123,6 +123,7 @@ class TestCacheRoundTrip:
 
     def test_round_trip(self):
         from unittest.mock import patch
+
         from enrich_language import load_cache, save_cache
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("enrich_language.CACHE_DIR", tmpdir):
@@ -133,6 +134,7 @@ class TestCacheRoundTrip:
 
     def test_empty_cache(self):
         from unittest.mock import patch
+
         from enrich_language import load_cache
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("enrich_language.CACHE_DIR", tmpdir):

--- a/tests/test_fetch_parallel.py
+++ b/tests/test_fetch_parallel.py
@@ -50,7 +50,7 @@ class TestFetchParallelDifferentHosts:
         Sequential with 0.5s polite_get delay + per-host politeness would take
         ~5-8s. Parallel should finish in ~1-2s.
         """
-        from catalog_syllabi import PAGES_PATH, SEARCH_PATH, stage_fetch
+        from catalog_syllabi import stage_fetch
 
         urls = [f"http://host{i}.example.com/syllabus" for i in range(10)]
         search_records = [_make_search_record(u) for u in urls]

--- a/tests/test_find_doi.py
+++ b/tests/test_find_doi.py
@@ -25,7 +25,7 @@ class TestResolveDoi:
 
     def test_find_doi_cached_in_memory(self):
         """Calling find_doi twice with same title queries OpenAlex only once."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 
@@ -49,7 +49,7 @@ class TestResolveDoi:
 
     def test_find_doi_cached_on_disk(self):
         """After clearing in-memory cache, disk cache prevents re-query."""
-        from enrich_dois import find_doi, _title_cache, normalize_title
+        from enrich_dois import _title_cache, find_doi, normalize_title
 
         _title_cache.clear()
 
@@ -71,7 +71,7 @@ class TestResolveDoi:
 
     def test_find_doi_empty_title(self):
         """Empty or whitespace title returns empty string without querying."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 
@@ -85,7 +85,7 @@ class TestResolveDoi:
 
     def test_find_doi_below_threshold(self):
         """Title match below TITLE_SIM_THRESHOLD caches empty string."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 
@@ -102,7 +102,7 @@ class TestResolveDoi:
 
     def test_find_doi_author_cache_key(self):
         """find_doi with author+year checks precise key first, then title-only."""
-        from enrich_dois import find_doi, _title_cache, normalize_title
+        from enrich_dois import _title_cache, find_doi, normalize_title
 
         _title_cache.clear()
 
@@ -130,7 +130,7 @@ class TestResolveDoi:
 
     def test_find_doi_author_falls_back_to_title_only(self):
         """When no author-keyed entry exists, fall back to title-only cache."""
-        from enrich_dois import find_doi, _title_cache, normalize_title
+        from enrich_dois import _title_cache, find_doi, normalize_title
 
         _title_cache.clear()
 
@@ -154,7 +154,7 @@ class TestResolveDoi:
 
     def test_find_doi_author_writes_both_cache_keys(self):
         """When author is provided, find_doi writes to both author and title keys."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 
@@ -180,7 +180,7 @@ class TestResolveDoi:
 
     def test_find_doi_no_author_still_works(self):
         """find_doi without author but with year writes precise + title keys."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 
@@ -320,7 +320,7 @@ class TestResolveDoi:
 
     def test_find_doi_saves_to_disk_cache(self):
         """find_doi saves result to disk cache after OpenAlex query."""
-        from enrich_dois import find_doi, _title_cache
+        from enrich_dois import _title_cache, find_doi
 
         _title_cache.clear()
 

--- a/tests/test_gap_year.py
+++ b/tests/test_gap_year.py
@@ -16,7 +16,6 @@ def test_split_year_excluded_from_before_window():
     # Build synthetic df: papers at years 2000-2005
     df = pd.DataFrame({"year": list(range(2000, 2006)), "work_id": range(6)})
     emb = np.eye(6)
-    cfg = {"divergence": {"gap": 1, "max_subsample": 1000}}
 
     # Split year t=2003, window=2: before should be [2001, 2002], not including 2003
     result = _get_window_embeddings(

--- a/tests/test_in_v1_provenance.py
+++ b/tests/test_in_v1_provenance.py
@@ -14,7 +14,6 @@ import gzip
 import os
 import subprocess
 import sys
-import tempfile
 
 import pandas as pd
 import pytest
@@ -23,7 +22,6 @@ SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
 from corpus_filter import add_in_v1_column, load_v1_identifiers
-
 
 # ---------------------------------------------------------------------------
 # Unit tests: load_v1_identifiers

--- a/tests/test_join_enrichments.py
+++ b/tests/test_join_enrichments.py
@@ -4,13 +4,13 @@ Ticket #428: each enrichment writes to its own cache; this script joins them.
 """
 
 import os
-import json
+
+# Import after path setup
+import sys
 
 import pandas as pd
 import pytest
 
-# Import after path setup
-import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 

--- a/tests/test_language_table.py
+++ b/tests/test_language_table.py
@@ -9,8 +9,6 @@ Verifies that:
 import os
 import sys
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -41,8 +39,8 @@ def test_locale_normalised_hyphen():
 
 
 def test_none_returns_unknown():
-    from export_language_table import normalise_language
     import pandas as pd
+    from export_language_table import normalise_language
     assert normalise_language(pd.NA) == "unknown"
     assert normalise_language(float("nan")) == "unknown"
 

--- a/tests/test_near_duplicates.py
+++ b/tests/test_near_duplicates.py
@@ -15,7 +15,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from qa_near_duplicates import detect_near_duplicate_groups
 
-
 # ============================================================
 # Fixtures
 # ============================================================

--- a/tests/test_openalex_from_date.py
+++ b/tests/test_openalex_from_date.py
@@ -7,27 +7,21 @@ Covers:
 - Budget logging from response headers
 """
 
-import json
 import os
 import sys
-import tempfile
 from unittest.mock import MagicMock
-
-import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
 from openalex_pool import (
     build_filter,
-    read_last_run_date,
-    write_last_run_date,
     load_query_dates,
-    save_query_dates,
     query_slug,
-    LAST_RUN_PATH,
+    read_last_run_date,
+    save_query_dates,
+    write_last_run_date,
 )
-
 
 # ---------------------------------------------------------------------------
 # build_filter

--- a/tests/test_parse_citations_grobid.py
+++ b/tests/test_parse_citations_grobid.py
@@ -1,13 +1,11 @@
 """Tests for GROBID-based citation parsing."""
 
-import json
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-import pytest
-from corpus_parse_citations_grobid import parse_tei_citation, build_cache_key
+from corpus_parse_citations_grobid import build_cache_key, parse_tei_citation
 
 
 class TestParseTeiCitation:

--- a/tests/test_perf_baseline.py
+++ b/tests/test_perf_baseline.py
@@ -3,7 +3,6 @@
 import json
 import os
 import subprocess
-import sys
 
 import pytest
 

--- a/tests/test_phase1_contract.py
+++ b/tests/test_phase1_contract.py
@@ -11,15 +11,13 @@ Covers:
 """
 
 import os
-import sys
 import subprocess
-import tempfile
-
-import yaml
+import sys
 
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
@@ -93,6 +91,7 @@ class TestClimateFinanceDataSemantics:
     def test_catalogs_dir_appends_catalogs(self, monkeypatch):
         monkeypatch.setenv("CLIMATE_FINANCE_DATA", "/tmp/mydata")
         import importlib
+
         import pipeline_loaders
         importlib.reload(pipeline_loaders)
         try:
@@ -104,6 +103,7 @@ class TestClimateFinanceDataSemantics:
     def test_default_catalogs_dir_without_override(self, monkeypatch):
         monkeypatch.delenv("CLIMATE_FINANCE_DATA", raising=False)
         import importlib
+
         import pipeline_loaders
         importlib.reload(pipeline_loaders)
         try:

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -22,8 +22,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPTS_DIR = os.path.join(REPO_ROOT, "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
-from utils import WORKS_COLUMNS, FROM_COLS, normalize_doi
-
+from utils import FROM_COLS, WORKS_COLUMNS, normalize_doi
 
 # ============================================================
 # Fixture helpers

--- a/tests/test_pipeline_io.py
+++ b/tests/test_pipeline_io.py
@@ -9,7 +9,7 @@ import pytest
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 sys.path.insert(0, SCRIPTS_DIR)
 
-from pipeline_io import save_figure  # noqa: E402
+from pipeline_io import save_figure
 
 
 class TestSaveFigureDefault:

--- a/tests/test_priority_enrichment.py
+++ b/tests/test_priority_enrichment.py
@@ -29,7 +29,9 @@ class TestImportPriorityUtil:
             from utils import compute_priority_scores
         except ImportError:
             try:
-                from enrich_priority import compute_priority_scores
+                from enrich_priority import (
+                    compute_priority_scores,  # noqa: F401 -- import success is the assertion
+                )
             except ImportError:
                 pytest.fail(
                     "compute_priority_scores not found in utils.py or enrich_priority.py"
@@ -41,7 +43,9 @@ class TestImportPriorityUtil:
             from utils import sort_dois_by_priority
         except ImportError:
             try:
-                from enrich_priority import sort_dois_by_priority
+                from enrich_priority import (
+                    sort_dois_by_priority,  # noqa: F401 -- import success is the assertion
+                )
             except ImportError:
                 pytest.fail(
                     "sort_dois_by_priority not found in utils.py or enrich_priority.py"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -23,12 +23,18 @@ ROOT = os.path.join(os.path.dirname(__file__), "..")
 SCRIPTS_DIR = os.path.join(ROOT, "scripts")
 GOLDEN_PATH = os.path.join(ROOT, "tests", "fixtures", "smoke", "golden_hashes.json")
 
-import sys  # noqa: E402
+import sys
+
 sys.path.insert(0, SCRIPTS_DIR)
-from compute_regression_hashes import (  # noqa: E402
-    REGISTRY, ROOT as HARNESS_ROOT, _hash_output, _redirect_args, _smoke_env,
+from pathlib import Path
+
+from compute_regression_hashes import (
+    REGISTRY,
+    _redirect_args,
 )
-from pathlib import Path  # noqa: E402
+from compute_regression_hashes import (
+    ROOT as HARNESS_ROOT,
+)
 
 sys.path.pop(0)
 
@@ -230,6 +236,6 @@ class TestRegressionIsolation:
                     touched.append(str(f.relative_to(ROOT_PATH)))
 
         assert not touched, (
-            f"Regression fixture modified files in content/:\n"
+            "Regression fixture modified files in content/:\n"
             + "\n".join(f"  {p}" for p in touched)
         )

--- a/tests/test_retry_unification.py
+++ b/tests/test_retry_unification.py
@@ -21,7 +21,7 @@ class TestPoliteGetRobustness:
 
     def test_polite_get_survives_max_minus_one_429s(self, requests_mock):
         """polite_get should survive POLITE_MAX_RETRIES-1 consecutive 429s."""
-        from utils import polite_get, POLITE_MAX_RETRIES
+        from utils import POLITE_MAX_RETRIES, polite_get
 
         responses = [
             {"status_code": 429, "headers": {"Retry-After": "0"}}
@@ -50,10 +50,10 @@ class TestPoliteGetRobustness:
     def test_polite_get_uses_jitter(self, requests_mock, monkeypatch):
         """polite_get should use jittered backoff, not fixed waits."""
         import time
+
         from utils import polite_get
 
         sleeps = []
-        original_sleep = time.sleep
         monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
 
         responses = [

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -246,7 +246,6 @@ class TestJsonlLogging:
 
     def test_log_jsonl_path_accepted_without_error(self, tmp_path):
         """--log-jsonl flag is accepted by all three scripts without parse error."""
-        log_path = tmp_path / "run.jsonl"
         for script in [
             "enrich_abstracts.py",
             "enrich_citations_batch.py",
@@ -384,7 +383,7 @@ class TestResumePreview:
     @pytest.mark.timeout(30)
     def test_enrich_citations_batch_preview_on_empty_corpus(self, tmp_path):
         works_path = make_mini_works(tmp_path)
-        citations_path = make_mini_citations(tmp_path)
+        make_mini_citations(tmp_path)
         env = {
             **os.environ,
             "CLIMATE_FINANCE_DATA": str(tmp_path),

--- a/tests/test_save_csv_atomic.py
+++ b/tests/test_save_csv_atomic.py
@@ -9,7 +9,6 @@ Verifies:
 
 import os
 import sys
-import tempfile
 
 import pandas as pd
 import pytest
@@ -49,7 +48,6 @@ class TestSaveCsvAtomic:
         original_df.to_csv(target, index=False, encoding="utf-8")
         original_content = open(target, encoding="utf-8").read()
 
-        real_to_csv = pd.DataFrame.to_csv
 
         def crash_during_write(self_df, path_or_buf, **kwargs):
             # Write corrupted/partial data to whatever file we're given,

--- a/tests/test_schema_contracts.py
+++ b/tests/test_schema_contracts.py
@@ -22,7 +22,7 @@ sys.path.insert(0, SCRIPTS_DIR)
 
 class TestSchemaModuleExists:
     def test_schemas_importable(self):
-        from schemas import RefinedWorksSchema, RefinedCitationsSchema
+        from schemas import RefinedCitationsSchema, RefinedWorksSchema
         assert RefinedWorksSchema is not None
         assert RefinedCitationsSchema is not None
 
@@ -73,8 +73,8 @@ class TestSchemaRejectsBadData:
     """Schemas catch common contract violations."""
 
     def test_missing_required_column(self):
-        from schemas import RefinedWorksSchema
         import pandera.pandas as pa
+        from schemas import RefinedWorksSchema
         df = pd.DataFrame({"title": ["test"], "year": ["2020"]})
         with pytest.raises(pa.errors.SchemaError):
             RefinedWorksSchema.validate(df)

--- a/tests/test_smoke_pipeline.py
+++ b/tests/test_smoke_pipeline.py
@@ -18,7 +18,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 
 import numpy as np
 import pandas as pd

--- a/tests/test_split_embeddings.py
+++ b/tests/test_split_embeddings.py
@@ -11,8 +11,8 @@ Verifies:
 import os
 import sys
 
-import yaml
 import pytest
+import yaml
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 DVC_YAML = os.path.join(os.path.dirname(__file__), "..", "dvc.yaml")

--- a/tests/test_summarize_abstracts.py
+++ b/tests/test_summarize_abstracts.py
@@ -9,7 +9,6 @@ Exit criteria (from ticket):
 - Summaries preserve key terms from the original
 """
 
-import json
 import os
 import sys
 
@@ -19,14 +18,12 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from summarize_abstracts import (
-    TOKEN_LIMIT,
     classify_abstract_length,
     generate_summary,
     load_summary_cache,
     save_summary_cache,
     summarize_too_long_abstracts,
 )
-
 
 # ============================================================
 # Fixtures

--- a/tests/test_teaching_pipeline.py
+++ b/tests/test_teaching_pipeline.py
@@ -11,7 +11,6 @@ Verifies that:
 
 import os
 import sys
-import tempfile
 
 import pandas as pd
 import pytest
@@ -37,7 +36,7 @@ class TestBuildTeachingYaml:
 
     def test_csv_to_yaml_roundtrip(self, tmp_path):
         """CSV readings are converted to YAML with correct schema."""
-        from build_teaching_yaml import load_scraped, build_yaml_structure
+        from build_teaching_yaml import build_yaml_structure, load_scraped
 
         rows = [
             {"doi": "10.1234/test1", "title": "Test Paper",
@@ -72,7 +71,7 @@ class TestBuildTeachingYaml:
 
     def test_doi_dedup_within_course(self, tmp_path):
         """Duplicate DOIs within same course are deduplicated."""
-        from build_teaching_yaml import load_scraped, build_yaml_structure
+        from build_teaching_yaml import build_yaml_structure, load_scraped
 
         rows = [
             {"doi": "10.1234/dup", "title": "Paper A", "authors": "",
@@ -214,6 +213,7 @@ class TestBuildTeachingYamlNoManual:
     def test_no_manual_catalog_import(self):
         """build_teaching_yaml.py should not reference manual catalog."""
         import inspect
+
         import build_teaching_yaml
         source = inspect.getsource(build_teaching_yaml)
         assert "manual_catalog" not in source, \
@@ -221,7 +221,7 @@ class TestBuildTeachingYamlNoManual:
 
     def test_main_runs_without_manual(self, tmp_path, monkeypatch):
         """main() should succeed with only a CSV input, no manual YAML."""
-        from build_teaching_yaml import load_scraped, build_yaml_structure
+        from build_teaching_yaml import build_yaml_structure, load_scraped
 
         # Create a CSV with readings meeting the threshold
         cols = ["doi", "title", "authors", "year", "journal_or_publisher",
@@ -356,7 +356,7 @@ class TestTwoTierFilter:
 
     def test_detailed_syllabus_readings_pass_at_one_course(self, tmp_path):
         """Readings from detailed syllabi (>=MIN_READINGS_DETAILED DOIs) pass at n_courses=1."""
-        from build_teaching_yaml import load_scraped, MIN_READINGS_DETAILED, MIN_COURSES
+        from build_teaching_yaml import MIN_COURSES, MIN_READINGS_DETAILED, load_scraped
 
         # Create a CSV: one detailed course with many readings + one small course
         rows = []
@@ -416,7 +416,7 @@ class TestTwoTierFilter:
 
     def test_standard_filter_still_applies(self, tmp_path):
         """Title-only readings still need n_courses>=3 to pass the filter."""
-        from build_teaching_yaml import load_scraped, MIN_COURSES
+        from build_teaching_yaml import MIN_COURSES, load_scraped
 
         # DOI reading at n_courses=1 — passes because MIN_COURSES=1
         # (DOI from a classified syllabus is reliable provenance)

--- a/tickets/0230-repo-wide-ruff-adherence-test.erg
+++ b/tickets/0230-repo-wide-ruff-adherence-test.erg
@@ -2,7 +2,6 @@
 Title: Add a repo-wide ruff adherence test
 Created: 2026-07-10
 Author: HDMX-coding-agent
-Blocked-by: 0232
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
@@ -10,6 +9,7 @@ Blocked-by: 0232
 2026-07-10T10:52Z HDMX-coding-agent note blocker 0211 closed — Blocked-by removed.
 
 2026-07-10T00:00Z HDMX-coding-agent note rescoped to guard-only; cleanup split to 0232 (171 live violations would keep the guard red). Blocked-by 0232. Added requirement to declare a lockfile-pinned ruff dev dep (today uv run resolves system ruff, so the verdict is version-unstable across machines).
+2026-07-10T14:31Z HDMX-coding-agent note blocker 0232 closed — Blocked-by removed.
 --- body ---
 ## Context
 Multiple /gaze reviewers (#956/#958/#960) noted the repo has no `def test_ruff`

--- a/tickets/closed/0232-make-repo-ruff-clean.erg
+++ b/tickets/closed/0232-make-repo-ruff-clean.erg
@@ -2,11 +2,13 @@
 Title: Make the repo ruff-clean
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #993
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
 2026-07-10T12:11Z HDMX-coding-agent note blocker 0218 closed — Blocked-by removed.
+2026-07-10T14:31Z HDMX-coding-agent closed — autoclosed — PR #993
 --- body ---
 ## Context
 Split out of 0230. Adding a repo-wide ruff adherence guard (0230) is blocked by


### PR DESCRIPTION
## What

Clears all **170 ruff violations** so the 0230 adherence guard can land green. Net −13 lines (dead code removed), 66 files.

## How

- **146 auto-fixed** (`ruff --fix`): F401 unused imports, I001 import sorting, RUF100 unused-noqa, D413 docstring blank lines, F541.
- **24 hand-resolved:**
  - **F841** — deleted genuinely-dead vars; where the RHS has a side effect (matplotlib `ax.bar`/`ax.legend` draw calls, `make_mini_citations` fixture, `_read_dockerfile`) kept the call, dropped only the binding.
  - **C901/PLR0912/PLR0915** — `# noqa` with reason on working plot code + the archived exploratory script (invariant: don't refactor numerics for lint).
  - **D417** — documented missing params on three permutation/citation helpers.
  - **PERF102** — `.items()`→`.values()` in `plot_fig_traditions`.
  - **F401** in `test_priority_enrichment` — `# noqa` (the import *is* the availability assertion).

## Re-export facade rescue (the `--fix` risk 0232 flagged)

`--fix` stripped re-exported symbols that tests import *through* a module. Root cause: **two per-file-ignores were stale after past renames** — `collect_syllabi.py`→`catalog_syllabi.py`, `compare_clustering.py`→`compute_clustering_comparison.py` — so those facades silently lost their F401 exemption. Restored both files + corrected the ignores, and restored `fetch_query`/`build_filter` in `catalog_openalex` with a noqa. A static probe of **every** reach-through import in `tests/` confirms none remain broken.

## Verification

- `ruff check .` → **rc 0** (incl. `libs/`)
- `make check-fast` → **926 passed**
- `make lint` (mypy/hygiene) → **118 passed**
- Integration/regression failures observed in-worktree are **pre-existing environment limits** (no corpus data, no `bibtexparser`, network timing) — proven not-the-diff: the whole regression Wave 2 fails including 3 scripts with **0 changed lines**.

## Harness findings (separate follow-ups)

- `pytest` recurses into `.claude/worktrees/` (unlike ruff, which honors `.gitignore`) — inflates the primary checkout's `make check`. Worth a `norecursedirs` fix; offering to file a ticket.

**Ticket:** tickets/0232-make-repo-ruff-clean.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)