### PR TITLE
reorg code 4/4: sever compute_clustering_comparison → plotter backward arrow (0242)

### DIFF
--- a/scripts/compute_clustering_comparison.py
+++ b/scripts/compute_clustering_comparison.py
@@ -1,7 +1,9 @@
 """Clustering methods comparison: KMeans vs HDBSCAN vs Spectral.
 
-Orchestrator script: loads corpus snapshots, runs comparison, saves tables,
-delegates figure generation to dedicated plot_fig_*.py scripts.
+Compute script: loads corpus snapshots, runs comparison, saves tables. Figures
+are produced separately by the dedicated plot_fig_clustering_*.py scripts, which
+read the saved tables from disk — this module never imports a plotter
+(architecture rule 4).
 
 Ticket: #299 (tracking), sub-issues #300–#304.
 
@@ -41,8 +43,6 @@ from clustering_methods import (
     silhouette_sweep,
     spectral_eigengap,
 )
-from plot_fig_clustering_comparison import generate_figures
-from plot_fig_clustering_spaces import plot_multi_space_figure
 from utils import (
     BASE_DIR,
     get_logger,
@@ -310,12 +310,12 @@ def main():
     # Save results
     save_results(ari_table, perturbation_table, optimal_k)
 
-    # Generate figures — delegates to dedicated plot_fig_*.py scripts
-    generate_figures(ari_table, perturbation_table, optimal_k,
-                     pdf=args.pdf)
-    plot_multi_space_figure(space_results, pdf=args.pdf)
-
-    log.info("Comparison complete.")
+    # Figures are produced by the dedicated plot_fig_*.py scripts, which read
+    # the tables saved above from disk (architecture rule 4: compute never
+    # imports a plotter). Regenerate them with:
+    #   uv run python scripts/plot_fig_clustering_comparison.py --output ...
+    #   uv run python scripts/plot_fig_clustering_spaces.py --output ...
+    log.info("Comparison complete. Run plot_fig_clustering_*.py for figures.")
 
 
 if __name__ == "__main__":

--- a/scripts/compute_clustering_comparison.py
+++ b/scripts/compute_clustering_comparison.py
@@ -266,8 +266,6 @@ def main():
     parser = argparse.ArgumentParser(
         description="Compare clustering methods across corpus snapshots"
     )
-    parser.add_argument("--pdf", action="store_true",
-                        help="Also save PDF output")
     parser.add_argument("--no-perturbation", action="store_true",
                         help="Skip perturbation stability (saves time)")
     parser.add_argument("--n-perturbation", type=int, default=10,

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,0 +1,93 @@
+"""Layering guard: compute scripts must not import plotters.
+
+Architecture rule 4 (`.claude/rules/architecture.md`): "Compute / Plot / Include
+are separate. A compute script produces a table. A plot script reads a table and
+produces a figure ... Never mix." The dependency arrow runs compute → plot only,
+never back: a `compute_*` module that imports a `plot_*` module is a backward
+arrow that couples the analysis layer to the presentation layer.
+
+This standing guard parses every `compute_*.py` module's imports and fails if any
+of them import a `plot_*` module. Adherence tier — runs under `make lint`, not the
+fast inner loop.
+
+Ticket 0242 severed `compute_clustering_comparison.py`'s import of the two
+clustering plotters. `compute_null_separation.py` retains a second, distinct
+violation (it imports the analysis helper `build_pre2007_traditions`, which is
+misplaced inside `plot_fig_traditions.py`); relocating that helper is separate
+work tracked by ticket 0250 and is allowlisted below until then.
+"""
+
+import ast
+import os
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIR = os.path.join(REPO, "scripts")
+
+# Known, pre-existing compute → plot violations awaiting their own relocation
+# ticket. Each entry MUST cite the tracking ticket. Remove an entry the moment
+# its violation is fixed — see test_no_stale_layering_allowlist.
+LAYERING_ALLOWLIST = {
+    # compute_null_separation.py imports build_pre2007_traditions() from
+    # plot_fig_traditions.py — a misplaced shared analysis helper. Ticket 0250
+    # relocates it to a neutral module.
+    "compute_null_separation.py": "0250",
+}
+
+
+def _compute_scripts():
+    """Top-level `compute_*.py` scripts under scripts/ (archive excluded)."""
+    result = []
+    for f in os.listdir(SCRIPTS_DIR):
+        if f.startswith("compute_") and f.endswith(".py"):
+            result.append(f)
+    return sorted(result)
+
+
+def _imported_plot_modules(name):
+    """Return the sorted set of `plot_*` module names imported by a script."""
+    with open(os.path.join(SCRIPTS_DIR, name)) as fh:
+        tree = ast.parse(fh.read(), filename=name)
+    hits = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod.startswith("plot_"):
+                hits.add(mod)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("plot_"):
+                    hits.add(alias.name)
+    return sorted(hits)
+
+
+def test_no_compute_imports_plotter():
+    """No compute_*.py imports a plot_* module (allowlist excepted)."""
+    violators = {}
+    for name in _compute_scripts():
+        if name in LAYERING_ALLOWLIST:
+            continue
+        plots = _imported_plot_modules(name)
+        if plots:
+            violators[name] = plots
+    assert not violators, (
+        "compute → plot backward arrow (architecture rule 4). "
+        "A compute module must not import a plotter:\n"
+        + "\n".join(f"  {k} imports {v}" for k, v in sorted(violators.items()))
+    )
+
+
+def test_no_stale_layering_allowlist():
+    """Every allowlisted violation still offends — remove it once fixed."""
+    stale = [
+        name
+        for name in LAYERING_ALLOWLIST
+        if name in _compute_scripts() and not _imported_plot_modules(name)
+    ]
+    assert not stale, (
+        "These scripts no longer import a plotter — remove them from "
+        f"LAYERING_ALLOWLIST: {stale}"
+    )

--- a/tickets/0250-reorg-code-relocate-build-pre2007-traditions.erg
+++ b/tickets/0250-reorg-code-relocate-build-pre2007-traditions.erg
@@ -1,0 +1,67 @@
+%erg 0.1
+Title: Relocate build_pre2007_traditions out of plot_fig_traditions (compute → plot arrow)
+Created: 2026-07-11
+Author: HDMX-coding-agent
+Label: deferred
+
+--- log ---
+2026-07-11T00:00Z HDMX-coding-agent created
+2026-07-11T00:00Z HDMX-coding-agent note discovered while doing 0242 (sever clustering back-arrow). The layering guard added in 0242 (tests/test_layering.py) allowlists compute_null_separation.py pending this ticket.
+
+--- body ---
+## Context
+The layering guard added in ticket 0242 (`tests/test_layering.py`) forbids any
+`compute_*.py` from importing a `plot_*` module (architecture rule 4: a compute
+module never imports a plotter). It flagged a second, distinct violation beyond
+the clustering one that 0242 fixed:
+
+`scripts/compute_null_separation.py:60` does
+`from plot_fig_traditions import build_pre2007_traditions`, then calls it at
+`:148` to build the pre-2007 traditions network it runs the null-separation test
+on. Unlike the clustering case (where the compute module *drove* the plotters),
+here a genuine **analysis helper** (`build_pre2007_traditions`) is misplaced
+inside a plot module. `plot_fig_traditions.py` also uses it for its own figure,
+so it is a shared analysis routine living on the wrong layer.
+
+This is allowlisted in `LAYERING_ALLOWLIST` (test_layering.py) with a
+stale-entry check that fails once the import is gone — so closing this ticket
+requires removing the allowlist entry in the same change.
+
+## Relevant files
+- `scripts/compute_null_separation.py` — imports+calls `build_pre2007_traditions`
+- `scripts/plot_fig_traditions.py` — current home of `build_pre2007_traditions`; also its consumer
+- `tests/test_layering.py` — guard + `LAYERING_ALLOWLIST["compute_null_separation.py"] = "0250"`
+
+## Actions
+1. Move `build_pre2007_traditions` (and any private helpers it needs) into a
+   neutral analysis module both sides can import — e.g. a new
+   `scripts/_pre2007_traditions.py`, or fold it into `compute_null_separation`'s
+   analysis layer if `plot_fig_traditions` can import it there without creating a
+   plot → compute cycle that violates the arrow the other way. Prefer a neutral
+   `_pre2007_traditions.py` shared module.
+2. Update both `compute_null_separation.py` and `plot_fig_traditions.py` to
+   import from the new location.
+3. Remove the `compute_null_separation.py` entry from `LAYERING_ALLOWLIST`.
+
+## Test
+- RED first: with the allowlist entry removed and no relocation yet,
+  `tests/test_layering.py::test_no_compute_imports_plotter` fails on
+  `compute_null_separation.py`. (Or drive it via the existing stale-entry check.)
+
+## Verification
+- [ ] `compute_null_separation.py` no longer imports any `plot_*` module.
+- [ ] `plot_fig_traditions.py` still produces its figure (unchanged output).
+- [ ] `compute_null_separation.py` output byte-identical before/after (same
+      function, same data — relocation only).
+- [ ] `LAYERING_ALLOWLIST` no longer contains `compute_null_separation.py`.
+
+## Invariants
+- No behaviour change; pure relocation. `make lint` and `make check-fast` green.
+- No plot → compute cycle introduced by the move.
+
+## Exit criteria
+- `build_pre2007_traditions` lives in a neutral (non-plot) module; both callers
+  import it from there; the layering allowlist is empty of this entry and the
+  guard passes with it removed.
+
+Ticket-ref: tickets/0242-reorg-code-4-sever-clustering-backarrow.erg

--- a/tickets/closed/0242-reorg-code-4-sever-clustering-backarrow.erg
+++ b/tickets/closed/0242-reorg-code-4-sever-clustering-backarrow.erg
@@ -3,11 +3,13 @@ Title: Reorg code 4/4 — sever compute_clustering_comparison's import of the pl
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: severed compute->plot backward arrow; standing layering guard added; PR #1017 approved
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; off-critical-path follow-up. Independent of the moves, but cleanest once scripts/ is grouped (0240). Parked behind the Œconomia R&R per 0223.
 
+2026-07-11T06:19Z HDMX-coding-agent closed — severed compute->plot backward arrow; standing layering guard added; PR #1017 approved
 --- body ---
 ## Context
 Final, off-critical-path stage of the code reorg (parent sub-tracker `0225`,


### PR DESCRIPTION
**Ticket:** tickets/0242-reorg-code-4-sever-clustering-backarrow.erg

## The coupling found
The ticket guessed a "shared label/order helper." It was not. `scripts/compute_clustering_comparison.py` **imported two plotter modules** and **drove them** at the end of `main()`:

- `:44-45` — `from plot_fig_clustering_comparison import generate_figures` / `from plot_fig_clustering_spaces import plot_multi_space_figure`
- `:314-316` — called `generate_figures(...)` and `plot_multi_space_figure(...)` after saving its tables.

This is a compute → plot backward arrow (architecture rule 4: *a compute module never imports a plotter*). There is **no Makefile/.mk target** for `compute_clustering_comparison` — it is a manually-run analysis, so no build wiring changed.

## Sever design chosen (pure deletion)
Both plotters **already have self-sufficient `__main__` blocks** that read the saved tables from disk (`tab_clustering_ari.csv`, `tab_clustering_perturbation.csv`, `clustering_optimal_k.json`, `clustering_multi_space.json` — all written by the compute module *before* the calls). So **no disk-loading path had to be added** to either plot script. The sever is:

- deleted the two plotter imports (`:44-45`);
- deleted the two calls (the `generate_figures(...)` / `plot_multi_space_figure(...)` block);
- updated the module docstring + trailing log line to point at the standalone `plot_fig_clustering_*.py` commands.

The compute module still computes and saves every table (`save_results(...)`, `clustering_multi_space.json`) unchanged. Figures are now produced by running the plot scripts standalone.

## Byte-identity argument (no data build run)
The sever **relocates** the same plotter calls with identical inputs: the plotters previously received the tables in-memory; they now read the byte-identical tables the compute module still writes to disk. Same plotting function + same data ⇒ byte-identical figures **by construction**. No heavy data build was needed; running a corpus rebuild in a worktree is out of scope and disallowed.

## TDD — the standing guard is the deliverable
New adherence guard `tests/test_layering.py::test_no_compute_imports_plotter` parses every `compute_*.py`'s imports (AST) and fails on any `plot_*` import.

- **RED** (commit `bc353fd`): failed on `compute_clustering_comparison.py` (both clustering plotters).
- **GREEN** (commit `00bd25b`): sever ⇒ guard passes.
- **Mutation proof of teeth**: temporarily re-added `from plot_fig_traditions import build_pre2007_traditions` to the compute module → guard **failed** with `{'compute_clustering_comparison.py': ['plot_fig_traditions']}`; removed it → green again, working tree clean.

## Second violation found → follow-up ticket 0250
The guard surfaced a **distinct** compute → plot arrow: `compute_null_separation.py:60` imports the analysis helper `build_pre2007_traditions` from `plot_fig_traditions.py` (a misplaced shared helper, not figure-driving). Relocating it is out of 0242's clustering scope, so it is **allowlisted** in `test_layering.py` (`LAYERING_ALLOWLIST`, with a `test_no_stale_layering_allowlist` stale-entry check) and filed as **ticket 0250** (`tickets/0250-reorg-code-relocate-build-pre2007-traditions.erg`).

## Gates
- `make lint` (adherence): 153 passed.
- `make check-fast`: 945 passed, 10 skipped.
- No CI in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)