### PR TITLE
tests(0260): subdir-safe script enumeration before epic-0240 wave-1 moves

### DIFF
--- a/tests/_script_discovery.py
+++ b/tests/_script_discovery.py
@@ -1,0 +1,71 @@
+"""Shared `scripts/` discovery for the script-enumeration guards (ticket 0260).
+
+One place enumerates every active pipeline script, recursively, so a future
+`scripts/` reorg (epic 0240 moves 132 entry points into `scripts/figures/`,
+`scripts/harvest/`, `scripts/analysis/`, `scripts/qa/`) updates a single list and
+no guard can silently narrow its coverage. This closes the same class defect
+that ticket 0248 fixed for `.mk` discovery: several guards each hand-rolled a
+*flat* `os.listdir(SCRIPTS_DIR)` / `glob("*.py")` union, so a moved file drops
+out of a guard's coverage and the test keeps passing — over fewer files, not
+because the contract still holds.
+
+`<repo>` is resolved from this file's own location, so the helper is correct in
+any worktree.
+
+Exclusions: `scripts/archive*/` (frozen, superseded experimental scripts, not
+active code and not part of the wave-1 moves) and `__pycache__/`.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _is_excluded(rel_parts: tuple[str, ...]) -> bool:
+    """A path is excluded when any directory component is archive-like or a cache.
+
+    `archive/` and `archive_traditions/` both hold frozen scripts preserved for
+    reference; neither is active code nor a wave-1 move target, so the active-
+    script guards must not see them. `__pycache__/` holds compiled bytecode.
+    """
+    for part in rel_parts[:-1]:  # directory components only
+        if part.startswith("archive") or part == "__pycache__":
+            return True
+    return False
+
+
+def all_script_files() -> list[Path]:
+    """Every active `scripts/**/*.py`, recursively, sorted for stable test IDs.
+
+    Full paths. Covers the flat `scripts/` root and every phase subdirectory the
+    reorg introduces (`figures/`, `harvest/`, `analysis/`, `qa/`). Excludes
+    `scripts/archive*/` and `__pycache__/`. This is the ONE sanctioned script
+    enumeration — every guard routes through it (or a derived shape below) so a
+    relocation can never narrow a guard's file set.
+    """
+    files = [
+        p
+        for p in SCRIPTS_DIR.rglob("*.py")
+        if not _is_excluded(p.relative_to(SCRIPTS_DIR).parts)
+    ]
+    return sorted(files)
+
+
+def all_script_basenames() -> list[str]:
+    """Basenames (e.g. ``plot_fig1_bars.py``) of every active script, sorted."""
+    return sorted(p.name for p in all_script_files())
+
+
+def all_script_stems() -> list[str]:
+    """Module stems (e.g. ``plot_fig1_bars``) of every active script, sorted."""
+    return sorted(p.stem for p in all_script_files())
+
+
+def script_paths_by_stem() -> dict[str, Path]:
+    """Map module stem -> path, for guards that resolve a script by import name.
+
+    A moved file keeps its stem (imports are by basename), so this map lets a
+    guard read the file wherever it now lives without assuming the flat root.
+    """
+    return {p.stem: p for p in all_script_files()}

--- a/tests/test_evict_analysis_intermediates.py
+++ b/tests/test_evict_analysis_intermediates.py
@@ -41,18 +41,17 @@ which is the regression this guard exists to catch (0218 evicted the top-level
 literal set; 0231 evicted the variable-routed sub-Makefile class).
 """
 
-import glob
 import os
 import re
 
 import pytest
 from _mk_discovery import all_makefiles
