### PR TITLE
ticket(0239): relocate the 5 Phase-2 analysis .mk into scripts/analysis/

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -55,7 +55,7 @@ The pipeline has four phases. Each phase's scripts follow a naming convention an
 
 1. **1 invocation = 1 output.** Each Make target calls one script that writes one file. No side-effect outputs.
 2. **Schema-validated.** New CSV artifacts get a Pandera schema in `scripts/schemas.py` (strict=True, coerce=True). Validate at write time — if the schema fails, the script fails, Make stops. (Legacy scripts are migrated as touched.)
-3. **Modular Makefiles.** Each analysis concern gets its own `.mk` file (`divergence.mk`, etc.), included by the main Makefile. Adding a new analysis = adding a `.mk`, not editing a 400-line Makefile.
+3. **Modular Makefiles.** Each analysis concern gets its own `.mk` file under `scripts/analysis/` (`divergence.mk`, etc.; ticket 0239), `-include`d by the main Makefile. Adding a new analysis = adding a `.mk`, not editing a 400-line Makefile.
 4. **Compute / Plot / Include are separate.** A compute script produces a table. A plot script reads a table and produces a figure. An include reads tables/figures and produces prose. Never mix.
 5. **`save_figure()` mandatory.** All plot scripts use `save_figure(fig, stem, dpi=N)` from `pipeline_io.py` — strips metadata for byte-reproducible PNGs. Never call `fig.savefig()` directly.
 6. **Config-driven parameters.** All research parameters in `config/analysis.yaml`, read via `load_analysis_config()`. No hardcoded constants for values that might change (windows, seeds, thresholds).
@@ -71,7 +71,7 @@ The permutation null models in `scripts/compute_null_model.py` use three complem
 - **Precomputed TF-IDF** for `L1`: the vectorizer runs once per window; permutations only reshuffle row indices into the sparse matrix — eliminating redundant `vectorizer.transform()` calls per (year, window).
 - **CPU parallel via joblib** across (year, window) pairs for `G2_spectral`, `G9_community`, and `L2`. Default `n_jobs=1` at the API boundary preserves test determinism; the CLI exposes `--n-jobs` (`-1` = all cores) for production runs.
 
-The Makefile knob is `NJOBS` (in `divergence.mk`). Default `-1` uses all cores — fine for a single method, oversubscribes under `make -jN`. When composing with `-j`, pass `NJOBS ≈ cores/N` (e.g. on 24 cores: `make -j4 NJOBS=6 null-model`). End-to-end on padme: ~3h → ~7min.
+The Makefile knob is `NJOBS` (in `scripts/analysis/divergence.mk`). Default `-1` uses all cores — fine for a single method, oversubscribes under `make -jN`. When composing with `-j`, pass `NJOBS ≈ cores/N` (e.g. on 24 cores: `make -j4 NJOBS=6 null-model`). End-to-end on padme: ~3h → ~7min.
 
 **Phase 3 — Render** (Quarto → PDF/DOCX):
 - Reads Phase 2 outputs. Each deliverable's PDF/DOCX renders next to its `.qmd` under `deliverables/<x>/` (gitignored).

--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,11 @@ endif
 # The per-deliverable render .mk (Phase 3) are NOT included here: `make papers`
 # calls them via `$(MAKE) -f deliverables/<x>/<x>.mk` so the render process never
 # parses these Phase-2 rules (ticket 0237).
--include divergence.mk
--include multilayer-detection.mk
--include zoo.mk
--include venues.mk
--include separation.mk
+-include scripts/analysis/divergence.mk
+-include scripts/analysis/multilayer-detection.mk
+-include scripts/analysis/zoo-figures.mk
+-include scripts/analysis/venues.mk
+-include scripts/analysis/separation.mk
 
 # ── Quarto ───────────────────────────────────────────────
 # The per-document include sets (*_INCLUDES) and figure sets (*_FIGS) live in

--- a/deliverables/multilayer/multilayer.mk
+++ b/deliverables/multilayer/multilayer.mk
@@ -12,7 +12,7 @@
 # Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
 # process never parses the root Phase-2 rules (ticket 0237). The Phase-2 remainder
 # of the old multilayer-detection.mk (the four companion-figure compute rules)
