### PR TITLE
build(0247): reclassify bibtexparser as a main dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "networkx",
     "requests",
     "pyyaml",
+    "bibtexparser",
     "langdetect>=1.0.9",
     "pdfplumber",
     "pytest",
@@ -54,7 +55,6 @@ corpus = [
     "beautifulsoup4",
     "pdfplumber",
     "ddgs",
-    "bibtexparser",
 ]
 dev = [
     "fpdf2>=2.8.7",

--- a/tickets/0247-shared-venv-missing-bibtexparser.erg
+++ b/tickets/0247-shared-venv-missing-bibtexparser.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-11T01:05Z HDMX-coding-agent created
+2026-07-11T09:00Z HDMX-coding-agent note Corrected diagnosis: bibtexparser is not missing from a stale env — it was declared in the `corpus` dependency GROUP (Phase-1, not installed on Phase-2/3 machines). But the three importing scripts serve the WRITING side: qa_bibliography.py reads bibliography/main.bib + corpus and writes a match CSV; qa_bib_doi.py reads deliverables/_shared/bibliography/main.bib and audits DOIs vs Crossref; qa_missing_references.py reads deliverables/_shared/bibliography/main.bib and writes the missing-refs list (DOIfetch sync). The dependency was misclassified. Fix: moved bibtexparser from the `corpus` group to `[project]` dependencies; `uv lock`. Verified import + the three TestMigratedScripts tests green.
 
 --- body ---
 ## Context
@@ -17,12 +18,14 @@ during the 2026-07-10 lair full-suite run; also blocked the DOIfetch
 missing-references regeneration earlier that day (worked around by editing the
 DOIfetch queue directly).
 
-## Actions
-1. When no sibling session is mid-run on the shared env: `uv sync` from the
-   main checkout (norm: never sync the shared /data env while a sibling
-   background agent is running — memory feedback_no_shared_env_sync).
-2. Re-run the three tests; confirm green.
+## Actions (superseded — see 2026-07-11 log)
+The env was not stale; the dependency was misclassified. The three scripts that
+import bibtexparser are writing-side (they read `deliverables/_shared/bibliography/main.bib`),
+so the dependency belongs in `[project]`, not the Phase-1 `corpus` group.
+1. Move `bibtexparser` from the `corpus` group to `[project]` dependencies. Done.
+2. `uv lock` to update the lockfile. Done.
+3. Re-run the three tests; confirm green. Done.
 
 ## Exit criteria
-- [ ] `uv run python -c "import bibtexparser"` succeeds
-- [ ] tests/test_io_discipline.py TestMigratedScripts all green
+- [x] `uv run python -c "import bibtexparser"` succeeds (bibtexparser 1.4.4)
+- [x] tests/test_io_discipline.py TestMigratedScripts all green (12 passed, incl. qa_bib_doi / qa_bibliography / qa_missing_references × requires_output)

--- a/tickets/closed/0247-shared-venv-missing-bibtexparser.erg
+++ b/tickets/closed/0247-shared-venv-missing-bibtexparser.erg
@@ -2,11 +2,13 @@
 Title: Shared venv missing bibtexparser (declared in pyproject) — 3 io_discipline failures
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1014
 
 --- log ---
 2026-07-11T01:05Z HDMX-coding-agent created
 2026-07-11T09:00Z HDMX-coding-agent note Corrected diagnosis: bibtexparser is not missing from a stale env — it was declared in the `corpus` dependency GROUP (Phase-1, not installed on Phase-2/3 machines). But the three importing scripts serve the WRITING side: qa_bibliography.py reads bibliography/main.bib + corpus and writes a match CSV; qa_bib_doi.py reads deliverables/_shared/bibliography/main.bib and audits DOIs vs Crossref; qa_missing_references.py reads deliverables/_shared/bibliography/main.bib and writes the missing-refs list (DOIfetch sync). The dependency was misclassified. Fix: moved bibtexparser from the `corpus` group to `[project]` dependencies; `uv lock`. Verified import + the three TestMigratedScripts tests green.
 
+2026-07-11T00:45Z HDMX-coding-agent closed — autoclosed — PR #1014
 --- body ---
 ## Context
 `bibtexparser` is declared in pyproject.toml (line 57) but absent from the

--- a/uv.lock
+++ b/uv.lock
@@ -758,6 +758,7 @@ name = "climate-finance-het"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "bibtexparser" },
     { name = "dcor" },
     { name = "ftfy" },
     { name = "langdetect" },
@@ -801,7 +802,6 @@ cu130 = [
 [package.dev-dependencies]
 corpus = [
     { name = "beautifulsoup4" },
-    { name = "bibtexparser" },
     { name = "ddgs" },
     { name = "dvc" },
     { name = "dvc-ssh" },
@@ -819,6 +819,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bibtexparser" },
     { name = "dcor", specifier = ">=0.6.1" },
     { name = "ftfy", specifier = ">=6.3.1" },
     { name = "langdetect", specifier = ">=1.0.9" },
@@ -853,7 +854,6 @@ provides-extras = ["cpu", "cu130"]
 [package.metadata.requires-dev]
 corpus = [
     { name = "beautifulsoup4" },
-    { name = "bibtexparser" },
     { name = "ddgs" },
     { name = "dvc", specifier = ">=3.67.0" },
     { name = "dvc-ssh", specifier = ">=4.2.2" },


### PR DESCRIPTION
## Summary

`bibtexparser` was declared in the Phase-1 `corpus` dependency **group** — deliberately not installed on Phase-2/3 (writing) machines like doudou. But its three importers serve the **writing** side, not corpus building:

- `scripts/qa_bibliography.py` — reads `bibliography/main.bib`, writes a per-entry corpus-match CSV
- `scripts/qa_bib_doi.py` — reads `deliverables/_shared/bibliography/main.bib`, audits DOIs against Crossref
- `scripts/qa_missing_references.py` — reads `deliverables/_shared/bibliography/main.bib`, writes the missing-references list (DOIfetch sync)

On a writing-only env they crashed on `import bibtexparser`, turning three `test_io_discipline.py::TestMigratedScripts` `--output required` argparse checks into `ModuleNotFoundError` tracebacks (and blocking a DOIfetch missing-refs regen on 2026-07-10).

## Fix

The dependency was misclassified. Move `bibtexparser` from the `corpus` group to `[project]` dependencies (small pure-Python package) and relock. The corpus group is otherwise unchanged.

## Verification

- `uv run python -c "import bibtexparser"` → `bibtexparser 1.4.4`
- `tests/test_io_discipline.py::TestMigratedScripts` → 12 passed (incl. the three qa_ `requires_output` cases)
- `make check-fast` (945 passed) and `make lint` (151 passed) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Ticket:** tickets/0247-shared-venv-missing-bibtexparser.erg