### PR TITLE
ticket(0237): Phase-3 render as per-deliverable .mk (file under 0221)

### DIFF
--- a/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
+++ b/tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
@@ -8,6 +8,8 @@ Author: HDMX-coding-agent
 2026-07-10T10:00Z note 0222 landed: communities.csv evicted to data/derived/, and the phase-layout guard generalized from a two-basename whitelist to a producer-phase CLASS rule (any Phase-2-produced Make target under data/catalogs/ now fails without editing the test; consumer-side CATALOGS_DIR reads of derived outputs also caught). data/het/ + data/run_reports/ classified in the architecture.md tree. Remaining before this tracker closes: 0218 (content/tables residual + pole-papers fallback).
 2026-07-10T09:46Z note /roar sweep after 0222 filed child 0227: the class guard has two blind spots — it only sees Makefile-wired targets, and it keys phase off filename prefix (which has exceptions: compute_reranker_calibration is Phase-1, qa_embeddings/qa_detect_type are Phase-2). No active leak; low-priority hardening. Tracker now waits on 0218 + 0227.
 
+2026-07-10T15:20Z HDMX-coding-agent note 0231 confirmation session surfaced the BUILD logic's biggest gap: `make papers` is not Phase-3 (starts with check-corpus, companion PDF rules depend on Phase-2 figures scattered into the analysis .mk). Filed child 0237 to make Phase-3 a per-deliverable .mk (manuscript.mk is the reference) and split include sets. Blocked-by 0226 so each render .mk lands beside its _quarto.yml.
+
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T09:50Z note audit 2026-07-10: code+prose axis of this reorg is tracked separately by 0223 (children 0225 code, 0226 prose); 0224 closed as duplicate of this tracker's data-layout scope (0218/0222). 0223's src/ + deliverables/ proposals depart from architecture.md and need author ratification before Execute
 2026-07-10T10:11Z HDMX-coding-agent unlabel deferred
@@ -61,6 +63,10 @@ Open:
   `CATALOGS_DIR`.
 - **0222** — complete the `data/catalogs/` eviction (`communities.csv` + sweep) and
   generalize the per-file guard to the class (see Remaining).
+- **0237** — **build logic**: make Phase-3 render a per-deliverable `.mk` (one per
+  paper/slide, `manuscript.mk` as template); un-scatter the companion PDF rules out
+  of the analysis concern `.mk`; split the include sets so `make papers` is Phase-3
+  (no `check-corpus`, no `uv run`). Blocked-by 0226 (co-locate with each `_quarto.yml`).
 
 ## Remaining (the incompleteness this tracker exists to close)
 

