### PR TITLE
ticket(0225): remodel code workstream — strip cyclic edge + split into integer children 0239-0242

### DIFF
--- a/tickets/0223-repo-layout-reorg.erg
+++ b/tickets/0223-repo-layout-reorg.erg
@@ -9,6 +9,7 @@ Label: deferred
 
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T10:07Z note author-adjudicated 2026-07-10: deliverables/ RATIFIED, src/ DECLINED (keep libs/ for cross-repo), AEDIST shared harvest/index → 0229
+2026-07-10T00:00Z HDMX-coding-agent note child 0226 (prose) closed via PR #1002; child 0225 (code) fanned out into integer sub-children 0239-0242 (0225 is now a sub-tracker). This tracker closes when 0225 closes. All parked behind the Œconomia R&R.
 --- body ---
 ## Context
 Top level reached 43 entries with two flat mega-directories: `scripts/` (173

--- a/tickets/0225-reorg-code.erg
+++ b/tickets/0225-reorg-code.erg
@@ -2,7 +2,6 @@
 Title: Reorg workstream — code (scripts/ by phase; shared harvest/index → libs/)
 Created: 2026-07-10
 Author: HDMX-coding-agent
-Blocked-by: 0223
 Label: deferred
 
 --- log ---
@@ -10,6 +9,7 @@ Label: deferred
 
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T10:07Z note author decision: decline src/; keep _-private/pipeline_/scripts convention + phase subgrouping; extractions land in phase subdir; shared harvest/index → libs/ (0229)
+2026-07-10T00:00Z HDMX-coding-agent note strip stale Blocked-by 0223 — the edge encoded "wait for layout ratification", discharged 2026-07-10 (0223 log: deliverables/ RATIFIED, src/ DECLINED). 0223 is a tracking parent that stays open until this child closes, so child-blocked-by-parent was an inverted/cyclic edge (0226, same edge, was executed and merged regardless). Ticket stays deferred: parked behind the Œconomia R&R per 0223 scheduling.
 --- body ---
 ## Context
 Second stage of the top-level tidy (tracker `0223`). `scripts/` holds 173 flat

--- a/tickets/0225-reorg-code.erg
+++ b/tickets/0225-reorg-code.erg
@@ -10,6 +10,7 @@ Label: deferred
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T10:07Z note author decision: decline src/; keep _-private/pipeline_/scripts convention + phase subgrouping; extractions land in phase subdir; shared harvest/index → libs/ (0229)
 2026-07-10T00:00Z HDMX-coding-agent note strip stale Blocked-by 0223 — the edge encoded "wait for layout ratification", discharged 2026-07-10 (0223 log: deliverables/ RATIFIED, src/ DECLINED). 0223 is a tracking parent that stays open until this child closes, so child-blocked-by-parent was an inverted/cyclic edge (0226, same edge, was executed and merged regardless). Ticket stays deferred: parked behind the Œconomia R&R per 0223 scheduling.
+2026-07-10T00:00Z HDMX-coding-agent note split into integer children 0239-0242 (author directive); 0225 now a sub-tracker. Fixed .mk scope: all 5 analysis .mk relocate (was 3); render/manuscript .mk already per-deliverable via 0237; root zoo.mk is Phase-2-pure (render split out by 0237) but name-clashes with deliverables/zoo/zoo.mk → rename on relocation.
 --- body ---
 ## Context
 Second stage of the top-level tidy (tracker `0223`). `scripts/` holds 173 flat
@@ -31,33 +32,41 @@ package is this-repo-internal; AEDIST consumes `libs/` by git source).
 - `divergence.mk`, `separation.mk`, `venues.mk` — shared-analysis fragments → `scripts/analysis/analysis.mk`
 - `libs/openalex-corpus` — the AEDIST-shared harvest package (indexing conventions to be added; see 0229 seed / memory)
 