-# stays at root as multilayer-detection.mk.
+# lives at scripts/analysis/multilayer-detection.mk (ticket 0239).
 
 -include paths.mk
 

--- a/deliverables/zoo/zoo.mk
+++ b/deliverables/zoo/zoo.mk
@@ -9,7 +9,7 @@
 #
 # Invoked by the root Makefile's `papers` target via `$(MAKE) -f` so this render
 # process never parses the root Phase-2 rules (ticket 0237). The Phase-2 remainder
-# (schematic/result-panel/cross-year compute rules) stays at root as zoo.mk.
+# (schematic/result-panel/cross-year compute rules) lives at scripts/analysis/zoo-figures.mk (ticket 0239).
 #
 # The figure prerequisites reference $(ZOO_SCHEMATICS) $(ZOO_RESULT_FIGS)
 # explicitly, not the ambiguous $(ZOO_FIGS) — at the root the latter shadowed a

--- a/docs/handoff-padme-divergence.md
+++ b/docs/handoff-padme-divergence.md
@@ -12,7 +12,7 @@ methods (5 semantic, 3 lexical, 8 citation graph), 3 change point detectors
 convergence analysis across channels.
 
 Architecture: 1-script-1-output, Pandera schema validation, modular
-Makefile (`divergence.mk`), configurable seeds, shared I/O module.
+Makefile (`scripts/analysis/divergence.mk`), configurable seeds, shared I/O module.
 
 77 tests (27 fast / 50 slow), 15 golden value regression tests.
 
@@ -115,7 +115,7 @@ scripts/
   plot_convergence.py            # heatmap + stacked bars
   schemas.py                     # DivergenceSchema (Pandera)
 config/analysis.yaml             # all parameters (divergence section)
