### PR TITLE
0259: RANDOM_STATE to config; restore seed-scan coverage

### DIFF
--- a/config/analysis.yaml
+++ b/config/analysis.yaml
@@ -152,6 +152,16 @@ sensitivity:
   equal_n_r: 3         # R=3 median-of-three equal-n subsample replicates
   method: S2_energy
 
+# ── Pre-2007 co-citation traditions (tickets 0250, 0259) ─────────────────
+# build_pre2007_traditions in scripts/_pre2007_traditions.py builds the
+# co-citation network of the most-cited pre-2007 references and assigns its
+# Louvain communities to three intellectual traditions. louvain_seed is that
+# partition's random_state; plot_fig_traditions imports it (figure spring
+# layout) and compute_null_separation runs against the same seed-sets, so one
+# key fixes the seed the published figure and the null model both use.
+pre2007_traditions:
+  louvain_seed: 42     # Louvain partition random_state (was RANDOM_STATE=42)
+
 # ── Pre-2007 tradition-separation null model (ticket 0182) ───────────────
 # compute_null_separation.py degree-preserving-rewiring null for the
 # separation of the three pre-2007 intellectual traditions. The graph-

--- a/scripts/_pre2007_traditions.py
+++ b/scripts/_pre2007_traditions.py
@@ -35,7 +35,11 @@ log = get_logger("_pre2007_traditions")
 # of truth shared with compute_pre2007_coverage.py.
 TOP_N = 250
 MIN_COCIT = 3
-RANDOM_STATE = 42
+# Louvain partition seed, sourced from config/analysis.yaml (architecture
+# rule 7 — no hardcoded seeds). plot_fig_traditions imports this constant for
+# its spring-layout seed, so it stays a module-level name; only its *value*
+# now comes from config.
+RANDOM_STATE = int(load_analysis_config()["pre2007_traditions"]["louvain_seed"])
 
 TRADITION_ANCHORS = {
     "pricing": ["weitzman", "barrett", "carraro", "montgomery", "pizer"],

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -250,7 +250,20 @@ class TestNoHardcodedSeeds:
 
     Detection: regex scan for literal integer arguments to known seed
     parameters (random_state=N, seed=N) and RandomState(N) calls.
+
+    Scope: Phase-2-prefixed scripts AND shared private helper modules (_*.py).
+    A stochastic op relocated into a neutral _*.py helper (ticket 0250 moved
+    RANDOM_STATE into _pre2007_traditions.py) must stay under rule-7 coverage —
+    a fixed-prefix glob would otherwise silently narrow, hiding the seed from
+    the guard (feedback moving_files_narrows_guard_globs, 0259).
     """
+
+    @staticmethod
+    def _in_scope(name):
+        """Phase-2-prefixed scripts or shared private helpers (_*.py)."""
+        return name.startswith(_PHASE2_PREFIXES) or os.path.basename(
+            name
+        ).startswith("_")
 
     # Pre-existing violations. Remove entries as they are migrated to config.
     KNOWN_VIOLATIONS = {
@@ -270,9 +283,9 @@ class TestNoHardcodedSeeds:
         "plot_fig45_pca_scatter.py",
         # plot_fig_traditions.py removed (ticket 0250): its RANDOM_STATE=42
         # relocated with build_pre2007_traditions into the neutral helper
-        # scripts/_pre2007_traditions.py, so the plot module no longer hardcodes
-        # a seed. The relocated seed is a pre-existing un-migrated violation now
-        # in a non-Phase-2-prefixed helper, outside this prefix-gated scan.
+        # scripts/_pre2007_traditions.py. That helper now sources the seed from
+        # config (pre2007_traditions.louvain_seed, ticket 0259) and the scan
+        # covers _*.py helpers, so neither module hardcodes a seed.
         "plot_figS_kde.py",
         "plot_heatmap_communities_clusters.py",
         "plot_ncc_bimodality.py",
@@ -298,7 +311,7 @@ class TestNoHardcodedSeeds:
         """No Phase 2 script (outside known violations) may hardcode seeds."""
         violations = []
         for name in _all_scripts():
-            if not name.startswith(_PHASE2_PREFIXES):
+            if not self._in_scope(name):
                 continue
             if name in self.KNOWN_VIOLATIONS:
                 continue

--- a/tickets/closed/0259-hygiene-random-state-seed-to-config-anal.erg
+++ b/tickets/closed/0259-hygiene-random-state-seed-to-config-anal.erg
@@ -3,11 +3,13 @@ Title: Hygiene — RANDOM_STATE seed to config/analysis.yaml (restore seed-scan 
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Label: deferred
+Closed: seed sourced from config pre2007_traditions.louvain_seed; seed scan widened to _*.py helpers; gates green
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note fallout of epic 0240's exemplar (0250). Independent — no prerequisite. Restores the seed-scan coverage 0250 silently narrowed.
 
+2026-07-11T07:06Z HDMX-coding-agent closed — seed sourced from config pre2007_traditions.louvain_seed; seed scan widened to _*.py helpers; gates green
 --- body ---
 ## Context
 Independent hygiene item surfaced by the code reorg epic (tracker `0240`). Ticket


### PR DESCRIPTION
## What

Ticket 0250 relocated `RANDOM_STATE = 42` into `scripts/_pre2007_traditions.py`, a neutral helper with no Phase-2 filename prefix. That reintroduced a hardcoded seed (architecture rule 7 forbids it) and put it *outside* the prefix-gated seed scan in `tests/test_arch_compliance.py`, leaving the seed unguarded. This closes both the leak and the coverage gap.

## Changes

- **`config/analysis.yaml`** — new `pre2007_traditions.louvain_seed: 42` key (the Louvain partition seed used by the figure and the null model).
- **`scripts/_pre2007_traditions.py`** — `RANDOM_STATE` now reads `load_analysis_config()["pre2007_traditions"]["louvain_seed"]` instead of a literal. The module-level name is kept so `plot_fig_traditions`'s `from _pre2007_traditions import RANDOM_STATE` (spring-layout seed) still resolves. Value unchanged → byte-identical partition.
- **`tests/test_arch_compliance.py`** — widened the rule-7 seed scan to cover shared `_*.py` helper modules, not just Phase-2-prefixed scripts. This is the durable class fix (feedback `moving_files_narrows_guard_globs`): a stochastic op relocated into a neutral helper can no longer slip the guard.

## Verification

- Effective seed still `42` (verified: `from _pre2007_traditions import RANDOM_STATE` → 42).
- RED→GREEN: widened scan flagged `_pre2007_traditions.py` before the config move, green after.
- Mutation-proven teeth: injecting a seed literal into an unrelated `_*.py` helper fails the scan.
- `make lint` green (155 passed, 5 skipped); `make check-fast` green (945 passed, 10 skipped).

**Ticket:** tickets/0259-hygiene-random-state-seed-to-config-anal.erg