--- a/tickets/0237-phase3-deliverable-mk-split.erg
+++ b/tickets/0237-phase3-deliverable-mk-split.erg
@@ -1,0 +1,132 @@
+%erg 0.1
+Title: Phase-3 render as per-deliverable .mk — un-scatter PDF rules, split render from compute
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0226
+
+--- log ---
+2026-07-10T15:20Z HDMX-coding-agent created
+2026-07-10T15:20Z note spun out of the 0231 confirmation session (2026-07-10). `make papers` is not a Phase-3 build: it starts with `check-corpus` and each companion PDF rule depends on Phase-2 outputs (figures/tables), so asking for a PDF drags in the whole analysis. Demonstrated twice live: `make papers` died on a missing Phase-1 `citations.csv`, then on `import umap` in a Phase-2 clustering step — neither should touch a render. `manuscript.mk` already proves the target shape (3 render rules, 0 Phase-2 rules). Blocked-by 0226 so each deliverable's `_quarto.yml` home is settled before the render `.mk` moves beside it.
+
+--- body ---
+## Context
+
+Spun out of the 0231 confirmation session (2026-07-10). The author's mental model
+is that `make papers` should be a **Phase-3 build** — render the companion PDFs
+from handoff artifacts, no corpus, no `uv run`, no analysis. It is not.
+
+- `make manuscript` (Makefile:667) already IS Phase-3: it depends only on the
+  rendered PDF/DOCX, built by `manuscript.mk` from `$(MANUSCRIPT_INPUTS)` — a
+  per-deliverable render `.mk` with **3 render rules and 0 Phase-2 rules**. This is
+  the reference implementation.
+- `make papers` (Makefile:669) is not: it opens with `check-corpus` (asserts the
+  322 MB corpus contract) and each companion PDF rule depends on Phase-2 outputs
+  (e.g. `zoo.mk:153` → `$(ZOO_FIGS)`), which chain back through the derived tables
+  to the corpus. So a "render" request regenerates the analysis.
+
+The entanglement is a live defect, demonstrated twice this session: `make papers`
+died first on a missing Phase-1 `data/catalogs/citations.csv`, then on
+`ModuleNotFoundError: umap` inside `analyze_embeddings.py` (a Phase-2 clustering
+step). A Phase-3 render should never need the corpus, a GPU, or `umap`.
+
+Root cause: **the render rules (Phase 3) are scattered into the analysis `.mk`
+files (Phase 2), so render and compute share a file and a dependency edge.** The
+decomposition axis is wrong for Phase 3: analysis is organized by *concern*
+(`divergence.mk`, `zoo.mk`, …); a paper draws from several concerns and has no
+single owning concern file, so its render rule ends up wherever it was convenient.
+
+## The decision — decompose Phase 3 by deliverable, split the build by phase
+
+This is the build half of tracker 0221 (layout mirrors dataflow phase) and the
+build companion to 0226 (deliverables/<x>/ per-paper Quarto projects). Settled in
+the 2026-07-10 discussion (author = MOA):
+
+1. **One Phase-3 render `.mk` per deliverable** (each paper AND each slide deck),
+   living beside its `_quarto.yml` under `deliverables/<x>/` (0226). It owns the
+   PDF/DOCX render rule(s) and nothing else. `manuscript.mk` is the template.
+2. **Analysis concern `.mk` stay pure Phase-2** — produce `data/derived/`,
+   `content/figures/`, `content/tables/*.md`, `content/*-vars.yml`. No render rules.
+3. **Split the include sets by phase.** The writing-side build (`make papers` /
+   `make manuscript` / `make slides`) `-include`s only the deliverable `.mk` and
+   renders from artifacts on disk — no `check-corpus`, no `uv run`. The
+   analysis-side build (`make analysis` / `make corpus`) `-include`s the concern
+   `.mk`. (This is `~/.claude/rules/git.md` § "Split the build by workpackage.")
+4. **Shared interface = a tiny `paths.mk`** defining the artifact locations
+   (`DERIVED`, `content/figures`, `content/tables`, the `*-vars.yml` names)
+   `-include`d by both sides, so render and compute agree on paths without either
+   triggering the other. 0231 already centralized the table half (`$(DERIVED)` /
+   `DERIVED_TABLES_DIR`).
+
+**Accepted trade-off (Option A, hard split):** once render and compute are in
+separate include sets, `make papers` will NOT rebuild a stale figure — by design.
+The discipline becomes "run analysis, then render," the same contract the frozen
+manuscript already lives under (0163/0207). This preserves the live-vs-frozen
+distinction (project memory `frozen_manuscript_vs_live_companions`): a companion is
+frozen into committed artifacts only at submission, on its submission branch.
+
+## Relevant files
+
+- `manuscript.mk` — REFERENCE implementation (per-deliverable Phase-3 `.mk`).
+- Render rules to extract (the scatter inventory, 2026-07-10):
+  - `Makefile:682` — `output/content/corpus-report.pdf`
+  - `Makefile:685` — `output/content/technical-report.pdf`
+  - `Makefile:688` — `output/content/data-paper.pdf`
+  - `Makefile:691` — `output/content/multilayer-detection.pdf`
+  - `zoo.mk:153` — `output/content/breakpoint-detect-method-zoo.pdf` (1 render rule
+    buried among 13 Phase-2 rules)
+  - `multilayer-detection.mk:98` — `output/content/multilayer-detection-techrep.pdf`
+    (1 render rule among 7 Phase-2 rules)
+- `Makefile:669` (`papers:` target, drop `check-corpus`), `Makefile:335`
+  (`check-corpus`), the `-include` block (Makefile:83-88).
+- `divergence.mk`, `zoo.mk`, `multilayer-detection.mk`, `venues.mk` — become
+  pure Phase-2 after their render rules are extracted.
+
+## Actions
+
+1. Create a per-deliverable render `.mk` for each companion (co-located with its
+   `_quarto.yml` per 0226): corpus-report, technical-report, data-paper,
+   multilayer-detection, breakpoint-detect-method-zoo, multilayer-detection-techrep.
+   Move the render rule verbatim; its Phase-2 prerequisites become artifact-file
+   dependencies satisfied by a prior `make analysis`, not targets the render build
+   knows how to rebuild.
+2. Extract `DERIVED`, `content/figures`, `content/tables`, vars-file names into
+   `paths.mk`; `-include` it from both the analysis and writing sides.
+3. Re-cut the top-level include block: `make papers`/`manuscript`/`slides`
+   `-include` only deliverable `.mk`; `make analysis`/`corpus` `-include` concern
+   `.mk`. Drop `check-corpus` from the `papers` prerequisite list.
+4. Any slide decks get the same per-deliverable render `.mk` treatment.
+
+## Test
+
+First (RED): a phase-purity guard in `tests/test_phase_layout.py` (or a new
+`tests/test_build_phase_separation.py`) — **no `.mk` file may contain BOTH a
+`output/content/*.pdf` render target AND a Phase-2 compute target** (a
+`$(...)/tab_*.csv:` or `content/figures/fig_*.png:` rule). RED now on `zoo.mk` and
+`multilayer-detection.mk`; GREEN once render rules are extracted to deliverable
+`.mk`. Mutation-proof by fabricating a mixed rule.
+
+## Verification
+
+- [ ] `grep -c '\.pdf:' <concern>.mk` == 0 for divergence/zoo/multilayer/venues.
+- [ ] With all handoff artifacts present, `make -n papers` emits **no** `uv run`
+      and does not invoke `check-corpus` — proof it is Phase-3-only.
+- [ ] `make papers` on a checkout with artifacts present but NO corpus succeeds
+      (the clean-room property `make manuscript` already has).
+- [ ] `make analysis` still regenerates every artifact from the corpus.
+
+## Invariants
+
+- The six companion PDFs + the manuscript still build (given artifacts / corpus).
+- No Phase-1 trigger from any writing-side target. DVC untouched.
+- Live-vs-frozen distinction preserved: companions regenerate from data via
+  `make analysis`; freezing happens only at submission.
+
+## Exit criteria
+
+- Each deliverable (paper + slide) has its own Phase-3 render `.mk`; concern `.mk`
+  hold zero render rules; the four inline PDF rules leave the top-level Makefile.
+- `make papers` is Phase-3: no `check-corpus`, no `uv run`, renders from artifacts.
+- Phase-purity guard is GREEN and has teeth.
+
+Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg
+Ticket-ref: tickets/0226-reorg-prose.erg


