### PR TITLE
feat(0231): evict sub-Makefile tab_* intermediates to $(DERIVED)

### DIFF
--- a/divergence.mk
+++ b/divergence.mk
@@ -20,7 +20,7 @@
 
 # ── Paths ─────────────────────────────────────────────────────────────────
 
-DIV_TABLES := content/tables
+DIV_TABLES := $(DERIVED)
 DIV_FIGS   := content/figures
 DIV_CFG    := config/analysis.yaml
 DIV_DISPATCH := scripts/compute_divergence.py

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -8,14 +8,14 @@
 #   companion-figures  — build all four PNGs
 #
 # Inputs (ticket 0042 rerun outputs; produced by divergence-summary):
-#   content/tables/tab_summary_{S2_energy,L1,G9_community,G2_spectral}.csv
-#   content/tables/tab_div_C2ST_{embedding,lexical}.csv
+#   $(COMP_TABLES)/tab_summary_{S2_energy,L1,G9_community,G2_spectral}.csv
+#   $(COMP_TABLES)/tab_div_C2ST_{embedding,lexical}.csv
 #
 # Optional inputs (ticket 0056 interpretation layer; stub fallback if absent):
 #   content/tables/tab_discrim_terms*.csv
 #   content/tables/tab_community_shifts*.csv
 
-COMP_TABLES := content/tables
+COMP_TABLES := $(DERIVED)
 COMP_FIGS   := content/figures
 COMP_CFG    := config/analysis.yaml
 COMP_UTILS  := scripts/_companion_plot_utils.py

--- a/scripts/_companion_plot_utils.py
+++ b/scripts/_companion_plot_utils.py
@@ -17,13 +17,9 @@ from typing import Any
 
 import pandas as pd
 from pipeline_io import save_figure
-from utils import load_analysis_config
+from utils import DERIVED_TABLES_DIR, load_analysis_config
 
-DEFAULT_TABLES_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "content",
-    "tables",
-)
+DEFAULT_TABLES_DIR = DERIVED_TABLES_DIR
 
 # Method IDs in the fixed lead order used by the heatmap and Z-series panels.
 DISTANCE_METHODS = ("S2_energy", "L1", "G9_community", "G2_spectral")

--- a/scripts/compute_changepoints.py
+++ b/scripts/compute_changepoints.py
@@ -29,7 +29,7 @@ import os
 import pandas as pd
 import ruptures
 from _divergence_io import load_divergence_tables
-from pipeline_loaders import load_analysis_config
+from pipeline_loaders import DERIVED_TABLES_DIR, load_analysis_config
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger
 
@@ -313,11 +313,7 @@ def main():
     if io_args.input:
         input_paths = io_args.input
     else:
-        tables_dir = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "content",
-            "tables",
-        )
+        tables_dir = DERIVED_TABLES_DIR
         # Try new-style first
         input_paths = sorted(glob.glob(os.path.join(tables_dir, "tab_div_*.csv")))
         if not input_paths:

--- a/scripts/compute_crossyear_zscore.py
+++ b/scripts/compute_crossyear_zscore.py
@@ -24,7 +24,7 @@ import sys
 
 import pandas as pd
 from pipeline_io import save_csv
-from pipeline_loaders import load_analysis_config
+from pipeline_loaders import DERIVED_TABLES_DIR, load_analysis_config
 from schemas import CrossyearZscoreSchema
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger
@@ -186,7 +186,9 @@ def main() -> None:
 
     method = args.method
     input_path = (
-        io_args.input[0] if io_args.input else f"content/tables/tab_div_{method}.csv"
+        io_args.input[0]
+        if io_args.input
+        else f"{DERIVED_TABLES_DIR}/tab_div_{method}.csv"
     )
 
     validate_io(output=io_args.output, inputs=io_args.input)

--- a/scripts/plot_divergence.py
+++ b/scripts/plot_divergence.py
@@ -42,7 +42,7 @@ from _divergence_io import load_divergence_tables
 from pipeline_io import save_figure
 from plot_style import apply_style
 from script_io_args import parse_io_args, validate_io
