### PR TITLE
relocate build_pre2007_traditions out of plot module (sever compute → plot arrow)

### DIFF
--- a/scripts/_pre2007_traditions.py
+++ b/scripts/_pre2007_traditions.py
@@ -1,0 +1,260 @@
+"""Pre-2007 co-citation traditions: shared analysis helper.
+
+Builds the co-citation network of the most-cited pre-2007 references and
+assigns its Louvain communities to three intellectual traditions by anchor
+matching. This is the single source of truth for the pre-2007 tradition
+seed-sets: the figure (`plot_fig_traditions.py`) renders it, and
+`compute_null_separation.py` tests it against a degree-preserving null.
+
+It lives in a neutral (non-plot, non-compute) module so both the plot and the
+compute layer import it without a compute → plot backward arrow (architecture
+rule 4; ticket 0250).
+"""
+
+import community as community_louvain
+import networkx as nx
+import numpy as np
+import pandas as pd
+from pipeline_loaders import (
+    load_analysis_config,
+    load_refined_works,
+    pre2007_cutoff_year,
+)
+from scipy.sparse import lil_matrix
+from utils import (
+    get_logger,
+    load_refined_citations,
+    normalize_doi,
+)
+
+log = get_logger("_pre2007_traditions")
+
+# --- Parameters ---
+# CUTOFF_YEAR is not a hardcoded constant: it is derived from the config
+# periodization (first break - 1) via pre2007_cutoff_year(), the single source
+# of truth shared with compute_pre2007_coverage.py.
+TOP_N = 250
+MIN_COCIT = 3
+RANDOM_STATE = 42
+
+TRADITION_ANCHORS = {
+    "pricing": ["weitzman", "barrett", "carraro", "montgomery", "pizer"],
+    "cdm":     ["michaelowa", "sutter", "ellis", "haites", "pearson"],
+    "unfccc":  ["north", "dimaggio", "finnemore"],
+}
+
+
+def _load_data(works_path, cit_path):
+    """Load citations and works, build DOI metadata lookup."""
+    log.info("Loading citations...")
+    if cit_path is not None:
+        cit = pd.read_csv(cit_path, low_memory=False)
+    else:
+        cit = load_refined_citations()
+    cit["source_doi"] = cit["source_doi"].apply(normalize_doi)
+    cit["ref_doi"] = cit["ref_doi"].apply(normalize_doi)
+    cit = cit[(cit["source_doi"] != "") & (cit["ref_doi"] != "")]
+    cit = cit[~cit["source_doi"].isin(["nan", "none"])]
+    cit = cit[~cit["ref_doi"].isin(["nan", "none"])]
+    log.info("  Citation pairs: %d", len(cit))
+
+    if works_path is not None:
+        works = pd.read_csv(works_path)
+    else:
+        works = load_refined_works()
+    works["doi_norm"] = works["doi"].apply(normalize_doi)
+    doi_meta = {}
+    for _, row in works.iterrows():
+        d = row["doi_norm"]
+        if d and d not in ("nan", "none"):
+            doi_meta[d] = {
+                "title": str(row.get("title", "") or ""),
+                "author": str(row.get("first_author", "") or ""),
+                "year": row.get("year", ""),
+            }
+    for _, row in cit.iterrows():
+        d = row["ref_doi"]
+        if d and d not in ("nan", "none") and d not in doi_meta:
+            doi_meta[d] = {
+                "title": str(row.get("ref_title", "") or ""),
+                "author": str(row.get("ref_first_author", "") or ""),
+                "year": row.get("ref_year", "") or "",
+            }
+    return cit, doi_meta
+
+
+def _build_cocitation_network(cit, doi_meta, ref_counts, top_refs):
+    """Build co-citation graph from top references."""
+    actual_top_n = len(top_refs)
+    top_set = set(top_refs)
+    ref_to_idx = {r: i for i, r in enumerate(top_refs)}
+
+    log.info("Building co-citation matrix...")
+    source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
+
+    cocit = lil_matrix((actual_top_n, actual_top_n), dtype=np.float32)
+    for ref_list in source_groups.values:
+        in_top = [r for r in ref_list if r in top_set]
+        if len(in_top) < 2:
+            continue
+        for i in range(len(in_top)):
+            for j in range(i + 1, len(in_top)):
+                a = ref_to_idx[in_top[i]]
+                b = ref_to_idx[in_top[j]]
+                cocit[a, b] += 1
+                cocit[b, a] += 1
+
+    cocit_dense = cocit.toarray()
+    log.info("  Non-zero co-citation pairs: %d",
+             np.count_nonzero(cocit_dense) // 2)
+
+    G = nx.Graph()
+    for doi in top_refs:
+        meta = doi_meta.get(doi, {})
+        author = (str(meta.get("author", "") or "")
+                  .split(",")[0].split(";")[0].strip())
+        year = str(meta.get("year", "") or "")
+        title = str(meta.get("title", "") or "")
+        if "." in year:
+            year = year.split(".")[0]
+        label = _make_node_label(author, year, title, doi)
+        G.add_node(doi, label=label,
+                   citations=int(ref_counts.get(doi, 0)),
+                   author=author.lower())
+
+    for i in range(actual_top_n):
+        for j in range(i + 1, actual_top_n):
+            w = cocit_dense[i, j]
+            if w >= MIN_COCIT:
+                G.add_edge(top_refs[i], top_refs[j], weight=float(w))
+
+    isolates = list(nx.isolates(G))
+    G.remove_nodes_from(isolates)
+    log.info("Network: %d nodes, %d edges",
+             G.number_of_nodes(), G.number_of_edges())
+    log.info("  Removed %d isolates", len(isolates))
+    return G
+
+
+def _make_node_label(author, year, title, doi):
+    """Create a readable label for a network node."""
+    if (author and author.lower() not in ("nan", "none", "")
+            and year and year not in ("nan", "none", "")):
+        return f"{author} {year}"
+    if title and title.lower() not in ("nan", "none", ""):
+        words = [w for w in title.split() if len(w) > 2][:3]
+        suffix = f" {year}" if year and year not in ("nan", "none") else ""
+        return " ".join(words) + suffix
+    return doi.split("/")[-1][:16]
+
+
+def _assign_traditions(G, partition):
+    """Map Louvain communities to named traditions via anchor matching."""
+    comm_to_nodes = {}
+    for doi, c in partition.items():
+        comm_to_nodes.setdefault(c, []).append(doi)
+
+    scores = {}
+    for c, nodes in comm_to_nodes.items():
+        for trad, anchors in TRADITION_ANCHORS.items():
+            count = sum(
+                1 for doi in nodes
+                if any(a in G.nodes[doi].get("author", "")
+                       for a in anchors)
+            )
+            scores[(c, trad)] = count
+
+    comm_to_tradition = {}
+    trad_to_comm = {}
+    assigned_comms = set()
+    assigned_trads = set()
+
+    for (c, trad), score in sorted(scores.items(), key=lambda x: -x[1]):
+        if score == 0:
+            break
+        if c in assigned_comms or trad in assigned_trads:
+            continue
+        comm_to_tradition[c] = trad
+        trad_to_comm[trad] = c
+        assigned_comms.add(c)
+        assigned_trads.add(trad)
+
+    for c in comm_to_nodes:
+        if c not in comm_to_tradition:
+            comm_to_tradition[c] = "other"
+
+    return comm_to_tradition, trad_to_comm, comm_to_nodes
+
+
+def build_pre2007_traditions(works_path, cit_path=None):
+    """Build the pre-2007 co-citation graph and its tradition assignment.
+
+    This is the single source of truth for the pre-2007 tradition seed-sets:
+    the figure renders it, and compute_null_separation.py tests it against a
+    degree-preserving null. Returns None when there is no pre-2007 network.
+
+    Returns
+    -------
+    dict | None
+        graph, partition (node->community), comm_to_tradition,
+        trad_to_comm, comm_to_nodes, ref_counts, n_comm, modularity,
+        actual_top_n.
+
+    """
+    cutoff_year = pre2007_cutoff_year(load_analysis_config())
+
+    cit, doi_meta = _load_data(works_path, cit_path)
+
+    # Filter to pre-2007 references
+    cit["ref_year_num"] = pd.to_numeric(cit["ref_year"], errors="coerce")
+    pre_dois = (
+        set(cit.loc[cit["ref_year_num"] <= cutoff_year, "ref_doi"])
+        - {"", "nan", "none"}
+    )
+
+    ref_counts_all = cit.groupby("ref_doi").size()
+    ref_counts = ref_counts_all.loc[
+        ref_counts_all.index.isin(pre_dois)
+    ].sort_values(ascending=False)
+    log.info("  Pre-%d refs: %d (cited >= 1)",
+             cutoff_year, len(ref_counts))
+
+    actual_top_n = min(TOP_N, len(ref_counts))
+    if actual_top_n == 0:
+        log.info("No pre-%d references found.", cutoff_year)
+        return None
+
+    top_refs = ref_counts.head(actual_top_n).index.tolist()
+    log.info("  Using top %d; citation range: %d .. %d",
+             actual_top_n,
+             ref_counts.iloc[0],
+             ref_counts.iloc[actual_top_n - 1])
+
+    G = _build_cocitation_network(cit, doi_meta, ref_counts, top_refs)
+    if G.number_of_nodes() == 0:
+        log.info("Empty network.")
+        return None
+
+    partition = community_louvain.best_partition(
+        G, weight="weight", random_state=RANDOM_STATE)
+    n_comm = len(set(partition.values()))
+    modularity = community_louvain.modularity(
+        partition, G, weight="weight")
+    log.info("  Louvain: %d communities, modularity=%.4f",
+             n_comm, modularity)
+
+    comm_to_tradition, trad_to_comm, comm_to_nodes = _assign_traditions(
+        G, partition)
+
+    return {
+        "graph": G,
+        "partition": partition,
+        "comm_to_tradition": comm_to_tradition,
+        "trad_to_comm": trad_to_comm,
+        "comm_to_nodes": comm_to_nodes,
+        "ref_counts": ref_counts,
+        "n_comm": n_comm,
+        "modularity": modularity,
+        "actual_top_n": actual_top_n,
+        "cutoff_year": cutoff_year,
+    }

--- a/scripts/compute_null_separation.py
+++ b/scripts/compute_null_separation.py
@@ -56,8 +56,8 @@ from _null_separation import (
     partition_modularity,
     within_tradition_share,
 )
+from _pre2007_traditions import build_pre2007_traditions
 from pipeline_loaders import load_analysis_config
-from plot_fig_traditions import build_pre2007_traditions
 from schemas import NullSeparationSchema
 from script_io_args import parse_io_args, validate_io
 from utils import get_logger, normalize_doi

--- a/scripts/plot_fig_traditions.py
+++ b/scripts/plot_fig_traditions.py
@@ -17,42 +17,21 @@ Usage:
 import argparse
 import os
 
-import community as community_louvain
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
-import pandas as pd
+from _pre2007_traditions import (
+    RANDOM_STATE,
+    TRADITION_ANCHORS,
+    build_pre2007_traditions,
+)
 from pipeline_io import save_figure
-from pipeline_loaders import (
-    load_analysis_config,
-    load_refined_works,
-    pre2007_cutoff_year,
-)
 from plot_style import DARK, DPI, FIGWIDTH, apply_style
-from scipy.sparse import lil_matrix
 from script_io_args import parse_io_args, validate_io
-from utils import (
-    get_logger,
-    load_refined_citations,
-    normalize_doi,
-)
+from utils import get_logger
 
 log = get_logger("plot_fig_traditions")
-
-# --- Parameters ---
-# CUTOFF_YEAR is not a hardcoded constant: it is derived from the config
-# periodization (first break - 1) via pre2007_cutoff_year(), the single source
-# of truth shared with compute_pre2007_coverage.py.
-TOP_N = 250
-MIN_COCIT = 3
-RANDOM_STATE = 42
-
-TRADITION_ANCHORS = {
-    "pricing": ["weitzman", "barrett", "carraro", "montgomery", "pizer"],
-    "cdm":     ["michaelowa", "sutter", "ellis", "haites", "pearson"],
-    "unfccc":  ["north", "dimaggio", "finnemore"],
-}
 
 TRADITION_LABELS = {
     "pricing": "Environmental economics\n(pricing & quantities)",
@@ -73,148 +52,6 @@ TRADITION_EDGE_COLORS = {
     "unfccc":  "#4a9e6b",
     "other":   "#CCCCCC",
 }
-
-
-def _load_data(works_path, cit_path):
-    """Load citations and works, build DOI metadata lookup."""
-    log.info("Loading citations...")
-    if cit_path is not None:
-        cit = pd.read_csv(cit_path, low_memory=False)
-    else:
-        cit = load_refined_citations()
-    cit["source_doi"] = cit["source_doi"].apply(normalize_doi)
-    cit["ref_doi"] = cit["ref_doi"].apply(normalize_doi)
-    cit = cit[(cit["source_doi"] != "") & (cit["ref_doi"] != "")]
-    cit = cit[~cit["source_doi"].isin(["nan", "none"])]
-    cit = cit[~cit["ref_doi"].isin(["nan", "none"])]
-    log.info("  Citation pairs: %d", len(cit))
-
-    if works_path is not None:
-        works = pd.read_csv(works_path)
-    else:
-        works = load_refined_works()
-    works["doi_norm"] = works["doi"].apply(normalize_doi)
-    doi_meta = {}
-    for _, row in works.iterrows():
-        d = row["doi_norm"]
-        if d and d not in ("nan", "none"):
-            doi_meta[d] = {
-                "title": str(row.get("title", "") or ""),
-                "author": str(row.get("first_author", "") or ""),
-                "year": row.get("year", ""),
-            }
-    for _, row in cit.iterrows():
-        d = row["ref_doi"]
-        if d and d not in ("nan", "none") and d not in doi_meta:
-            doi_meta[d] = {
-                "title": str(row.get("ref_title", "") or ""),
-                "author": str(row.get("ref_first_author", "") or ""),
-                "year": row.get("ref_year", "") or "",
-            }
-    return cit, doi_meta
-
-
-def _build_cocitation_network(cit, doi_meta, ref_counts, top_refs):
-    """Build co-citation graph from top references."""
-    actual_top_n = len(top_refs)
-    top_set = set(top_refs)
-    ref_to_idx = {r: i for i, r in enumerate(top_refs)}
-
-    log.info("Building co-citation matrix...")
-    source_groups = cit.groupby("source_doi")["ref_doi"].apply(list)
-
-    cocit = lil_matrix((actual_top_n, actual_top_n), dtype=np.float32)
-    for ref_list in source_groups.values:
-        in_top = [r for r in ref_list if r in top_set]
-        if len(in_top) < 2:
-            continue
-        for i in range(len(in_top)):
-            for j in range(i + 1, len(in_top)):
-                a = ref_to_idx[in_top[i]]
-                b = ref_to_idx[in_top[j]]
-                cocit[a, b] += 1
-                cocit[b, a] += 1
-
-    cocit_dense = cocit.toarray()
-    log.info("  Non-zero co-citation pairs: %d",
-             np.count_nonzero(cocit_dense) // 2)
-
-    G = nx.Graph()
-    for doi in top_refs:
-        meta = doi_meta.get(doi, {})
-        author = (str(meta.get("author", "") or "")
-                  .split(",")[0].split(";")[0].strip())
-        year = str(meta.get("year", "") or "")
-        title = str(meta.get("title", "") or "")
-        if "." in year:
-            year = year.split(".")[0]
-        label = _make_node_label(author, year, title, doi)
-        G.add_node(doi, label=label,
-                   citations=int(ref_counts.get(doi, 0)),
-                   author=author.lower())
-
-    for i in range(actual_top_n):
-        for j in range(i + 1, actual_top_n):
-            w = cocit_dense[i, j]
-            if w >= MIN_COCIT:
-                G.add_edge(top_refs[i], top_refs[j], weight=float(w))
-
-    isolates = list(nx.isolates(G))
-    G.remove_nodes_from(isolates)
-    log.info("Network: %d nodes, %d edges",
-             G.number_of_nodes(), G.number_of_edges())
-    log.info("  Removed %d isolates", len(isolates))
-    return G
-
-
-def _make_node_label(author, year, title, doi):
-    """Create a readable label for a network node."""
-    if (author and author.lower() not in ("nan", "none", "")
-            and year and year not in ("nan", "none", "")):
-        return f"{author} {year}"
-    if title and title.lower() not in ("nan", "none", ""):
-        words = [w for w in title.split() if len(w) > 2][:3]
-        suffix = f" {year}" if year and year not in ("nan", "none") else ""
-        return " ".join(words) + suffix
-    return doi.split("/")[-1][:16]
-
-
-def _assign_traditions(G, partition):
-    """Map Louvain communities to named traditions via anchor matching."""
-    comm_to_nodes = {}
-    for doi, c in partition.items():
-        comm_to_nodes.setdefault(c, []).append(doi)
-
-    scores = {}
-    for c, nodes in comm_to_nodes.items():
-        for trad, anchors in TRADITION_ANCHORS.items():
-            count = sum(
-                1 for doi in nodes
-                if any(a in G.nodes[doi].get("author", "")
-                       for a in anchors)
-            )
-            scores[(c, trad)] = count
-
-    comm_to_tradition = {}
-    trad_to_comm = {}
-    assigned_comms = set()
-    assigned_trads = set()
-
-    for (c, trad), score in sorted(scores.items(), key=lambda x: -x[1]):
-        if score == 0:
-            break
-        if c in assigned_comms or trad in assigned_trads:
-            continue
-        comm_to_tradition[c] = trad
-        trad_to_comm[trad] = c
-        assigned_comms.add(c)
-        assigned_trads.add(trad)
-
-    for c in comm_to_nodes:
-        if c not in comm_to_tradition:
-            comm_to_tradition[c] = "other"
-
-    return comm_to_tradition, trad_to_comm, comm_to_nodes
 
 
 def _render_traditions(G, partition, pos, comm_to_tradition,
@@ -328,80 +165,6 @@ def _draw_legend(ax, trad_to_comm, comm_to_nodes, comm_to_tradition):
     ax.legend(handles=legend_handles, loc="lower left",
               framealpha=0.9, edgecolor=DARK, fontsize=6,
               handlelength=1.2, handleheight=1.0)
-
-
-def build_pre2007_traditions(works_path, cit_path=None):
-    """Build the pre-2007 co-citation graph and its tradition assignment.
-
-    This is the single source of truth for the pre-2007 tradition seed-sets:
-    the figure renders it, and compute_null_separation.py tests it against a
-    degree-preserving null. Returns None when there is no pre-2007 network.
-
-    Returns
-    -------
-    dict | None
-        graph, partition (node->community), comm_to_tradition,
-        trad_to_comm, comm_to_nodes, ref_counts, n_comm, modularity,
-        actual_top_n.
-
-    """
-    cutoff_year = pre2007_cutoff_year(load_analysis_config())
-
-    cit, doi_meta = _load_data(works_path, cit_path)
-
-    # Filter to pre-2007 references
-    cit["ref_year_num"] = pd.to_numeric(cit["ref_year"], errors="coerce")
-    pre_dois = (
-        set(cit.loc[cit["ref_year_num"] <= cutoff_year, "ref_doi"])
-        - {"", "nan", "none"}
-    )
-
-    ref_counts_all = cit.groupby("ref_doi").size()
-    ref_counts = ref_counts_all.loc[
-        ref_counts_all.index.isin(pre_dois)
-    ].sort_values(ascending=False)
-    log.info("  Pre-%d refs: %d (cited >= 1)",
-             cutoff_year, len(ref_counts))
-
-    actual_top_n = min(TOP_N, len(ref_counts))
-    if actual_top_n == 0:
-        log.info("No pre-%d references found.", cutoff_year)
-        return None
-
-    top_refs = ref_counts.head(actual_top_n).index.tolist()
-    log.info("  Using top %d; citation range: %d .. %d",
-             actual_top_n,
-             ref_counts.iloc[0],
-             ref_counts.iloc[actual_top_n - 1])
-
-    G = _build_cocitation_network(cit, doi_meta, ref_counts, top_refs)
-    if G.number_of_nodes() == 0:
-        log.info("Empty network.")
-        return None
-
-    partition = community_louvain.best_partition(
-        G, weight="weight", random_state=RANDOM_STATE)
-    n_comm = len(set(partition.values()))
-    modularity = community_louvain.modularity(
-        partition, G, weight="weight")
-    log.info("  Louvain: %d communities, modularity=%.4f",
-             n_comm, modularity)
-
-    comm_to_tradition, trad_to_comm, comm_to_nodes = _assign_traditions(
-        G, partition)
-
-    return {
-        "graph": G,
-        "partition": partition,
-        "comm_to_tradition": comm_to_tradition,
-        "trad_to_comm": trad_to_comm,
-        "comm_to_nodes": comm_to_nodes,
-        "ref_counts": ref_counts,
-        "n_comm": n_comm,
-        "modularity": modularity,
-        "actual_top_n": actual_top_n,
-        "cutoff_year": cutoff_year,
-    }
 
 
 def main():

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -268,7 +268,11 @@ class TestNoHardcodedSeeds:
         "plot_bimodality.py",
         "plot_cocitation.py",
         "plot_fig45_pca_scatter.py",
-        "plot_fig_traditions.py",
+        # plot_fig_traditions.py removed (ticket 0250): its RANDOM_STATE=42
+        # relocated with build_pre2007_traditions into the neutral helper
+        # scripts/_pre2007_traditions.py, so the plot module no longer hardcodes
+        # a seed. The relocated seed is a pre-existing un-migrated violation now
+        # in a non-Phase-2-prefixed helper, outside this prefix-gated scan.
         "plot_figS_kde.py",
         "plot_heatmap_communities_clusters.py",
         "plot_ncc_bimodality.py",

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -11,10 +11,10 @@ of them import a `plot_*` module. Adherence tier — runs under `make lint`, not
 fast inner loop.
 
 Ticket 0242 severed `compute_clustering_comparison.py`'s import of the two
-clustering plotters. `compute_null_separation.py` retains a second, distinct
-violation (it imports the analysis helper `build_pre2007_traditions`, which is
-misplaced inside `plot_fig_traditions.py`); relocating that helper is separate
-work tracked by ticket 0250 and is allowlisted below until then.
+clustering plotters. Ticket 0250 severed the second violation by relocating the
+shared analysis helper `build_pre2007_traditions` out of `plot_fig_traditions.py`
+into the neutral module `_pre2007_traditions.py`, which both the plot and the
+compute layer import. The allowlist is now empty.
 """
 
 import ast

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -30,12 +30,7 @@ SCRIPTS_DIR = os.path.join(REPO, "scripts")
 # Known, pre-existing compute → plot violations awaiting their own relocation
 # ticket. Each entry MUST cite the tracking ticket. Remove an entry the moment
 # its violation is fixed — see test_no_stale_layering_allowlist.
-LAYERING_ALLOWLIST = {
-    # compute_null_separation.py imports build_pre2007_traditions() from
-    # plot_fig_traditions.py — a misplaced shared analysis helper. Ticket 0250
-    # relocates it to a neutral module.
-    "compute_null_separation.py": "0250",
-}
+LAYERING_ALLOWLIST: dict[str, str] = {}
 
 
 def _compute_scripts():

--- a/tests/test_null_separation.py
+++ b/tests/test_null_separation.py
@@ -252,8 +252,8 @@ def test_load_data_reads_works_through_loader(monkeypatch):
     pd.read_csv. Shared by the figure (plot_fig_traditions) and the
     pre-2007 separation null (compute_null_separation), both via the
     neutral _pre2007_traditions module."""
-    import pandas as pd
     import _pre2007_traditions as p27
+    import pandas as pd
 
     works = pd.DataFrame({
         "doi": ["10.1/a"],

--- a/tests/test_null_separation.py
+++ b/tests/test_null_separation.py
@@ -250,9 +250,10 @@ def test_load_data_reads_works_through_loader(monkeypatch):
     """arch rule 9 (ticket 0185): with no explicit works_path, _load_data
     must read the works catalog via load_refined_works(), not a direct
     pd.read_csv. Shared by the figure (plot_fig_traditions) and the
-    pre-2007 separation null (compute_null_separation)."""
+    pre-2007 separation null (compute_null_separation), both via the
+    neutral _pre2007_traditions module."""
     import pandas as pd
-    import plot_fig_traditions as pft
+    import _pre2007_traditions as p27
 
     works = pd.DataFrame({
         "doi": ["10.1/a"],
@@ -273,10 +274,10 @@ def test_load_data_reads_works_through_loader(monkeypatch):
         calls["works"] += 1
         return works.copy()
 
-    monkeypatch.setattr(pft, "load_refined_works", fake_load_works)
-    monkeypatch.setattr(pft, "load_refined_citations", lambda: cit.copy())
+    monkeypatch.setattr(p27, "load_refined_works", fake_load_works)
+    monkeypatch.setattr(p27, "load_refined_citations", lambda: cit.copy())
 
-    _cit, doi_meta = pft._load_data(None, None)
+    _cit, doi_meta = p27._load_data(None, None)
 
     assert calls["works"] == 1, "works must be read through load_refined_works()"
     assert "10.1/a" in doi_meta

--- a/tickets/closed/0250-reorg-code-relocate-build-pre2007-traditions.erg
+++ b/tickets/closed/0250-reorg-code-relocate-build-pre2007-traditions.erg
@@ -3,11 +3,13 @@ Title: Relocate build_pre2007_traditions out of plot_fig_traditions (compute →
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Label: deferred
+Closed: relocated build_pre2007_traditions to neutral _pre2007_traditions.py; layering allowlist empty
 
 --- log ---
 2026-07-11T00:00Z HDMX-coding-agent created
 2026-07-11T00:00Z HDMX-coding-agent note discovered while doing 0242 (sever clustering back-arrow). The layering guard added in 0242 (tests/test_layering.py) allowlists compute_null_separation.py pending this ticket.
 
+2026-07-11T06:42Z HDMX-coding-agent closed — relocated build_pre2007_traditions to neutral _pre2007_traditions.py; layering allowlist empty
 --- body ---
 ## Context
 The layering guard added in ticket 0242 (`tests/test_layering.py`) forbids any


### PR DESCRIPTION
**Ticket:** tickets/0250-relocate-pre2007-traditions.erg

## Summary
Pure relocation. Moves the pre-2007 co-citation **analysis** machinery out of the plot module `scripts/plot_fig_traditions.py` into a new neutral module `scripts/_pre2007_traditions.py`, so `scripts/compute_null_separation.py` imports the helper from a non-plot module. This severs the last `compute → plot` backward arrow that the layering guard (`tests/test_layering.py`, ticket 0242) allowlisted.

Moved into `_pre2007_traditions.py` (byte-identical): functions `_load_data`, `_build_cocitation_network`, `_make_node_label`, `_assign_traditions`, `build_pre2007_traditions`; constants `TOP_N=250`, `MIN_COCIT=3`, `RANDOM_STATE=42`, `TRADITION_ANCHORS`.

Stays in `plot_fig_traditions.py` (the plotting layer): `TRADITION_LABELS`, `TRADITION_COLORS`, `TRADITION_EDGE_COLORS`, `_render_traditions`, `_draw_labels`, `_draw_legend`, `main`. It now imports `build_pre2007_traditions`, `RANDOM_STATE` (spring_layout seed) and `TRADITION_ANCHORS` (used by `_draw_labels`) from the neutral module.

Call sites repointed: `compute_null_separation.py` (`from _pre2007_traditions import build_pre2007_traditions`) and `tests/test_null_separation.py` (`import _pre2007_traditions as p27`).

## Byte-identity argument
The moved functions and constants are copied verbatim; `RANDOM_STATE=42`, `TOP_N=250`, `MIN_COCIT=3` and the anchor dict are unchanged; the data path (loaders / optional `--input`) is identical. Therefore both the figure output (`plot_fig_traditions`) and the `compute_null_separation` output are byte-identical by construction. No data build was run (this worktree has no corpus; a Phase-2 data build is out of scope for a relocation).

## Layering allowlist now empty
`tests/test_layering.py` `LAYERING_ALLOWLIST` is now `{}` — the `compute_null_separation.py` entry is removed and `test_no_stale_layering_allowlist` / `test_no_compute_imports_plotter` both pass. No `compute_*.py` imports any `plot_*` module.

## Guard-coverage note (follow-up candidate)
`RANDOM_STATE=42` was a KNOWN_VIOLATIONS entry for `plot_fig_traditions.py` in `tests/test_arch_compliance.py` (hardcoded-seed guard). It relocated with the code into `_pre2007_traditions.py`, which has no Phase-2 prefix and so is outside that prefix-gated seed scan. The stale `plot_fig_traditions.py` entry is removed (documented inline). The relocated seed is a pre-existing, un-migrated hardcoded seed now unguarded — same guard-narrowing pattern as tickets 0239→0248. A follow-up could either migrate `RANDOM_STATE` to `config/analysis.yaml` or extend the seed scan to shared `_*.py` helpers. Not done here to keep this a pure relocation.

## TDD / gates
- RED: dropped the allowlist entry with no relocation → `test_no_compute_imports_plotter` failed on `compute_null_separation.py`.
- GREEN: created the module, moved the unit, repointed all call sites → guard + null-separation tests green.
- REFACTOR: pruned now-unused imports from `plot_fig_traditions.py` (see below), fixed import order, dropped the stale seed allowlist entry.
- `make lint` (adherence): 155 passed. `make check-fast`: 945 passed, 10 skipped (exit 0).

## Imports pruned from `plot_fig_traditions.py`
`community as community_louvain`, `pandas as pd`, `from scipy.sparse import lil_matrix`, and from `pipeline_loaders`: `load_analysis_config`, `load_refined_works`, `pre2007_cutoff_year`; from `utils`: `load_refined_citations`, `normalize_doi`. Kept: `numpy as np` (still used by `_render_traditions`), plus `argparse`, `os`, `mpatches`, `plt`, `nx`, `save_figure`, `plot_style` symbols, `parse_io_args`/`validate_io`, `get_logger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)