+from _script_discovery import all_script_files
 
 # Grep-ratchet guard — belongs to the mechanical adherence gate (`pytest -m adherence`).
 pytestmark = pytest.mark.adherence
 
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
-SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 
 # Intermediates evicted to $(DERIVED) — 0208 (heavy four) + 0218 (the residual class).
 EVICTED = [
@@ -104,8 +103,9 @@ def _makefiles():
 
 
 def _scripts():
-    # Top-level scripts only — archived/ variants are frozen and not built.
-    return glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))
+    # Recursive, subdir-safe enumeration via the shared helper (ticket 0260) —
+    # archive*/ variants are frozen and excluded there.
+    return all_script_files()
 
 
 def _offending_lines(path, basename):

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -18,14 +18,11 @@ compute layer import. The allowlist is now empty.
 """
 
 import ast
-import os
 
 import pytest
+from _script_discovery import all_script_files
 
 pytestmark = pytest.mark.adherence
-
-REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SCRIPTS_DIR = os.path.join(REPO, "scripts")
 
 # Known, pre-existing compute → plot violations awaiting their own relocation
 # ticket. Each entry MUST cite the tracking ticket. Remove an entry the moment
@@ -34,18 +31,19 @@ LAYERING_ALLOWLIST: dict[str, str] = {}
 
 
 def _compute_scripts():
-    """Top-level `compute_*.py` scripts under scripts/ (archive excluded)."""
-    result = []
-    for f in os.listdir(SCRIPTS_DIR):
-        if f.startswith("compute_") and f.endswith(".py"):
-            result.append(f)
-    return sorted(result)
+    """Every `compute_*.py` script, recursively (archive excluded).
+
+    Routed through the shared recursive enumerator (ticket 0260) so a wave-1
+    move of a `compute_*` entry point into `scripts/analysis/` cannot silently
+    drop it from this compute↛plot guard. Returns full paths.
+    """
+    return [p for p in all_script_files() if p.name.startswith("compute_")]
 
 
-def _imported_plot_modules(name):
+def _imported_plot_modules(path):
     """Return the sorted set of `plot_*` module names imported by a script."""
-    with open(os.path.join(SCRIPTS_DIR, name)) as fh:
-        tree = ast.parse(fh.read(), filename=name)
+    with open(path) as fh:
+        tree = ast.parse(fh.read(), filename=path.name)
     hits = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -62,12 +60,12 @@ def _imported_plot_modules(name):
 def test_no_compute_imports_plotter():
     """No compute_*.py imports a plot_* module (allowlist excepted)."""
     violators = {}
-    for name in _compute_scripts():
-        if name in LAYERING_ALLOWLIST:
+    for path in _compute_scripts():
+        if path.name in LAYERING_ALLOWLIST:
             continue
-        plots = _imported_plot_modules(name)
+        plots = _imported_plot_modules(path)
         if plots:
-            violators[name] = plots
+            violators[path.name] = plots
     assert not violators, (
         "compute → plot backward arrow (architecture rule 4). "
         "A compute module must not import a plotter:\n"
@@ -77,10 +75,11 @@ def test_no_compute_imports_plotter():
 
 def test_no_stale_layering_allowlist():
     """Every allowlisted violation still offends — remove it once fixed."""
+    by_name = {p.name: p for p in _compute_scripts()}
     stale = [
         name
         for name in LAYERING_ALLOWLIST
-        if name in _compute_scripts() and not _imported_plot_modules(name)
+        if name in by_name and not _imported_plot_modules(by_name[name])
     ]
     assert not stale, (
         "These scripts no longer import a plotter — remove them from "

--- a/tests/test_phase_layout.py
+++ b/tests/test_phase_layout.py
@@ -11,18 +11,17 @@ output from `CATALOGS_DIR`. A newly-introduced Phase-2 output under `data/catalo
 fails the test with no edit to this file.
 """
 
-import glob
 import os
 import re
 
 import pytest
+from _script_discovery import all_script_files
 
 # Mechanical adherence gate (`make lint` / `pytest -m adherence`).
 pytestmark = pytest.mark.adherence
 
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..")
 MAKEFILE = os.path.join(PROJECT_ROOT, "Makefile")
-SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
 
 # A Make prerequisite naming one of these script prefixes marks a Phase-2 producer.
 #
@@ -94,7 +93,7 @@ def test_no_script_reads_derived_output_from_catalogs():
         os.path.basename(v) for v in consts.values() if DERIVED in v and v.endswith((".csv", ".json", ".npz"))
     }
     offenders = []
-    for path in glob.glob(os.path.join(SCRIPTS_DIR, "*.py")):
+    for path in all_script_files():  # recursive, subdir-safe (ticket 0260)
         with open(path, encoding="utf-8") as fh:
             for i, line in enumerate(fh, 1):
                 for name in derived_names:

--- a/tests/test_script_classification.py
+++ b/tests/test_script_classification.py
@@ -20,14 +20,11 @@ Adherence tier — runs under `make lint`, not the fast inner loop.
 """
 
 import ast
-import os
 
 import pytest
+from _script_discovery import script_paths_by_stem
 
 pytestmark = pytest.mark.adherence
-
-REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SCRIPTS_DIR = os.path.join(REPO, "scripts")
 
 # Tier-2 named libraries (no __main__; imported as a library surface).
 NAMED_LIBRARIES = {
@@ -56,16 +53,10 @@ RECLASSIFIED_DUAL_ROLE = {
 NAMED_FLAT = NAMED_LIBRARIES | RECLASSIFIED_DUAL_ROLE
 
 
-def _top_modules():
-    return sorted(
-        f[:-3] for f in os.listdir(SCRIPTS_DIR) if f.endswith(".py")
-    )
-
-
-def _script_imports(name):
-    """Top-level module names imported by scripts/<name>.py."""
-    with open(os.path.join(SCRIPTS_DIR, name + ".py")) as fh:
-        tree = ast.parse(fh.read(), filename=name + ".py")
+def _script_imports(path):
+    """Top-level module names imported by a script at `path`."""
+    with open(path) as fh:
+        tree = ast.parse(fh.read(), filename=path.name)
     hits = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -78,11 +69,15 @@ def _script_imports(name):
 
 
 def _imported_by_script():
-    """Map: top-level module -> set of top-level scripts that import it."""
-    modules = set(_top_modules())
+    """Map: module stem -> set of script stems that import it."""
+    # Recursive enumeration via the shared helper (ticket 0260): a wave-1 move of
+    # an entry point into scripts/<phase>/ keeps its module stem, so it stays in
+    # the surface this Tier gate pins instead of silently dropping out.
+    paths = script_paths_by_stem()
+    modules = set(paths)
     importers = {}
-    for name in sorted(modules):
-        for m in _script_imports(name):
+    for name, path in sorted(paths.items()):
+        for m in _script_imports(path):
             if m in modules and m != name:
                 importers.setdefault(m, set()).add(name)
     return importers

--- a/tests/test_script_discovery_unified.py
+++ b/tests/test_script_discovery_unified.py
@@ -1,0 +1,63 @@
+"""Meta-guard — no test may hand-roll a flat `scripts/` enumeration (ticket 0260).
+
+Several script guards used to each `os.listdir(SCRIPTS_DIR)` or `glob("*.py")`
+the flat `scripts/` root to enumerate the pipeline's entry points. Epic 0240
+moves ~132 entry points into phase subdirectories (`scripts/figures/`,
+`scripts/harvest/`, `scripts/analysis/`, `scripts/qa/`); under a flat glob a
+moved file silently drops out of a guard's coverage and the test keeps passing —
+over fewer files, not because the contract still holds.
+
+The class fix is one shared discovery helper, `tests/_script_discovery.py`
+(recursive `scripts/**/*.py`). This guard is the standing regression test for
+the class: it fails if any test file outside the helper hand-rolls a *flat*
+script enumeration (a `listdir(SCRIPTS_DIR)`, a `glob.glob(... SCRIPTS ... *.py)`
+union, or a `Path(SCRIPTS_DIR).glob("*.py")`). Recursive `os.walk(SCRIPTS_DIR)`
+guards are already subdir-safe and are deliberately NOT flagged.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# A hand-rolled *flat* script enumeration rooted at SCRIPTS_DIR:
+#  - os.listdir(SCRIPTS_DIR)                       -> non-recursive dir listing
+#  - glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))  -> non-recursive glob union
+#  - Path(SCRIPTS_DIR).glob("*.py")                -> non-recursive pathlib glob
+# `os.walk(SCRIPTS_DIR)` and the helper's own `.rglob("*.py")` are recursive and
+# subdir-safe, so they are not matched.
+_FLAT_SCRIPT_ENUM = re.compile(
+    r"""listdir\s*\([^)]*SCRIPTS                 # os.listdir(SCRIPTS_DIR)
+      | glob\.glob\([^)]*SCRIPTS[^)]*\*\.py      # glob.glob(os.path.join(SCRIPTS_DIR, "*.py"))
+      | SCRIPTS[^\n]*?\.glob\(\s*['"]\*\.py      # Path(SCRIPTS_DIR).glob("*.py")
+    """,
+    re.VERBOSE,
+)
+
+# Files permitted to enumerate scripts directly:
+#  - the shared helper itself is the ONE sanctioned enumeration;
+#  - this meta-guard names the pattern it searches for.
+_ALLOWLIST = {
+    "_script_discovery.py",
+    Path(__file__).name,
+}
+
+
+@pytest.mark.adherence
+def test_no_handrolled_script_enumeration():
+    offenders = []
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        if path.name in _ALLOWLIST:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if _FLAT_SCRIPT_ENUM.search(line):
+                offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Hand-rolled flat `scripts/` enumeration found — use "
+        "tests/_script_discovery.py (all_script_files / all_script_basenames / "
+        "all_script_stems / script_paths_by_stem) so a `scripts/` relocation "
+        "updates one place and no guard silently narrows:\n" + "\n".join(offenders)
+    )

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from _script_discovery import all_script_files
 
 # The entire file is rule-enforcement / lint / hygiene: ruff and mypy invocations,
 # complexity and length smells, arch-rule and contract checks. It belongs to the
