### PR TITLE
docs(0245): record 2026-07-10 settled editorial decisions in the brief

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -63,8 +63,14 @@ literature (Desrosières, Lepenies on GDP, Morgan/Tooze on aggregates) to *justi
 the aggregate-birth framing, but do **not** develop a systematic GDP ↔ climate-finance
 comparison. The analogy licenses the framing; it is not itself a section of the paper.
 
+**Intro body pivots too (author, 2026-07-10):** the introduction — not only the
+title and abstract — opens on the birth-of-an-aggregate question, citing the
+GDP-construction research (Lepenies 2016, Desrosières 1998) as the lineage. The
+case's contested functioning (the number is always arguable) is a trait of *this*
+aggregate, not the organizing frame of the paper.
+
 **Ticket:** 0165 (base decision); 0171 (conclusion landing, action 7 bib anchoring);
-`docs/notes-vannes-2026-07.md` §1, §4.
+0245 (intro pivot, commit 485bd92); `docs/notes-vannes-2026-07.md` §1, §4.
 
 **Status:** active
 
@@ -270,5 +276,63 @@ defense, now formulated head-on).
 
 **Ticket:** 0171 (conclusion engagement); 0143 (Star refs); 0173 translation
 keeps "borderline object" in the introduction.
+
+**Status:** active
+
+## green-finance-is-a-cousin-not-a-sister
+
+**Decision:** In the §Controversies preamble, name green finance as a *cousin* of
+climate finance, not a sister — an adjacent lineage, not a parallel object. The
+article's object stays the climate-finance aggregate; green finance is placed, not
+analysed alongside.
+
+**Rationale:** Author decision 2026-07-10. A sister framing would double the paper's
+scope and blur the very aggregate whose birth it traces; cousin acknowledges the
+neighbouring field without annexing it.
+
+**Ticket:** 0245 (this record); commit 1fe8e29 (§Controversies preamble lineage
+statement).
+
+**Status:** active
+
+## scientization-of-central-banking-frames-the-officials
+
+**Decision:** Frame the economist-officials in §Crystallization through the
+scientization-of-central-banking research programme, citing Marcussen 2009,
+Claveau & Dion 2018, Acosta et al. 2024, and Goutsmedt & Sergi 2025.
+
+**Rationale:** Author decision 2026-07-10. The programme gives a documented scholarly
+basis for the claim that an economic mode of reasoning entered institutional practice
+through trained officials — cross-ref `economic-rationality-carried-by-economists`,
+which this literature substantiates rather than the bare "economists built it".
+
+**Ticket:** 0245; commit 1fe8e29.
+
+**Status:** active
+
+## second-tradition-opens-on-poverty-eradication
+
+**Decision:** The second pre-history tradition (development economics / aid
+statistics) opens on its target: the eradication of poverty.
+
+**Rationale:** Author decision 2026-07-10. Naming what the tradition was *for* grounds
+the aid-statistics lineage in its purpose before the accounting machinery (DAC, Rio
+markers) enters, keeping the actor-and-motivation discipline of the writing rules.
+
+**Ticket:** 0245; commit 1fe8e29.
+
+**Status:** active
+
+## response-letter-first-person-singular-a4
+
+**Decision:** The resubmission response letter is written in the first person
+singular (the paper has a sole author). Every generated PDF uses A4 paper size.
+
+**Rationale:** Author decision 2026-07-10 (session 0152). A single-author letter reads
+in the first person singular, not an editorial "we"; A4 is the house paper size for
+all generated PDFs. The letter lives outside the repo, in the submission records under
+`papiers/<state>/<track>/`.
+
+**Ticket:** 0245; session 0152 (letter is outside the repo — no commit in this repo).
 
 **Status:** active

--- a/tickets/0245-editorial-brief-20260710-decisions.erg
+++ b/tickets/0245-editorial-brief-20260710-decisions.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-11T00:00Z HDMX-coding-agent created
+2026-07-11T00:00Z HDMX-coding-agent note Added brief entries: extended title-frames-aggregate-birth (intro pivot, 485bd92); new entries green-finance-is-a-cousin-not-a-sister, scientization-of-central-banking-frames-the-officials, second-tradition-opens-on-poverty-eradication (all 1fe8e29), response-letter-first-person-singular-a4 (session 0152)
 
 --- body ---
 ## Context

--- a/tickets/closed/0245-editorial-brief-20260710-decisions.erg
+++ b/tickets/closed/0245-editorial-brief-20260710-decisions.erg
@@ -2,11 +2,13 @@
 Title: Record the 2026-07-10 settled editorial decisions in the brief
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1012
 
 --- log ---
 2026-07-11T00:00Z HDMX-coding-agent created
 2026-07-11T00:00Z HDMX-coding-agent note Added brief entries: extended title-frames-aggregate-birth (intro pivot, 485bd92); new entries green-finance-is-a-cousin-not-a-sister, scientization-of-central-banking-frames-the-officials, second-tradition-opens-on-poverty-eradication (all 1fe8e29), response-letter-first-person-singular-a4 (session 0152)
 
+2026-07-10T22:38Z HDMX-coding-agent closed — autoclosed — PR #1012
 --- body ---
 ## Context
 Session 0152 (2026-07-10) settled several editorial decisions now implemented


### PR DESCRIPTION
Records the five editorial decisions settled in session 0152 (2026-07-10) into `docs/editorial-brief.md`, per the standing norm that settled debates enter the brief at settlement time or get re-litigated.

## Entries
1. **title-frames-aggregate-birth** (extended) — the intro body, not only title/abstract, pivots to the birth-of-an-aggregate question, citing GDP-construction research (Lepenies 2016, Desrosières 1998); the contested functioning is a trait of the aggregate, not the frame. Commit 485bd92.
2. **green-finance-is-a-cousin-not-a-sister** (new) — green finance named as a cousin in the §Controversies preamble; the article's object stays the aggregate. Commit 1fe8e29.
3. **scientization-of-central-banking-frames-the-officials** (new) — the economist-officials in §Crystallization framed via the scientization programme (Marcussen 2009; Claveau & Dion 2018; Acosta et al. 2024; Goutsmedt & Sergi 2025). Commit 1fe8e29.
4. **second-tradition-opens-on-poverty-eradication** (new) — the development-economics / aid-statistics tradition opens on its target, poverty eradication. Commit 1fe8e29.
5. **response-letter-first-person-singular-a4** (new) — the response letter is first-person singular (sole author); all generated PDFs use A4. Session 0152 (letter lives outside the repo).

Decision 1 extended the existing `title-frames-aggregate-birth` entry rather than duplicating it. Gates: `make check-fast` (exit 0) and `make lint` (151 passed, 6 skipped) both green.

**Ticket:** tickets/0245-editorial-brief-20260710-decisions.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)