### PR TITLE
docs(0241): reconcile the five SPLIT extractions to final flat state

### DIFF
--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -177,6 +177,25 @@ audit: `qa_near_duplicates` has no `__main__` and its docstring documents a
 `from qa_near_duplicates import …` API — it is already a pure library (Tier-2),
 never dual-role.
 
+### Reconciliation of the original five SPLIT extractions (ticket 0241)
+
+The pre-two-tier audit named five leaked-helper clusters to "extract into the
+owning phase subdir." The ratified two-tier rule overrode the *destination* — an
+imported helper stays flat as a `_`-module, never in a phase subdir — but every
+cluster is now resolved. Final state:
+
+| Original SPLIT target (phase subdir) | Leaked symbol(s) | Final resolution |
+|---|---|---|
+| `corpus_filters` (`build_het_core`) | `is_global_south`, `is_non_english` | flat `_corpus_predicates.py` (0254); importers `build_het_core`, `analyze_multilingual` |
+| `traditions` (`plot_fig_traditions`) | `build_pre2007_traditions` | flat `_pre2007_traditions.py` (0250); importers `plot_fig_traditions`, `compute_null_separation` |
+| `teaching` (`build_teaching_yaml`) | `_dedup_course_names` | flat `_course_dedup.py` (0254); importers `build_teaching_yaml`, `analyze_syllabi` |
+| `venues` (`summarize_core_venues`) | `canonical_venue`, `venue_type`, `institution_group` | flat `_venue_naming.py` (0254); importers `summarize_core_venues`, `compute_venue_concentration`, `export_core_venues_markdown` |
+| `changepoints` (`compute_changepoints`) | `compute_convergence` | no extraction — `compute_changepoints` reclassified Tier-2 (stays flat), imported by `compute_convergence`; a helper module was unnecessary |
+
+The `corpus_filters` name was the phase-subdir proposal; the shared predicate
+landed as `_corpus_predicates.py`. Change-point detection (`ruptures` Pelt/Dynp/
+KernelCPD) lives only in `compute_changepoints.py` — no inlined duplicate remains.
+
 ### Flags for the move tickets
 
 - **Prefix gaps.** The move tickets key on filename prefixes, but three Tier-3

--- a/tickets/closed/0241-reorg-code-3-split-extractions.erg
+++ b/tickets/closed/0241-reorg-code-3-split-extractions.erg
@@ -3,6 +3,7 @@ Title: Reorg code 3/4 — land the 5 SPLIT extractions in their phase subdir
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: All five SPLIT extractions resolved by prior tickets under the two-tier rule: traditions -> _pre2007_traditions.py (0250); venues -> _venue_naming.py, teaching -> _course_dedup.py, corpus_filters -> _corpus_predicates.py (all 0254, flat _-modules not phase subdirs); changepoints reclassified Tier-2 (compute_changepoints stays flat, imported by compute_convergence — no helper module needed). Importers repointed and verified; change-point detection centralized. repo-layout.md reconciliation table added. No code left to write.
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Label: deferred
 2026-07-11T06:52Z HDMX-coding-agent note re-pointed Blocked-by 0240 → 0257. 0240 became the epic TRACKER (decomposed 2026-07-11); a leaf blocked-by its own tracker is the anti-pattern the author flagged. The real prerequisite is the wave-1 analysis move (0257) — the extracted modules land in the scripts/analysis/ subdir that 0257 creates.
 
 2026-07-11T09:20Z HDMX-coding-agent note blocker 0257 closed — Blocked-by removed.
+2026-07-11T10:00Z HDMX-coding-agent closed — All five SPLIT extractions resolved by prior tickets under the two-tier rule: traditions -> _pre2007_traditions.py (0250); venues -> _venue_naming.py, teaching -> _course_dedup.py, corpus_filters -> _corpus_predicates.py (all 0254, flat _-modules not phase subdirs); changepoints reclassified Tier-2 (compute_changepoints stays flat, imported by compute_convergence — no helper module needed). Importers repointed and verified; change-point detection centralized. repo-layout.md reconciliation table added. No code left to write.
 --- body ---
 ## Context
 Third stage of the code reorg (parent sub-tracker `0225`, grand-tracker


### PR DESCRIPTION
Reconciles and closes ticket 0241 ("land the 5 SPLIT extractions"). No code was
left to write: verification shows all five leaked-helper clusters were already
resolved by prior tickets under the two-tier rule ratified in 0254. This PR
documents the final state and closes the ticket.

## Final state of the five extractions

| Original SPLIT target | Symbol(s) | Resolution |
|---|---|---|
| `corpus_filters` | `is_global_south`, `is_non_english` | flat `_corpus_predicates.py` (0254); importers `build_het_core`, `analyze_multilingual` |
| `traditions` | `build_pre2007_traditions` | flat `_pre2007_traditions.py` (0250); importers `plot_fig_traditions`, `compute_null_separation` |
| `teaching` | `_dedup_course_names` | flat `_course_dedup.py` (0254); importers `build_teaching_yaml`, `analyze_syllabi` |
| `venues` | `canonical_venue`, `venue_type`, `institution_group` | flat `_venue_naming.py` (0254); importers `summarize_core_venues`, `compute_venue_concentration`, `export_core_venues_markdown` |
| `changepoints` | `compute_convergence` | reclassified Tier-2 — `compute_changepoints` stays flat, imported by `compute_convergence`; no helper module needed |

The `corpus_filters` phase-subdir name was superseded: the shared predicate
landed flat as `_corpus_predicates.py`. Change-point detection (`ruptures`
Pelt/Dynp/KernelCPD) lives only in `compute_changepoints.py` — grep confirms no
inlined duplicate.

## Changes
- `docs/repo-layout.md`: reconciliation table mapping the original five-item
  SPLIT list to its final flat-module / reclassified outcome.

## Verification
- Importers of each `_`-module confirmed via grep (owner + secondary importers).
- Classification gate `test_script_classification.py`: 2 passed (new `_`-modules
  correctly Tier-2 flat).
- `make lint` (adherence): 163 passed, 5 skipped.
- `make check-fast`: 945 passed, 10 skipped.

Ticket: none

_(0241 is already closed + archived on this branch — commit `ticket(0241): close and archive`. Per this repo's erg-pr-merge behavior the close-claim uses `Ticket: none` to avoid a double-close rejection; the ticket is discharged on-branch.)_