@@ -994,7 +995,7 @@ class TestScriptNaming:
     }
 
     def test_all_scripts_have_conforming_prefix(self):
-        for f in Path(SCRIPTS_DIR).glob("*.py"):
+        for f in all_script_files():  # recursive, subdir-safe (ticket 0260)
             if f.name.startswith("_") or f.name in self.LIBRARY_MODULES:
                 continue
             assert any(f.name.startswith(p) for p in self.PREFIXES), (
@@ -1202,7 +1203,7 @@ class TestOutputFlag:
     def test_all_producing_scripts_accept_output(self):
         """Every script with __main__ that writes files must accept --output."""
         violators = []
-        for f in Path(SCRIPTS_DIR).glob("*.py"):
+        for f in all_script_files():  # recursive, subdir-safe (ticket 0260)
             src = f.read_text()
             if "__name__" not in src or "__main__" not in src:
                 continue

--- a/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
+++ b/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
@@ -2,6 +2,7 @@
 Title: Reorg code — move scripts/figures/ (plot_/export_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Blocked-by: 0260
 Label: deferred
 
 --- log ---

--- a/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
+++ b/tickets/0255-reorg-code-move-scripts-figures-plot-exp.erg
@@ -2,7 +2,6 @@
 Title: Reorg code — move scripts/figures/ (plot_/export_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
-Blocked-by: 0260
 Label: deferred
 
 --- log ---
@@ -11,6 +10,7 @@ Label: deferred
 
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0253 closed — Blocked-by removed.
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
+2026-07-11T08:12Z HDMX-coding-agent note blocker 0260 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-2

--- a/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
+++ b/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
@@ -2,7 +2,6 @@
 Title: Reorg code — move scripts/harvest/ (catalog_/enrich_/corpus_/scout entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
-Blocked-by: 0260
 Label: deferred
 
 --- log ---
@@ -11,6 +10,7 @@ Label: deferred
 
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0253 closed — Blocked-by removed.
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
+2026-07-11T08:12Z HDMX-coding-agent note blocker 0260 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-1

--- a/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
+++ b/tickets/0256-reorg-code-move-scripts-harvest-catalog.erg
@@ -2,6 +2,7 @@
 Title: Reorg code — move scripts/harvest/ (catalog_/enrich_/corpus_/scout entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Blocked-by: 0260
 Label: deferred
 
 --- log ---

--- a/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
+++ b/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
@@ -2,6 +2,7 @@
 Title: Reorg code — move scripts/analysis/ (analyze_/compute_/summarize_/build_het_core)
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Blocked-by: 0260
 Label: deferred
 
 --- log ---

--- a/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
+++ b/tickets/0257-reorg-code-move-scripts-analysis-analyze.erg
@@ -2,7 +2,6 @@
 Title: Reorg code — move scripts/analysis/ (analyze_/compute_/summarize_/build_het_core)
 Created: 2026-07-11
 Author: HDMX-coding-agent
-Blocked-by: 0260
 Label: deferred
 
 --- log ---
@@ -11,6 +10,7 @@ Label: deferred
 
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0253 closed — Blocked-by removed.
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
+2026-07-11T08:12Z HDMX-coding-agent note blocker 0260 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the Phase-2

--- a/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
+++ b/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
@@ -2,7 +2,6 @@
 Title: Reorg code — move scripts/qa/ (qa_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
-Blocked-by: 0260
 Label: deferred
 
 --- log ---
@@ -11,6 +10,7 @@ Label: deferred
 
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0253 closed — Blocked-by removed.
 2026-07-11T07:22Z HDMX-coding-agent note blocker 0254 closed — Blocked-by removed.
+2026-07-11T08:12Z HDMX-coding-agent note blocker 0260 closed — Blocked-by removed.
 --- body ---
 ## Context
 Wave-1 move of the code reorg epic (tracker `0240`). Relocate the `qa_*` **entry

--- a/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
+++ b/tickets/0258-reorg-code-move-scripts-qa-qa-entry-poin.erg
@@ -2,6 +2,7 @@
 Title: Reorg code — move scripts/qa/ (qa_ entry points)
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Blocked-by: 0260
 Label: deferred
 
 --- log ---

--- a/tickets/0260-make-script-enumeration-guards-subdir-sa.erg
+++ b/tickets/0260-make-script-enumeration-guards-subdir-sa.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: Make script-enumeration guards subdir-safe before wave-1 moves
+Created: 2026-07-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-11T08:02Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Coordination PR for epic 0240 (reorg scripts/ by dataflow phase). Wave-1
+(tickets 0255-0258) moves ~132 `scripts/*.py` entry points into phase
+subdirectories (`scripts/figures/`, `scripts/harvest/`, `scripts/analysis/`,
+`scripts/qa/`). Six test guards enumerate scripts with a **flat**
+`os.listdir(SCRIPTS_DIR)` / `glob("*.py")` — so a moved file silently drops out
+of the guard's coverage and the test keeps passing over fewer files. This is the
+same coverage-narrowing class defect as ticket 0248 (`.mk` discovery) and 0259
+(seed scan). Fix the CLASS *before* the moves, so no move can narrow a guard.
+
+This is a child of epic 0240 (`Ticket-ref` above, NOT `Blocked-by` — it is not
+blocked by the epic, it unblocks it). It PRECEDES and unblocks 0255-0258, which
+are re-pointed `Blocked-by: 0260`. It mirrors the 0248 shared-helper pattern
+(`tests/_mk_discovery.py` + `tests/test_mk_discovery_unified.py`).
+
+## Relevant files
+- `tests/_script_discovery.py` — NEW canonical recursive enumerator (mirrors `tests/_mk_discovery.py`).
+- `tests/test_script_discovery_unified.py` — NEW adherence meta-guard (mirrors `tests/test_mk_discovery_unified.py`).
+- `tests/test_script_classification.py:61` — 0254 Tier gate; `os.listdir` → recursive (CRITICAL: must see moved files).
+- `tests/test_layering.py:39` — 0242 compute↛plot guard; `os.listdir` → recursive.
+- `tests/test_phase_layout.py:97` — `glob("*.py")` → recursive.
+- `tests/test_script_hygiene.py:997,1205` — `glob("*.py")` → recursive.
+- `tests/test_evict_analysis_intermediates.py:108` — `glob("*.py")` → recursive.
+
+## Actions
+1. Add `tests/_script_discovery.py`: `all_script_files()` (recursive `scripts/**/*.py`, excl `archive*/` + `__pycache__`), plus basenames/stems/stem-map shapes.
+2. Migrate the 6 flat sites to it, preserving each guard's exact contract (only the file set widens).
+3. Add the meta-guard: fail if any test file outside the helper hand-rolls a flat script enumeration. Prove teeth by mutation.
+4. Re-point 0255-0258 to `Blocked-by: 0260`.
+
+## Test
+Red first: the meta-guard `test_no_handrolled_script_enumeration` fails while the
+6 flat sites still hand-roll their glob; goes green once all 6 route through the
+helper. Mutation-prove: temporarily re-add a flat glob to a migrated site → the
+meta-guard fails → revert.
+
+## Verification
+- [ ] `make check-fast` and `make lint` pass; per-guard counts do not DROP (may rise: `scripts/figures/plot_schematic_L3_burst.py` already exists in a subdir, so the widening is exercised today, not a pure no-op).
+- [ ] Meta-guard green on the migrated tree, red on a reintroduced flat glob.
+- [ ] 0255-0258 show `Blocked-by: 0260`.
+
+## Invariants
+- Each migrated guard still enforces its SAME rule (import-leaf classification, compute↛plot layering, phase-layout, conforming-prefix, --output, no-intermediate-in-tables). Only file coverage widens.
+- Already-recursive guards (`os.walk` in `test_arch_compliance`, `test_fabricated_doi_class_guard`, `test_script_hygiene:58`) are left untouched.
+
+## Exit criteria
+- Shared helper + meta-guard landed; 6 flat sites migrated; 0255-0258 `Blocked-by: 0260`; full suite green.

--- a/tickets/closed/0260-make-script-enumeration-guards-subdir-sa.erg
+++ b/tickets/closed/0260-make-script-enumeration-guards-subdir-sa.erg
@@ -2,10 +2,12 @@
 Title: Make script-enumeration guards subdir-safe before wave-1 moves
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: Shared recursive enumerator tests/_script_discovery.py + meta-guard landed; 6 flat guards migrated; 0255-0258 Blocked-by 0260; make lint + fast tier green
 
 --- log ---
 2026-07-11T08:02Z HDMX-coding-agent created
 
+2026-07-11T08:12Z HDMX-coding-agent closed — Shared recursive enumerator tests/_script_discovery.py + meta-guard landed; 6 flat guards migrated; 0255-0258 Blocked-by 0260; make lint + fast tier green
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Coordination PR — must land before wave-1 moves (0255-0258)

Wave-1 of epic 0240 moves ~132 `scripts/*.py` entry points into phase
subdirectories (`figures/`, `harvest/`, `analysis/`, `qa/`). Six test guards
enumerated scripts with a **flat** `os.listdir` / `glob("*.py")`, so a moved file
would silently drop out of a guard's coverage while the test kept passing over
fewer files — the same coverage-narrowing class defect as 0248 (`.mk` discovery)
and 0259 (seed scan). This fixes the CLASS before any move.

### What changed
- **`tests/_script_discovery.py`** — the ONE sanctioned enumerator: recursive
  `scripts/**/*.py` (excludes `archive*/` + `__pycache__`), exposing
  files / basenames / stems / stem-map so no caller re-globs. Mirrors
  `tests/_mk_discovery.py`.
- **6 flat guards migrated**, each preserving its exact rule (only file coverage
  widens): `test_script_classification.py` (0254 Tier gate), `test_layering.py`
  (0242 compute↛plot), `test_phase_layout.py`, `test_script_hygiene.py` (×2),
  `test_evict_analysis_intermediates.py`.
- **`tests/test_script_discovery_unified.py`** — adherence meta-guard: fails if
  any test hand-rolls a flat script enumeration. Mirrors
  `test_mk_discovery_unified.py`. Recursive `os.walk` guards are subdir-safe and
  left untouched.
- **0255-0258 gated** on this ticket (`Blocked-by: 0260`); `erg close` on-branch
  auto-resolved the dependency, retaining the log-note audit trail.

### Proof
- Widening exercised today, not a no-op: `scripts/figures/plot_schematic_L3_burst.py`
  already lives in a subdir, so recursive enumeration covers **177** scripts vs
  the flat **176** — counts rise, never drop.
- Meta-guard teeth mutation-proven: a reintroduced flat glob makes it fail; removed, it passes.
- `make lint` 163 passed / 5 skipped; project fast tier 945 passed / 10 skipped; libs 25 passed.

Ticket: none (0260 closed + archived on-branch)