### PR DESCRIPTION
Files ticket **0237** under tracker **0221** (build logic) and registers it in the
tracker's children. **This PR creates a ticket — it closes nothing.**

## Why
`make papers` is not a Phase-3 build. It opens with `check-corpus` and each
companion PDF rule depends on Phase-2 figures **scattered into the analysis `.mk`**
(`zoo.mk:153` = 1 render rule among 13 compute rules; `multilayer-detection.mk:98`;
plus 4 inline PDF rules in the top-level Makefile). So a "render" regenerates the
analysis. Demonstrated live during the 0231 confirmation: `make papers` died first
on a missing Phase-1 `citations.csv`, then on `import umap` in a Phase-2 clustering
step — neither should touch a render.

`manuscript.mk` already proves the target shape: **3 render rules, 0 Phase-2 rules**.

## What 0237 proposes
- One Phase-3 render `.mk` **per deliverable** (paper + slide), beside its
  `_quarto.yml` (0226). Concern `.mk` (divergence/zoo/multilayer/venues) stay pure
  Phase-2.
- Split include sets: writing-side build renders from artifacts (no `check-corpus`,
  no `uv run`); analysis-side regenerates from corpus.
- Shared `paths.mk` interface (0231 already centralized the table half).
- Accepted trade-off (hard split): `make papers` won't rebuild a stale figure —
  "run analysis, then render", the contract the frozen manuscript already lives under.

First test spec: a phase-purity guard — no `.mk` holds both a PDF render target and
a Phase-2 compute target (RED now on zoo/multilayer).

Blocked-by 0226 (per-paper `_quarto.yml` homes must land first).

Ticket-ref: tickets/0237-phase3-deliverable-mk-split.erg
Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg