### PR TITLE
reorg(0254): definitive Tier-2/Tier-3 script classification + dual-role extractions

### DIFF
--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -91,53 +91,112 @@ Moving a `.mk` file is cheap: `-include`d rules resolve relative to the *root*
 Makefile, so paths inside are unchanged — only the `-include` line edits.
 Moving the referenced *scripts* is the real edit (prereq paths).
 
-## Migration checklist — the 19 flagged dual-role files
+## Definitive Tier-2 / Tier-3 classification (ticket 0254)
 
-Audited by intent (2026-07-10). 10 were false positives (declared libraries the
-syntactic filter mis-flagged); 9 are genuinely dual-role. Destinations are
-`scripts/<phase>/`, not `src/`.
+> **This table is the contract wave-1 moves (0255–0258) consume.** It supersedes
+> the 2026-07-10 "19 flagged dual-role files" checklist (which predates the
+> two-tier rule and proposed phase-subdir destinations for *imported* files — a
+> contradiction the ratified rule resolves: **imported by another script ⇒ stays
+> flat**). Built mechanically from the `scripts/*.py` import graph; the gate test
+> `tests/test_script_classification.py` pins it.
 
-### LIBRARY → stays in `scripts/` (relocated by phase), no split (10)
+**The rule.** A top-level `scripts/*.py` is **Tier-2 (stays flat)** iff it is
+imported by any other top-level script (test-only importers do not count);
+otherwise it is **Tier-3 (a pure entry point that moves to `scripts/<phase>/`)**.
+`_`-prefix, a `__main__` guard, or filename prefix are heuristics, not the test —
+being imported is.
 
-`clustering_methods`, `script_io_args`, `_companion_plot_utils`,
-`_divergence_{citation,lexical,semantic}`,
-`_permutation_{c2st,graph,lexical,semantic}`. Each self-declares as a library
-(`_`-prefix + "no main" docstring, or "Pure algorithmic module"). No CLI, no
-split — already the existing convention.
+**Reconciliation.** 177 top-level `scripts/*.py` (174 audited + 3 modules 0254
+extracted) = **45 Tier-2 (flat)** + **132 Tier-3 (movers)**. Movers by phase:
+figures 62 · harvest 25 · analysis 34 · qa 11.
 
-### SPLIT — extract leaked *computation* into `scripts/<phase>/`, script stays (5)
+### Tier-2 — flat library surface (45, stay at `scripts/` root)
 
-| Script (stays in `scripts/`) | Extract to | Leaked symbol(s) |
+**Private `_`-modules (21):** `_citation_methods`, `_companion_plot_utils`,
+`_corpus_predicates`, `_course_dedup`, `_divergence_backend`, `_divergence_c2st`,
+`_divergence_citation`, `_divergence_community`, `_divergence_io`,
+`_divergence_lexical`, `_divergence_semantic`, `_null_separation`,
+`_permutation_accel`, `_permutation_c2st`, `_permutation_citation`,
+`_permutation_graph`, `_permutation_io`, `_permutation_lexical`,
+`_permutation_semantic`, `_pre2007_traditions`, `_venue_naming`.
+
+**Named libraries, no `__main__` (18):** `clustering_methods`, `filter_flags`,
+`filter_flags_llm`, `openalex_pool`, `pipeline_io`, `pipeline_loaders`,
+`pipeline_progress`, `pipeline_text`, `plot_style`, `qa_near_duplicates`,
+`schemas`, `script_io_args`, `syllabi_config`, `syllabi_crossref`,
+`syllabi_harvest`, `syllabi_io`, `syllabi_process`, `utils`.
+
+**Dual-role reclassified Tier-2 (6, have a thin `main()` but are genuinely
+reused computational libraries — extraction would fracture a tight cluster):**
+`compute_divergence` (`METHODS` dispatch registry, rule 8), `compute_null_model`
++ `compute_divergence_bootstrap` (permutation drivers imported across the
+divergence family), `compute_changepoints` (convergence computation reused by
+`compute_convergence.py`), `corpus_merge_citations` (`merge_citations` reused by
+the cache-migration one-off), `enrich_dois` (`find_doi` cached-lookup API reused
+by `syllabi_process`). Extracting any is a viable future refinement but not
+required; the flat classification already makes every mover import-leaf.
+
+### Tier-3 — movers by phase (132; each an entry point imported by no script)
+
+- **→ `scripts/figures/` (0255): 62** — all `plot_*` and `export_*`. Includes
+  `export_core_venues_markdown` (now imports `_venue_naming`, not
+  `summarize_core_venues`) and both clustering plotters (the former
+  `compute_clustering_comparison` backward arrow was already severed by 0242).
+- **→ `scripts/harvest/` (0256): 25** — all `catalog_*`, `enrich_*`, `corpus_*`,
+  `scout_tradition_coupling`, plus the two Phase-1 teaching-harvest builders
+  `build_teaching_yaml` / `build_teaching_canon`, and the semantic exception
+  `compute_reranker_calibration` (Phase-1 despite its `compute_` prefix).
+- **→ `scripts/analysis/` (0257): 34** — all `analyze_*`, the Tier-3 `compute_*`,
+  `summarize_*`, `build_het_core`, plus `build_smoke_fixture` (test-fixture
+  builder). `summarize_core_venues` and `build_het_core` are movers *because* 0254
+  extracted their leaked helpers.
+- **→ `scripts/qa/` (0258): 11** — all `qa_*` except `qa_near_duplicates` (a
+  pure library, Tier-2).
+
+### 0254 resolutions of the dual-role hazard
+
+Nine files were entry-point-AND-imported. Three had a genuine helper leaked from
+an output-producing entry point → **extracted to a neutral flat `_`-module (the
+0250 pattern), byte-identical by construction**, freeing the entry point to move:
+
+| Entry point (now Tier-3) | Extracted helper(s) → flat module | Repointed importer(s) |
 |---|---|---|