-## Actions (risk ascending — separate PRs)
-1. Relocate shared-analysis fragments to `scripts/analysis/analysis.mk` (pure
-   `-include` path edits).
-2. Group entry points by phase: `scripts/{harvest,analysis,figures,qa}/`.
-   `plot_*`/`export_*` → `figures/`; `analyze_*`/`compute_*` → `analysis/`;
-   `catalog_*`/`enrich_*`/`corpus_*`/`scout*` → `harvest/`; `qa_*` → `qa/`.
-3. Land the five SPLIT extractions (`corpus_filters`, `traditions`,
-   `changepoints`, `teaching`, `venues`) as plain/`_`-private modules in the
-   owning phase subdir; the leaking scripts import from them. LIBRARY-10 and
-   MOVE-2 stay in `scripts/` (relocated by phase) — no `src/`, no `python -m`.
-4. (follow-up, off critical path) sever `compute_clustering_comparison.py`'s
-   import of the two clustering plotters — the backward arrow.
+## Sub-tracker — the four Actions are now integer child tickets
+This ticket held four Actions explicitly slated for separate PRs; per ticket
+discipline a multi-PR ticket is split into one child per PR before work starts.
+`0225` is now a **sub-tracker** (grand-tracker `0223` → `0225` → children below)
+and stays open until its children close. Children are NOT `blocked-by 0225` — a
+leaf blocked-by its own tracker is the cyclic edge stripped from this ticket on
+2026-07-10; only real prerequisites are encoded.
 
-## Test
-- Byte-check each SPLIT as old-code-vs-new-code on the same input, not vs a
-  drifting golden.
-- `make -n <target>` produces an identical target/prereq list before and after
-  each relocation (paths change, graph does not).
+- **0239** — code 1/4: relocate the **5** Phase-2 analysis `.mk` into
+  `scripts/analysis/` (0225's Action 1 named only 3 — `multilayer-detection.mk`
+  and `zoo.mk` are the same class; scope corrected). Rename the Phase-2 `zoo.mk`
+  to end the basename clash with the Phase-3 `deliverables/zoo/zoo.mk`.
+  `paths.mk` stays at root; render `.mk` already per-deliverable (0237).
+  Low-risk, independent — lands first.
+- **0240** — code 2/4: group `scripts/` 173 files by phase
+  (`harvest/analysis/figures/qa/`). High-risk (import-path churn), independent.
+- **0241** — code 3/4: land the five SPLIT extractions in their phase subdir.
+  Blocked-by 0240 (destination dirs come from 0240).
+- **0242** — code 4/4 (follow-up): sever `compute_clustering_comparison.py`'s
+  plotter import — the backward arrow. Off critical path.
 
-## Invariants
+## Invariants (inherited by every child)
 - Layering: a compute module never imports a plotter (architecture.md rule 4).
 - Existing library convention unchanged: `_`-private + `pipeline_*` loaders;
-  no top-level `src/`.
+  no top-level `src/`, no `python -m`.
 - `make check` green; `make clean && make all` green.
 - One logical move per PR.
 
-## Exit criteria
-- `scripts/` grouped by phase; no flat 170-file directory.
-- The five extractions live beside their phase; leaking scripts import them.
+## Exit criteria (tracker closes when)
+- 0239, 0240, 0241, 0242 all closed.
+- `scripts/` grouped by phase; no flat ~170-file directory; no analysis `.mk` at
+  root except `paths.mk`.
 - Full build green; `make -n` target lists unchanged by the moves.
+
+Ticket-ref: tickets/0239-reorg-code-1-analysis-mk-relocate.erg
+Ticket-ref: tickets/0240-reorg-code-2-scripts-by-phase.erg
+Ticket-ref: tickets/0241-reorg-code-3-split-extractions.erg
+Ticket-ref: tickets/0242-reorg-code-4-sever-clustering-backarrow.erg

--- a/tickets/0239-reorg-code-1-analysis-mk-relocate.erg
+++ b/tickets/0239-reorg-code-1-analysis-mk-relocate.erg
@@ -1,0 +1,66 @@
+%erg 0.1
+Title: Reorg code 1/4 — relocate the 5 Phase-2 analysis .mk into scripts/analysis/
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Label: deferred
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; parent 0225 is the sub-tracker. Scope corrected to ALL 5 analysis .mk (0225 Action 1 named only 3). Parked behind the Œconomia R&R per 0223.
+
+--- body ---
+## Context
+First and lowest-risk stage of the code reorg (parent sub-tracker `0225`,
+grand-tracker `0223`). The main `Makefile` `-include`s five Phase-2 "concern"
+`.mk` fragments that still sit at the repo root. Move them under
+`scripts/analysis/` so the top level stops carrying build fragments.
+
+`0225` Action 1 named only three (`divergence.mk`, `separation.mk`,
+`venues.mk`). There are **five** — `multilayer-detection.mk` and `zoo.mk` are
+the same class (Phase-2, `-include`d at `Makefile:91-95`, each defines
+`$(DERIVED)` tables + `deliverables/_shared/figures`). Relocate all five.
+
+## Not in scope (already done / stays put)
+- **Render / manuscript `.mk` — already per-deliverable** (ticket 0237):
+  `deliverables/{manuscript,corpus-report,data-paper,multilayer,technical-report,zoo}/*.mk`.
+  No Phase-3 `.mk` remains at root. This ticket is Phase-2 only.
+- **`paths.mk` stays at root** — it is the shared variable interface (`DERIVED`,
+  `BIB`, `CSL`, `*_INCLUDES`, `*_FIGS`) `-include`d by BOTH the Phase-2 Makefile
+  and every Phase-3 render `.mk` (0237). Moving it would break the render
+  workpackages.
+
+## Name collision to resolve
+Root `zoo.mk` is Phase-2-pure (0237 moved its render rule to
+`deliverables/zoo/zoo.mk`), but the two files share the basename `zoo.mk`.
+On relocation, rename the Phase-2 one (e.g. `scripts/analysis/zoo-figures.mk`)
+so the render `deliverables/zoo/zoo.mk` remains the unambiguous `zoo.mk`.
+
+## Relevant files
+- `divergence.mk`, `separation.mk`, `venues.mk`, `multilayer-detection.mk`,
+  `zoo.mk` — the five to move
+- `Makefile:91-95` — the `-include` lines to repoint
+- `paths.mk` — stays; do not move
+- `docs/repo-layout.md` — placement rule
+
+## Actions
+1. `git mv` the five fragments into `scripts/analysis/` (renaming the Phase-2
+   `zoo.mk`); repoint the `-include` lines in `Makefile`.
+2. Grep for any other reference to the old root paths (sub-makes, docs, CI).
+
+## Test
+- `make -n <target>` yields an identical target/prereq list before and after
+  (paths in the `.mk` change, the dependency graph does not) for one target per
+  moved fragment.
+
+## Invariants
+- `make check` green; the moves are pure `-include` path edits — no recipe
+  logic changes.
+- `paths.mk` untouched at root; render `.mk` untouched under `deliverables/`.
+
+## Exit criteria
+- The five Phase-2 analysis `.mk` live under `scripts/analysis/`; none at root
+  except `paths.mk`.
+- No dangling reference to a moved fragment's old path.
+- `make -n` target lists unchanged by the move.
+
+Ticket-ref: tickets/0225-reorg-code.erg

--- a/tickets/0240-reorg-code-2-scripts-by-phase.erg
+++ b/tickets/0240-reorg-code-2-scripts-by-phase.erg
@@ -1,0 +1,58 @@
+%erg 0.1
+Title: Reorg code 2/4 — group scripts/ 173 files by dataflow phase
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Label: deferred
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; the high-risk stage (173-file move, import-path churn). Parked behind the Œconomia R&R per 0223.
+
+--- body ---
+## Context
+Second stage of the code reorg (parent sub-tracker `0225`, grand-tracker
+`0223`). `scripts/` holds 173 flat files that are really a library plus a set of
+entry points. Group the entry points by dataflow phase so the directory names
+the phase, WITHOUT introducing a top-level `src/` package (author declined
+2026-07-10; the `_`-private + `pipeline_*` loader convention stands, cross-repo
+sharing via `libs/`).
+
+This is the highest-risk stage: it rewrites import paths across the tree
+(`utils` is imported ~160×, `script_io_args` ~93×). Land it alone.
+
+## Relevant files
+- `scripts/*.py` — 173 files
+- `docs/repo-layout.md` — the placement rule + 19-file migration audit
+  (destinations `scripts/<phase>/`, not `src/`)
+- `.claude/rules/architecture.md` § Pipeline phases — the phase → prefix map
+
+## Actions
+1. Create phase subdirs and move entry points:
+   - `plot_*` / `export_*` → `scripts/figures/`
+   - `analyze_*` / `compute_*` → `scripts/analysis/`
+   - `catalog_*` / `enrich_*` / `corpus_*` / `scout*` → `scripts/harvest/`
+   - `qa_*` → `scripts/qa/`
+   Respect the semantic-phase exceptions (architecture.md § "Phase is semantic":
+   `compute_reranker_calibration` is Phase-1; `qa_embeddings` / `qa_detect_type`
+   emit Phase-2 outputs). Shared library modules (`utils`, `pipeline_*`,
+   `_*`-private) stay where imports resolve, or move as a unit with call-site
+   fixes.
+2. Update every import and every Makefile / `.mk` script path to the new
+   locations.
+
+## Test
+- `make check` green after the move (import resolution is the real gate).
+- `make -n <target>` for one target per phase yields the same prereq graph
+  (only the `scripts/<phase>/…` path segment changes).
+
+## Invariants
+- No top-level `src/`; no `python -m` flip; library convention unchanged.
+- Layering (architecture.md rule 4): a compute module never imports a plotter.
+- One logical move per PR (this ticket = the phase-grouping move only).
+
+## Exit criteria
+- `scripts/` grouped by phase; no flat ~170-file directory remains.
+- `make check` and `make clean && make all` green from the regrouped tree.
+- All imports and Make script paths repointed; no dangling reference.
+
+Ticket-ref: tickets/0225-reorg-code.erg

