### PR TITLE
Unify .mk discovery across build guards (0248)

### DIFF
--- a/tests/_mk_discovery.py
+++ b/tests/_mk_discovery.py
@@ -1,0 +1,44 @@
+"""Shared `.mk` discovery for the build-guard tests (ticket 0248).
+
+One place enumerates every Makefile fragment the pipeline `-include`s, so a
+future `.mk` relocation updates a single list and no guard can silently narrow
+its coverage. This closes the class defect that ticket 0239 surfaced: five
+guards each hand-rolled a fixed-directory glob union that drifted apart when
+fragments moved.
+
+`<repo>` is resolved from this file's own location, so the helper is correct in
+any worktree.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def mk_fragments() -> list[Path]:
+    """Every `-include`d build fragment, sorted for stable parametrized test IDs.
+
+    Covers the three homes a `.mk` fragment can live in:
+      - repo-root ``*.mk`` (``paths.mk``, the shared variable interface);
+      - ``scripts/analysis/*.mk`` (Phase-2 analysis concerns, relocated by 0239);
+      - ``deliverables/*/*.mk`` (per-deliverable Phase-3 render fragments).
+
+    Excludes the top-level ``Makefile`` — use :func:`all_makefiles` for that.
+    """
+    fragments = list(REPO_ROOT.glob("*.mk"))
+    fragments += list((REPO_ROOT / "scripts" / "analysis").glob("*.mk"))
+    fragments += list((REPO_ROOT / "deliverables").glob("*/*.mk"))
+    return sorted(fragments)
+
+
+def all_makefiles(include_main: bool = True) -> list[Path]:
+    """Every Makefile the build reads: the top-level ``Makefile`` plus fragments.
+
+    Pass ``include_main=False`` for a guard that asserts a property of the
+    ``-include``d *fragments* alone — e.g. single-phase purity, since the main
+    ``Makefile`` legitimately wires both render and compute concerns.
+    """
+    files = mk_fragments()
+    if include_main:
+        files = [REPO_ROOT / "Makefile"] + files
+    return files

--- a/tests/test_build_phase_separation.py
+++ b/tests/test_build_phase_separation.py
@@ -17,12 +17,13 @@ a `quarto render` recipe or `.pdf:`/`.docx:` target marks Phase-3 render; a
 Phase-2 compute — and fails any file that carries both.
 """
 
-import glob
 import os
 import re
 import subprocess
+from pathlib import Path
 
 import pytest
+from _mk_discovery import mk_fragments
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 MANUSCRIPT_MK = os.path.join(REPO_ROOT, "deliverables", "manuscript", "manuscript.mk")
@@ -44,13 +45,15 @@ def _has_phase2(text: str) -> bool:
     return bool(_PHASE2_RECIPE_RE.search(text))
 
 
-def _all_mk_files() -> list[str]:
-    """Every build fragment: root paths.mk + Phase-2 analysis concern .mk under
-    scripts/analysis/ (relocated by ticket 0239) + per-deliverable render .mk."""
-    files = glob.glob(os.path.join(REPO_ROOT, "*.mk"))
-    files += glob.glob(os.path.join(REPO_ROOT, "scripts", "analysis", "*.mk"))
-    files += glob.glob(os.path.join(REPO_ROOT, "deliverables", "*", "*.mk"))
-    return sorted(files)
+def _all_mk_files() -> list[Path]:
+    """Every `-include`d build fragment (shared discovery, ticket 0248).
+
+    The single-phase purity guard checks the *fragments* — not the top-level
+    Makefile, which legitimately wires both render and compute — so this uses
+    `mk_fragments()` (root + scripts/analysis/ + per-deliverable render .mk),
+    without the main Makefile.
+    """
+    return mk_fragments()
 
 
 @pytest.mark.adherence

--- a/tests/test_deliverables_layout.py
+++ b/tests/test_deliverables_layout.py
@@ -24,6 +24,8 @@ import glob
 import os
 import re
 
+from _mk_discovery import all_makefiles
+
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DELIVERABLES = os.path.join(REPO_ROOT, "deliverables")
 