-| `build_het_core.py` | `scripts/harvest/corpus_filters.py` | `is_global_south`, `is_non_english` |
-| `build_teaching_yaml.py` | `scripts/harvest/teaching.py` | `_dedup_course_names` (private!) |
-| `compute_changepoints.py` | `scripts/analysis/changepoints.py` | `compute_convergence` |
-| `summarize_core_venues.py` | `scripts/analysis/venues.py` | `canonical_venue`, `venue_type`, `institution_group` |
-| `plot_fig_traditions.py` | `scripts/analysis/traditions.py` | `build_pre2007_traditions` (network build + Louvain, not rendering) |
+| `summarize_core_venues` | `canonical_venue`/`venue_type`/`institution_group` → `_venue_naming.py` | `compute_venue_concentration`, `export_core_venues_markdown` |
+| `build_het_core` | `is_global_south`/`is_non_english` → `_corpus_predicates.py` | `analyze_multilingual` |
+| `build_teaching_yaml` | `_dedup_course_names` → `_course_dedup.py` | `analyze_syllabi` |
 
-### MOVE — stays in `scripts/analysis/`, no split, no `-m` (2)
+The other six were **reclassified Tier-2** (see above). One correction to the old
+audit: `qa_near_duplicates` has no `__main__` and its docstring documents a
+`from qa_near_duplicates import …` API — it is already a pure library (Tier-2),
+never dual-role.
 
-`compute_divergence` (`METHODS` registry + dispatch), `compute_null_model`
-(permutation drivers). Import-clean, reused by multiple non-test callers; they
-relocate by phase but keep path invocation.
+### Flags for the move tickets
 
-### STAY in `scripts/figures/` — the importer is the bug (2)
-
-`plot_fig_clustering_comparison`, `plot_fig_clustering_spaces`. What leaked is
-pure rendering; the smell is that `compute_clustering_comparison.py` (a compute
-script) imports a plotter — the backward arrow. Fix by severing the import
-(compute writes tables; Make runs the plotter separately), not by relocating.
+- **Prefix gaps.** The move tickets key on filename prefixes, but three Tier-3
+  entry points match no listed prefix: `build_teaching_yaml`, `build_teaching_canon`
+  (→ harvest, above) and `build_smoke_fixture` (→ analysis). Route them by phase,
+  not prefix.
+- **Unwired orphans (4).** `analyze_alluvial`, `analyze_communities_clusters`,
+  `compute_temporal_communities`, `plot_interactive_corpus` have no `__main__`
+  guard and no Make target — they run at module top level and nothing invokes
+  them. Classified Tier-3 (not library surface), but they are dead-code
+  candidates: verify before moving, or triage separately. Out of 0254 scope.
 
 ## Ordered moves (risk ascending)
 
 1. **Analysis fragments** → `scripts/analysis/analysis.mk` (pure `-include` path
    edits; zero build-graph change). Do first.
-2. **Phase sub-grouping** — `plot_*`/`export_*` → `scripts/figures/`;
-   `analyze_*`/`compute_*` + `_`-private → `scripts/analysis/`;
-   `catalog_*`/`enrich_*`/`corpus_*` → `scripts/harvest/`; `qa_*` → `scripts/qa/`.
+2. **Phase sub-grouping** — move only the Tier-3 entry points per the table
+   above: `plot_*`/`export_*` → `scripts/figures/`; Tier-3 `analyze_*`/`compute_*`/
+   `summarize_*`/`build_het_core`/`build_smoke_fixture` → `scripts/analysis/`;
+   `catalog_*`/`enrich_*`/`corpus_*`/`scout*`/`build_teaching_*`/
+   `compute_reranker_calibration` → `scripts/harvest/`; `qa_*` → `scripts/qa/`.
+   Every Tier-2 module (all `_`-private and the named libraries) stays flat.
 3. **`deliverables/` co-location** + per-paper `_quarto.yml` (kills the
    exclusion-mask profile files; DVC-independent).
-4. **The five extractions** land beside their phase; leaking scripts import them.
-   Behind a full `make clean && make all` gate.
-5. **`compute_clustering_comparison` dependency-inversion cleanup** — separate
-   follow-up; not on the reorg critical path.
+4. **Dual-role extractions** — done in wave-0a as flat `_`-modules, not phase
+   subdirs (0250 extracted `_pre2007_traditions`; 0254 extracted `_venue_naming`,
+   `_corpus_predicates`, `_course_dedup`). The remaining six dual-role files stay
+   flat as Tier-2 libraries; no phase-subdir extraction is required.
+5. **`compute_clustering_comparison` dependency-inversion cleanup** — already
+   severed by 0242; the two clustering plotters move as ordinary Tier-3 figures.

