### PR TITLE
build(0237): Phase-3 render as per-deliverable .mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -556,24 +556,13 @@ manuscript-figures: figures-manuscript
 datapaper-render: deliverables/data-paper/data-paper.pdf
 datapaper-figures: figures-datapaper
 
-# The manuscript render rules live in deliverables/manuscript/manuscript.mk
-# (Phase 3 writing workpackage, -include'd above). They depend only on committed
-# handoff artifacts so the manuscript builds clean-room with no data — ticket 0131.
-# Each deliverable's PDF is rendered NEXT TO its source (quarto's single-file
-# render ignores a project output-dir), so the Make target IS the output file and
-# Make verifies it exists (ticket 0226).
-
-deliverables/corpus-report/corpus-report.pdf: deliverables/corpus-report/corpus-report.qmd $(PROJECT_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml
-	quarto render $< --to pdf
-
-deliverables/technical-report/technical-report.pdf: deliverables/technical-report/technical-report.qmd $(PROJECT_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml $(TECHREP_FIGS) $(MULTILAYER_FIGS) .lexical_tfidf.stamp
-	quarto render $< --to pdf
-
-deliverables/data-paper/data-paper.pdf: deliverables/data-paper/data-paper.qmd $(PROJECT_INCLUDES) $(BIB) deliverables/data-paper/data-paper-vars.yml
-	quarto render $< --to pdf
-
-deliverables/multilayer/multilayer-detection.pdf: deliverables/multilayer/multilayer-detection.qmd $(PROJECT_INCLUDES) $(BIB) deliverables/multilayer/multilayer-detection-vars.yml
-	quarto render $< --to pdf
+# Each deliverable owns a Phase-3 render .mk beside its source under
+# deliverables/<x>/ (ticket 0237). The `manuscript` and `papers` targets above
+# invoke them via `$(MAKE) -f`, so no render rule lives in this Phase-2 Makefile.
+# Each render .mk depends only on committed/handoff artifacts, so a deliverable
+# builds clean-room with no corpus data. Quarto's single-file render writes the
+# PDF NEXT TO its source (it ignores a project output-dir), so the Make target IS
+# the output file and Make verifies it exists (tickets 0131, 0226, 0237).
 
 # ── Phase 4a — analysis archive (packages Phase 2 outputs) ─
 # Data + scripts: reviewers verify figures/tables are reproducible.

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ NCC_FIGS        := deliverables/_shared/figures/fig_ncc_divergence.png \
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-package check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
+.PHONY: all setup manuscript papers corpus-report technical-report data-paper multilayer-detection multilayer-techrep zoo figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-package check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
 
 .DEFAULT_GOAL := manuscript
 
@@ -545,24 +545,45 @@ analysis-stats: stats
 # PHASE 3 — Render (Quarto → PDF/DOCX)
 # ═══════════════════════════════════════════════════════════
 
-manuscript: deliverables/manuscript/manuscript.pdf deliverables/manuscript/manuscript.docx
+# Each deliverable owns a Phase-3 render .mk beside its source under
+# deliverables/<x>/ (ticket 0237). `manuscript` and `papers` invoke them via
+# `$(MAKE) -f` — a separate make process that parses only the render .mk (+
+# paths.mk), never these Phase-2 rules. So `papers` is Phase-3 only: no
+# check-corpus, no uv run, rendering from artifacts a prior `make analysis` left
+# on disk. Each render .mk depends only on committed/handoff artifacts, so a
+# deliverable builds clean-room with no corpus data. Quarto's single-file render
+# writes the PDF NEXT TO its source (it ignores a project output-dir), so the
+# Make target IS the output file and Make verifies it (tickets 0131, 0226, 0237).
 
-papers: check-corpus deliverables/corpus-report/corpus-report.pdf deliverables/technical-report/technical-report.pdf deliverables/zoo/breakpoint-detect-method-zoo.pdf deliverables/data-paper/data-paper.pdf deliverables/multilayer/multilayer-detection.pdf deliverables/multilayer/multilayer-detection-techrep.pdf
+manuscript:
+	$(MAKE) -f deliverables/manuscript/manuscript.mk deliverables/manuscript/manuscript.pdf deliverables/manuscript/manuscript.docx
+
+papers: corpus-report technical-report data-paper multilayer-detection multilayer-techrep zoo
+
+corpus-report:
+	$(MAKE) -f deliverables/corpus-report/corpus-report.mk deliverables/corpus-report/corpus-report.pdf
+
+technical-report:
+	$(MAKE) -f deliverables/technical-report/technical-report.mk deliverables/technical-report/technical-report.pdf
+
+data-paper:
+	$(MAKE) -f deliverables/data-paper/data-paper.mk deliverables/data-paper/data-paper.pdf
+
+multilayer-detection:
+	$(MAKE) -f deliverables/multilayer/multilayer.mk deliverables/multilayer/multilayer-detection.pdf
+
+multilayer-techrep:
+	$(MAKE) -f deliverables/multilayer/multilayer.mk deliverables/multilayer/multilayer-detection-techrep.pdf
+
+zoo:
+	$(MAKE) -f deliverables/zoo/zoo.mk deliverables/zoo/breakpoint-detect-method-zoo.pdf
 
 # ── Namespaced aliases (Phase 3) ────────────────────────
 manuscript-render: manuscript
 manuscript-figures: figures-manuscript
 
-datapaper-render: deliverables/data-paper/data-paper.pdf
+datapaper-render: data-paper
 datapaper-figures: figures-datapaper
-
-# Each deliverable owns a Phase-3 render .mk beside its source under
-# deliverables/<x>/ (ticket 0237). The `manuscript` and `papers` targets above
-# invoke them via `$(MAKE) -f`, so no render rule lives in this Phase-2 Makefile.
-# Each render .mk depends only on committed/handoff artifacts, so a deliverable
-# builds clean-room with no corpus data. Quarto's single-file render writes the
-# PDF NEXT TO its source (it ignores a project output-dir), so the Make target IS
-# the output file and Make verifies it exists (tickets 0131, 0226, 0237).
 
 # ── Phase 4a — analysis archive (packages Phase 2 outputs) ─
 # Data + scripts: reviewers verify figures/tables are reproducible.
@@ -586,7 +607,7 @@ archive-analysis: check-manuscript-data $(ANALYSIS_OUTPUTS)
 # No Python needed — only Quarto + XeLaTeX.
 #   tar xzf archive.tar.gz && cd ... && make
 
-archive-manuscript: $(MANUSCRIPT_FIGS) $(MANUSCRIPT_INCLUDES) deliverables/manuscript/manuscript-vars.yml deliverables/manuscript/manuscript.pdf
+archive-manuscript: $(MANUSCRIPT_FIGS) $(MANUSCRIPT_INCLUDES) deliverables/manuscript/manuscript-vars.yml manuscript
 	bash build/build_manuscript_archive.sh
 
 # ── Phase 4c — data paper archive (full pipeline) ─────────

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,21 @@
 #   make clean              Remove build outputs
 #   make rebuild            Clean + rebuild everything
 
+# ── Shared artifact-location interface (ticket 0237) ──────
+# paths.mk holds the variable definitions (DERIVED, BIB, CSL, the per-doc
+# *_INCLUDES and *_FIGS lists) shared between the analysis-side build (concern
+# .mk at root) and the writing-side build (per-deliverable render .mk under
+# deliverables/<x>/). Included FIRST so immediate (:=) uses below resolve.
+-include paths.mk
+
 # ── Paths ─────────────────────────────────────────────────
 # data/ is split by dataflow phase (see .claude/rules/architecture.md § Data location):
 #   data/catalogs/ (+ pool/ exports/ syllabi/) = Phase-1 corpus, DVC-managed.
 #   data/derived/  = Phase-2 derived data, gitignored + regenerable.
 # Python scripts resolve the same paths via utils.py (CATALOGS_DIR / DERIVED_TABLES_DIR).
+# DERIVED, BIB, CSL now live in paths.mk (shared with the render workpackages).
 DATA_DIR     := data/catalogs
-DERIVED      := data/derived/tables
 CONFIG       := config/analysis.yaml
-BIB         := deliverables/_shared/bibliography/main.bib
-CSL         := deliverables/_shared/bibliography/oeconomia.csl
 SRC         := deliverables/manuscript/manuscript.qmd
 
 # Phase 1 artifact chain (the contract between phases)
@@ -79,152 +84,28 @@ ifneq ($(UV_PROJECT_ENVIRONMENT),)
 export UV_PROJECT_ENVIRONMENT
 endif
 
-# ── Modular Makefile includes ────────────────────────────
+# ── Modular Makefile includes (Phase-2 concern .mk only) ─────
+# The per-deliverable render .mk (Phase 3) are NOT included here: `make papers`
+# calls them via `$(MAKE) -f deliverables/<x>/<x>.mk` so the render process never
+# parses these Phase-2 rules (ticket 0237).
 -include divergence.mk
 -include multilayer-detection.mk
 -include zoo.mk
 -include venues.mk
 -include separation.mk
--include deliverables/manuscript/manuscript.mk
 
 # ── Quarto ───────────────────────────────────────────────
-# ── Per-document include sets ────────────────────────────
-MANUSCRIPT_INCLUDES := deliverables/_shared/tables/tab_venues.md
-
-TECHREP_INCLUDES := deliverables/_shared/_includes/corpus-construction.md \
-		deliverables/_shared/_includes/corpus-enrichment.md \
-		deliverables/_shared/_includes/corpus-filtering.md \
-		deliverables/_shared/_includes/core-vs-full.md \
-		deliverables/_shared/_includes/structural-breaks.md \
-		deliverables/_shared/_includes/alluvial-diagram.md \
-		deliverables/_shared/_includes/bimodality-analysis.md \
-		deliverables/_shared/_includes/pca-scatter.md \
-		deliverables/_shared/_includes/citation-genealogy.md \
-		deliverables/_shared/_includes/cocitation-communities.md \
-		deliverables/_shared/_includes/citation-quality.md \
-		deliverables/_shared/_includes/reproducibility.md \
-		deliverables/_shared/tables/tab_citation_coverage.md
-
-DATAPAPER_INCLUDES := deliverables/_shared/_includes/corpus-construction.md \
-		deliverables/_shared/_includes/corpus-filtering.md \
-		deliverables/_shared/_includes/embedding-generation.md \
-		deliverables/_shared/_includes/reproducibility.md \
-		deliverables/_shared/tables/tab_corpus_sources.md \
-		deliverables/_shared/tables/tab_languages.md
-
-MULTILAYER_INCLUDES := deliverables/_shared/_includes/embedding-generation.md \
-		deliverables/_shared/_includes/structural-breaks.md \
-		deliverables/_shared/_includes/alluvial-diagram.md \
-		deliverables/_shared/_includes/bimodality-analysis.md \
-		deliverables/_shared/_includes/pca-scatter.md \
-		deliverables/_shared/_includes/core-vs-full.md
-
-# Method-zoo include tree: one composer + 18 per-method entries.
-# Used by breakpoint-detect-method-zoo.qmd and transitively by technical-report.qmd.
-ZOO_INCLUDES := deliverables/_shared/_includes/techrep/overview.md \
-		deliverables/_shared/_includes/techrep/zscore.md \
-		deliverables/_shared/_includes/techrep/null-model.md \
-		deliverables/_shared/_includes/techrep-zoo.md \
-		deliverables/_shared/_includes/zoo/S1_mmd.md \
-		deliverables/_shared/_includes/zoo/S2_energy.md \
-		deliverables/_shared/_includes/zoo/S3_sliced_wasserstein.md \
-		deliverables/_shared/_includes/zoo/S4_frechet.md \
-		deliverables/_shared/_includes/zoo/C2ST_embedding.md \
-		deliverables/_shared/_includes/zoo/L1_js.md \
-		deliverables/_shared/_includes/zoo/L2_ntr.md \
-		deliverables/_shared/_includes/zoo/L3_term_burst.md \
-		deliverables/_shared/_includes/zoo/C2ST_lexical.md \
-		deliverables/_shared/_includes/zoo/G1_pagerank.md \
-		deliverables/_shared/_includes/zoo/G2_spectral.md \
-		deliverables/_shared/_includes/zoo/G3_coupling_age.md \
-		deliverables/_shared/_includes/zoo/G4_cross_tradition.md \
-		deliverables/_shared/_includes/zoo/G5_pref_attachment.md \
-		deliverables/_shared/_includes/zoo/G6_entropy.md \
-		deliverables/_shared/_includes/zoo/G7_disruption.md \
-		deliverables/_shared/_includes/zoo/G8_betweenness.md \
-		deliverables/_shared/_includes/zoo/G9_community.md
-
-# Quarto resolves includes across ALL project files (_quarto.yml render list),
-# even when rendering a single document. Every render target needs the full set.
-PROJECT_INCLUDES := $(MANUSCRIPT_INCLUDES) $(TECHREP_INCLUDES) \
-		$(DATAPAPER_INCLUDES) $(MULTILAYER_INCLUDES) $(ZOO_INCLUDES)
-
-# ── Per-document figure sets ─────────────────────────────
-MANUSCRIPT_FIGS := deliverables/_shared/figures/fig_bars_v1.png deliverables/_shared/figures/fig_composition.png deliverables/_shared/figures/fig_breaks.png
-
-DATAPAPER_FIGS  := deliverables/_shared/figures/fig_bars.png deliverables/_shared/figures/fig_dag.png
-
-MULTILAYER_FIGS  := deliverables/_shared/figures/fig_breakpoints.png deliverables/_shared/figures/fig_alluvial.png \
-                   deliverables/_shared/figures/fig_breaks.png \
-                   deliverables/_shared/figures/fig_bimodality.png \
-                   deliverables/_shared/figures/fig_seed_axis_core.png deliverables/_shared/figures/fig_pca_scatter.png \
-                   deliverables/_shared/figures/fig_genealogy.png \
-                   deliverables/_shared/figures/fig_companion_zseries.png \
-                   deliverables/_shared/figures/fig_companion_heatmap.png \
-                   deliverables/_shared/figures/fig_companion_terms.png \
-                   deliverables/_shared/figures/fig_companion_community.png
-
-TECHREP_FIGS    := deliverables/_shared/figures/fig_alluvial_core.png \
-                   deliverables/_shared/figures/fig_bimodality_core.png \
-                   deliverables/_shared/figures/fig_bimodality_lexical_core.png \
-                   deliverables/_shared/figures/fig_bimodality_keywords_core.png \
-                   deliverables/_shared/figures/fig_bimodality_lexical.png \
-                   deliverables/_shared/figures/fig_bimodality_keywords.png \
-                   deliverables/_shared/figures/fig_kde.png \
-                   deliverables/_shared/figures/fig_traditions.png \
-                   deliverables/_shared/figures/fig_communities.png \
-                   deliverables/_shared/figures/fig_semantic.png \
-                   deliverables/_shared/figures/fig_semantic_lang.png \
-                   deliverables/_shared/figures/fig_semantic_period.png
+# The per-document include sets (*_INCLUDES) and figure sets (*_FIGS) live in
+# paths.mk, shared with the render workpackages. NCC_FIGS is analysis-only.
 
 NCC_FIGS        := deliverables/_shared/figures/fig_ncc_divergence.png \
                    deliverables/_shared/figures/fig_ncc_core_comparison.png \
                    deliverables/_shared/figures/fig_ncc_bimodality.png \
                    deliverables/_shared/figures/fig_ncc_alluvial.png
 
-# Method-zoo figures (17 schematics + 18 zoo result panels).
-# schematic_C2ST.png serves both C2ST_embedding and C2ST_lexical, hence 17 schematics for 18 methods.
-ZOO_SCHEMATICS := deliverables/_shared/figures/schematic_S1_mmd.png \
-                  deliverables/_shared/figures/schematic_S2_energy.png \
-                  deliverables/_shared/figures/schematic_S3_sliced_wasserstein.png \
-                  deliverables/_shared/figures/schematic_S4_frechet.png \
-                  deliverables/_shared/figures/schematic_C2ST.png \
-                  deliverables/_shared/figures/schematic_L1_js.png \
-                  deliverables/_shared/figures/schematic_L2_ntr.png \
-                  deliverables/_shared/figures/schematic_L3_burst.png \
-                  deliverables/_shared/figures/schematic_G1_pagerank.png \
-                  deliverables/_shared/figures/schematic_G2_spectral.png \
-                  deliverables/_shared/figures/schematic_G3_coupling_age.png \
-                  deliverables/_shared/figures/schematic_G4_cross_tradition.png \
-                  deliverables/_shared/figures/schematic_G5_pref_attachment.png \
-                  deliverables/_shared/figures/schematic_G6_entropy.png \
-                  deliverables/_shared/figures/schematic_G7_disruption.png \
-                  deliverables/_shared/figures/schematic_G8_betweenness.png \
-                  deliverables/_shared/figures/schematic_G9_community.png
-
-ZOO_RESULT_FIGS := deliverables/_shared/figures/fig_zoo_S1_MMD.png \
-                   deliverables/_shared/figures/fig_zoo_S2_energy.png \
-                   deliverables/_shared/figures/fig_zoo_S3_sliced_wasserstein.png \
-                   deliverables/_shared/figures/fig_zoo_S4_frechet.png \
-                   deliverables/_shared/figures/fig_zoo_C2ST_embedding.png \
-                   deliverables/_shared/figures/fig_zoo_C2ST_lexical.png \
-                   deliverables/_shared/figures/fig_zoo_L1.png \
-                   deliverables/_shared/figures/fig_zoo_L2.png \
-                   deliverables/_shared/figures/fig_zoo_L3.png \
-                   deliverables/_shared/figures/fig_zoo_G1_pagerank.png \
-                   deliverables/_shared/figures/fig_zoo_G2_spectral.png \
-                   deliverables/_shared/figures/fig_zoo_G3_coupling_age.png \
-                   deliverables/_shared/figures/fig_zoo_G4_cross_tradition.png \
-                   deliverables/_shared/figures/fig_zoo_G5_pref_attachment.png \
-                   deliverables/_shared/figures/fig_zoo_G6_entropy.png \
-                   deliverables/_shared/figures/fig_zoo_G7_disruption.png \
-                   deliverables/_shared/figures/fig_zoo_G8_betweenness.png \
-                   deliverables/_shared/figures/fig_zoo_G9_community.png
-
-ZOO_FIGS := $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
-
-# ZOO_FIGS deliberately excluded from ALL_FIGS / make figures: plot scripts not yet wired.
-# Add to ALL_FIGS when plot_schematic_*.py and plot_zoo_results.py have Makefile targets.
+# Zoo figures (ZOO_SCHEMATICS / ZOO_RESULT_FIGS, defined in paths.mk) are
+# deliberately excluded from ALL_FIGS / make figures: plot scripts not yet wired.
+# Add them to ALL_FIGS when plot_schematic_*.py and plot_zoo_results.py have targets.
 ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────

--- a/deliverables/corpus-report/corpus-report.mk
+++ b/deliverables/corpus-report/corpus-report.mk
@@ -1,0 +1,20 @@
+# corpus-report.mk — Phase 3 render workpackage for the corpus report.
+#
+# Render-only: produces deliverables/corpus-report/corpus-report.pdf from the
+# prose source, its includes, bibliography and vars — artifacts a prior
+# `make analysis` (Phase 2) put on disk. No uv, no corpus data, no compute rules.
+# Toolchain: Quarto + a LaTeX engine only.
+#
+#   make -f deliverables/corpus-report/corpus-report.mk deliverables/corpus-report/corpus-report.pdf
+#
+# Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
+# process never parses the root Phase-2 rules (ticket 0237). Quarto's single-file
+# render writes the PDF next to the source, so the Make target is that file.
+
+-include paths.mk
+
+deliverables/corpus-report/corpus-report.pdf: deliverables/corpus-report/corpus-report.qmd $(CORPUS_REPORT_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml
+	quarto render $< --to pdf
+
+.PHONY: corpus-report
+corpus-report: deliverables/corpus-report/corpus-report.pdf

--- a/deliverables/data-paper/data-paper.mk
+++ b/deliverables/data-paper/data-paper.mk
@@ -1,0 +1,19 @@
+# data-paper.mk — Phase 3 render workpackage for the RDJ4HSS data paper.
+#
+# Render-only: produces deliverables/data-paper/data-paper.pdf from handoff
+# artifacts on disk (includes, bibliography, vars) — produced by a prior
+# `make analysis` (Phase 2). No uv, no corpus data, no compute rules.
+# Toolchain: Quarto + a LaTeX engine only.
+#
+#   make -f deliverables/data-paper/data-paper.mk deliverables/data-paper/data-paper.pdf
+#
+# Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
+# process never parses the root Phase-2 rules (ticket 0237).
+
+-include paths.mk
+
+deliverables/data-paper/data-paper.pdf: deliverables/data-paper/data-paper.qmd $(DATAPAPER_INCLUDES) $(BIB) deliverables/data-paper/data-paper-vars.yml
+	quarto render $< --to pdf
+
+.PHONY: data-paper
+data-paper: deliverables/data-paper/data-paper.pdf

--- a/deliverables/multilayer/multilayer.mk
+++ b/deliverables/multilayer/multilayer.mk
@@ -1,0 +1,27 @@
+# multilayer.mk — Phase 3 render workpackage for the multilayer-detection paper.
+#
+# Render-only: owns BOTH the main paper (multilayer-detection.pdf) and its
+# technical supplement (multilayer-detection-techrep.pdf, ticket 0096), rendered
+# from handoff artifacts on disk (includes, bibliography, vars) produced by a
+# prior `make analysis` (Phase 2). No uv, no corpus data, no compute rules.
+# Toolchain: Quarto + a LaTeX engine only.
+#
+#   make -f deliverables/multilayer/multilayer.mk deliverables/multilayer/multilayer-detection.pdf
+#   make -f deliverables/multilayer/multilayer.mk deliverables/multilayer/multilayer-detection-techrep.pdf
+#
+# Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
+# process never parses the root Phase-2 rules (ticket 0237). The Phase-2 remainder
+# of the old multilayer-detection.mk (the four companion-figure compute rules)
+# stays at root as multilayer-detection.mk.
+
+-include paths.mk
+
+deliverables/multilayer/multilayer-detection.pdf: deliverables/multilayer/multilayer-detection.qmd $(MULTILAYER_INCLUDES) $(BIB) deliverables/multilayer/multilayer-detection-vars.yml
+	quarto render $< --to pdf
+
+deliverables/multilayer/multilayer-detection-techrep.pdf: deliverables/multilayer/multilayer-detection-techrep.qmd $(MULTILAYER_TECHREP_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml
+	quarto render $< --to pdf
+
+.PHONY: multilayer-detection multilayer-techrep
+multilayer-detection: deliverables/multilayer/multilayer-detection.pdf
+multilayer-techrep: deliverables/multilayer/multilayer-detection-techrep.pdf

--- a/deliverables/technical-report/technical-report.mk
+++ b/deliverables/technical-report/technical-report.mk
@@ -1,0 +1,21 @@
+# technical-report.mk — Phase 3 render workpackage for the technical report.
+#
+# Render-only: produces deliverables/technical-report/technical-report.pdf from
+# handoff artifacts on disk (includes, bibliography, vars, figures, the lexical
+# TF-IDF stamp) — all produced by a prior `make analysis` (Phase 2). No uv, no
+# corpus data, no compute rules. Toolchain: Quarto + a LaTeX engine only.
+#
+#   make -f deliverables/technical-report/technical-report.mk deliverables/technical-report/technical-report.pdf
+#
+# Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
+# process never parses the root Phase-2 rules (ticket 0237). The figure lists and
+# .lexical_tfidf.stamp are plain artifact-file prerequisites here, satisfied by a
+# prior analysis build — not targets this file knows how to rebuild.
+
+-include paths.mk
+
+deliverables/technical-report/technical-report.pdf: deliverables/technical-report/technical-report.qmd $(TECHREP_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml $(TECHREP_FIGS) $(MULTILAYER_FIGS) .lexical_tfidf.stamp
+	quarto render $< --to pdf
+
+.PHONY: technical-report
+technical-report: deliverables/technical-report/technical-report.pdf

--- a/deliverables/zoo/zoo.mk
+++ b/deliverables/zoo/zoo.mk
@@ -1,0 +1,24 @@
+# zoo.mk (render) — Phase 3 render workpackage for the method-zoo report.
+#
+# Render-only: produces deliverables/zoo/breakpoint-detect-method-zoo.pdf from
+# handoff artifacts on disk (the zoo includes, bibliography, vars, the 17
+# schematics and 18 result panels) produced by a prior `make analysis` (Phase 2).
+# No uv, no corpus data, no compute rules. Toolchain: Quarto + a LaTeX engine only.
+#
+#   make -f deliverables/zoo/zoo.mk deliverables/zoo/breakpoint-detect-method-zoo.pdf
+#
+# Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
+# process never parses the root Phase-2 rules (ticket 0237). The Phase-2 remainder
+# (schematic/result-panel/cross-year compute rules) stays at root as zoo.mk.
+#
+# The figure prerequisites reference $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
+# explicitly, not the ambiguous $(ZOO_FIGS) — at the root the latter shadowed a
+# file-list alias with the concern zoo.mk's directory-path definition.
+
+-include paths.mk
+
+deliverables/zoo/breakpoint-detect-method-zoo.pdf: deliverables/zoo/breakpoint-detect-method-zoo.qmd $(ZOO_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
+	quarto render $< --to pdf
+
+.PHONY: zoo
+zoo: deliverables/zoo/breakpoint-detect-method-zoo.pdf

--- a/multilayer-detection.mk
+++ b/multilayer-detection.mk
@@ -83,24 +83,8 @@ companion-sensitivity: \
     $(COMP_FIGS)/fig_companion_sensitivity.png
 
 # ── Technical supplement (ticket 0096) ───────────────────────────────────
-
-MULTILAYER_TECHREP_INCLUDES := \
-    deliverables/_shared/_includes/techrep/overview.md \
-    deliverables/_shared/_includes/techrep/zscore.md \
-    deliverables/_shared/_includes/techrep/null-model.md \
-    deliverables/_shared/_includes/zoo/S2_energy.md \
-    deliverables/_shared/_includes/zoo/L1_js.md \
-    deliverables/_shared/_includes/zoo/G9_community.md \
-    deliverables/_shared/_includes/zoo/G2_spectral.md \
-    deliverables/_shared/_includes/zoo/C2ST_embedding.md \
-    deliverables/_shared/_includes/zoo/C2ST_lexical.md
-
-deliverables/multilayer/multilayer-detection-techrep.pdf: \
-    deliverables/multilayer/multilayer-detection-techrep.qmd \
-    $(MULTILAYER_TECHREP_INCLUDES) \
-    $(BIB) \
-    deliverables/_shared/technical-report-vars.yml
-	quarto render $< --to pdf
-
-.PHONY: multilayer-techrep
-multilayer-techrep: deliverables/multilayer/multilayer-detection-techrep.pdf
+# The Phase-3 render rules for BOTH multilayer-detection.pdf and its technical
+# supplement (multilayer-detection-techrep.pdf) now live in
+# deliverables/multilayer/multilayer.mk, invoked via `$(MAKE) -f` by the root
+# `papers` target. MULTILAYER_TECHREP_INCLUDES moved to paths.mk. This file is the
+# Phase-2 remainder: it only PRODUCES the companion figures (ticket 0237).

--- a/paths.mk
+++ b/paths.mk
@@ -1,0 +1,168 @@
+# paths.mk — shared artifact-location interface between build phases (ticket 0237).
+#
+# Variable definitions ONLY (zero recipes). This file is the thin contract that
+# lets the analysis-side build (Phase 2, concern .mk at root) and the writing-side
+# build (Phase 3, per-deliverable render .mk under deliverables/<x>/) agree on
+# where artifacts live without either triggering the other. -include'd FIRST by
+# the root Makefile and by every per-deliverable render .mk.
+
+# ── Phase-2 derived-data root ─────────────────────────────
+DERIVED := data/derived/tables
+
+# ── Shared bibliography ───────────────────────────────────
+BIB := deliverables/_shared/bibliography/main.bib
+CSL := deliverables/_shared/bibliography/oeconomia.csl
+
+# ── Per-document include sets ─────────────────────────────
+# Each render rule depends on its own doc's includes. Since 0226 every deliverable
+# is a folder-scoped Quarto project, so a render needs only its own includes — not
+# the union of all docs (the retired PROJECT_INCLUDES model).
+MANUSCRIPT_INCLUDES := deliverables/_shared/tables/tab_venues.md
+
+# corpus-report.qmd {{< include >}} directives (authored by grepping the .qmd).
+CORPUS_REPORT_INCLUDES := deliverables/_shared/_includes/corpus-construction.md \
+		deliverables/_shared/_includes/corpus-enrichment.md \
+		deliverables/_shared/_includes/corpus-filtering.md \
+		deliverables/_shared/tables/tab_corpus_sources.md \
+		deliverables/_shared/_includes/metadata-quality.md \
+		deliverables/_shared/_includes/embedding-quality.md \
+		deliverables/_shared/_includes/citation-quality.md \
+		deliverables/_shared/tables/tab_languages.md \
+		deliverables/_shared/_includes/core-vs-full-definition.md \
+		deliverables/_shared/_includes/reproducibility.md \
+		deliverables/_shared/_includes/annex-crossencoder.md \
+		deliverables/_shared/_includes/teaching-convergence.md
+
+TECHREP_INCLUDES := deliverables/_shared/_includes/corpus-construction.md \
+		deliverables/_shared/_includes/corpus-enrichment.md \
+		deliverables/_shared/_includes/corpus-filtering.md \
+		deliverables/_shared/_includes/core-vs-full.md \
+		deliverables/_shared/_includes/structural-breaks.md \
+		deliverables/_shared/_includes/alluvial-diagram.md \
+		deliverables/_shared/_includes/bimodality-analysis.md \
+		deliverables/_shared/_includes/pca-scatter.md \
+		deliverables/_shared/_includes/citation-genealogy.md \
+		deliverables/_shared/_includes/cocitation-communities.md \
+		deliverables/_shared/_includes/citation-quality.md \
+		deliverables/_shared/_includes/reproducibility.md \
+		deliverables/_shared/tables/tab_citation_coverage.md
+
+DATAPAPER_INCLUDES := deliverables/_shared/_includes/corpus-construction.md \
+		deliverables/_shared/_includes/corpus-filtering.md \
+		deliverables/_shared/_includes/embedding-generation.md \
+		deliverables/_shared/_includes/reproducibility.md \
+		deliverables/_shared/tables/tab_corpus_sources.md \
+		deliverables/_shared/tables/tab_languages.md
+
+MULTILAYER_INCLUDES := deliverables/_shared/_includes/embedding-generation.md \
+		deliverables/_shared/_includes/structural-breaks.md \
+		deliverables/_shared/_includes/alluvial-diagram.md \
+		deliverables/_shared/_includes/bimodality-analysis.md \
+		deliverables/_shared/_includes/pca-scatter.md \
+		deliverables/_shared/_includes/core-vs-full.md
+
+# Technical supplement to the multilayer paper (ticket 0096).
+MULTILAYER_TECHREP_INCLUDES := \
+	deliverables/_shared/_includes/techrep/overview.md \
+	deliverables/_shared/_includes/techrep/zscore.md \
+	deliverables/_shared/_includes/techrep/null-model.md \
+	deliverables/_shared/_includes/zoo/S2_energy.md \
+	deliverables/_shared/_includes/zoo/L1_js.md \
+	deliverables/_shared/_includes/zoo/G9_community.md \
+	deliverables/_shared/_includes/zoo/G2_spectral.md \
+	deliverables/_shared/_includes/zoo/C2ST_embedding.md \
+	deliverables/_shared/_includes/zoo/C2ST_lexical.md
+
+# Method-zoo include tree: one composer + 18 per-method entries.
+# Used by breakpoint-detect-method-zoo.qmd.
+ZOO_INCLUDES := deliverables/_shared/_includes/techrep/overview.md \
+		deliverables/_shared/_includes/techrep/zscore.md \
+		deliverables/_shared/_includes/techrep/null-model.md \
+		deliverables/_shared/_includes/techrep-zoo.md \
+		deliverables/_shared/_includes/zoo/S1_mmd.md \
+		deliverables/_shared/_includes/zoo/S2_energy.md \
+		deliverables/_shared/_includes/zoo/S3_sliced_wasserstein.md \
+		deliverables/_shared/_includes/zoo/S4_frechet.md \
+		deliverables/_shared/_includes/zoo/C2ST_embedding.md \
+		deliverables/_shared/_includes/zoo/L1_js.md \
+		deliverables/_shared/_includes/zoo/L2_ntr.md \
+		deliverables/_shared/_includes/zoo/L3_term_burst.md \
+		deliverables/_shared/_includes/zoo/C2ST_lexical.md \
+		deliverables/_shared/_includes/zoo/G1_pagerank.md \
+		deliverables/_shared/_includes/zoo/G2_spectral.md \
+		deliverables/_shared/_includes/zoo/G3_coupling_age.md \
+		deliverables/_shared/_includes/zoo/G4_cross_tradition.md \
+		deliverables/_shared/_includes/zoo/G5_pref_attachment.md \
+		deliverables/_shared/_includes/zoo/G6_entropy.md \
+		deliverables/_shared/_includes/zoo/G7_disruption.md \
+		deliverables/_shared/_includes/zoo/G8_betweenness.md \
+		deliverables/_shared/_includes/zoo/G9_community.md
+
+# ── Per-document figure sets ─────────────────────────────
+# Artifact-file lists. A render rule lists these as plain file prerequisites; the
+# Phase-2 rules that PRODUCE them live in the concern .mk (root), not here.
+MANUSCRIPT_FIGS := deliverables/_shared/figures/fig_bars_v1.png deliverables/_shared/figures/fig_composition.png deliverables/_shared/figures/fig_breaks.png
+
+DATAPAPER_FIGS  := deliverables/_shared/figures/fig_bars.png deliverables/_shared/figures/fig_dag.png
+
+MULTILAYER_FIGS  := deliverables/_shared/figures/fig_breakpoints.png deliverables/_shared/figures/fig_alluvial.png \
+                   deliverables/_shared/figures/fig_breaks.png \
+                   deliverables/_shared/figures/fig_bimodality.png \
+                   deliverables/_shared/figures/fig_seed_axis_core.png deliverables/_shared/figures/fig_pca_scatter.png \
+                   deliverables/_shared/figures/fig_genealogy.png \
+                   deliverables/_shared/figures/fig_companion_zseries.png \
+                   deliverables/_shared/figures/fig_companion_heatmap.png \
+                   deliverables/_shared/figures/fig_companion_terms.png \
+                   deliverables/_shared/figures/fig_companion_community.png
+
+TECHREP_FIGS    := deliverables/_shared/figures/fig_alluvial_core.png \
+                   deliverables/_shared/figures/fig_bimodality_core.png \
+                   deliverables/_shared/figures/fig_bimodality_lexical_core.png \
+                   deliverables/_shared/figures/fig_bimodality_keywords_core.png \
+                   deliverables/_shared/figures/fig_bimodality_lexical.png \
+                   deliverables/_shared/figures/fig_bimodality_keywords.png \
+                   deliverables/_shared/figures/fig_kde.png \
+                   deliverables/_shared/figures/fig_traditions.png \
+                   deliverables/_shared/figures/fig_communities.png \
+                   deliverables/_shared/figures/fig_semantic.png \
+                   deliverables/_shared/figures/fig_semantic_lang.png \
+                   deliverables/_shared/figures/fig_semantic_period.png
+
+# Method-zoo figures (17 schematics + 18 zoo result panels).
+# schematic_C2ST.png serves both C2ST_embedding and C2ST_lexical, hence 17 schematics for 18 methods.
+ZOO_SCHEMATICS := deliverables/_shared/figures/schematic_S1_mmd.png \
+                  deliverables/_shared/figures/schematic_S2_energy.png \
+                  deliverables/_shared/figures/schematic_S3_sliced_wasserstein.png \
+                  deliverables/_shared/figures/schematic_S4_frechet.png \
+                  deliverables/_shared/figures/schematic_C2ST.png \
+                  deliverables/_shared/figures/schematic_L1_js.png \
+                  deliverables/_shared/figures/schematic_L2_ntr.png \
+                  deliverables/_shared/figures/schematic_L3_burst.png \
+                  deliverables/_shared/figures/schematic_G1_pagerank.png \
+                  deliverables/_shared/figures/schematic_G2_spectral.png \
+                  deliverables/_shared/figures/schematic_G3_coupling_age.png \
+                  deliverables/_shared/figures/schematic_G4_cross_tradition.png \
+                  deliverables/_shared/figures/schematic_G5_pref_attachment.png \
+                  deliverables/_shared/figures/schematic_G6_entropy.png \
+                  deliverables/_shared/figures/schematic_G7_disruption.png \
+                  deliverables/_shared/figures/schematic_G8_betweenness.png \
+                  deliverables/_shared/figures/schematic_G9_community.png
+
+ZOO_RESULT_FIGS := deliverables/_shared/figures/fig_zoo_S1_MMD.png \
+                   deliverables/_shared/figures/fig_zoo_S2_energy.png \
+                   deliverables/_shared/figures/fig_zoo_S3_sliced_wasserstein.png \
+                   deliverables/_shared/figures/fig_zoo_S4_frechet.png \
+                   deliverables/_shared/figures/fig_zoo_C2ST_embedding.png \
+                   deliverables/_shared/figures/fig_zoo_C2ST_lexical.png \
+                   deliverables/_shared/figures/fig_zoo_L1.png \
+                   deliverables/_shared/figures/fig_zoo_L2.png \
+                   deliverables/_shared/figures/fig_zoo_L3.png \
+                   deliverables/_shared/figures/fig_zoo_G1_pagerank.png \
+                   deliverables/_shared/figures/fig_zoo_G2_spectral.png \
+                   deliverables/_shared/figures/fig_zoo_G3_coupling_age.png \
+                   deliverables/_shared/figures/fig_zoo_G4_cross_tradition.png \
+                   deliverables/_shared/figures/fig_zoo_G5_pref_attachment.png \
+                   deliverables/_shared/figures/fig_zoo_G6_entropy.png \
+                   deliverables/_shared/figures/fig_zoo_G7_disruption.png \
+                   deliverables/_shared/figures/fig_zoo_G8_betweenness.png \
+                   deliverables/_shared/figures/fig_zoo_G9_community.png

--- a/tests/test_build_phase_separation.py
+++ b/tests/test_build_phase_separation.py
@@ -1,6 +1,6 @@
-"""Phase-2/Phase-3 separation for the manuscript writing workpackage (ticket 0131).
+"""Phase-2/Phase-3 separation for the writing workpackages (tickets 0131, 0237).
 
-The harness Build rule requires that a writing-side build produce the manuscript
+The harness Build rule requires that a writing-side build produce a deliverable
 from handoff artifacts alone — no `uv run`, no data fetch. Two things enforce it:
 
 1. The manuscript's small, byte-stable writing-facing deliverables (3 PNGs +
@@ -8,15 +8,84 @@ from handoff artifacts alone — no `uv run`, no data fetch. Two things enforce 
    Phase 2 or pulling corpus data.
 2. A standalone `manuscript.mk` renders the PDF/DOCX with prerequisites limited
    to committed prose + deliverables — no Phase-1 data dependency.
+
+Ticket 0237 generalizes (2): each deliverable owns a Phase-3 render `.mk`
+(render-only), the analysis concern `.mk` stay pure Phase-2, and no single `.mk`
+mixes the two. The phase-purity guard below classifies each `.mk` by RECIPE —
+a `quarto render` recipe or `.pdf:`/`.docx:` target marks Phase-3 render; a
+`scripts/(analyze_|compute_|plot_|export_|summarize_|build_het)` recipe marks
+Phase-2 compute — and fails any file that carries both.
 """
 
+import glob
 import os
+import re
 import subprocess
 
 import pytest
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 MANUSCRIPT_MK = os.path.join(REPO_ROOT, "deliverables", "manuscript", "manuscript.mk")
+
+# ── Phase-purity guard (ticket 0237) ─────────────────────────────────────────
+# Classify by RECIPE, not by any target-string convention.
+_RENDER_RECIPE_RE = re.compile(r"quarto\s+render")
+_RENDER_TARGET_RE = re.compile(r"^[\w./$()-]+\.(?:pdf|docx)\s*:", re.MULTILINE)
+_PHASE2_RECIPE_RE = re.compile(
+    r"scripts/(?:analyze_|compute_|plot_|export_|summarize_|build_het)"
+)
+
+
+def _has_render(text: str) -> bool:
+    return bool(_RENDER_RECIPE_RE.search(text) or _RENDER_TARGET_RE.search(text))
+
+
+def _has_phase2(text: str) -> bool:
+    return bool(_PHASE2_RECIPE_RE.search(text))
+
+
+def _all_mk_files() -> list[str]:
+    """Every build fragment: root concern .mk + per-deliverable render .mk."""
+    files = glob.glob(os.path.join(REPO_ROOT, "*.mk"))
+    files += glob.glob(os.path.join(REPO_ROOT, "deliverables", "*", "*.mk"))
+    return sorted(files)
+
+
+@pytest.mark.adherence
+@pytest.mark.parametrize("mkpath", _all_mk_files())
+def test_mk_file_is_single_phase(mkpath):
+    """No .mk may carry BOTH a Phase-3 render recipe and a Phase-2 compute recipe."""
+    with open(mkpath, encoding="utf-8") as f:
+        text = f.read()
+    render, phase2 = _has_render(text), _has_phase2(text)
+    assert not (render and phase2), (
+        f"{os.path.relpath(mkpath, REPO_ROOT)} mixes a Phase-3 render recipe "
+        f"(quarto render / .pdf|.docx target) with a Phase-2 compute recipe "
+        f"(scripts/analyze_|compute_|plot_|export_|summarize_|build_het). "
+        f"Render and compute must live in separate .mk (ticket 0237)."
+    )
+
+
+@pytest.mark.adherence
+def test_phase_purity_guard_has_teeth(tmp_path):
+    """The guard must trip on a fabricated mixed .mk and pass a single-kind one."""
+    render_only = "foo.pdf: foo.qmd\n\tquarto render $< --to pdf\n"
+    compute_only = "bar.csv: baz.py\n\t$(PYTHON) scripts/compute_bar.py --output $@\n"
+    mixed = render_only + compute_only
+
+    # Mixed file: both detectors fire → the parametrized guard would fail on it.
+    assert _has_render(mixed) and _has_phase2(mixed)
+
+    # Single-kind files: exactly one detector fires.
+    assert _has_render(render_only) and not _has_phase2(render_only)
+    assert _has_phase2(compute_only) and not _has_render(compute_only)
+
+    # Round-trip through disk so the guard's file read is exercised.
+    p = tmp_path / "mixed.mk"
+    p.write_text(mixed)
+    with open(p, encoding="utf-8") as f:
+        disk = f.read()
+    assert _has_render(disk) and _has_phase2(disk)
 
 # The manuscript's writing-facing deliverables — what manuscript.qmd actually
 # consumes via ![](../_shared/figures/...) and

--- a/tests/test_deliverables_layout.py
+++ b/tests/test_deliverables_layout.py
@@ -50,11 +50,12 @@ _SHARED_REF = re.compile(
 # A Make render rule: the target (first token, left of `:`) is a PDF/DOCX file.
 _RENDER_TARGET = re.compile(r"^(?P<t>[\w./-]+\.(?:pdf|docx))\s*:")
 
-# Makefiles that carry render rules (top-level + concern .mk + the manuscript's).
+# Makefiles that carry render rules (top-level + concern .mk + every
+# per-deliverable render .mk under deliverables/<x>/, ticket 0237).
 _MAKEFILES = (
     [os.path.join(REPO_ROOT, "Makefile")]
     + glob.glob(os.path.join(REPO_ROOT, "*.mk"))
-    + [os.path.join(DELIVERABLES, "manuscript", "manuscript.mk")]
+    + glob.glob(os.path.join(DELIVERABLES, "*", "*.mk"))
 )
 
 

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -221,27 +221,49 @@ class TestFailFastChecks:
 
 
 # ---------------------------------------------------------------------------
-# Quarto project-wide include resolution (#217)
+# Per-deliverable render rules (#217, tickets 0226 + 0237)
 # ---------------------------------------------------------------------------
 
-class TestProjectWideIncludes:
-    """Quarto resolves includes across ALL project files, even when rendering
-    a single document. Every render target must depend on all includes."""
+def read_paths_mk():
+    p = os.path.join(os.path.dirname(__file__), "..", "paths.mk")
+    with open(p) as f:
+        return f.read()
+
+
+class TestPerDeliverableIncludes:
+    """Since 0226 each deliverable is a folder-scoped Quarto project, and since
+    0237 each owns a render-only .mk that depends on its OWN includes (not the
+    retired PROJECT_INCLUDES union). The per-doc include sets live in paths.mk."""
 
     def test_citation_coverage_in_techrep_includes(self):
         """tab_citation_coverage.md is included transitively via citation-quality.md."""
-        mk = read_makefile()
-        m = re.search(r"^TECHREP_INCLUDES\s*:=\s*(.*?)(?=\n\S|\n\n)", mk,
+        paths = read_paths_mk()
+        m = re.search(r"^TECHREP_INCLUDES\s*:=\s*(.*?)(?=\n\S|\n\n)", paths,
                        re.MULTILINE | re.DOTALL)
-        assert m, "TECHREP_INCLUDES not found"
+        assert m, "TECHREP_INCLUDES not found in paths.mk"
         assert "tab_citation_coverage.md" in m.group(1), \
             "TECHREP_INCLUDES must list tab_citation_coverage.md (transitive dep of citation-quality.md)"
 
-    def test_project_includes_variable_exists(self):
-        """A PROJECT_INCLUDES variable must aggregate all per-document include sets."""
-        mk = read_makefile()
-        assert re.search(r"^PROJECT_INCLUDES\s*:?=", mk, re.MULTILINE), \
-            "PROJECT_INCLUDES variable not declared"
+    def test_project_includes_union_retired(self):
+        """The PROJECT_INCLUDES union model is retired (0237): no render rule uses it.
+
+        Each render .mk depends on its own doc's includes, so no `.mk` may still
+        reference $(PROJECT_INCLUDES).
+        """
+        import glob
+        root = os.path.join(os.path.dirname(__file__), "..")
+        # A live use ($(PROJECT_INCLUDES)) or definition (PROJECT_INCLUDES :=/=),
+        # not an incidental mention in a comment.
+        use_or_def = re.compile(r"\$\(PROJECT_INCLUDES\)|^\s*PROJECT_INCLUDES\s*:?=", re.MULTILINE)
+        offenders = []
+        for mkpath in [os.path.join(root, "Makefile")] + glob.glob(
+            os.path.join(root, "*.mk")
+        ) + glob.glob(os.path.join(root, "deliverables", "*", "*.mk")):
+            with open(mkpath) as f:
+                if use_or_def.search(f.read()):
+                    offenders.append(os.path.relpath(mkpath, root))
+        assert not offenders, \
+            f"PROJECT_INCLUDES is retired; still used/defined in: {offenders}"
 
     def test_manuscript_pdf_rule_lives_in_manuscript_mk(self):
         """The manuscript render rule lives in deliverables/manuscript/manuscript.mk (tickets 0131, 0226).
@@ -266,13 +288,25 @@ class TestProjectWideIncludes:
         assert "PROJECT_INCLUDES" not in wp, \
             "manuscript.mk must not couple to PROJECT_INCLUDES (it is its own Quarto project)"
 
-    def test_techrep_pdf_depends_on_project_includes(self):
-        """technical-report.pdf must depend on PROJECT_INCLUDES."""
+    def test_techrep_pdf_rule_lives_in_render_mk(self):
+        """technical-report.pdf lives in its render .mk and depends on TECHREP_INCLUDES (0237)."""
         mk = read_makefile()
-        m = re.search(r"^deliverables/technical-report/technical-report\.pdf\s*:(.*?)$", mk, re.MULTILINE)
-        assert m, "technical-report.pdf target not found"
-        assert "PROJECT_INCLUDES" in m.group(1), \
-            "technical-report.pdf must depend on $(PROJECT_INCLUDES)"
+        assert not re.search(
+            r"^deliverables/technical-report/technical-report\.pdf\s*:", mk, re.MULTILINE
+        ), "technical-report.pdf rule must live in its render .mk, not the top-level Makefile"
+        render_path = os.path.join(
+            os.path.dirname(__file__), "..", "deliverables", "technical-report",
+            "technical-report.mk",
+        )
+        with open(render_path) as f:
+            wp = f.read()
+        m = re.search(
+            r"^deliverables/technical-report/technical-report\.pdf\s*:(.*?)$",
+            wp, re.MULTILINE,
+        )
+        assert m, "technical-report.pdf target not found in technical-report.mk"
+        assert "TECHREP_INCLUDES" in m.group(1), \
+            "technical-report.pdf must depend on $(TECHREP_INCLUDES)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -6,6 +6,11 @@ from pathlib import Path
 import pytest
 
 ZOO_MK = Path(__file__).resolve().parent.parent / "zoo.mk"
+# The Phase-3 render rule moved beside its source (ticket 0237); the root zoo.mk
+# is now the pure Phase-2 concern file.
+ZOO_RENDER_MK = (
+    Path(__file__).resolve().parent.parent / "deliverables" / "zoo" / "zoo.mk"
+)
 
 _CROSSYEAR_RE = re.compile(
     r"^CROSSYEAR_METHODS\s*:=\s*(.*?)(?=\n\S|\n\n|\Z)",
@@ -67,10 +72,22 @@ class TestZooMkStructure:
         ):
             assert expected in methods, f"{expected} missing from CROSSYEAR_METHODS"
 
-    def test_zoo_pdf_target_in_zoo_mk(self, zoo_mk_text):
-        """breakpoint-detect-method-zoo.pdf recipe must live in zoo.mk, not only in Makefile."""
+    def test_zoo_pdf_target_in_render_mk(self):
+        """The zoo PDF render rule lives in deliverables/zoo/zoo.mk (ticket 0237).
+
+        Phase 3 render is split from Phase 2 compute: the render rule sits beside
+        its source under deliverables/zoo/, not in the root concern zoo.mk.
+        """
+        render_text = ZOO_RENDER_MK.read_text()
         assert re.search(
             r"^deliverables/zoo/breakpoint-detect-method-zoo\.pdf\s*:",
-            zoo_mk_text,
+            render_text,
             re.MULTILINE,
-        ), "breakpoint-detect-method-zoo.pdf recipe must live in zoo.mk"
+        ), "breakpoint-detect-method-zoo.pdf recipe must live in deliverables/zoo/zoo.mk"
+
+    def test_root_zoo_mk_has_no_render_rule(self, zoo_mk_text):
+        """The root concern zoo.mk must be pure Phase-2 — no render rule (0237)."""
+        assert "quarto render" not in zoo_mk_text, (
+            "root zoo.mk must not carry a render recipe; it moved to deliverables/zoo/zoo.mk"
+        )
+        assert ".pdf:" not in zoo_mk_text, "root zoo.mk must carry no .pdf render target"

--- a/tickets/0237-phase3-deliverable-mk-split.erg
+++ b/tickets/0237-phase3-deliverable-mk-split.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-07-10T15:20Z note spun out of the 0231 confirmation session (2026-07-10). `make papers` is not a Phase-3 build: it starts with `check-corpus` and each companion PDF rule depends on Phase-2 outputs (figures/tables), so asking for a PDF drags in the whole analysis. Demonstrated twice live: `make papers` died on a missing Phase-1 `citations.csv`, then on `import umap` in a Phase-2 clustering step — neither should touch a render. `manuscript.mk` already proves the target shape (3 render rules, 0 Phase-2 rules). Blocked-by 0226 so each deliverable's `_quarto.yml` home is settled before the render `.mk` moves beside it.
 
 2026-07-10T16:37Z HDMX-coding-agent note blocker 0226 closed — Blocked-by removed.
+2026-07-10T18:00Z HDMX-coding-agent note executed on branch t237-phase3-deliverable-mk-split. Action 4 (slide decks get a render .mk) was vacuous: no slide-deck render rule exists in any .mk (slides-gide / slides-eshet have _quarto.yml but no Make render target), so there was nothing to extract. ZOO_FIGS shadow fixed during zoo render extraction: the render prereqs now reference $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS) explicitly (at root, ZOO_FIGS aliased a file list in Makefile but a directory path in the concern zoo.mk). multilayer Phase-2 remainder stays at root as multilayer-detection.mk; zoo Phase-2 remainder stays at root as zoo.mk (rename to scripts/analysis/ deferred to 0225). PR closes this ticket.
 --- body ---
 ## Context
 

--- a/tickets/closed/0237-phase3-deliverable-mk-split.erg
+++ b/tickets/closed/0237-phase3-deliverable-mk-split.erg
@@ -2,6 +2,7 @@
 Title: Phase-3 render as per-deliverable .mk — un-scatter PDF rules, split render from compute
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1003
 
 --- log ---
 2026-07-10T15:20Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 
 2026-07-10T16:37Z HDMX-coding-agent note blocker 0226 closed — Blocked-by removed.
 2026-07-10T18:00Z HDMX-coding-agent note executed on branch t237-phase3-deliverable-mk-split. Action 4 (slide decks get a render .mk) was vacuous: no slide-deck render rule exists in any .mk (slides-gide / slides-eshet have _quarto.yml but no Make render target), so there was nothing to extract. ZOO_FIGS shadow fixed during zoo render extraction: the render prereqs now reference $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS) explicitly (at root, ZOO_FIGS aliased a file list in Makefile but a directory path in the concern zoo.mk). multilayer Phase-2 remainder stays at root as multilayer-detection.mk; zoo Phase-2 remainder stays at root as zoo.mk (rename to scripts/analysis/ deferred to 0225). PR closes this ticket.
+2026-07-10T17:41Z HDMX-coding-agent closed — autoclosed — PR #1003
 --- body ---
 ## Context
 

--- a/zoo.mk
+++ b/zoo.mk
@@ -147,8 +147,7 @@ $(ZOO_FIGS)/fig_zoo_bias_%.png: scripts/plot_zoo_bias_comparison.py \
 bias-tables: $(foreach m,$(BIAS_METHODS),$(ZOO_TABLES)/tab_div_biased_$(m).csv)
 bias-figures: $(BIAS_FIGS)
 
-# ── Zoo PDF render (Phase 3) ─────────────────────────────────────────────────
-# Thin wrapper over $(ZOO_INCLUDES) for reviewers or cherry-picking.
-# Mirrors the TR recipe; same vars file, same bibliography, same engine.
-deliverables/zoo/breakpoint-detect-method-zoo.pdf: deliverables/zoo/breakpoint-detect-method-zoo.qmd $(PROJECT_INCLUDES) $(BIB) deliverables/_shared/technical-report-vars.yml $(ZOO_FIGS)
-	quarto render $< --to pdf
+# The Phase-3 render rule (breakpoint-detect-method-zoo.pdf) now lives in
+# deliverables/zoo/zoo.mk, invoked via `$(MAKE) -f` by the root `papers` target.
+# This file is the Phase-2 remainder: it only PRODUCES the zoo figures/tables the
+# render consumes (ticket 0237).


### PR DESCRIPTION
## Phase-3 render as per-deliverable `.mk` (ticket 0237)

Each deliverable now owns a Phase-3 render-only `.mk` beside its source; the
analysis concern `.mk` are pure Phase-2; `make papers` is corpus-free (no
`check-corpus`, no `uv run`), rendering from artifacts a prior `make analysis`
left on disk. `deliverables/manuscript/manuscript.mk` was the reference template.

### What changed (staged)
- **A — `paths.mk`** (new, repo root): variable-only shared interface (`DERIVED`,
  `BIB`, `CSL`, per-doc `*_INCLUDES` + `*_FIGS`, `ZOO_SCHEMATICS`/`ZOO_RESULT_FIGS`,
  `MULTILAYER_TECHREP_INCLUDES`, freshly-authored `CORPUS_REPORT_INCLUDES`).
  `-include`d FIRST by the root Makefile and by every render `.mk`. Dropped the
  now-obsolete `PROJECT_INCLUDES` union (each deliverable is a folder-scoped
  Quarto project since 0226, so a render needs only its own includes).
- **B — extract render rules** into `deliverables/<x>/<x>.mk` for corpus-report,
  technical-report, data-paper, multilayer (owns BOTH the paper and its techrep
  supplement) and zoo. Deleted them from `Makefile`, `zoo.mk`,
  `multilayer-detection.mk` (concern files now `grep -c '.pdf:' == 0`).
- **C — re-cut targets**: `manuscript` and `papers` are phony recipes invoking
  each render `.mk` via `$(MAKE) -f` (a separate make process that never parses
  the root Phase-2 rules). `papers` dropped `check-corpus`. Retargeted
  `archive-manuscript` → phony `manuscript`, `datapaper-render` → phony `data-paper`.
- **D — tests**: adherence-tier phase-purity guard in
  `tests/test_build_phase_separation.py` (classify by RECIPE; parametrized over
  all `.mk` + a mutation-proof teeth test). Updated `_MAKEFILES` glob in
  `test_deliverables_layout.py`, the zoo render-rule location in `test_zoo_mk.py`,
  and `TestProjectWideIncludes` → `TestPerDeliverableIncludes` in
  `test_makefile_contract.py`.

### Authoritative decisions honored
- Include split via recursive `$(MAKE) -f`, not conditional `-include`.
- The multilayer Phase-2 remainder **stays at root** as `multilayer-detection.mk`;
  the zoo Phase-2 remainder stays at root as `zoo.mk` (rename to `scripts/analysis/`
  deferred to 0225).
- **ZOO_FIGS shadow fixed**: zoo render prereqs reference `$(ZOO_SCHEMATICS)
  $(ZOO_RESULT_FIGS)` explicitly (at root `ZOO_FIGS` aliased a file list in the
  Makefile but a directory path in the concern `zoo.mk`).
- Ticket Action 4 (slide-deck render `.mk`) was vacuous — no slide-deck render
  rule exists in any `.mk`, so there was nothing to extract.

### Verification (dry-run gates)
- `make -n papers | grep -E 'uv run|check-corpus'` → empty.
- `make -n manuscript | grep -E 'uv run|check-corpus'` → empty.
- `grep -c '.pdf:' divergence.mk zoo.mk multilayer-detection.mk venues.mk separation.mk` → 0 each.
- Phase-purity guard was RED pre-Stage-B (zoo.mk + multilayer-detection.mk mixed),
  GREEN now. `make check-fast`: all Makefile/test targets pass. (One unrelated
  pre-existing failure, `test_robustness_observability.py`, needs corpus data
  absent in this bare worktree — untouched by this branch.)

Render validation (byte-compare of all 6 companions + manuscript) is done by the
raid orchestrator post-push, with Phase-2 artifacts present.

**Ticket:** tickets/0237-phase3-deliverable-mk-split.erg
Ticket-ref: tickets/0221-tracking-reorganize-the-repo-so-layout-m.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
