### PR TITLE
fix(0235): purge stale references to renamed scripts

### DIFF
--- a/scripts/plot_fig_clustering_spaces.py
+++ b/scripts/plot_fig_clustering_spaces.py
@@ -103,7 +103,7 @@ def main():
     input_path = io_args.input[0] if io_args.input else os.path.join(TABLES_DIR, "clustering_multi_space.json")
     if not os.path.exists(input_path):
         log.error("Input file not found: %s", input_path)
-        log.error("Run compare_clustering.py first to generate it.")
+        log.error("Run compute_clustering_comparison.py first to generate it.")
         raise SystemExit(1)
 
     with open(input_path) as f:

--- a/tests/test_compute_clustering_comparison.py
+++ b/tests/test_compute_clustering_comparison.py
@@ -1,4 +1,4 @@
-"""Tests for compare_clustering.py — clustering methods comparison.
+"""Tests for compute_clustering_comparison.py — clustering methods comparison.
 
 Ticket: #299 (tracking), sub-issues #300–#304.
 Tests clustering method implementations and comparison framework.

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -1301,3 +1301,41 @@ class TestNoHalfFinishedWork:
                 if rx.search(line) and "noqa: hygiene" not in line:
                     offenders.append(f"{script}:{i}: {line.strip()}")
         assert not offenders, f"{name} found:\n  " + "\n  ".join(offenders)
+
+
+class TestNoStaleRenamedScriptRefs:
+    """Renamed scripts must not be referenced by their old basenames (0235).
+
+    collect_syllabi.py  -> catalog_syllabi.py
+    compare_clustering.py -> compute_clustering_comparison.py
+
+    A lingering old name in a log hint or docstring sends a reader (or a
+    future grep) to a script that no longer exists. Git history is exempt —
+    this scans only live code under scripts/ and tests/.
+    """
+
+    OLD_NAMES = ("collect_syllabi", "compare_clustering")
+
+    def test_no_old_script_basenames_in_code(self):
+        offenders = []
+        for name in _all_scripts():
+            src = _read_script(name)
+            for old in self.OLD_NAMES:
+                if old in src:
+                    offenders.append(f"scripts/{name}: {old}")
+        # tests/ — exclude this guard file itself, which names the old
+        # basenames as data (its OLD_NAMES list would otherwise self-match).
+        self_name = os.path.basename(__file__)
+        for fname in sorted(os.listdir(TESTS_DIR)):
+            if not fname.endswith(".py") or fname == self_name:
+                continue
+            with open(os.path.join(TESTS_DIR, fname)) as f:
+                src = f.read()
+            for old in self.OLD_NAMES:
+                if old in src:
+                    offenders.append(f"tests/{fname}: {old}")
+        assert not offenders, (
+            "Stale references to pre-rename script basenames "
+            "(update the reference, or move it to git history):\n  "
+            + "\n  ".join(offenders)
+        )

--- a/tickets/closed/0235-stale-renamed-script-references.erg
+++ b/tickets/closed/0235-stale-renamed-script-references.erg
@@ -2,10 +2,12 @@
 Title: Fix stale references to renamed scripts (collect_syllabi, compare_clustering)
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #999
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T15:13Z HDMX-coding-agent closed — autoclosed — PR #999
 --- body ---
 ## Context
 Two scripts were renamed at some point — `collect_syllabi.py` →


### PR DESCRIPTION
## Summary
Two scripts were renamed but a few references still named the old files. The functional cases (stale `per-file-ignores`) were fixed in 0232; these are the remaining cosmetic ones, left out so 0232 stayed atomic.

- `collect_syllabi.py` → `catalog_syllabi.py`
- `compare_clustering.py` → `compute_clustering_comparison.py`

## Changes
- `plot_fig_clustering_spaces.py`: the "Input file not found" log hint named `compare_clustering.py`; the actual producer of `clustering_multi_space.json` is `compute_clustering_comparison.py` (verified at its line 305).
- `git mv` `test_compare_clustering.py` → `test_compute_clustering_comparison.py` and fixed its module docstring — the filename itself was a stale reference, and nothing imports it by name.
- `TestNoStaleRenamedScriptRefs` (adherence) pins the invariant: neither old basename may appear in live code under scripts/ or tests/ (git history and the guard's own `OLD_NAMES` data are exempt).

## Verification
- Red→green: guard failed on exactly the two known offenders, passes after the fix.
- Renamed test file still collects and passes (17 tests).
- `grep -rn "compare_clustering\|collect_syllabi"` over scripts/tests/config/Makefile/pyproject returns nothing outside the guard's data.

**Ticket:** tickets/0235-stale-renamed-script-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)