--- a/scripts/_corpus_predicates.py
+++ b/scripts/_corpus_predicates.py
@@ -1,0 +1,60 @@
+"""Corpus row predicates: shared library module.
+
+Row-level classifiers over a works DataFrame: whether a paper is non-English,
+and whether it carries a Global-South affiliation. Pure functions with no I/O.
+The core-set builder (`build_het_core.py`) flags rows with them, and
+`analyze_multilingual.py` reuses the same predicates so both layers agree on the
+definition.
+
+It lives in a neutral flat `_`-module so the entry point can move by phase while
+the shared predicates stay on the flat library surface (ticket 0254; the 0250
+pattern). The keyword set and function bodies are relocated verbatim from
+`build_het_core.py` — output is byte-identical by construction.
+"""
+
+GLOBAL_SOUTH_KEYWORDS = {
+    "china", "india", "brazil", "indonesia", "mexico", "nigeria",
+    "bangladesh", "pakistan", "vietnam", "ethiopia", "egypt",
+    "philippines", "kenya", "tanzania", "colombia", "argentina",
+    "south africa", "peru", "venezuela", "chile", "ecuador",
+    "guatemala", "cameroon", "ghana", "senegal", "morocco",
+    "tunisia", "algeria", "thailand", "malaysia", "sri lanka",
+    "nepal", "myanmar", "cambodia", "laos", "mongolia",
+    "fiji", "samoa", "tonga", "tuvalu", "vanuatu",
+    "bolivia", "paraguay", "uruguay", "costa rica", "panama",
+    "honduras", "nicaragua", "el salvador", "dominican republic",
+    "jamaica", "trinidad", "barbados", "cuba", "haiti",
+    "uganda", "mozambique", "zambia", "zimbabwe", "malawi",
+    "madagascar", "niger", "mali", "burkina faso", "chad",
+    "congo", "rwanda", "burundi", "benin", "togo",
+    "sierra leone", "liberia", "guinea", "gambia",
+    "jordan", "lebanon", "iraq", "iran", "afghanistan",
+    "uzbekistan", "kazakhstan", "kyrgyzstan", "tajikistan",
+    "beijing", "shanghai", "mumbai", "delhi", "são paulo",
+    "nairobi", "dar es salaam", "lagos", "cairo", "dhaka",
+    "jakarta", "manila", "hanoi", "bogota", "lima",
+    "buenos aires", "santiago", "quito", "accra", "dakar",
+    "addis ababa", "kampala", "lusaka", "harare", "maputo",
+    "bangui", "kinshasa", "abidjan", "tunis", "rabat",
+    "islamabad", "karachi", "colombo", "kathmandu",
+    "flacso", "eclac", "cepal",
+}
+
+
+def is_non_english(row):
+    """Check if paper is non-English."""
+    lang = str(row.get("language", "") or "").lower().strip()
+    if not lang:
+        return False
+    return lang not in ("en", "eng", "en_us", "english")
+
+
+def is_global_south(row):
+    """Detect Global South affiliation from affiliations field."""
+    aff = str(row.get("affiliations", "") or "").lower()
+    if not aff:
+        return False
+    for kw in GLOBAL_SOUTH_KEYWORDS:
+        if kw in aff:
+            return True
+    return False

--- a/scripts/_course_dedup.py
+++ b/scripts/_course_dedup.py
@@ -1,0 +1,78 @@
+"""Course-name deduplication: shared library helper.
+
+Merges near-duplicate course names in the teaching-syllabi table (co-organized
+MOOCs listed under several institution names) and recomputes n_courses. The
+teaching-YAML builder (`build_teaching_yaml.py`) applies it, and
+`analyze_syllabi.py` reuses it so both agree on the dedup definition.
+
+It lives in a neutral flat `_`-module so the entry point can move by phase while
+the shared helper stays on the flat library surface (ticket 0254; the 0250
+pattern). The thresholds and function body are relocated verbatim from
+`build_teaching_yaml.py` — output is byte-identical by construction.
+"""
+
+from collections import defaultdict
+
+from utils import get_logger
+
+log = get_logger("build_teaching_yaml")
+
+OVERLAP_THRESHOLD = 0.8  # Course pairs sharing >80% readings are duplicates
+MIN_SHARED_READINGS = 10  # Require >=10 shared readings to consider dedup
+
+
+def _dedup_course_names(df):
+    """Merge near-duplicate course names and recompute n_courses.
+
+    Two courses are considered duplicates if they share >=MIN_SHARED_READINGS
+    AND >OVERLAP_THRESHOLD of the smaller course's readings. This catches
+    co-organized MOOCs listed under multiple institution names.
+    """
+    # Build course -> set of row indices
+    course_rows = defaultdict(set)
+    for idx, row in df.iterrows():
+        for c in str(row.get("courses", "")).split(";"):
+            c = c.strip()
+            if c:
+                course_rows[c].add(idx)
+
+    # Find overlapping course pairs
+    courses = list(course_rows.keys())
+    merged = {}  # alias -> canonical
+    for i, c1 in enumerate(courses):
+        if c1 in merged:
+            continue
+        for c2 in courses[i + 1:]:
+            if c2 in merged:
+                continue
+            s1, s2 = course_rows[c1], course_rows[c2]
+            if not s1 or not s2:
+                continue
+            n_shared = len(s1 & s2)
+            overlap = n_shared / min(len(s1), len(s2))
+            if n_shared >= MIN_SHARED_READINGS and overlap > OVERLAP_THRESHOLD:
+                canonical = c1 if len(c1) <= len(c2) else c2
+                alias = c2 if canonical == c1 else c1
+                merged[alias] = canonical
+
+    if not merged:
+        return df
+
+    log.info("  Course dedup: merged %d duplicate course names", len(merged))
+
+    def apply_merge(courses_str):
+        parts = [c.strip() for c in str(courses_str).split(";")]
+        deduped = []
+        seen = set()
+        for c in parts:
+            canonical = merged.get(c, c)
+            if canonical and canonical not in seen:
+                deduped.append(canonical)
+                seen.add(canonical)
+        return " ; ".join(sorted(deduped))
+
+    df = df.copy()
+    df["courses"] = df["courses"].apply(apply_merge)
+    df["n_courses"] = df["courses"].apply(
+        lambda x: len([c for c in x.split(" ; ") if c.strip()]))
+    return df

