### PR TITLE
ticket(0246): false alarm — make propagates exit code; `| tail` swallowed it

### DIFF
--- a/tickets/0246-make-check-exit-zero-despite-failures.erg
+++ b/tickets/0246-make-check-exit-zero-despite-failures.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-11T01:05Z HDMX-coding-agent created
+2026-07-11T00:37Z HDMX-coding-agent note False alarm: make DOES propagate the exit code; the observed 0 came from a `| tail` pipeline in a shell with pipefail OFF. Evidence — real recipe is plain `$(PYTHON) -m pytest tests/ -v --tb=short -n 4` (no `-` prefix, no `|| true`; `check-package` is a hard prereq that passed). Scratch repro (deliberate failing test under a scratch makefile): `make -f /tmp/t0246.mk check; echo $?` -> 2 (propagates); `make ... check 2>&1 | tail -1; echo $?` -> 0 (pipe swallows, pipefail off); same with `set -o pipefail` -> 2 (recovers). rtk proxy is exit-faithful: `rtk make ... check` and `rtk proxy make ... check` both -> 2. The lair log is an rtk `tee` capture, so the reader saw the pipeline's exit, not make's. Lesson: read exit status from `$?`/`PIPESTATUS[0]` of make itself, never from a `| tail` (or any pipeline) unless `set -o pipefail` is active. No repo code change needed.
 
 --- body ---
 ## Context
@@ -26,5 +27,5 @@ exit code. Log: `~/.local/share/rtk/tee/1783717128_make_check.log`.
   check, then revert).
 
 ## Exit criteria
-- [ ] `make check` exit code equals pytest verdict
-- [ ] Mechanism documented in the ticket log
+- [x] `make check` exit code equals pytest verdict (holds vacuously: make propagates the code; scratch repro `make check; echo $?` -> non-zero. The observed 0 was a `| tail` pipeline in a no-pipefail shell, not make.)
+- [x] Mechanism documented in the ticket log (2026-07-11T00:37Z entry)

--- a/tickets/closed/0246-make-check-exit-zero-despite-failures.erg
+++ b/tickets/closed/0246-make-check-exit-zero-despite-failures.erg
@@ -2,11 +2,13 @@
 Title: make check exits 0 while pytest reports failures — gate integrity
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1013
 
 --- log ---
 2026-07-11T01:05Z HDMX-coding-agent created
 2026-07-11T00:37Z HDMX-coding-agent note False alarm: make DOES propagate the exit code; the observed 0 came from a `| tail` pipeline in a shell with pipefail OFF. Evidence — real recipe is plain `$(PYTHON) -m pytest tests/ -v --tb=short -n 4` (no `-` prefix, no `|| true`; `check-package` is a hard prereq that passed). Scratch repro (deliberate failing test under a scratch makefile): `make -f /tmp/t0246.mk check; echo $?` -> 2 (propagates); `make ... check 2>&1 | tail -1; echo $?` -> 0 (pipe swallows, pipefail off); same with `set -o pipefail` -> 2 (recovers). rtk proxy is exit-faithful: `rtk make ... check` and `rtk proxy make ... check` both -> 2. The lair log is an rtk `tee` capture, so the reader saw the pipeline's exit, not make's. Lesson: read exit status from `$?`/`PIPESTATUS[0]` of make itself, never from a `| tail` (or any pipeline) unless `set -o pipefail` is active. No repo code change needed.
 
+2026-07-10T23:39Z HDMX-coding-agent closed — autoclosed — PR #1013
 --- body ---
 ## Context
 Lair run 2026-07-10 (background `make check` on main, doudou): pytest printed


### PR DESCRIPTION
## Outcome: false alarm (Makefile innocent)

The lair observation — `make check` exiting 0 while pytest reported `21 failed ... 4 errors` — is **not** a Makefile or rtk-proxy defect. `make` propagates the failing exit code faithfully. The observed 0 came from reading the exit status of a `| tail` pipeline in a shell with `pipefail` **off**, not from `make` itself.

### Evidence

Real recipe (Makefile ~line 643), no exit-code suppression:
```make
check: check-package | venv-canonicalize
	$(PYTHON) -m pytest tests/ -v --tb=short -n 4
```
No `-` prefix, no `|| true`; `check-package` is a hard prerequisite that passed.

Scratch reproduction (deliberate failing test under a scratch makefile, written under `/tmp`, never in the repo):

| invocation | exit |
|---|---|
| `make -f /tmp/t0246.mk check; echo $?` | **2** (make propagates) |
| `make ... check 2>&1 \| tail -1; echo $?` | **0** (pipe swallows, pipefail off) |
| `set -o pipefail; make ... check 2>&1 \| tail -1` | **2** (recovers) |

rtk is exit-faithful: `rtk make ... check` -> 2 and `rtk proxy make ... check` -> 2. The lair log (`~/.local/share/rtk/tee/1783717128_make_check.log`) is an rtk `tee` capture, so the reader observed the pipeline's exit, not make's.

### Operational lesson (documented in ticket log)

Read exit status from `$?` / `PIPESTATUS[0]` of `make` itself, never from a `| tail` (or any pipeline) unless `set -o pipefail` is active.

No repo code change is warranted. Both exit criteria satisfied (criterion 1 holds vacuously — make DOES propagate).

### Gates
- `make lint` — 151 passed, 6 skipped, exit 0
- `make check-fast` — passed, exit 0

**Ticket:** tickets/0246-make-check-exit-zero-despite-failures.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)