-divergence.mk                   # Make targets
+scripts/analysis/divergence.mk  # Make targets
 docs/literature-review-structural-break-detection.md
 ```
 

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -71,13 +71,21 @@ layering constraint. **Nothing that renders is imported by compute.**
 
 ### Makefile fragments
 
-A build fragment lives next to what it *builds*:
+A build fragment lives next to what it *builds*, and the split is by phase:
 
-- Deliverable-scoped (`manuscript.mk`, `zoo.mk`, `multilayer-detection.mk`) →
-  into that `deliverables/<x>/` folder.
-- Shared analysis (`divergence.mk`, `separation.mk`, `venues.mk`) →
-  `scripts/analysis/analysis.mk`, because what they build feeds several
-  deliverables, not one.
+- **Phase-3 render** fragments → the deliverable's own folder,
+  `deliverables/<x>/<x>.mk` (`manuscript.mk`, `zoo.mk`, `multilayer.mk`, …).
+  `make papers` invokes each via `$(MAKE) -f`, so the render process never
+  parses the Phase-2 rules (ticket 0237).
+- **Phase-2 analysis concern** fragments → `scripts/analysis/`, one file per
+  concern (`divergence.mk`, `separation.mk`, `venues.mk`,
+  `multilayer-detection.mk`, `zoo-figures.mk`), because what they build feeds
+  several deliverables, not one (ticket 0239). They stay separate, not merged —
+  the modular-Makefile rule (architecture.md Phase-2 rule 3) is one `.mk` per
+  concern. The Phase-2 `zoo` fragment is `zoo-figures.mk` to disambiguate from
+  the Phase-3 render `deliverables/zoo/zoo.mk`.
+- `paths.mk` stays at the repo root — the shared variable interface `-include`d
+  by both the Phase-2 Makefile and every Phase-3 render fragment.
 
 Moving a `.mk` file is cheap: `-include`d rules resolve relative to the *root*
 Makefile, so paths inside are unchanged — only the `-include` line edits.

--- a/scripts/analysis/divergence.mk
+++ b/scripts/analysis/divergence.mk
@@ -1,6 +1,6 @@
 # divergence.mk — Multi-channel structural break detection pipeline
 #
-# Include from the main Makefile:  include divergence.mk
+# Include from the main Makefile:  -include scripts/analysis/divergence.mk
 #
 # Architecture: one CSV per method via scripts/compute_divergence.py --method X
 #

--- a/scripts/analysis/multilayer-detection.mk
+++ b/scripts/analysis/multilayer-detection.mk
@@ -2,7 +2,7 @@
 #
 # Four canonical PNGs consumed by deliverables/multilayer/multilayer-detection.qmd.
 #
-# Include from the main Makefile:  include multilayer-detection.mk
+# Include from the main Makefile:  -include scripts/analysis/multilayer-detection.mk
 #
 # Targets:
 #   companion-figures  — build all four PNGs

--- a/scripts/analysis/separation.mk
+++ b/scripts/analysis/separation.mk
@@ -1,6 +1,6 @@
 # separation.mk — Pre-2007 tradition-separation fortify-or-demote (ticket 0182)
 #
-# Include from the main Makefile:  -include separation.mk
+# Include from the main Makefile:  -include scripts/analysis/separation.mk
 #
 # Tests whether the observed separation of the three pre-2007 intellectual
 # traditions in the co-citation graph exceeds what the degree sequence alone

--- a/scripts/analysis/venues.mk
+++ b/scripts/analysis/venues.mk
@@ -1,6 +1,6 @@
 # venues.mk — Venue concentration analysis (ticket 0073)
 #
-# Include from the main Makefile:  include venues.mk
+# Include from the main Makefile:  -include scripts/analysis/venues.mk
 #
 # Targets:
 #   venue-concentration-table  Compute HHI + Shannon entropy per year

--- a/scripts/analysis/zoo-figures.mk
+++ b/scripts/analysis/zoo-figures.mk
@@ -1,6 +1,8 @@
-# zoo.mk — Zoo figures: 17 ELI15 schematics + 18 cross-year result panels
+# zoo-figures.mk — Zoo figures: 17 ELI15 schematics + 18 cross-year result panels
 #
-# Included from the main Makefile:  -include zoo.mk
+# Phase-2 concern fragment (renamed from zoo.mk to disambiguate from the Phase-3
+# render fragment deliverables/zoo/zoo.mk; ticket 0239).
+# Included from the main Makefile:  -include scripts/analysis/zoo-figures.mk
 #
 # Targets:
 #   zoo-figures      All 35 zoo figures (schematics + result panels)

--- a/tests/test_analysis_mk_layout.py
+++ b/tests/test_analysis_mk_layout.py
@@ -1,0 +1,43 @@
+"""Layout guard — Phase-2 analysis .mk live under scripts/analysis/, not root.
+
+Ticket 0239 (code reorg 1/4): the top level stopped carrying build fragments.
+The five Phase-2 "concern" Makefile fragments moved under `scripts/analysis/`;
+the only `.mk` left at the repo root is `paths.mk` (the shared variable
+interface `-include`d by both the Phase-2 Makefile and every Phase-3 render
+`.mk`). This guard fails if a new analysis `.mk` reappears at root or a moved
+one goes missing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO = Path(__file__).resolve().parent.parent
+ANALYSIS_MK_DIR = REPO / "scripts" / "analysis"
+
+# The five Phase-2 analysis fragments, at their post-0239 home. The root
+# `zoo.mk` was renamed `zoo-figures.mk` to end the basename clash with the
+# Phase-3 render fragment `deliverables/zoo/zoo.mk`.
+EXPECTED_ANALYSIS_MK = {
+    "divergence.mk",
+    "separation.mk",
+    "venues.mk",
+    "multilayer-detection.mk",
+    "zoo-figures.mk",
+}
+
+
+def test_analysis_mk_live_under_scripts_analysis():
+    present = {p.name for p in ANALYSIS_MK_DIR.glob("*.mk")}
+    missing = EXPECTED_ANALYSIS_MK - present
+    assert not missing, f"analysis .mk missing from scripts/analysis/: {sorted(missing)}"
+
+
+def test_root_carries_only_paths_mk():
+    root_mk = {p.name for p in REPO.glob("*.mk")}
+    assert root_mk == {"paths.mk"}, (
+        f"repo root must carry only paths.mk; found {sorted(root_mk)}. "
+        "Phase-2 analysis fragments belong under scripts/analysis/ (ticket 0239)."
+    )

--- a/tests/test_build_phase_separation.py
+++ b/tests/test_build_phase_separation.py
@@ -45,8 +45,10 @@ def _has_phase2(text: str) -> bool:
 
 
 def _all_mk_files() -> list[str]:
-    """Every build fragment: root concern .mk + per-deliverable render .mk."""
+    """Every build fragment: root paths.mk + Phase-2 analysis concern .mk under
+    scripts/analysis/ (relocated by ticket 0239) + per-deliverable render .mk."""
     files = glob.glob(os.path.join(REPO_ROOT, "*.mk"))
+    files += glob.glob(os.path.join(REPO_ROOT, "scripts", "analysis", "*.mk"))
     files += glob.glob(os.path.join(REPO_ROOT, "deliverables", "*", "*.mk"))
     return sorted(files)
 

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -28,7 +28,8 @@ Two guards, complementary:
    class, out of 0218's scope, and are neither flagged nor moved here.
 
 Scope (ticket 0231): the class ratchet scans the top-level `Makefile` AND every
-sub-Makefile (`divergence.mk`, `zoo.mk`, `multilayer-detection.mk`, `venues.mk`).
+sub-Makefile under `scripts/analysis/` (`divergence.mk`, `zoo-figures.mk`,
+`multilayer-detection.mk`, `venues.mk`, `separation.mk`; relocated by 0239).
 Those subsystems route their `tab_*` targets through a per-subsystem directory
 variable (`DIV_TABLES`, `ZOO_TABLES`, `COMP_TABLES`, `VENUE_TABLE`), so a target
 line reads `$(DIV_TABLES)/tab_div_$(m).csv`, not a literal `deliverables/_shared/tables/...`
@@ -98,6 +99,9 @@ def _bad_patterns(basename):
 def _makefiles():
     paths = [os.path.join(PROJECT_ROOT, "Makefile")]
     paths += glob.glob(os.path.join(PROJECT_ROOT, "*.mk"))
+    # Phase-2 analysis concern .mk moved under scripts/analysis/ (ticket 0239);
+    # keep scanning them so the eviction guard still covers the moved fragments.
+    paths += glob.glob(os.path.join(SCRIPTS_DIR, "analysis", "*.mk"))
     return paths
 
 

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -6,6 +6,7 @@ Covers:
 - Makefile pattern rule exists for figure scripts
 """
 
+import glob
 import os
 import subprocess
 import sys
@@ -272,14 +273,19 @@ class TestComputeBreakpointsOneOutput:
 
 
 def _makefile_text():
-    """Concatenate the main Makefile and every included *.mk."""
+    """Concatenate the main Makefile and every included *.mk.
+
+    Phase-2 analysis concern fragments moved under scripts/analysis/ (ticket
+    0239); include them so the $(DERIVED)-producer scan still sees their targets.
+    """
     root = os.path.join(os.path.dirname(__file__), "..")
+    mk_files = [os.path.join(root, "Makefile")]
+    mk_files += sorted(glob.glob(os.path.join(root, "*.mk")))
+    mk_files += sorted(glob.glob(os.path.join(root, "scripts", "analysis", "*.mk")))
     text = ""
-    for name in ["Makefile"] + sorted(
-        f for f in os.listdir(root) if f.endswith(".mk")
-    ):
-        with open(os.path.join(root, name)) as f:
-            text += f"\n# === {name} ===\n" + f.read()
+    for path in mk_files:
+        with open(path) as f:
+            text += f"\n# === {os.path.basename(path)} ===\n" + f.read()
     return text
 
 

--- a/tests/test_multilayer_detection_figures.py
+++ b/tests/test_multilayer_detection_figures.py
@@ -249,7 +249,7 @@ def test_community_runs(tmp_path: Path, companion_tables: Path):
 
 # ─── Stub-fallback smoke (no interpretation CSV → PNG still rendered) ────
 #
-# Figures 3 and 4 promise in multilayer-detection.mk that the Make target succeeds
+# Figures 3 and 4 promise in scripts/analysis/multilayer-detection.mk that the Make target succeeds
 # even when ticket 0056's interpretation layer is absent. Drive the
 # fallback path by pointing --tables-dir at an empty directory.
 

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -1,13 +1,20 @@
-"""Tests for zoo.mk structure — schematic + result panel recipes."""
+"""Tests for the zoo Phase-2 concern .mk structure — schematic + result panels.
+
+The Phase-2 concern fragment moved to `scripts/analysis/zoo-figures.mk` and was
+renamed to end the basename clash with the Phase-3 render fragment
+`deliverables/zoo/zoo.mk` (ticket 0239).
+"""
 
 import re
 from pathlib import Path
 
 import pytest
 
-ZOO_MK = Path(__file__).resolve().parent.parent / "zoo.mk"
-# The Phase-3 render rule moved beside its source (ticket 0237); the root zoo.mk
-# is now the pure Phase-2 concern file.
+ZOO_MK = (
+    Path(__file__).resolve().parent.parent / "scripts" / "analysis" / "zoo-figures.mk"
+)
+# The Phase-3 render rule lives beside its source (ticket 0237); the Phase-2
+# concern fragment is scripts/analysis/zoo-figures.mk (ticket 0239).
 ZOO_RENDER_MK = (
     Path(__file__).resolve().parent.parent / "deliverables" / "zoo" / "zoo.mk"
 )
@@ -20,7 +27,7 @@ _CROSSYEAR_RE = re.compile(
 
 def _parse_crossyear_methods(mk: str) -> list[str]:
     m = _CROSSYEAR_RE.search(mk)
-    assert m, "CROSSYEAR_METHODS not found in zoo.mk"
+    assert m, "CROSSYEAR_METHODS not found in zoo-figures.mk"
     return [t for t in m.group(1).split() if t != "\\"]
 
 
@@ -37,17 +44,17 @@ class TestZooMkStructure:
 
     def test_zoo_figures_target_exists(self, zoo_mk_text):
         assert re.search(r"^zoo-figures\s*:", zoo_mk_text, re.MULTILINE), (
-            "zoo-figures target missing from zoo.mk"
+            "zoo-figures target missing from zoo-figures.mk"
         )
 
     def test_schematic_pattern_recipe_exists(self, zoo_mk_text):
         assert re.search(r"schematic_%\.png\s*:.*plot_schematic_%\.py", zoo_mk_text), (
-            "Pattern rule for schematic_%.png missing from zoo.mk"
+            "Pattern rule for schematic_%.png missing from zoo-figures.mk"
         )
 
     def test_result_panel_pattern_recipe_exists(self, zoo_mk_text):
         assert re.search(r"fig_zoo_%\.png\s*:.*plot_zoo_results\.py", zoo_mk_text), (
-            "Pattern rule for fig_zoo_%.png missing from zoo.mk"
+            "Pattern rule for fig_zoo_%.png missing from zoo-figures.mk"
         )
 
     def test_crossyear_tables_is_phony(self, zoo_mk_text):
@@ -85,9 +92,12 @@ class TestZooMkStructure:
             re.MULTILINE,
         ), "breakpoint-detect-method-zoo.pdf recipe must live in deliverables/zoo/zoo.mk"
 
-    def test_root_zoo_mk_has_no_render_rule(self, zoo_mk_text):
-        """The root concern zoo.mk must be pure Phase-2 — no render rule (0237)."""
+    def test_concern_zoo_mk_has_no_render_rule(self, zoo_mk_text):
+        """The concern fragment must be pure Phase-2 — no render rule (0237)."""
         assert "quarto render" not in zoo_mk_text, (
-            "root zoo.mk must not carry a render recipe; it moved to deliverables/zoo/zoo.mk"
+            "zoo-figures.mk must not carry a render recipe; render lives in "
+            "deliverables/zoo/zoo.mk"
         )
-        assert ".pdf:" not in zoo_mk_text, "root zoo.mk must carry no .pdf render target"
+        assert ".pdf:" not in zoo_mk_text, (
+            "zoo-figures.mk must carry no .pdf render target"
+        )

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -83,7 +83,8 @@ class TestZooMkStructure:
         """The zoo PDF render rule lives in deliverables/zoo/zoo.mk (ticket 0237).
 
         Phase 3 render is split from Phase 2 compute: the render rule sits beside
-        its source under deliverables/zoo/, not in the root concern zoo.mk.
+        its source under deliverables/zoo/, not in the concern fragment
+        scripts/analysis/zoo-figures.mk.
         """
         render_text = ZOO_RENDER_MK.read_text()
         assert re.search(

--- a/tickets/closed/0239-reorg-code-1-analysis-mk-relocate.erg
+++ b/tickets/closed/0239-reorg-code-1-analysis-mk-relocate.erg
@@ -3,11 +3,13 @@ Title: Reorg code 1/4 — relocate the 5 Phase-2 analysis .mk into scripts/analy
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: autoclosed — PR #1006
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; parent 0225 is the sub-tracker. Scope corrected to ALL 5 analysis .mk (0225 Action 1 named only 3). Parked behind the Œconomia R&R per 0223.
 
+2026-07-10T21:38Z HDMX-coding-agent closed — autoclosed — PR #1006
 --- body ---
 ## Context
 First and lowest-risk stage of the code reorg (parent sub-tracker `0225`,


### PR DESCRIPTION
Code reorg 1/4 (parent sub-tracker 0225, grand-tracker 0223) — the low-risk, lands-first stage. Pure file-move + `-include` repoint; no recipe logic changes.

## What moved
The main `Makefile` `-include`d five Phase-2 "concern" fragments from the repo root. They now live under `scripts/analysis/`:

| From (root) | To |
|-------------|-----|
| `divergence.mk` | `scripts/analysis/divergence.mk` |
| `separation.mk` | `scripts/analysis/separation.mk` |
| `venues.mk` | `scripts/analysis/venues.mk` |
| `multilayer-detection.mk` | `scripts/analysis/multilayer-detection.mk` |
| `zoo.mk` | `scripts/analysis/zoo-figures.mk` *(renamed)* |

`zoo.mk` → `zoo-figures.mk` ends the basename clash with the Phase-3 render fragment `deliverables/zoo/zoo.mk` (0237). `paths.mk` stays at root (shared variable interface); render `.mk` untouched. Scope corrected from 0225's Action 1, which named only 3 of the 5.

## Reference sweep
- `Makefile`: 5 `-include` lines repointed.
- `tests/test_zoo_mk.py`: `ZOO_MK` path + stale messages.
- `tests/test_evict_analysis_intermediates.py` **and** `tests/test_io_discipline.py`: both globbed only root `*.mk` for their guards — extended to `scripts/analysis/*.mk` so the eviction and `$(DERIVED)`-producer scans keep covering the moved fragments. (`test_io_discipline` was caught by `make lint` — same class as the eviction glob.)
- `docs/repo-layout.md`: **corrected** — it wrongly classified the zoo/multilayer concern `.mk` as deliverable-scoped and prescribed a single merged `analysis.mk`; now phase-split, one file per concern.
- `.claude/rules/architecture.md`, `docs/handoff-padme-divergence.md`: paths.

## Verification (path refactor → `make -n` + grep + spot-check, not a full build)
- **`make -n`** for one target per fragment: recipe lines **byte-identical** before/after — dependency graph unchanged, `-include` repoint correct.
- **New guard** `tests/test_analysis_mk_layout.py` (adherence): 5 fragments under `scripts/analysis/`, root carries only `paths.mk`. RED before the move, GREEN after.
- **Runtime spot-check**: `make venue-concentration-table` (defined in the relocated `scripts/analysis/venues.mk`) builds end-to-end and writes valid output (38 rows) — the fragment is correctly `-include`d.
- **`make lint` green** (146 passed) — adherence gate satisfied, `/gaze` can skip the mechanical phase.
- `make check-fast`: only pre-existing tracked flaky `test_step1_counter_attempted` (ticket 0238, xdist-order; passes in isolation), unrelated to this change.

**Ticket:** tickets/0239-reorg-code-1-analysis-mk-relocate.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)