--- a/scripts/_venue_naming.py
+++ b/scripts/_venue_naming.py
@@ -1,0 +1,95 @@
+"""Venue-name canonicalization helpers: shared library module.
+
+Maps a raw venue string to its canonical name, its type
+(journal / working-paper / report / repository / missing), and its
+institutional owner. These are pure string-classification helpers with no I/O:
+`summarize_core_venues.py` (the entry point that renders the core-venue tables),
+`compute_venue_concentration.py`, and `export_core_venues_markdown.py` all reuse
+them.
+
+It lives in a neutral flat `_`-module so the entry point can move by phase while
+the shared helpers stay on the flat library surface (ticket 0254; the 0250
+pattern). The rules and function bodies are relocated verbatim from
+`summarize_core_venues.py` — output is byte-identical by construction.
+"""
+
+import re
+
+# Each entry is (matcher, canonical_name).
+# matcher is either a substring str or a callable(low: str) -> bool.
+# More specific patterns must precede more general ones within the same family.
+_VENUE_RULES: list[tuple] = [
+    # Exact-match edge case
+    (lambda s: s == "mf policy paper", "IMF Policy Paper"),
+    # World Bank — most specific first
+    (lambda s: "world bank" in s and ("ebook" in s or "publication" in s or "washington, dc" in s),
+     "World Bank eBooks"),
+    ("world bank policy research working paper", "World Bank Policy Research Working Paper"),
+    ("world bank", "World Bank"),
+    # OECD — most specific first
+    ("oecd/iea climate change expert group papers", "OECD/IEA Climate Change Expert Group Papers"),
+    (lambda s: "oecd" in s and "working paper" in s, "OECD Working Papers"),
+    (lambda s: "oecd" in s and "paper" in s, "OECD Papers"),
+    (lambda s: s.startswith("oecd"), "OECD"),
+    # IMF — most specific first
+    ("imf working paper", "IMF Working Paper"),
+    ("imf staff climate notes", "IMF Staff Climate Notes"),
+    ("imf staff country reports", "IMF Staff Country Reports"),
+    (lambda s: "imf" in s and ("discussion note" in s or "staff" in s), "IMF Staff Notes"),
+    ("imf", "IMF"),
+    # Repositories and indexes
+    ("ssrn", "SSRN Electronic Journal"),
+    ("repec", "RePEc"),
+    ("depositonce", "DepositOnce"),
+    ("zenodo", "Zenodo"),
+    ("figshare", "Figshare"),
+    ("preprints", "Preprints"),
+]
+
+
+def canonical_venue(name):
+    v = str(name or "").strip()
+    low = v.lower()
+    if not low:
+        return "[missing]"
+    for matcher, canonical in _VENUE_RULES:
+        matched = matcher(low) if callable(matcher) else (matcher in low)
+        if matched:
+            return canonical
+    return v
+
+
+def venue_type(name):
+    low = str(name or "").lower()
+    if not low or low == "[missing]":
+        return "missing"
+
+    if low == "climate finance and the usd 100 billion goal":
+        return "report_series"
+
+    wp_pattern = re.compile(r"working paper|working papers|discussion paper|policy research working paper|\bwp\b")
+    report_pattern = re.compile(
+        r"ebook|ebooks|report|reports|publications|world bank|oecd|imf|unfccc|climate policy initiative|\bcpi\b"
+    )
+    non_journal_pattern = re.compile(
+        r"ssrn|repec|zenodo|figshare|preprints|open science framework|depositonce|research online"
+    )
+
+    if wp_pattern.search(low):
+        return "working_paper_series"
+    if report_pattern.search(low):
+        return "report_series"
+    if non_journal_pattern.search(low):
+        return "repository_or_index"
+    return "journal"
+
+
+def institution_group(name):
+    low = str(name or "").lower()
+    if "oecd" in low:
+        return "OECD"
+    if "world bank" in low:
+        return "World Bank"
+    if "imf" in low:
+        return "IMF"
+    return "Other/None"

--- a/scripts/analyze_multilingual.py
+++ b/scripts/analyze_multilingual.py
@@ -12,7 +12,7 @@ import resource
 
 import numpy as np
 import pandas as pd