-from utils import get_logger
+from utils import DERIVED_TABLES_DIR, get_logger
 
 log = get_logger("plot_divergence")
 
@@ -390,12 +390,11 @@ def main():
     args = parser.parse_args(extra)
 
     if not io_args.input:
-        tables_dir = os.path.join(
-            os.path.dirname(os.path.dirname(io_args.output)), "tables"
-        )
         import glob
 
-        io_args.input = sorted(glob.glob(os.path.join(tables_dir, "tab_div_*.csv")))
+        io_args.input = sorted(
+            glob.glob(os.path.join(DERIVED_TABLES_DIR, "tab_div_*.csv"))
+        )
 
     div_df, breaks_df = load_divergence_tables(io_args.input)
 

--- a/scripts/plot_zoo_results.py
+++ b/scripts/plot_zoo_results.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import pandas as pd
 from pipeline_io import save_figure
-from pipeline_loaders import load_analysis_config
+from pipeline_loaders import DERIVED_TABLES_DIR, load_analysis_config
 from plot_style import DARK, FILL, LIGHT, MED, apply_style
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger
@@ -365,7 +365,7 @@ def main() -> None:
     validate_io(output=io_args.output)
 
     output_stem = os.path.splitext(io_args.output)[0]
-    input_path = f"content/tables/tab_crossyear_{method}.csv"
+    input_path = os.path.join(DERIVED_TABLES_DIR, f"tab_crossyear_{method}.csv")
 
     if not os.path.exists(input_path):
         log.warning("Input not found: %s — producing empty figure", input_path)

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -1,4 +1,4 @@
-"""Tickets 0208 + 0218 — analysis intermediates evicted from content/tables/.
+"""Tickets 0208 + 0218 + 0231 — analysis intermediates evicted from content/tables/.
 
 `content/tables/` conflates small byte-stable *writing deliverables* (the `.md`
 `{{< include >}}` fragments and a few pinned `.csv`) with *analysis
@@ -27,12 +27,17 @@ Two guards, complementary:
    (`qa_citations_report.json`, `multilingual_report.json`) are a distinct
    class, out of 0218's scope, and are neither flagged nor moved here.
 
-Scope boundary (ticket 0218, scoping finding 2): the class ratchet scans the
-top-level `Makefile` ONLY. The sub-Makefiles (`divergence.mk`, `zoo.mk`,
-`multilayer-detection.mk`, `venues.mk`) route ~70 more `tab_*` targets to
-`content/tables/` via their own `*_TABLES` dir variable; scanning them would go
-RED on all ~70 pre-existing targets — a false-positive storm, not a regression.
-Widening the guard to those subsystems is ticket 0231 (blocked by this one).
+Scope (ticket 0231): the class ratchet scans the top-level `Makefile` AND every
+sub-Makefile (`divergence.mk`, `zoo.mk`, `multilayer-detection.mk`, `venues.mk`).
+Those subsystems route their `tab_*` targets through a per-subsystem directory
+variable (`DIV_TABLES`, `ZOO_TABLES`, `COMP_TABLES`, `VENUE_TABLE`), so a target
+line reads `$(DIV_TABLES)/tab_div_$(m).csv`, not a literal `content/tables/...`
+path. The ratchet therefore resolves Make variable references before matching:
+it expands `$(VAR)` from the assignments collected across all makefiles, then
+flags any target whose *resolved* path lands under `content/tables/`. Flipping a
+`*_TABLES` variable back to `content/tables` re-reddens the whole subsystem —
+which is the regression this guard exists to catch (0218 evicted the top-level
+literal set; 0231 evicted the variable-routed sub-Makefile class).
 """
 
 import glob
@@ -170,11 +175,54 @@ def _logical_lines(path):
     return out
 
 
-def _content_table_targets(makefile_path):
+_ASSIGN = re.compile(r"^\s*([A-Za-z_][\w]*)\s*[:?]?=\s*(.*?)\s*$")
+_VARREF = re.compile(r"\$[({]([A-Za-z_][\w]*)[)}]")
+
+
+def _variable_map(paths):
+    """Collect `NAME = value` / `:=` / `?=` assignments across all makefiles.
+
+    Make variables are global across `-include`d sub-Makefiles, so the map is
+    built from the union. Later assignments win (matches Make's last-wins for
+    the simple `:=`/`=` used here). Recipe lines (leading TAB) are skipped.
+    """
+    varmap = {}
+    for path in paths:
+        for line in _logical_lines(path):
+            if line.startswith("\t") or line.lstrip().startswith("#"):
+                continue
+            m = _ASSIGN.match(line)
+            if m and ":" not in m.group(2).split("#", 1)[0]:
+                # Guard against matching a rule like `target: dep` as NAME=value:
+                # a real assignment's RHS holds no rule separator. `:=`/`?=` are
+                # handled by the optional `[:?]?=` in the pattern.
+                varmap[m.group(1)] = m.group(2)
+    return varmap
+
+
+def _resolve(token, varmap, _depth=0):
+    """Expand `$(VAR)`/`${VAR}` references in `token` using `varmap`.
+
+    Bounded recursion; unknown or loop variables (e.g. a `$(m)` foreach index)
+    are left verbatim, which is sufficient — we only need the *directory* prefix
+    to resolve to decide whether a target lands under content/tables/.
+    """
+    if _depth > 10 or "$" not in token:
+        return token
+    return _VARREF.sub(
+        lambda mo: _resolve(varmap.get(mo.group(1), mo.group(0)), varmap, _depth + 1),
+        token,
+    )
+
+
+def _content_table_targets(makefile_path, varmap):
     """Basenames of content/tables/tab_*.csv appearing as a Make target.
 
     The *target* is the text left of the `:` / `&:` rule separator on a
     non-recipe logical line; prerequisites and recipe arguments are ignored.
