### PR TITLE
ticket(0234,0235): file roar-sweep follow-ups from 0232

### DIFF
--- a/tickets/0234-pytest-norecursedirs-worktrees.erg
+++ b/tickets/0234-pytest-norecursedirs-worktrees.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: pytest recurses into .claude/worktrees/ — exclude via norecursedirs
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+`pytest` does not honour `.gitignore`, so from the primary checkout `make check`
+(and any `pytest tests/` variant that reaches the repo root) descends into
+`.claude/worktrees/*/`, collecting each live worktree's copy of `tests/`. This
+inflates the run (duplicate collection across every worktree — the cause of the
+"tests are really slow" report on 2026-07-10) and can surface confusing
+cross-worktree failures when a sibling worktree holds different code. ruff is
+unaffected: it respects `.gitignore` and skips the worktrees dir.
+
+Found during ticket 0232 (repo ruff-clean) wrap-up.
+
+## Relevant files
+- `pyproject.toml` — `[tool.pytest.ini_options]` (add `norecursedirs`).
+- `Makefile` — `check` / `check-fast` / `lint` targets pass `tests/`, but a
+  bare `pytest` or a test that walks the tree can still recurse.
+
+## Actions
+1. Add `.claude` (and any other worktree/venv roots) to `norecursedirs` in
+   `[tool.pytest.ini_options]`, e.g.
+   `norecursedirs = [".claude", ".venv", ".git", "output", "data"]`.
+   Confirm the existing defaults (`.*`, `build`, `dist`, etc.) are preserved.
+2. Verify `make check-fast` collection count is unchanged when run from the
+   primary checkout with live worktrees present (no duplicate test IDs).
+
+## Test
+Write first (red): an adherence test asserting `norecursedirs` in
+`[tool.pytest.ini_options]` includes `.claude`, OR a collection-count check that
+`pytest --collect-only -q tests/` from the repo root with a worktree present
+yields no `.claude/worktrees` node ids.
+
+## Verification
+- [ ] `pytest --collect-only` from the primary checkout lists no test under
+      `.claude/worktrees/`.
+- [ ] `make check-fast` runtime/collection unaffected by the number of live
+      worktrees.
+
+## Invariants
+- Do not exclude `tests/` or any real source dir.
+
+## Exit criteria
+- pytest collection ignores `.claude/worktrees/`, so `make check` runtime no
+  longer scales with the number of live worktrees.

--- a/tickets/0235-stale-renamed-script-references.erg
+++ b/tickets/0235-stale-renamed-script-references.erg
@@ -1,0 +1,52 @@
+%erg 0.1
+Title: Fix stale references to renamed scripts (collect_syllabi, compare_clustering)
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Two scripts were renamed at some point — `collect_syllabi.py` →
+`catalog_syllabi.py` and `compare_clustering.py` →
+`compute_clustering_comparison.py` — but a few references still name the old
+files. The functional cases (stale `per-file-ignores` entries that silently
+dropped F401 facade exemptions) were fixed in 0232; these remaining two are
+cosmetic (a user-facing log hint and a test docstring) and were left for a
+separate cleanup so 0232 stayed atomic.
+
+Found during 0232 roar sweep. See memory
+`feedback_ruff_fix_breaks_reexport_facades`.
+
+## Relevant files
+- `scripts/plot_fig_clustering_spaces.py:106` — `log.error("Run
+  compare_clustering.py first ...")` names the old script; should be
+  `compute_clustering_comparison.py` (verify the actual invocation/target).
+- `tests/test_compare_clustering.py:1` — module docstring says "Tests for
+  compare_clustering.py"; the test file targets `compute_clustering_comparison`.
+  Update the docstring (renaming the test file itself is optional and higher-
+  churn — decide during execution).
+
+## Actions
+1. Update the log-hint string to the current script name.
+2. Update the test docstring (and decide whether to `git mv` the test file to
+   match — optional).
+3. Grep once more for both old basenames repo-wide to confirm nothing else
+   lingers.
+
+## Test
+Write first (red): a hygiene assertion (or a one-off grep in an existing
+adherence test) that neither `collect_syllabi` nor `compare_clustering` appears
+as a filename reference outside git history.
+
+## Verification
+- [ ] `grep -rn "compare_clustering\|collect_syllabi"` returns only intentional
+      history/this-ticket references.
+
+## Invariants
+- Cosmetic only — no behaviour change.
+
+## Exit criteria
+- No stale references to the pre-rename script names remain in code, config, or
+  docstrings.


### PR DESCRIPTION
Two follow-up tickets from the 0232 (repo ruff-clean) roar sweep. No code, tickets only.

- **0234** — `pytest` recurses into `.claude/worktrees/` (it doesn't honor `.gitignore`), inflating `make check` from the primary checkout and risking cross-worktree collection. Fix: add `norecursedirs`. This is the "tests are really slow" report from 2026-07-10.
- **0235** — cosmetic stale references to pre-rename script names (`collect_syllabi`, `compare_clustering`) in a log hint + a test docstring. The *functional* staleness (per-file-ignore facade exemptions) was already fixed in 0232.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)