### PR TITLE
ticket(0236): resolve ruff/mypy via shutil.which in hygiene tests

### DIFF
--- a/tests/test_ruff.py
+++ b/tests/test_ruff.py
@@ -37,3 +37,30 @@ def test_ruff_clean():
     assert result.returncode == 0, (
         "ruff reported lint violations:\n" + result.stdout + result.stderr
     )
+
+
+def test_hygiene_tool_probes_use_shutil_which():
+    """The adherence hygiene tests must resolve ruff/mypy via ``shutil.which``.
+
+    Ticket 0236: ``tests/test_script_hygiene.py`` used to gate its ruff and mypy
+    tests on module-level ``subprocess.run(["uv", "run", <tool>, "--version"])``
+    probes evaluated at collection time. A nested ``uv run`` re-enters uv from
+    inside the venv pytest already runs in, spawning a per-call sync check that
+    misbehaves under ``UV_NO_SYNC`` in a clean CI/cloud container. Resolve the
+    binary with ``shutil.which`` instead, matching ``test_ruff_clean`` above.
+
+    Checked from this sibling module (not in-file) so the test's own search
+    tokens cannot self-match the source it inspects.
+    """
+    hygiene_src = (REPO_ROOT / "tests" / "test_script_hygiene.py").read_text()
+    normalized = "".join(hygiene_src.split())
+    assert '"uv","run"' not in normalized, (
+        "nested `uv run` tool invocation remains in test_script_hygiene.py; "
+        "resolve ruff/mypy binaries via shutil.which instead (ticket 0236)"
+    )
+    assert 'shutil.which("ruff")' in hygiene_src, (
+        "ruff availability must resolve via shutil.which (ticket 0236)"
+    )
+    assert 'shutil.which("mypy")' in hygiene_src, (
+        "mypy availability must resolve via shutil.which (ticket 0236)"
+    )

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -20,6 +20,7 @@ Uses existing code checkers where available:
 import ast
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -121,10 +122,13 @@ _SYSPATH_EXEMPT = {
     )
 }
 
-_RUFF_AVAILABLE = (
-    subprocess.run(["uv", "run", "ruff", "--version"], capture_output=True).returncode
-    == 0
-)
+# Resolve the tool binary via shutil.which, not a nested `uv run` (ticket 0236):
+# pytest already runs inside the project venv under `make lint`, so a declared,
+# lockfile-pinned tool is on PATH. A nested `uv run` re-enters uv from inside uv,
+# forcing a per-call sync check that breaks under `UV_NO_SYNC` in a clean
+# CI/cloud container. Mirrors the pattern in test_ruff.py.
+_RUFF = shutil.which("ruff")
+_RUFF_AVAILABLE = _RUFF is not None
 
 
 # ---------------------------------------------------------------------------
@@ -249,9 +253,7 @@ class TestRuffModernPython:
         """No legacy typing imports (List, Dict, Tuple, Optional, Union)."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "UP006,UP007,UP035",
@@ -304,9 +306,7 @@ class TestFunctionComplexity:
         """No function exceeds McCabe complexity 25 (C901 wall)."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "C901",
@@ -329,9 +329,7 @@ class TestFunctionComplexity:
         """No function exceeds 120 statements (PLR0915 wall)."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "PLR0915",
@@ -355,9 +353,7 @@ class TestFunctionComplexity:
         """No function exceeds 25 branches (PLR0912 wall)."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "PLR0912",
@@ -382,9 +378,7 @@ class TestFunctionComplexity:
         """Warn when functions exceed McCabe complexity 15."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "C901",
@@ -408,9 +402,7 @@ class TestFunctionComplexity:
         """Warn when functions exceed 80 statements."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "PLR0915",
@@ -434,9 +426,7 @@ class TestFunctionComplexity:
         """Warn when functions exceed 15 branches."""
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "ruff",
+                _RUFF,
                 "check",
                 "--select",
                 "PLR0912",
@@ -719,10 +709,8 @@ class TestNoBarePrint:
 # Type annotations on core modules (mypy)
 # ---------------------------------------------------------------------------
 
-_MYPY_AVAILABLE = (
-    subprocess.run(["uv", "run", "mypy", "--version"], capture_output=True).returncode
-    == 0
-)
+_MYPY = shutil.which("mypy")
+_MYPY_AVAILABLE = _MYPY is not None
 
 
 class TestTypingCoreModules:
@@ -746,9 +734,7 @@ class TestTypingCoreModules:
         paths = [os.path.join(SCRIPTS_DIR, m) for m in self.TYPED_MODULES]
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "mypy",
+                _MYPY,
                 "--ignore-missing-imports",
                 "--disallow-untyped-defs",
                 "--follow-imports=silent",

--- a/tickets/closed/0236-shutil-which-tool-checks.erg
+++ b/tickets/closed/0236-shutil-which-tool-checks.erg
@@ -2,10 +2,12 @@
 Title: Migrate nested `uv run <tool>` availability checks to shutil.which
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: done
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-10T15:01Z HDMX-coding-agent closed — done
 --- body ---
 ## Context
 `tests/test_script_hygiene.py` gates its ruff and mypy hygiene tests on


### PR DESCRIPTION
## Summary
`tests/test_script_hygiene.py` gated its ruff and mypy adherence tests on module-level `subprocess.run(["uv", "run", <tool>, "--version"])` probes evaluated at **collection time**, and invoked the tools via nested `uv run` in their bodies. A nested `uv run` re-enters uv from inside the venv pytest already runs in under `make lint`, spawning a per-call sync check that misbehaves under `UV_NO_SYNC` in a clean CI/cloud container.

This migrates both probes and all invocation sites to resolve the binary once via `shutil.which`, matching the pattern established in `tests/test_ruff.py` (ticket 0230). No nested `uv run` remains for ruff/mypy — at collection or execution time.

## Changes
- `tests/test_script_hygiene.py`: `_RUFF = shutil.which("ruff")` / `_MYPY = shutil.which("mypy")`; `_*_AVAILABLE` derived from them; every ruff/mypy body invokes the resolved binary path.
- `tests/test_ruff.py`: new adherence guard `test_hygiene_tool_probes_use_shutil_which` — inspects `test_script_hygiene.py` from this sibling module (so its search tokens cannot self-match) and asserts no nested uv-run tool invocation remains and both gates resolve via `shutil.which`.

## Invariant preserved
Test selection is unchanged — the `skipif` gates stay, now keyed on whether `shutil.which` found the binary.

## Verification
- [x] `make lint` green (120 passed, 3 skipped).
- [x] No `subprocess.run(["uv", "run", ...])` remains for tool availability in the adherence tests.
- [x] Pre-PR `/verify-adherence` self-gate: **PASS** (mechanical, test-only diff; semantic phase not triggered).

## Ticket
Ticket 0236 is already closed and archived within this branch (commit closing+moving `tickets/0236-shutil-which-tool-checks.erg` → `tickets/closed/`). Nothing remains for the merge to close.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)