--- a/tickets/0241-reorg-code-3-split-extractions.erg
+++ b/tickets/0241-reorg-code-3-split-extractions.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: Reorg code 3/4 — land the 5 SPLIT extractions in their phase subdir
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Blocked-by: 0240
+Label: deferred
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child. Blocked-by 0240: the extractions land inside the phase subdirs 0240 creates. Parked behind the Œconomia R&R per 0223.
+
+--- body ---
+## Context
+Third stage of the code reorg (parent sub-tracker `0225`, grand-tracker
+`0223`). The `scripts/` audit (`docs/repo-layout.md`) flagged five clusters of
+duplicated / in-lined computation that should be extracted into their own
+modules so the leaking scripts import them instead of re-implementing. Land each
+extraction as a plain or `_`-private module **inside the owning phase subdir**
+(created by 0240) — no top-level `src/`.
+
+## Depends on 0240
+The destination phase subdirs (`scripts/analysis/`, `scripts/harvest/`, …) are
+created by 0240. This ticket places the extracted modules there and repoints the
+importing scripts, so it must land after 0240.
+
+## The five extractions
+- `corpus_filters` — shared corpus-filtering predicate
+- `traditions` — tradition-assignment logic
+- `changepoints` — change-point helper
+- `teaching` — teaching-corpus helper
+- `venues` — venue-concentration helper
+(LIBRARY-10 and MOVE-2 from the audit stay in `scripts/`, relocated by phase in
+0240 — no `src/`.)
+
+## Relevant files
+- `docs/repo-layout.md` — the audit rows naming each extraction + its importers
+- the five owning phase subdirs under `scripts/` (from 0240)
+
+## Test
+- Byte-check each extraction as **old-code-vs-new-code on the same input**
+  (import the pre-extraction function and the extracted one, assert identical
+  output on the current corpus slice) — never against a drifting committed
+  golden. See feedback memory `bytecheck_old_vs_new_not_golden`.
+
+## Invariants
+- No behaviour change: each extraction is a pure move of logic + an import.
+- Layering (architecture.md rule 4): a compute module never imports a plotter.
+- One extraction per commit; `make check` green.
+
+## Exit criteria
+- The five extractions live beside their phase; each leaking script imports the
+  shared module instead of re-implementing.
+- Byte-identical output before/after for every extraction.
+- `make check` green.
+
+Ticket-ref: tickets/0225-reorg-code.erg

--- a/tickets/0242-reorg-code-4-sever-clustering-backarrow.erg
+++ b/tickets/0242-reorg-code-4-sever-clustering-backarrow.erg
@@ -1,0 +1,44 @@
+%erg 0.1
+Title: Reorg code 4/4 — sever compute_clustering_comparison's import of the plotters
+Created: 2026-07-10
+Author: HDMX-coding-agent
+Label: deferred
+
+--- log ---
+2026-07-10T00:00Z HDMX-coding-agent created
+2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; off-critical-path follow-up. Independent of the moves, but cleanest once scripts/ is grouped (0240). Parked behind the Œconomia R&R per 0223.
+
+--- body ---
+## Context
+Final, off-critical-path stage of the code reorg (parent sub-tracker `0225`,
+grand-tracker `0223`). `compute_clustering_comparison.py` imports the two
+clustering *plotter* modules — a compute → plot backward arrow that violates the
+layering rule (architecture.md rule 4: a compute module never imports a
+plotter). Sever it so the dependency points only compute → plot, never back.
+
+## Relevant files
+- `scripts/compute_clustering_comparison.py` — holds the backward import
+- the two clustering plotter modules it imports (identify from the import lines)
+
+## Actions
+1. Identify what `compute_clustering_comparison` actually needs from the
+   plotters (likely a shared label/order helper, not the plotting itself).
+2. Extract that shared piece into a neutral module both can import, or inline it
+   compute-side; drop the plotter import.
+
+## Test
+- Byte-check `compute_clustering_comparison`'s output unchanged (old-vs-new on
+  the same input).
+- A grep/import-graph assertion: no `compute_*` module imports a `plot_*`
+  module (candidate standing guard, if cheap).
+
+## Invariants
+- No behaviour change; layering restored (compute never imports plot).
+- `make check` green.
+
+## Exit criteria
+- `compute_clustering_comparison` no longer imports either plotter.
+- Output byte-identical before/after.
+- Optionally: a standing test that no `compute_*` imports a `plot_*`.
+
+Ticket-ref: tickets/0225-reorg-code.erg


### PR DESCRIPTION
Two ticket-modeling fixes to the code-reorg workstream (0225), both metadata-only — no code moves. The reorg stays deferred behind the Œconomia R&R.

## 1. Strip the cyclic Blocked-by edge (commit c8464ba)

`0225` (a leaf) carried `Blocked-by: 0223`, but `0223` is its own **tracking parent** that *"stays open until its children close"*. Leaf-blocked-by-parent + parent-open-until-leaf-closes is a cycle — `0225` could never reach `erg ready`. The edge stood in for a *prerequisite* (author ratification of the target layout) discharged 2026-07-10; once ratified nothing blocked the child. Sibling `0226` carried the identical edge and was executed + merged regardless (PR #1002), confirming it vestigial. Dropped.

## 2. Split 0225 into integer children 0239–0242 (commit 73b0f0e)

`0225` planned four Actions across separate PRs; ticket discipline splits a multi-PR ticket into one child per PR. `0225` becomes a sub-tracker (`0223 → 0225 → 0239-0242`):

| Child | Scope | Risk | Dep |
|-------|-------|------|-----|
| **0239** | relocate the **5** Phase-2 analysis `.mk` → `scripts/analysis/` | low | — |
| **0240** | group `scripts/` 173 files by phase | high (import churn) | — |
| **0241** | land the 5 SPLIT extractions in phase subdirs | med | blocked-by 0240 |
| **0242** | sever `compute_clustering_comparison` → plotter back-arrow | low | — (follow-up) |

No child is `blocked-by` its own tracker — the same cyclic edge fix #1 removed; only `0241→0240` (a real prerequisite) is encoded.

### Scope corrections surfaced by review
- The `.mk` relocation now covers **all 5** root Phase-2 analysis `.mk`. `0225` Action 1 named only 3 (`divergence`/`separation`/`venues`); `multilayer-detection.mk` and `zoo.mk` are the same class (`-include`d at `Makefile:91-95`).
- Root `zoo.mk` is **Phase-2-pure** — 0237 already split its render rule to `deliverables/zoo/zoo.mk` — but the two share the basename, so it's renamed on relocation. Render/manuscript `.mk` are already per-deliverable (0237), out of scope.
- `paths.mk` stays at root (shared variable interface for both Phase-2 and the Phase-3 render `.mk`).

## Verification
- `erg validate` PASS (all 5 touched/new tickets); `erg check` PASS (no cycles, no dangling refs, 232 tickets).
- Reorg subtree: `0239`/`0240`/`0242` independent, `0241` blocked-by `0240`, `0225` sub-tracker — all deferred.

Ticket-ref: tickets/0225-reorg-code.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)