### PR TITLE
chore: weekend state refresh (STATE index, ROADMAP/README freshness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How economists and institutions co-produced the categories, metrics, and account
 
 | Document | File | Journal | Status |
 |----------|------|---------|--------|
-| Manuscript | `deliverables/manuscript/manuscript.qmd` | Œconomia (Varia) | Submitted 2026-03-18, under review |
+| Manuscript | `deliverables/manuscript/manuscript.qmd` | Œconomia (Varia) | Submitted 2026-03-18; R&R, revision v2.0.5 in progress |
 | Data paper | `deliverables/data-paper/data-paper.qmd` | RDJ4HSS (diamond OA) | Submitted 2026-03-26, under review |
 | Technical report | `deliverables/technical-report/technical-report.qmd` | HAL working paper | Complete |
 | Method paper | `deliverables/multilayer/multilayer-detection.qmd` | Scientometrics / QSS | Outline |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,11 @@ Building toward a book on international climate finance between solidarity and p
 
 ## Oeconomia manuscript next steps
 
-Submitted to Oeconomia (Varia) on 2026-03-18. Waiting for referee reports (~3 months).
+Submitted to Oeconomia (Varia) on 2026-03-18. Revise-and-resubmit received;
+manuscript rebuilt (v2.0.5), response letter drafted (ticket 0152).
 
-- [ ] Wait for reviewers feedback
-- [ ] Revise and Resubmit
+- [x] Wait for reviewers feedback
+- [ ] Revise and Resubmit — in progress: R1/R2 ledger sign-offs, then 0195 → 0153 (rebuild, deposit, resubmit)
 - [ ] Prepare Econom'IA conference slides (Cergy, May 27–28, 2026; present aedist results)
 - [ ] Continue Tier 1 reading plan (defence against reviewer questions)
 
@@ -25,8 +26,8 @@ Submitted data paper to RDJ4HSS (diamond OA).
 
 21st International Colloquium of the Charles Gide Association, theme "Crises". Abstract accepted.
 
-- [ ] Write conference paper (due 2026-06-15)
-- [ ] Present at Vannes (2026-07-02 to 04)
+- [x] Write conference paper (due 2026-06-15) — `manuscript-Gide.qmd`, French short version
+- [x] Present at Vannes (2026-07-02 to 04)
 - [ ] Consider submission to RHPE special issue on "Crises" (call post-conference)
 
 ## Next articles
@@ -47,3 +48,4 @@ Submitted data paper to RDJ4HSS (diamond OA).
 - **v1.1.1 — Pipeline refactor (2026-03)**: enrichment split into 4 independent DVC stages (#428), code smell cleanup (#507), agent harness consolidation, script I/O discipline (#547, #549)
 - **v1.1.2 — Citation enrichment (in progress)**: GROBID reference parsing (#539), Crossref DOI fallback, circuit breakers (#590, #598), citation hardening (#529)
 - **Imperial Dragon harness (2026-04-01)**: workflow renamed from Dragon Dreaming (4 phases) to Imperial Dragon (5 claws), generic harness extracted to ~/.claude/ (#628)
+- **v2.0.5 — Œconomia R&R revision (2026-06/07)**: referee reports answered point by point (60-remark ledger, ticket 0152), manuscript rebuilt on the "birth of an aggregate" framing, Gide-Vannes French short version presented (2026-07-02/04)

--- a/STATE.md
+++ b/STATE.md
@@ -1,28 +1,27 @@
 # State
 
-Last updated: 2026-07-10T20:48Z
+Last updated: 2026-07-11T06:55Z
 
 ## Current goal
 
-**Œconomia R&R resubmission.** v2.0.5 shipped. Critical path: **0152** letter
-(DRAFT v3 done 2026-07-10: first-person, A4, 60-row ledger filled, all 14
-Editor rows author-signed; **R1/R2 sign-offs next session**) → **0195** stat
-tables → **0153** final rebuild + Zenodo/HAL deposit + resubmit. Tracker 0156
-stays open until resubmitted (then closes 0133).
+**Œconomia R&R resubmission.** Critical path: **0152** (letter DRAFT v3 done,
+14 Editor rows signed; R1/R2 sign-offs + E3f vetting pending — see ticket) →
+**0195** stat tables → **0153** rebuild, deposit, resubmit. Tracker 0156 open
+until resubmitted.
 
-### Also open
-- **0244** — verify 4 AI-generated techrep includes (phantom ref caught in §11);
-  vet `cop-topic-structure.md` before the letter goes out (it backs E3f).
-- **0245** brief entries · **0243** Fable style alignment · **0026** method paper.
-- **0246/0247** — harness: make-check exit-0 bug; shared venv missing bibtexparser.
+### Also open (details live in the tickets)
+- **0243** voice alignment — author decisions on draft PR #1016.
+- **0244** AI-generated includes — author marker review.
+- **0252** hygiene sweep (.dvc pointers, dead branch) · **0026** method paper.
+- Harness PR #472 (reuse gate + supervisor doctrine) awaits author review.
 
 ## Status
-<!-- generated 2026-07-10T20:48Z -->
-**Tickets:** 5 ready · 43 blocked — `erg ready tickets/` for full list
+<!-- generated 2026-07-11T06:55Z -->
+**Tickets:** 4 ready · 42 blocked — `erg ready tickets/` for full list
 **Recent commits:**
-  76f6ca8 Merge pull request #1008 from MinhHaDuong/t-roar-file-tickets
-  fc6ef2d Merge pull request #1007 from MinhHaDuong/t152-response-letter
-  50927b8 manuscript(0152): drop the false pre-2007 co-citation paragraph
+  de07787c ticket(0251): close and archive — guard landed, gates green
+  caa2e2ed ticket(0248): close and archive — .mk discovery unified, PR #1019
+  fe53ba8b ticket(0242): close and archive — backward arrow severed, PR #1017
 
 ## Corpus (v1.1.1)
 
@@ -31,10 +30,10 @@ stays open until resubmitted (then closes 0133).
 
 ## Health
 
-check-fast 932 + lint 149 green. Full suite on doudou: 1388 passed, 21 failed + 4
-errors, all data/env-dependent (no local corpus data; C2ST timeouts; bibtexparser
-→ 0247), none from the merged diff. `make check` exited 0 despite failures → 0246.
+check-fast 954 + lint 152 green (wrong-namespace guard 0251 in). 0246 was a
+false alarm: make is exit-faithful, a `| tail` pipe swallowed the exit code.
+2026-07-10/11 night regime + morning: 8 PRs merged, 6 tickets closed.
 
 ## Next actions
 
-- **HITL:** 0152 R1/R2 sign-offs → 0195 → 0153 (rebuild, deposit, resubmit).
+- **HITL Monday:** 0152 · 0244 · 0243 — the tickets carry the work.

--- a/tickets/0252-hygiene-stale-dvc-pointers-dead-branch.erg
+++ b/tickets/0252-hygiene-stale-dvc-pointers-dead-branch.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Hygiene sweep: stale .dvc pointers and dead remote branch
+Created: 2026-07-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-11T06:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Two hygiene leftovers from the 2026-07-10/11 night run and morning wrap-up,
+parked here so STATE.md stays a pure index.
+
+1. Stale .dvc pointers: the night-run env sync surfaced a stale path in the
+   shared environment (openalex-corpus pointing at a defunct /tmp review
+   worktree, since fixed). A sweep of the repo's .dvc pointer files against
+   dvc.yaml outs and the current data/ layout (architecture.md) is pending —
+   pointers referencing moved or retired locations should be corrected or
+   removed.
+2. Dead remote branch `t-flaky-step1-counter-ticket`: its PR #1004 was closed
+   as superseded (0249 root-caused and fixed the flakiness it filed 0238 for).
+   Same profile as t0212, which the author had deleted on 2026-07-11. Deleting
+   discards the unmerged filing commit — author arbitration required.
+
+## Actions
+
+1. Inventory `*.dvc` files and dvc.yaml outs; diff against the data/ layout.
+2. Fix or remove stale pointers; note each decision in this ticket's log.
+3. Ask the author: delete `origin/t-flaky-step1-counter-ticket` yes/no; apply.
+
+## Verification
+
+- [ ] `dvc status` (on padme, where data lives) reports no missing/stale refs
+- [ ] `git branch -r` shows no branch whose PR is closed-unmerged without an
+      explicit author decision logged here
+
+## Invariants
+
+- No data deletion; pointers only. Data flows padme→doudou only.
+- make check-fast and make lint stay green.
+
+## Exit criteria
+
+- [ ] .dvc pointers consistent with dvc.yaml and data/ layout
+- [ ] Dead-branch decision logged and applied


### PR DESCRIPTION
Weekend wrap-up per author request: clean, saved state to resume next week.

- **STATE.md** rewritten as a pure index (38 lines): the Monday HITL work lives in tickets 0152 (R1/R2 sign-offs + E3f vetting), 0244 (marker review), 0243 (voice decisions, draft PR #1016); STATE only points at them.
- **ROADMAP.md** was 3 months stale: Œconomia section now reflects the R&R in progress, Gide-Vannes items checked, v2.0.5 milestone added.
- **README.md** manuscript status updated from 'under review' to R&R revision in progress.
- Files hygiene ticket 0252 (.dvc pointer sweep + dead-branch arbitration) so the leftovers are ticketed, not STATE bullets.

Ticket-ref: tickets/0252-hygiene-stale-dvc-pointers-dead-branch.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)