+    Each target token is variable-expanded first, so a subsystem target written
+    as `$(DIV_TABLES)/tab_div_$(m).csv` is judged by where `$(DIV_TABLES)`
+    resolves, not by its literal text.
     """
     basenames = set()
     for line in _logical_lines(makefile_path):
@@ -187,7 +235,8 @@ def _content_table_targets(makefile_path):
         if ":=" in line and sep == ":":    # variable assignment, not a rule
             continue
         for token in lhs.split():
-            m = _CONTENT_TABLE_DATA.search(token)
+            resolved = _resolve(token, varmap)
+            m = _CONTENT_TABLE_DATA.search(resolved)
             if m:
                 basenames.add(os.path.basename(m.group(1)))
     return basenames
@@ -210,13 +259,18 @@ def _gitignore_deliverable_whitelist():
 def test_content_tables_targets_are_declared_deliverables():
     """No un-whitelisted tab_*.csv intermediate may be a content/tables/ target.
 
-    Every `content/tables/tab_*.csv` produced by the top-level Makefile must be
-    a declared deliverable (a `!content/tables/...` negation in `.gitignore`).
-    Anything else is a Phase-2 intermediate that belongs under `$(DERIVED)`
-    (data/derived/tables).
+    Every `content/tables/tab_*.csv` produced by the top-level `Makefile` or any
+    sub-Makefile must be a declared deliverable (a `!content/tables/...` negation
+    in `.gitignore`). Anything else is a Phase-2 intermediate that belongs under
+    `$(DERIVED)` (data/derived/tables). Sub-Makefile targets routed through a
+    `*_TABLES` directory variable are variable-expanded before the check, so the
+    verdict follows where the variable resolves.
     """
-    makefile = os.path.join(PROJECT_ROOT, "Makefile")
-    targets = _content_table_targets(makefile)
+    makefiles = _makefiles()
+    varmap = _variable_map(makefiles)
+    targets = set()
+    for path in makefiles:
+        targets |= _content_table_targets(path, varmap)
     whitelist = _gitignore_deliverable_whitelist()
     offenders = sorted(targets - whitelist)
     assert not offenders, (

--- a/tests/test_sensitivity_grid.py
+++ b/tests/test_sensitivity_grid.py
@@ -24,7 +24,7 @@ def test_sensitivity_config_block_exists():
 
 def test_sensitivity_grid_schema():
     """tab_sensitivity_grid.csv carries required columns (smoke: file must exist)."""
-    path = "content/tables/tab_sensitivity_grid.csv"
+    path = "data/derived/tables/tab_sensitivity_grid.csv"
     if not os.path.exists(path):
         pytest.skip(
             "tab_sensitivity_grid.csv not yet generated — run compute_sensitivity_grid.py"

--- a/tests/test_zoo_figure_polish.py
+++ b/tests/test_zoo_figure_polish.py
@@ -19,7 +19,7 @@ def test_no_w5_in_crossyear_tables():
     L2 is excluded: it uses its own window config [3, 5] for novelty/transience
     lookback, which is a different concept from the sliding window w in S1-S4.
     """
