### PR TITLE
test(0249): isolate step1 counter test from the physical corpus

### DIFF
--- a/tests/test_retry_unification.py
+++ b/tests/test_retry_unification.py
@@ -71,9 +71,16 @@ class TestMineOpenalexKeywordsApiKey:
     """enrich_openalex_keywords.py should send the API key when available."""
 
     def test_fetch_sends_api_key(self, monkeypatch, requests_mock):
-        """fetch_openalex_metadata should include api_key in params."""
-        import utils
-        monkeypatch.setattr(utils, "OPENALEX_API_KEY", "test-key-123")
+        """fetch_openalex_metadata should include api_key in params.
+
+        Patch OPENALEX_API_KEY in the enrich_openalex_keywords namespace:
+        the module binds it by value at import, so patching utils reaches
+        it only while the module is not yet cached in sys.modules (same
+        defect class as the step1 counter test, ticket 0249).
+        """
+        import enrich_openalex_keywords as eok
+
+        monkeypatch.setattr(eok, "OPENALEX_API_KEY", "test-key-123")
 
         captured_params = {}
 
@@ -87,8 +94,7 @@ class TestMineOpenalexKeywordsApiKey:
             json=capture_request,
         )
 
-        from enrich_openalex_keywords import fetch_openalex_metadata
-        fetch_openalex_metadata(["10.1000/test"])
+        eok.fetch_openalex_metadata(["10.1000/test"])
 
         # The api_key param should be present
         assert "api_key" in captured_params, (

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -496,10 +496,9 @@ class TestStepCounters:
         step1_cross_source resolves CATALOGS_DIR at call time.
         """
         import enrich_abstracts as ea
-        import utils as utils_mod
 
         # Redirect CATALOGS_DIR so it doesn't look for real unified_works.csv
-        monkeypatch.setattr(utils_mod, "CATALOGS_DIR", str(tmp_path))
+        monkeypatch.setattr(ea, "CATALOGS_DIR", str(tmp_path))
 
         df = mini_df.copy()
         df["_missing"] = df["abstract"].apply(ea.is_missing)

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -487,20 +487,27 @@ class TestStepCounters:
         )
 
     def test_step1_counter_attempted(self, mini_df, tmp_path, monkeypatch):
-        """step1_cross_source sets step1_attempted in counters."""
-        # Redirect CATALOGS_DIR so it doesn't look for real unified_works.csv
+        """step1_cross_source sets step1_attempted in counters.
+
+        Import the module BEFORE patching, as any earlier test sharing the
+        worker does: enrich_abstracts binds CATALOGS_DIR by value at import,
+        so patching utils.CATALOGS_DIR never reaches a cached module. The
+        patch must target the enrich_abstracts namespace, where
+        step1_cross_source resolves CATALOGS_DIR at call time.
+        """
+        import enrich_abstracts as ea
         import utils as utils_mod
 
+        # Redirect CATALOGS_DIR so it doesn't look for real unified_works.csv
         monkeypatch.setattr(utils_mod, "CATALOGS_DIR", str(tmp_path))
-        from enrich_abstracts import is_missing, step1_cross_source
 
         df = mini_df.copy()
-        df["_missing"] = df["abstract"].apply(is_missing)
-        # Create a dummy unified_works.csv
+        df["_missing"] = df["abstract"].apply(ea.is_missing)
+        # Create a synthetic unified_works.csv in the tmp dir
         unified = df[["doi", "abstract"]].copy()
         unified.to_csv(os.path.join(str(tmp_path), "unified_works.csv"), index=False)
         counters = {}
-        step1_cross_source(df, counters)
+        ea.step1_cross_source(df, counters)
         assert "step1_attempted" in counters
         assert counters["step1_attempted"] >= 0
 

--- a/tickets/closed/0249-step1-counter-test-reads-hardcoded-catal.erg
+++ b/tickets/closed/0249-step1-counter-test-reads-hardcoded-catal.erg
@@ -2,10 +2,13 @@
 Title: step1 counter test reads hardcoded CATALOGS_DIR — fails in any data-less worktree
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: test isolation fixed; check-fast green on data-less worktree
 
 --- log ---
 2026-07-11T01:43Z HDMX-coding-agent created
+2026-07-11T06:06Z HDMX-coding-agent note Fixed via option 1 (synthetic fixture stays in fast tier): the test patched utils.CATALOGS_DIR but enrich_abstracts binds the value at import, so a cached module kept the real path; now patches enrich_abstracts.CATALOGS_DIR (call-time resolution). Sweep found and fixed the same wrong-namespace patch in test_retry_unification.py (OPENALEX_API_KEY). make check-fast 945 passed / 10 skipped, make lint 151 passed / 5 skipped, both exit 0 on corpus-less doudou worktree.
 
+2026-07-11T06:07Z HDMX-coding-agent closed — test isolation fixed; check-fast green on data-less worktree
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0249-step1-counter-test-reads-hardcoded-catal.erg

## Problem

`tests/test_robustness_observability.py::TestStepCounters::test_step1_counter_attempted` failed with `FileNotFoundError` on `data/catalogs/unified_works.csv` in any data-less worktree, breaking `make check-fast` (944 passed, 1 failed on doudou).

Root cause: the test patched `utils.CATALOGS_DIR` and then imported `enrich_abstracts` — but `enrich_abstracts` binds `CATALOGS_DIR` by value at import time. Whenever another test in the same xdist worker had already imported the module (e.g. `test_circuit_breaker_non_openalex.py`), the cached module kept the real path and `step1_cross_source` read the physical corpus.

## Fix (ticket option 1 — keep coverage in the fast tier)

- **Red** (a8f8211): import the module before patching, making the latent order-dependence deterministic — the test fails standalone, reproducing the check-fast failure mode.
- **Green** (36ad14a): patch `enrich_abstracts.CATALOGS_DIR` — the namespace where `step1_cross_source` resolves it at call time — so the counter runs against the three-row synthetic `unified_works.csv` in `tmp_path` regardless of import order. Assertions unchanged; nothing weakened where the corpus is present.
- **Sweep** (49419ab): grep for `monkeypatch.setattr(utils, ...)` found the same wrong-namespace pattern in `tests/test_retry_unification.py::test_fetch_sends_api_key` (`OPENALEX_API_KEY`); fixed identically.

## Exit criterion

`make check-fast` green in a fresh, data-less worktree: **945 passed, 10 skipped, exit 0** on corpus-less doudou. `make lint`: 151 passed, 5 skipped, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
