### PR TITLE
fix(0234): prune .claude/worktrees from pytest collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,14 @@ dev = [
 # descend into libs/, so an unscoped root run never chokes on `import
 # openalex_corpus`. The host `make check`/`check-fast` still gate the package —
 # they collect it explicitly via the `check-package` target.
-norecursedirs = ["libs"]
+# Setting norecursedirs REPLACES pytest's built-in defaults, so we must
+# re-list them. The load-bearing pattern is `.*` — it excludes every dotdir,
+# including `.claude/worktrees/*/` where live worktrees hold their own copy of
+# tests/ (ticket 0234: a bare `["libs"]` dropped `.*`, so from the primary
+# checkout a tree-walking pytest collected every worktree's tests/, inflating
+# the run and surfacing cross-worktree failures). `libs` keeps an unscoped root
+# run from choking on the openalex_corpus import (see note above the section).
+norecursedirs = [".*", "build", "dist", "CVS", "_darcs", "node_modules", "venv", "*.egg", "libs"]
 markers = [
     "slow: network access, external/real data, a heavy numerical dependency (dcor/torch/ot/sentence_transformers), matplotlib rendering, or heavy compute (deselect with '-m \"not slow\"')",
     "integration: marks tests that spawn subprocesses or use sleep-based timing (deselect with '-m \"not integration\"')",

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1301,3 +1301,45 @@ class TestNoHalfFinishedWork:
                 if rx.search(line) and "noqa: hygiene" not in line:
                     offenders.append(f"{script}:{i}: {line.strip()}")
         assert not offenders, f"{name} found:\n  " + "\n  ".join(offenders)
+
+
+class TestPytestCollectionScope:
+    """pytest must not recurse into .claude/worktrees/ (ticket 0234).
+
+    `norecursedirs` REPLACES pytest's built-in defaults rather than
+    appending to them. A value of just ["libs"] therefore silently dropped
+    the default `.*` pattern that excludes dotdirs like `.claude`. From the
+    primary checkout that made a tree-walking `pytest` descend into every
+    live worktree's copy of tests/, inflating collection (duplicate test IDs)
+    and surfacing confusing cross-worktree failures.
+    """
+
+    @staticmethod
+    def _norecursedirs():
+        import tomllib
+
+        with open(os.path.join(REPO, "pyproject.toml"), "rb") as f:
+            cfg = tomllib.load(f)
+        return cfg["tool"]["pytest"]["ini_options"].get("norecursedirs", [])
+
+    def test_claude_worktrees_excluded(self):
+        """A norecursedirs pattern must match `.claude` so worktree copies of
+        tests/ are never collected from the primary checkout."""
+        import fnmatch
+
+        patterns = self._norecursedirs()
+        assert any(fnmatch.fnmatch(".claude", p) for p in patterns), (
+            f"norecursedirs={patterns} does not exclude .claude — pytest will "
+            "recurse into .claude/worktrees/*/tests/ from the primary checkout"
+        )
+
+    def test_libs_still_excluded(self):
+        """The pre-existing libs exclusion must be preserved (an unscoped root
+        `pytest` must not choke on libs/openalex-corpus)."""
+        import fnmatch
+
+        patterns = self._norecursedirs()
+        assert any(fnmatch.fnmatch("libs", p) for p in patterns), (
+            f"norecursedirs={patterns} no longer excludes libs — an unscoped "
+            "root pytest run will choke on the openalex_corpus import"
+        )

--- a/tickets/closed/0234-pytest-norecursedirs-worktrees.erg
+++ b/tickets/closed/0234-pytest-norecursedirs-worktrees.erg
@@ -2,10 +2,12 @@
 Title: pytest recurses into .claude/worktrees/ — exclude via norecursedirs
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #998
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T15:09Z HDMX-coding-agent closed — autoclosed — PR #998
 --- body ---
 ## Context
 `pytest` does not honour `.gitignore`, so from the primary checkout `make check`


### PR DESCRIPTION
## Summary
`norecursedirs = ["libs"]` replaced pytest's built-in defaults instead of appending, dropping the `.*` pattern that excludes dotdirs. From the primary checkout a tree-walking `pytest` then descended into every live `.claude/worktrees/*/tests/`, inflating collection with duplicate test IDs (the "tests are slow" report of 2026-07-10) and surfacing cross-worktree failures.

## Fix
Re-list pytest's defaults (`.*`, `build`, `dist`, `CVS`, `_darcs`, `node_modules`, `venv`, `*.egg`) alongside `libs`. `.*` covers `.claude`, `.venv`, `.git` in one pattern.

## Test
`TestPytestCollectionScope` (adherence) pins both invariants via fnmatch: `.claude` is excluded and `libs` stays excluded. Verified `pytest --collect-only .claude` now collects 0 items.

**Ticket:** tickets/0234-pytest-norecursedirs-worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)