-    csvs = glob.glob("content/tables/tab_crossyear_*.csv")
+    csvs = glob.glob("data/derived/tables/tab_crossyear_*.csv")
     if not csvs:
         pytest.skip("No crossyear tables found — padme rerun needed (ticket 0100)")
     for path in csvs:
@@ -155,11 +155,11 @@ def test_l2_crossyear_value_matches_null_observed():
     RED before fix: crossyear value ≈ 5.35 (mean of 3 metrics) vs observed ≈ 3.38 (resonance only).
     Skips if artifacts absent OR stale (pre-fix mean-of-3 values still present).
     """
-    crossyear = "content/tables/tab_crossyear_L2.csv"
-    null_csv = "content/tables/tab_null_L2.csv"
+    crossyear = "data/derived/tables/tab_crossyear_L2.csv"
+    null_csv = "data/derived/tables/tab_null_L2.csv"
     if not (os.path.exists(crossyear) and os.path.exists(null_csv)):
         pytest.skip(
-            "Padme artifacts absent — run make content/tables/tab_crossyear_L2.csv first"
+            "Padme artifacts absent — run make data/derived/tables/tab_crossyear_L2.csv first"
         )
     cy = pd.read_csv(crossyear)
     # Detect stale artifact: pre-fix year=1999 value was ~5.35 (mean of 3 metrics);
@@ -168,7 +168,7 @@ def test_l2_crossyear_value_matches_null_observed():
     if not sentinel_rows.empty and sentinel_rows["value"].iloc[0] > 4.5:
         pytest.skip(
             f"tab_crossyear_L2.csv is stale (year=1999 value={sentinel_rows['value'].iloc[0]:.2f}); "
-            "regenerate with: make content/tables/tab_crossyear_L2.csv"
+            "regenerate with: make data/derived/tables/tab_crossyear_L2.csv"
         )
     nm = pd.read_csv(null_csv)
     merged = cy.merge(nm, on=["year", "window"])

--- a/tickets/closed/0231-evict-phase-2-intermediates-routed-via-s.erg
+++ b/tickets/closed/0231-evict-phase-2-intermediates-routed-via-s.erg
@@ -2,12 +2,15 @@
 Title: Evict Phase-2 intermediates routed via sub-Makefile *_TABLES dir vars (divergence/zoo/multilayer/venues)
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: evicted sub-Makefile tab_* class to $(DERIVED); guard widened; make papers post-merge on primary (author decision a)
 
 --- log ---
 2026-07-10T10:57Z HDMX-coding-agent created
 2026-07-10T11:00Z note spun out of the 0218 raid scoping pass (2026-07-10): the scoper found 0218's "~15 intermediates" undercounts the class 4-5x once sub-Makefiles are included. Different risk profile (~70 targets), own ticket. Blocked-by 0218 so the top-level Makefile eviction + generalized guard land first.
 
 2026-07-10T12:11Z HDMX-coding-agent note blocker 0218 closed — Blocked-by removed.
+2026-07-10T14:46Z code deliverables done + verified (make -n: all subsystem targets route to $(DERIVED), zero content/tables leak; guard widened GREEN; ruff clean post-232-merge). make papers gate runs post-merge on primary per author decision (a) 2026-07-10.
+2026-07-10T14:46Z HDMX-coding-agent closed — evicted sub-Makefile tab_* class to $(DERIVED); guard widened; make papers post-merge on primary (author decision a)
 --- body ---
 ## Context
 

--- a/venues.mk
+++ b/venues.mk
@@ -9,7 +9,7 @@
 
 # ── Paths ─────────────────────────────────────────────────────────────────
 
-VENUE_TABLE := content/tables/tab_venue_concentration.csv
+VENUE_TABLE := $(DERIVED)/tab_venue_concentration.csv
 VENUE_FIG   := content/figures/fig_venue_concentration.png
 
 # ── Phony targets ─────────────────────────────────────────────────────────

--- a/zoo.mk
+++ b/zoo.mk
@@ -12,7 +12,7 @@
 # ── Paths ─────────────────────────────────────────────────────────────────
 
 ZOO_FIGS   := content/figures
-ZOO_TABLES := content/tables
+ZOO_TABLES := $(DERIVED)
 
 # ── Schematic stems (match plot_schematic_{stem}.py filenames) ────────────
 
@@ -54,7 +54,7 @@ $(ZOO_FIGS)/schematic_%.png: scripts/plot_schematic_%.py scripts/script_io_args.
 # ── Cross-year Z-score tables ─────────────────────────────────────────────
 #
 # Standardise D(t,w) across years to produce Z(t,w).
-# Output: content/tables/tab_crossyear_{method}.csv
+# Output: $(ZOO_TABLES)/tab_crossyear_{method}.csv
 # Depends only on the corresponding tab_div_{method}.csv.
 
 .PHONY: crossyear-tables


### PR DESCRIPTION
Evicts the ~70 variable-routed Phase-2 `tab_*` intermediates that the four
sub-Makefiles route to `content/tables/` via a per-subsystem directory variable,
finishing the class 0218 started (0218 handled the top-level literal set only).

## What changed
- **Flip four dir-variables** to `$(DERIVED)` (`data/derived/tables`): `DIV_TABLES`,
  `ZOO_TABLES`, `COMP_TABLES`, and `VENUE_TABLE` (divergence/zoo/multilayer/venues `.mk`).
  `DERIVED` is defined (`Makefile:30`) before the `-include` lines, so `:=` is safe.
- **Widen the class-ratchet guard** (`test_evict_analysis_intermediates.py`): it now
  collects `NAME := value` assignments across all makefiles and **variable-expands**
  each target token before matching, then scans every `.mk` (not just the top-level
  Makefile). A target is judged by where its `*_TABLES` variable resolves — so
  flipping one back to `content/tables` re-reddens the whole subsystem.
- **Rewire standalone consumers**: script-internal fallback defaults that reference a
  moved table now use `DERIVED_TABLES_DIR` (`_companion_plot_utils`, `plot_zoo_results`,
  `compute_crossyear_zscore`, `plot_divergence`, `compute_changepoints`); two smoke
  tests' artifact paths + stale `make content/tables/...` hints updated.

## Scope discipline
Only fallbacks referencing tables tied to the four flipped variables were touched.
The ~10 scripts with their own `content/tables` constants that produce **deliverables**
(`tab_venues`, `tab_syllabi_breakdown`) or out-of-subsystem tables were left untouched.

## Verification
- Guard RED (commit 1) → GREEN (commit 2). Teeth proven: every subsystem has ≥1
  literal-named target that trips the guard on a `*_TABLES` flip-back.
- `make -n` on every subsystem target: producer `--output` and consumer `--input`
  both resolve under `data/derived/tables`, **zero** `content/tables/tab_*` left in any
  recipe. No `.qmd` `{{< include >}}`s any of these tables → manuscript unaffected.
- Targeted `pytest` (harness `make check` is currently broken): eviction guard +
  phase-layout + sensitivity-grid + zoo-figure-polish + zoo.mk + changepoints —
  **32 passed, 4 skipped** (artifact-absent smoke tests). `test_non_sliding_plots...`
  executed `plot_zoo_results` with the new path and passed.

## ⚠️ Draft — human merge gate
The ticket's exit criteria include a **human-run** long build: `make papers` (all six
PDFs) + manuscript clean-room build. I can't run it (and the harness is reported
broken). Please run `make papers` before un-drafting; the `**Ticket:**` line closes
0231 on merge.

**Ticket:** tickets/0231-evict-phase-2-intermediates-routed-via-s.erg