@@ -50,13 +52,12 @@ _SHARED_REF = re.compile(
 # A Make render rule: the target (first token, left of `:`) is a PDF/DOCX file.
 _RENDER_TARGET = re.compile(r"^(?P<t>[\w./-]+\.(?:pdf|docx))\s*:")
 
-# Makefiles that carry render rules (top-level + concern .mk + every
-# per-deliverable render .mk under deliverables/<x>/, ticket 0237).
-_MAKEFILES = (
-    [os.path.join(REPO_ROOT, "Makefile")]
-    + glob.glob(os.path.join(REPO_ROOT, "*.mk"))
-    + glob.glob(os.path.join(DELIVERABLES, "*", "*.mk"))
-)
+# Every Makefile that could carry a render rule. Shared discovery (ticket 0248):
+# all_makefiles() also covers scripts/analysis/*.mk, closing the gap where
+# relocated fragments (0239) went unscanned. Analysis fragments carry no render
+# target, so the widened set adds no offenders — it only guarantees a future
+# relocated render .mk cannot slip out of coverage.
+_MAKEFILES = all_makefiles()
 
 
 def test_no_root_quarto_masks():

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -46,6 +46,7 @@ import os
 import re
 
 import pytest
+from _mk_discovery import all_makefiles
 
 # Grep-ratchet guard — belongs to the mechanical adherence gate (`pytest -m adherence`).
 pytestmark = pytest.mark.adherence
@@ -97,12 +98,9 @@ def _bad_patterns(basename):
 
 
 def _makefiles():
-    paths = [os.path.join(PROJECT_ROOT, "Makefile")]
-    paths += glob.glob(os.path.join(PROJECT_ROOT, "*.mk"))
-    # Phase-2 analysis concern .mk moved under scripts/analysis/ (ticket 0239);
-    # keep scanning them so the eviction guard still covers the moved fragments.
-    paths += glob.glob(os.path.join(SCRIPTS_DIR, "analysis", "*.mk"))
-    return paths
+    # Shared discovery (ticket 0248): Makefile + every fragment, so a `.mk`
+    # relocation updates one place and this guard can never silently narrow.
+    return all_makefiles()
 
 
 def _scripts():

--- a/tests/test_io_discipline.py
+++ b/tests/test_io_discipline.py
@@ -6,12 +6,12 @@ Covers:
 - Makefile pattern rule exists for figure scripts
 """
 
-import glob
 import os
 import subprocess
 import sys
 
 import pytest
+from _mk_discovery import all_makefiles
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
 MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
@@ -275,15 +275,12 @@ class TestComputeBreakpointsOneOutput:
 def _makefile_text():
     """Concatenate the main Makefile and every included *.mk.
 
-    Phase-2 analysis concern fragments moved under scripts/analysis/ (ticket
-    0239); include them so the $(DERIVED)-producer scan still sees their targets.
+    Fragment discovery is shared (ticket 0248): `all_makefiles()` covers the
+    root, scripts/analysis/ (relocated by 0239), and deliverables/ fragments, so
+    the $(DERIVED)-producer scan can never silently miss a relocated fragment.
     """
-    root = os.path.join(os.path.dirname(__file__), "..")
-    mk_files = [os.path.join(root, "Makefile")]
-    mk_files += sorted(glob.glob(os.path.join(root, "*.mk")))
-    mk_files += sorted(glob.glob(os.path.join(root, "scripts", "analysis", "*.mk")))
     text = ""
-    for path in mk_files:
+    for path in all_makefiles():
         with open(path) as f:
             text += f"\n# === {os.path.basename(path)} ===\n" + f.read()
     return text

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 import yaml
+from _mk_discovery import all_makefiles
 
 MAKEFILE = os.path.join(os.path.dirname(__file__), "..", "Makefile")
 DVC_YAML = os.path.join(os.path.dirname(__file__), "..", "dvc.yaml")
@@ -250,15 +251,15 @@ class TestPerDeliverableIncludes:
         Each render .mk depends on its own doc's includes, so no `.mk` may still
         reference $(PROJECT_INCLUDES).
         """
-        import glob
         root = os.path.join(os.path.dirname(__file__), "..")
         # A live use ($(PROJECT_INCLUDES)) or definition (PROJECT_INCLUDES :=/=),
         # not an incidental mention in a comment.
         use_or_def = re.compile(r"\$\(PROJECT_INCLUDES\)|^\s*PROJECT_INCLUDES\s*:?=", re.MULTILINE)
         offenders = []
-        for mkpath in [os.path.join(root, "Makefile")] + glob.glob(
-            os.path.join(root, "*.mk")
-        ) + glob.glob(os.path.join(root, "deliverables", "*", "*.mk")):
+        # Shared discovery (ticket 0248): all_makefiles() now also covers
+        # scripts/analysis/*.mk, closing the gap where relocated fragments (0239)
+        # went unscanned for a lingering $(PROJECT_INCLUDES) reference.
+        for mkpath in all_makefiles():
             with open(mkpath) as f:
                 if use_or_def.search(f.read()):
                     offenders.append(os.path.relpath(mkpath, root))

--- a/tests/test_mk_discovery_unified.py
+++ b/tests/test_mk_discovery_unified.py
@@ -1,0 +1,61 @@
+"""Meta-guard — no test may hand-roll its own `.mk` enumeration (ticket 0248).
+
+Several build guards used to each glob a *fixed* set of directories to enumerate
+the pipeline's Makefile fragments. When a `.mk` moved (ticket 0239 relocated the
+five Phase-2 concern fragments to `scripts/analysis/`), it silently dropped out
+of a guard's coverage and the test kept passing — over fewer files, not because
+the contract still held.
+
+The class fix is one shared discovery helper, `tests/_mk_discovery.py`. This
+guard is the standing regression test for the class: it fails if any test file
+outside the helper hand-rolls a `.mk` enumeration (a `glob(... .mk)` union or a
+`listdir`/`endswith(".mk")` filter). A future PR that reintroduces a hand-rolled
+glob is caught here rather than rotting into a latent coverage gap.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# A hand-rolled `.mk` enumeration: a `glob(... .mk)` union (glob.glob or
+# pathlib `.glob`), or a `listdir`/`endswith(".mk")` filter over a directory.
+_HANDROLLED_MK = re.compile(
+    r"""glob\s*\([^)]*\.mk        # glob.glob(..., "*.mk") / path.glob("*.mk")
+      | listdir[^\n]*\.mk         # os.listdir(...) then a .mk filter on one line
+      | endswith\(\s*['"]\.mk['"] # [f for f in ... if f.endswith(".mk")]
+    """,
+    re.VERBOSE,
+)
+
+# Files permitted to enumerate `.mk` directly:
+#  - the shared helper itself is the ONE sanctioned enumeration;
+#  - this meta-guard names the pattern it searches for;
+#  - the layout guard globs each directory to assert *placement* (root carries
+#    only paths.mk; the five concern fragments live under scripts/analysis/) —
+#    a per-directory membership check, not a coverage union that can silently
+#    narrow, so unifying it would defeat its purpose.
+_ALLOWLIST = {
+    "_mk_discovery.py",
+    Path(__file__).name,
+    "test_analysis_mk_layout.py",
+}
+
+
+@pytest.mark.adherence
+def test_no_handrolled_mk_enumeration():
+    offenders = []
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        if path.name in _ALLOWLIST:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if _HANDROLLED_MK.search(line):
+                offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Hand-rolled `.mk` enumeration found — use tests/_mk_discovery.py "
+        "(all_makefiles / mk_fragments) so a `.mk` relocation updates one place "
+        "and no guard silently narrows:\n" + "\n".join(offenders)
+    )

--- a/tickets/closed/0248-unify-mk-discovery-in-guards.erg
+++ b/tickets/closed/0248-unify-mk-discovery-in-guards.erg
@@ -3,10 +3,12 @@ Title: Unify .mk discovery across test guards — close root-only globs before t
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: unified .mk discovery via tests/_mk_discovery.py; 5 sites migrated, 2 gaps closed, meta-guard added; PR #1019 approved
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 
+2026-07-11T06:20Z HDMX-coding-agent closed — unified .mk discovery via tests/_mk_discovery.py; 5 sites migrated, 2 gaps closed, meta-guard added; PR #1019 approved
 --- body ---
 ## Context
 Ticket 0239 relocated the 5 Phase-2 analysis `.mk` from the repo root to


### PR DESCRIPTION
## Summary

Five build-guard tests each hand-rolled a fixed-directory `.mk` glob union. When ticket 0239 relocated the five Phase-2 concern fragments to `scripts/analysis/`, a fragment could silently drop from a guard's coverage while the test kept passing (over fewer files). This fixes the **class**: one shared discovery helper, `tests/_mk_discovery.py`, and all five sites migrated to it. A future `.mk` relocation now updates one list and no guard can silently narrow.

## Helper API (`tests/_mk_discovery.py`)

- `mk_fragments()` — every `-include`d fragment: root `*.mk` + `scripts/analysis/*.mk` + `deliverables/*/*.mk`, sorted (stable parametrized IDs). No main Makefile.
- `all_makefiles(include_main=True)` — the top-level `Makefile` plus `mk_fragments()`. `include_main=False` for a fragments-only guard.

`<repo>` is resolved from the helper's own location, so it is correct in any worktree.

## The five sites

| Site | Change |
|------|--------|
| `test_evict_analysis_intermediates._makefiles` | pure migration → `all_makefiles()` |
| `test_io_discipline._makefile_text` | pure migration → `all_makefiles()` |
| `test_build_phase_separation._all_mk_files` | pure migration → `mk_fragments()` (fragments only — the single-phase purity guard must not include the main Makefile, which legitimately wires both render and compute) |
| `test_makefile_contract.test_project_includes_union_retired` | **GAP CLOSED** → `all_makefiles()` now also scans `scripts/analysis/*.mk` |
| `test_deliverables_layout._MAKEFILES` | **GAP CLOSED** → `all_makefiles()` now also scans `scripts/analysis/*.mk` |

The two gap guards' semantics are preserved on the widened set: the analysis fragments carry **no** render target and **no** `$(PROJECT_INCLUDES)` reference, so they contribute zero offenders — the widening is pure future coverage insurance, not a behaviour change.

## Meta-guard + mutation teeth

New adherence guard `tests/test_mk_discovery_unified.py` greps the `tests/` tree and fails on any hand-rolled `.mk` enumeration (`glob(... .mk)` union, or `listdir`/`endswith(".mk")` filter) outside the helper. RED first (flagged all five sites), GREEN after migration.

**Mutation teeth (feedback_pin_test_mutation_teeth):** temporarily re-adding `glob.glob(os.path.join(REPO_ROOT, "*.mk"))` to `test_deliverables_layout.py` made the meta-guard fail, pointing at the exact injected line (`test_deliverables_layout.py:61`); removing it returned to green. Mutation not committed.

## Real finding (not papered over)

`tests/test_analysis_mk_layout.py` also globs `.mk` directly, but it is a **layout** guard: each glob targets a single directory to assert *placement* (root carries only `paths.mk`; the five concerns live under `scripts/analysis/`), not a coverage union that can narrow. Unifying it would defeat its purpose, so the meta-guard allowlists it with a documented rationale. It is left unchanged by design.

## Gates

- `make lint` (`-m adherence`) — **152 passed, 5 skipped** (only a pre-existing module-length warning). This is the relevant gate; all touched tests are adherence.
- Fast tier: the six touched files pass (95 passed, 3 skipped). One unrelated failure in the full fast tier — `test_robustness_observability.py::TestStepCounters::test_step1_counter_attempted` — is a `FileNotFoundError` on the DVC-managed `data/catalogs/unified_works.csv`, absent in this data-less worktree; it drives a subprocess reading the real catalogs dir and does not touch `.mk` discovery.

This repo has no CI.

**Ticket:** tickets/0248-unify-mk-discovery-in-guards.erg