-from build_het_core import is_global_south, is_non_english
+from _corpus_predicates import is_global_south, is_non_english
 from pipeline_loaders import (
     DERIVED_TABLES_DIR,
     REFINED_WORKS_PATH,

--- a/scripts/analyze_syllabi.py
+++ b/scripts/analyze_syllabi.py
@@ -17,7 +17,7 @@ import argparse
 import os
 
 import pandas as pd
-from build_teaching_yaml import _dedup_course_names
+from _course_dedup import _dedup_course_names
 from utils import BASE_DIR, DATA_DIR, get_logger
 
 log = get_logger("analyze_syllabi")

--- a/scripts/build_het_core.py
+++ b/scripts/build_het_core.py
@@ -24,6 +24,7 @@ import re
 import networkx as nx
 import numpy as np
 import pandas as pd
+from _corpus_predicates import is_global_south, is_non_english
 from script_io_args import parse_io_args, validate_io
 from utils import (
     CATALOGS_DIR,
@@ -110,36 +111,6 @@ QUOTAS = {
     "global_south_min": 0.20,
 }
 
-# Global South country keywords for affiliation matching
-GLOBAL_SOUTH_KEYWORDS = {
-    "china", "india", "brazil", "indonesia", "mexico", "nigeria",
-    "bangladesh", "pakistan", "vietnam", "ethiopia", "egypt",
-    "philippines", "kenya", "tanzania", "colombia", "argentina",
-    "south africa", "peru", "venezuela", "chile", "ecuador",
-    "guatemala", "cameroon", "ghana", "senegal", "morocco",
-    "tunisia", "algeria", "thailand", "malaysia", "sri lanka",
-    "nepal", "myanmar", "cambodia", "laos", "mongolia",
-    "fiji", "samoa", "tonga", "tuvalu", "vanuatu",
-    "bolivia", "paraguay", "uruguay", "costa rica", "panama",
-    "honduras", "nicaragua", "el salvador", "dominican republic",
-    "jamaica", "trinidad", "barbados", "cuba", "haiti",
-    "uganda", "mozambique", "zambia", "zimbabwe", "malawi",
-    "madagascar", "niger", "mali", "burkina faso", "chad",
-    "congo", "rwanda", "burundi", "benin", "togo",
-    "sierra leone", "liberia", "guinea", "gambia",
-    "jordan", "lebanon", "iraq", "iran", "afghanistan",
-    "uzbekistan", "kazakhstan", "kyrgyzstan", "tajikistan",
-    "beijing", "shanghai", "mumbai", "delhi", "são paulo",
-    "nairobi", "dar es salaam", "lagos", "cairo", "dhaka",
-    "jakarta", "manila", "hanoi", "bogota", "lima",
-    "buenos aires", "santiago", "quito", "accra", "dakar",
-    "addis ababa", "kampala", "lusaka", "harare", "maputo",
-    "bangui", "kinshasa", "abidjan", "tunis", "rabat",
-    "islamabad", "karachi", "colombo", "kathmandu",
-    "flacso", "eclac", "cepal",
-}
-
-
 # ── HELPERS ─────────────────────────────────────────────────────────────
 
 def text_blob(row):
@@ -221,25 +192,6 @@ def field_score(row):
     if has_excluded:
         return "exclude"
     return "unknown"
-
-
-def is_non_english(row):
-    """Check if paper is non-English."""
-    lang = str(row.get("language", "") or "").lower().strip()
-    if not lang:
-        return False
-    return lang not in ("en", "eng", "en_us", "english")
-
-
-def is_global_south(row):
-    """Detect Global South affiliation from affiliations field."""
-    aff = str(row.get("affiliations", "") or "").lower()
-    if not aff:
-        return False
-    for kw in GLOBAL_SOUTH_KEYWORDS:
-        if kw in aff:
-            return True
-    return False
 
 
 def robust_minmax(values):

--- a/scripts/build_teaching_yaml.py
+++ b/scripts/build_teaching_yaml.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 
 import pandas as pd
 import yaml
+from _course_dedup import _dedup_course_names
 from utils import DATA_DIR, clean_doi, get_logger
 
 log = get_logger("build_teaching_yaml")
@@ -32,8 +33,6 @@ OUTPUT_YAML = os.path.join(DATA_DIR, "teaching_sources.yaml")
 MIN_COURSES = 1  # DOI entries: keep all — DOI from a classified syllabus is reliable
 MIN_COURSES_NO_DOI = 3  # Title-only entries: higher bar (>=3 syllabi)
 MIN_READINGS_DETAILED = 20  # Courses with >=20 DOI readings are "detailed syllabi"
-OVERLAP_THRESHOLD = 0.8  # Course pairs sharing >80% readings are duplicates
-MIN_SHARED_READINGS = 10  # Require >=10 shared readings to consider dedup
 FUZZY_THRESHOLD = 75  # rapidfuzz token_sort_ratio threshold for title grouping
 FUZZY_MIN_WORDS = 4   # titles shorter than this skip fuzzy matching (too generic)
 
@@ -218,63 +217,6 @@ def _fuzzy_dedup_title_only(df):
                  len(nodoi_rows), len(merged_rows))
 
     return result
-
-
-def _dedup_course_names(df):
-    """Merge near-duplicate course names and recompute n_courses.
-
-    Two courses are considered duplicates if they share >=MIN_SHARED_READINGS
-    AND >OVERLAP_THRESHOLD of the smaller course's readings. This catches
-    co-organized MOOCs listed under multiple institution names.
-    """
-    # Build course -> set of row indices
-    course_rows = defaultdict(set)
-    for idx, row in df.iterrows():
-        for c in str(row.get("courses", "")).split(";"):
-            c = c.strip()
-            if c:
-                course_rows[c].add(idx)
-
-    # Find overlapping course pairs
-    courses = list(course_rows.keys())
-    merged = {}  # alias -> canonical
-    for i, c1 in enumerate(courses):
-        if c1 in merged:
-            continue
-        for c2 in courses[i + 1:]:
-            if c2 in merged:
-                continue
-            s1, s2 = course_rows[c1], course_rows[c2]
-            if not s1 or not s2:
-                continue
-            n_shared = len(s1 & s2)
-            overlap = n_shared / min(len(s1), len(s2))
-            if n_shared >= MIN_SHARED_READINGS and overlap > OVERLAP_THRESHOLD:
-                canonical = c1 if len(c1) <= len(c2) else c2
-                alias = c2 if canonical == c1 else c1
-                merged[alias] = canonical
-
-    if not merged:
-        return df
-
-    log.info("  Course dedup: merged %d duplicate course names", len(merged))
-
-    def apply_merge(courses_str):
-        parts = [c.strip() for c in str(courses_str).split(";")]
-        deduped = []
-        seen = set()
-        for c in parts:
-            canonical = merged.get(c, c)
-            if canonical and canonical not in seen:
-                deduped.append(canonical)
-                seen.add(canonical)
-        return " ; ".join(sorted(deduped))
-
-    df = df.copy()
-    df["courses"] = df["courses"].apply(apply_merge)
-    df["n_courses"] = df["courses"].apply(
-        lambda x: len([c for c in x.split(" ; ") if c.strip()]))
-    return df
 
 
 # --- Source 1: scraped readings ---

--- a/scripts/compute_venue_concentration.py
+++ b/scripts/compute_venue_concentration.py
@@ -18,10 +18,10 @@ import os
 
 import numpy as np
 import pandas as pd
+from _venue_naming import canonical_venue, venue_type
 from pipeline_io import save_csv
 from schemas import VenueConcentrationSchema
 from script_io_args import parse_io_args, validate_io
-from summarize_core_venues import canonical_venue, venue_type
 from utils import get_logger
 
 log = get_logger("compute_venue_concentration")

--- a/scripts/export_core_venues_markdown.py
+++ b/scripts/export_core_venues_markdown.py
@@ -17,8 +17,8 @@ Usage:
 import os
 
 import pandas as pd
+from _venue_naming import canonical_venue, venue_type
 from script_io_args import parse_io_args, validate_io
-from summarize_core_venues import canonical_venue, venue_type
 from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger
 
 log = get_logger("export_core_venues_markdown")

--- a/scripts/summarize_core_venues.py
+++ b/scripts/summarize_core_venues.py
@@ -14,9 +14,9 @@ Usage:
 """
 
 import os
-import re
 
 import pandas as pd
+from _venue_naming import canonical_venue, institution_group, venue_type
 from script_io_args import parse_io_args, validate_io
 from utils import BASE_DIR, DERIVED_TABLES_DIR, get_logger, save_csv
 
@@ -51,86 +51,6 @@ def parse_args():
     args.out_institutions = os.path.join(out_dir, "tab_core_institutions.csv")
     args.out_institution_types = os.path.join(out_dir, "tab_core_institution_by_type.csv")
     return args
-
-
-# Each entry is (matcher, canonical_name).
-# matcher is either a substring str or a callable(low: str) -> bool.
-# More specific patterns must precede more general ones within the same family.
-_VENUE_RULES: list[tuple] = [
-    # Exact-match edge case
-    (lambda s: s == "mf policy paper", "IMF Policy Paper"),
-    # World Bank — most specific first
-    (lambda s: "world bank" in s and ("ebook" in s or "publication" in s or "washington, dc" in s),
-     "World Bank eBooks"),
-    ("world bank policy research working paper", "World Bank Policy Research Working Paper"),
-    ("world bank", "World Bank"),
-    # OECD — most specific first
-    ("oecd/iea climate change expert group papers", "OECD/IEA Climate Change Expert Group Papers"),
-    (lambda s: "oecd" in s and "working paper" in s, "OECD Working Papers"),
-    (lambda s: "oecd" in s and "paper" in s, "OECD Papers"),
-    (lambda s: s.startswith("oecd"), "OECD"),
-    # IMF — most specific first
-    ("imf working paper", "IMF Working Paper"),
-    ("imf staff climate notes", "IMF Staff Climate Notes"),
-    ("imf staff country reports", "IMF Staff Country Reports"),
-    (lambda s: "imf" in s and ("discussion note" in s or "staff" in s), "IMF Staff Notes"),
-    ("imf", "IMF"),
-    # Repositories and indexes
-    ("ssrn", "SSRN Electronic Journal"),
-    ("repec", "RePEc"),
-    ("depositonce", "DepositOnce"),
-    ("zenodo", "Zenodo"),
-    ("figshare", "Figshare"),
-    ("preprints", "Preprints"),
-]
-
-
-def canonical_venue(name):
-    v = str(name or "").strip()
-    low = v.lower()
-    if not low:
-        return "[missing]"
-    for matcher, canonical in _VENUE_RULES:
-        matched = matcher(low) if callable(matcher) else (matcher in low)
-        if matched:
-            return canonical
-    return v
-
-
-def venue_type(name):
-    low = str(name or "").lower()
-    if not low or low == "[missing]":
-        return "missing"
-
-    if low == "climate finance and the usd 100 billion goal":
-        return "report_series"
-
-    wp_pattern = re.compile(r"working paper|working papers|discussion paper|policy research working paper|\bwp\b")
-    report_pattern = re.compile(
-        r"ebook|ebooks|report|reports|publications|world bank|oecd|imf|unfccc|climate policy initiative|\bcpi\b"
-    )
-    non_journal_pattern = re.compile(
-        r"ssrn|repec|zenodo|figshare|preprints|open science framework|depositonce|research online"
-    )
-
-    if wp_pattern.search(low):
-        return "working_paper_series"
-    if report_pattern.search(low):
-        return "report_series"
-    if non_journal_pattern.search(low):
-        return "repository_or_index"
-    return "journal"
-
-
-def institution_group(name):
-    low = str(name or "").lower()
-    if "oecd" in low:
-        return "OECD"
-    if "world bank" in low:
-        return "World Bank"
-    if "imf" in low:
-        return "IMF"
-    return "Other/None"
 
 
 def summarize(df, group_cols, top_n):

--- a/tests/test_script_classification.py
+++ b/tests/test_script_classification.py
@@ -1,0 +1,117 @@
+"""Entry-point / library classification gate (ticket 0254).
+
+The `scripts/` reorg (epic 0240) moves only **Tier-3 pure entry points** into
+`scripts/<phase>/`; **Tier-2 library modules** (imported by another script) stay
+flat at `scripts/` root. The load-bearing invariant the wave-1 moves (0255–0258)
+rely on: **no Tier-3 file is imported by another top-level script** — i.e. the
+moving set is import-leaf on the flat library surface. Move a file that another
+module imports by flat name and the importer's `from <name> import …` breaks.
+
+This test pins the flat library surface. It parses every top-level `scripts/*.py`
+for cross-script imports and asserts that every imported module is either a
+`_`-private module or one of the two explicit Tier-2 allowlists below. A new
+`from <entry_point> import …` between two scripts fails the test, forcing the
+author to resolve the dual-role hazard first (extract the helper to a neutral
+`_`-module, the 0250/0254 pattern, or reclassify the file Tier-2 here) — exactly
+the contract `docs/repo-layout.md` § "Definitive Tier-2 / Tier-3 classification"
+publishes for the move tickets.
+
+Adherence tier — runs under `make lint`, not the fast inner loop.
+"""
+
+import ast
+import os
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIR = os.path.join(REPO, "scripts")
+
+# Tier-2 named libraries (no __main__; imported as a library surface).
+NAMED_LIBRARIES = {
+    "clustering_methods", "filter_flags", "filter_flags_llm", "openalex_pool",
+    "pipeline_io", "pipeline_loaders", "pipeline_progress", "pipeline_text",
+    "plot_style", "qa_near_duplicates", "schemas", "script_io_args",
+    "syllabi_config", "syllabi_crossref", "syllabi_harvest", "syllabi_io",
+    "syllabi_process", "utils",
+}
+
+# Dual-role files reclassified Tier-2: they carry a thin main() but are genuinely
+# reused computational libraries (extraction would fracture a tight cluster).
+# Each stays flat; see docs/repo-layout.md § "Dual-role reclassified Tier-2".
+RECLASSIFIED_DUAL_ROLE = {
+    "compute_divergence",          # METHODS dispatch registry (rule 8)
+    "compute_null_model",          # permutation drivers
+    "compute_divergence_bootstrap",  # divergence-family cluster
+    "compute_changepoints",        # convergence computation reused by compute_convergence
+    "corpus_merge_citations",      # merge_citations reused by the cache-migration one-off
+    "enrich_dois",                 # find_doi cached-lookup API reused by syllabi_process
+}
+
+# The full flat library surface = private `_` modules (matched by prefix) plus
+# these named modules. Anything else imported by another script is a Tier-3
+# entry point leaking a helper — a hazard the move tickets cannot absorb.
+NAMED_FLAT = NAMED_LIBRARIES | RECLASSIFIED_DUAL_ROLE
+
+
+def _top_modules():
+    return sorted(
+        f[:-3] for f in os.listdir(SCRIPTS_DIR) if f.endswith(".py")
+    )
+
+
+def _script_imports(name):
+    """Top-level module names imported by scripts/<name>.py."""
+    with open(os.path.join(SCRIPTS_DIR, name + ".py")) as fh:
+        tree = ast.parse(fh.read(), filename=name + ".py")
+    hits = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module:
+                hits.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                hits.add(alias.name.split(".")[0])
+    return hits
+
+
+def _imported_by_script():
+    """Map: top-level module -> set of top-level scripts that import it."""
+    modules = set(_top_modules())
+    importers = {}
+    for name in sorted(modules):
+        for m in _script_imports(name):
+            if m in modules and m != name:
+                importers.setdefault(m, set()).add(name)
+    return importers
+
+
+def test_no_tier3_entry_point_is_imported():
+    """Every script imported by another script is on the flat Tier-2 surface."""
+    importers = _imported_by_script()
+    violations = {
+        m: sorted(who)
+        for m, who in importers.items()
+        if not m.startswith("_") and m not in NAMED_FLAT
+    }
+    assert not violations, (
+        "These entry points are imported by another script but are NOT on the "
+        "flat Tier-2 library surface — a dual-role hazard the wave-1 moves "
+        "(0255–0258) cannot absorb. Resolve each: extract the leaked helper into "
+        "a neutral `_`-module (0250/0254 pattern) and repoint the importer, or "
+        "reclassify the file into RECLASSIFIED_DUAL_ROLE here (and "
+        "docs/repo-layout.md):\n"
+        + "\n".join(f"  {m} imported by {who}" for m, who in sorted(violations.items()))
+    )
+
+
+def test_no_stale_named_flat_allowlist():
+    """Every named Tier-2 entry actually is imported by some script."""
+    importers = _imported_by_script()
+    stale = sorted(m for m in NAMED_FLAT if m not in importers)
+    assert not stale, (
+        "These modules are on the NAMED_FLAT allowlist but no script imports "
+        f"them — remove them (or the file was deleted/renamed): {stale}"
+    )

--- a/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
+++ b/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
@@ -3,13 +3,13 @@ Title: Reorg code — move scripts/figures/ (plot_/export_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Blocked-by: 0253
-Blocked-by: 0254
 Label: deferred
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note wave-1 move of epic 0240. Blocked-by 0253 (path model must resolve subdir imports) + 0254 (Tier-2/Tier-3 list decides what moves).
 
+2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-2

--- a/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
+++ b/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
@@ -3,13 +3,13 @@ Title: Reorg code — move scripts/harvest/ (catalog_/enrich_/corpus_/scout entr
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Blocked-by: 0253
-Blocked-by: 0254
 Label: deferred
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note wave-1 move of epic 0240. Blocked-by 0253 (path model) + 0254 (Tier list). Respect semantic-phase exceptions: compute_reranker_calibration is Phase-1, qa_near_duplicates classification comes from 0254.
 
+2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-1

--- a/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
+++ b/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
@@ -3,13 +3,13 @@ Title: Reorg code — move scripts/analysis/ (analyze_/compute_/summarize_/build
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Blocked-by: 0253
-Blocked-by: 0254
 Label: deferred
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note wave-1 move of epic 0240. Blocked-by 0253 (path model) + 0254 (Tier list). scripts/analysis/ partly exists (the .mk fragments from 0239 already live there); this adds the entry-point scripts. Also the real prerequisite for 0241 (extractions land in this subdir).
 
+2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-2

--- a/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
+++ b/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
@@ -3,13 +3,13 @@ Title: Reorg code — move scripts/qa/ (qa_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Blocked-by: 0253
-Blocked-by: 0254
 Label: deferred
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note wave-1 move of epic 0240. Blocked-by 0253 (path model) + 0254 (Tier list). Respect qa_embeddings/qa_detect_type Phase-2 semantics; qa_near_duplicates classification comes from 0254.
 
+2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the `qa_*` **entry

--- a/tickets/closed/0254-reorg-code-entry-point-vs-library-classi.erg
+++ b/tickets/closed/0254-reorg-code-entry-point-vs-library-classi.erg
@@ -3,11 +3,13 @@ Title: Reorg code — entry-point vs library classification audit + extract embe
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Label: deferred
+Closed: Definitive Tier-2/Tier-3 classification published in docs/repo-layout.md; 3 dual-role helpers extracted to flat _venue_naming/_corpus_predicates/_course_dedup (byte-identical), 6 reclassified Tier-2; gate test tests/test_script_classification.py freezes the flat library surface. make check-fast + make lint green.
 
 --- log ---
 2026-07-11T06:52Z HDMX-coding-agent created
 2026-07-11T06:52Z HDMX-coding-agent note wave-0a of epic 0240. 0250 is the exemplar (extracted build_pre2007_traditions to neutral _pre2007_traditions.py). Produces the definitive Tier-2/Tier-3 file list the moves consume. Start now — no prerequisite.
 
+2026-07-11T07:22Z HDMX-coding-agent closed — Definitive Tier-2/Tier-3 classification published in docs/repo-layout.md; 3 dual-role helpers extracted to flat _venue_naming/_corpus_predicates/_course_dedup (byte-identical), 6 reclassified Tier-2; gate test tests/test_script_classification.py freezes the flat library surface. make check-fast + make lint green.
 --- body ---
 ## Context
 Wave-0a of the code reorg epic (tracker `0240`). The two-tier rule the epic


### PR DESCRIPTION
Wave-0a of the scripts/ reorg epic (tracker 0240). Produces the definitive
Tier-2 (stays flat) vs Tier-3 (moves by phase) classification the wave-1 move
tickets (0255-0258) consume, and resolves the entry-point-AND-imported (dual-role)
hazard so a moved file never breaks an importer's `from <name> import ...`.

## What landed

**Classification (deliverable).** `docs/repo-layout.md` § "Definitive Tier-2/Tier-3
classification" — built mechanically from the `scripts/*.py` import graph, it
replaces the stale 2026-07-10 checklist (which predated the ratified two-tier
rule and proposed phase-subdir homes for *imported* files). 177 files = **45
Tier-2 (flat)** + **132 Tier-3 (movers: figures 62, harvest 25, analysis 34, qa
11)**, with the full flat surface, per-phase mover lists, three build_* prefix
gaps, and four unwired dead-code-candidate orphans flagged.

**Dual-role resolution.** Nine files were entry-point-AND-imported.
- **3 extracted** to neutral flat `_`-modules (the 0250 pattern), byte-identical
  by construction, freeing the entry point to move — each its own commit:
  - `summarize_core_venues` → `_venue_naming.py` (canonical_venue/venue_type/institution_group)
  - `build_het_core` → `_corpus_predicates.py` (is_global_south/is_non_english)
  - `build_teaching_yaml` → `_course_dedup.py` (_dedup_course_names)
- **6 reclassified Tier-2** (genuine reused libraries with a thin main(); stay
  flat): compute_divergence, compute_null_model, compute_divergence_bootstrap,
  compute_changepoints, corpus_merge_citations, enrich_dois.
- Correction: `qa_near_duplicates` is already a pure library (no main), never dual-role.

**Gate test.** `tests/test_script_classification.py` fails if any Tier-3 entry
point becomes imported by another script (proven by mutation). Freezes the flat
library surface so the move tickets can relocate the Tier-3 set safely.

## Verification
- Each extraction byte-identical (verified old-vs-new on representative inputs).
- `make check-fast` (945 passed) and `make lint` (157 passed) green; rebased on
  current origin/main (0259 wave), combined seed-scan + classification + layering green.

## Ticket
Ticket 0254 is closed + archived on-branch (tickets/closed/0254-...erg), so this
PR closes nothing at merge.
Ticket: none