### PR TITLE
fix(0261): make analysis archive cp-loop subdir-aware after epic-0240 reorg

### DIFF
--- a/build/build_analysis_archive.sh
+++ b/build/build_analysis_archive.sh
@@ -45,14 +45,36 @@ cd "$PROJ_ROOT"
 cp -L "$DATA_DIR/refined_works.csv"     "$TMP/data/catalogs/"
 cp -L "$DATA_DIR/refined_embeddings.npz" "$TMP/data/catalogs/"
 
-# Scripts needed to build figures + tables
-for s in utils.py pipeline_loaders.py pipeline_io.py pipeline_progress.py \
-         pipeline_text.py plot_style.py plot_fig1_bars.py \
-         plot_fig2_composition.py compute_clusters.py build_het_core.py \
-         export_core_venues_markdown.py summarize_core_venues.py \
-         export_tab_venues.py export_citation_coverage.py analyze_bimodality.py \
-         plot_bimodality.py plot_bimodality_lexical.py plot_bimodality_keywords.py; do
-    cp "scripts/$s" "$TMP/scripts/"
+# Scripts needed to build figures + tables.
+# Full repo-relative paths, mirrored into the archive with `cp --parents` so the
+# archived tree matches the repo: tier-2 libs stay flat at scripts/ while the
+# reorg'd entry points keep their scripts/{figures,analysis}/ subdir (epic 0240).
+# The archived Makefile.analysis-manuscript invokes them at these mirrored paths,
+# and PYTHONPATH=scripts (ticket 0253) still resolves their flat `from utils …`
+# imports. Guarded by tests/test_archive_script_paths — every path here must
+# resolve to a real file, so the next mover cannot silently strand the cp.
+SCRIPTS=(
+    scripts/utils.py
+    scripts/pipeline_loaders.py
+    scripts/pipeline_io.py
+    scripts/pipeline_progress.py
+    scripts/pipeline_text.py
+    scripts/plot_style.py
+    scripts/figures/plot_fig1_bars.py
+    scripts/figures/plot_fig2_composition.py
+    scripts/analysis/compute_clusters.py
+    scripts/analysis/build_het_core.py
+    scripts/figures/export_core_venues_markdown.py
+    scripts/analysis/summarize_core_venues.py
+    scripts/figures/export_tab_venues.py
+    scripts/figures/export_citation_coverage.py
+    scripts/analysis/analyze_bimodality.py
+    scripts/figures/plot_bimodality.py
+    scripts/figures/plot_bimodality_lexical.py
+    scripts/figures/plot_bimodality_keywords.py
+)
+for src in "${SCRIPTS[@]}"; do
+    cp --parents "$src" "$TMP/"
 done
 
 # openalex-corpus convention package — imported as source via PYTHONPATH

--- a/build/templates/Makefile.analysis-manuscript
+++ b/build/templates/Makefile.analysis-manuscript
@@ -35,37 +35,40 @@ DERIVED := data/derived/tables
 figures: content/figures/fig_bars_v1.png content/figures/fig_composition.png \
          content/tables/tab_venues.md $(DERIVED)/tab_alluvial.csv
 
+# Script paths mirror the repo layout after the epic-0240 reorg: entry points
+# live under scripts/{figures,analysis}/, tier-2 libs (utils, plot_style) stay
+# flat at scripts/. PYTHONPATH=scripts resolves the flat imports either way.
 $(DERIVED)/tab_alluvial.csv $(DERIVED)/tab_core_shares.csv $(DERIVED)/cluster_labels.json &: \
-		scripts/compute_clusters.py scripts/utils.py $(REFINED) $(DATA)/refined_embeddings.npz
+		scripts/analysis/compute_clusters.py scripts/utils.py $(REFINED) $(DATA)/refined_embeddings.npz
 	$(UV_RUN) python $< --output $(DERIVED)/tab_alluvial.csv
 
 # ── Figures ─────────────────────────────────────────────────
-content/figures/fig_bars_v1.png: scripts/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(REFINED)
+content/figures/fig_bars_v1.png: scripts/figures/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(REFINED)
 	$(UV_RUN) python $< --v1-only
 
-content/figures/fig_composition.png: scripts/plot_fig2_composition.py scripts/plot_style.py scripts/utils.py \
+content/figures/fig_composition.png: scripts/figures/plot_fig2_composition.py scripts/plot_style.py scripts/utils.py \
 		config/v1_tab_alluvial.csv config/v1_cluster_labels.json
 	$(UV_RUN) python $< --alluvial config/v1_tab_alluvial.csv --labels config/v1_cluster_labels.json
 
-$(DATA)/het_mostcited_50.csv: scripts/build_het_core.py scripts/utils.py $(REFINED)
+$(DATA)/het_mostcited_50.csv: scripts/analysis/build_het_core.py scripts/utils.py $(REFINED)
 	$(UV_RUN) python $<
 
-content/tables/tab_venues.md: scripts/export_tab_venues.py scripts/utils.py $(REFINED) \
+content/tables/tab_venues.md: scripts/figures/export_tab_venues.py scripts/utils.py $(REFINED) \
 		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
-$(DERIVED)/tab_pole_papers.csv &: scripts/analyze_bimodality.py scripts/utils.py $(REFINED)
+$(DERIVED)/tab_pole_papers.csv &: scripts/analysis/analyze_bimodality.py scripts/utils.py $(REFINED)
 	$(UV_RUN) python $<
 
-content/figures/fig_bimodality.png: scripts/plot_bimodality.py scripts/utils.py \
+content/figures/fig_bimodality.png: scripts/figures/plot_bimodality.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
-content/figures/fig_bimodality_lexical.png: scripts/plot_bimodality_lexical.py scripts/utils.py \
+content/figures/fig_bimodality_lexical.png: scripts/figures/plot_bimodality_lexical.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 
-content/figures/fig_bimodality_keywords.png: scripts/plot_bimodality_keywords.py scripts/utils.py \
+content/figures/fig_bimodality_keywords.png: scripts/figures/plot_bimodality_keywords.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
 	$(UV_RUN) python $<
 

--- a/tests/test_archive_script_paths.py
+++ b/tests/test_archive_script_paths.py
@@ -1,0 +1,108 @@
+"""Path-resolution guard for the analysis reproducibility archive (ticket 0261).
+
+The older archive guards (`test_archive_checksums.py::TestArchiveScripts`,
+`test_script_hygiene.py::TestArchiveBitInvariance`) only assert that a script's
+*basename string* appears in the build script / Makefile. They pass regardless
+of which directory the file actually lives in, so the epic-0240 reorg — which
+moved figure/analysis entry points into `scripts/{figures,analysis}/` — left
+`build_analysis_archive.sh` copying `scripts/compute_clusters.py` from a path
+that no longer exists, and no test caught it (the repo has no CI).
+
+These guards have teeth: they resolve every script path the archive tooling will
+actually `cp`/invoke to a real file on disk. Point any listed path at a moved or
+missing file and the guard fails — so the next mover cannot silently strand the
+archive.
+"""
+
+import os
+import re
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BUILD_SCRIPT = os.path.join(REPO, "build", "build_analysis_archive.sh")
+MAKEFILE_ANALYSIS = os.path.join(
+    REPO, "build", "templates", "Makefile.analysis-manuscript"
+)
+
+# scripts/<optional-subdirs>/<name>.py — matches both flat (scripts/utils.py)
+# and reorg'd (scripts/figures/plot_fig1_bars.py) entry points.
+SCRIPT_PATH_RE = re.compile(r"scripts/(?:[\w-]+/)*[\w.-]+\.py")
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _archive_script_paths():
+    """Repo-relative scripts/ paths inside the build script's SCRIPTS=( ... ) array."""
+    content = _read(BUILD_SCRIPT)
+    m = re.search(r"SCRIPTS=\((.*?)\)", content, re.DOTALL)
+    assert m, (
+        "build_analysis_archive.sh must declare a SCRIPTS=( ... ) array of the "
+        "scripts it copies into the archive"
+    )
+    paths = SCRIPT_PATH_RE.findall(m.group(1))
+    assert paths, "SCRIPTS=( ... ) array holds no scripts/*.py paths"
+    return paths
+
+
+def _makefile_script_paths():
+    """scripts/*.py paths the archived Makefile invokes as recipe prerequisites.
+
+    Comment lines are stripped first: a `# … scripts/x.py …` example must not be
+    read as a real prerequisite.
+    """
+    lines = [
+        ln for ln in _read(MAKEFILE_ANALYSIS).splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    paths = SCRIPT_PATH_RE.findall("\n".join(lines))
+    assert paths, "Makefile.analysis-manuscript references no scripts/*.py paths"
+    return paths
+
+
+class TestArchiveScriptPathsResolve:
+    """Every script path the archive tooling names must resolve to a real file."""
+
+    def test_build_script_paths_exist(self):
+        """Each path in the build script's cp list must point at an existing file.
+
+        Red before ticket 0261: the loop copied `scripts/compute_clusters.py`,
+        but the file lives at `scripts/analysis/compute_clusters.py` post-reorg.
+        """
+        missing = [
+            p for p in _archive_script_paths()
+            if not os.path.isfile(os.path.join(REPO, p))
+        ]
+        assert not missing, (
+            "build_analysis_archive.sh lists scripts that do not exist at the "
+            f"path it will cp (moved or deleted?): {sorted(missing)}"
+        )
+
+    def test_makefile_script_paths_exist(self):
+        """Each scripts/*.py the archived Makefile invokes must exist in the repo,
+        so the mirrored archive tree the build script produces can build."""
+        missing = [
+            p for p in _makefile_script_paths()
+            if not os.path.isfile(os.path.join(REPO, p))
+        ]
+        assert not missing, (
+            "Makefile.analysis-manuscript invokes scripts that do not exist at "
+            f"the named path: {sorted(missing)}"
+        )
+
+    def test_build_and_makefile_agree_on_entry_points(self):
+        """Every entry point the archived Makefile invokes must be copied by the
+        build script at the same path — otherwise the archive Makefile references
+        a script the archive does not ship."""
+        copied = set(_archive_script_paths())
+        invoked = set(_makefile_script_paths())
+        not_shipped = invoked - copied
+        assert not not_shipped, (
+            "Makefile.analysis-manuscript invokes scripts the build script does "
+            f"not copy into the archive: {sorted(not_shipped)}"
+        )

--- a/tickets/closed/0261-make-build-analysis-archive-sh-cp-list-s.erg
+++ b/tickets/closed/0261-make-build-analysis-archive-sh-cp-list-s.erg
@@ -2,10 +2,12 @@
 Title: Make build_analysis_archive.sh cp-list subdir-aware for reorg movers
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: Analysis archive cp-loop now resolves each script's real path via cp --parents (mirrored subdirs); archived Makefile updated; path-resolution guard added and mutation-proven
 
 --- log ---
 2026-07-11T09:51Z HDMX-coding-agent created
 
+2026-07-11T10:02Z HDMX-coding-agent closed — Analysis archive cp-loop now resolves each script's real path via cp --parents (mirrored subdirs); archived Makefile updated; path-resolution guard added and mutation-proven
 --- body ---
 ## Context
 `build/build_analysis_archive.sh` copies the analysis scripts into the


### PR DESCRIPTION
## What

`build/build_analysis_archive.sh` copied every analysis script with a flat
`cp "scripts/$s"`. The epic-0240 reorg moved the figure/analysis entry points
into `scripts/{figures,analysis}/`, so post-reorg the loop failed with
`cp: cannot stat 'scripts/compute_clusters.py'` — a broken/empty
reproducibility archive. Latent because the repo has no CI and the existing
guards asserted only that the basename STRING appeared, not that the `cp`
resolved.

## Fix

- **`build/build_analysis_archive.sh`** — copy each script from its real
  repo-relative path with `cp --parents`, mirroring the repo tree into the
  archive: tier-2 libs stay flat at `scripts/`, moved entry points keep their
  `scripts/{figures,analysis}/` subdir. Verified by a real dry-run: all 18
  listed scripts land at their mirrored paths, no `cp: cannot stat`.
- **`build/templates/Makefile.analysis-manuscript`** — the shipped archive
  Makefile now invokes the entry points at the same mirrored paths;
  `PYTHONPATH=scripts` (ticket 0253) still resolves their flat `from utils …`
  imports.
- Swept the other archive builders: `build_datapaper_archive.sh` uses
  `git archive` (carries structure; its `export_deposit.py` ref is already
  subdir-correct) and `build_manuscript_archive.sh` copies no scripts — neither
  needed a change.

## Guard (durable class fix)

New `tests/test_archive_script_paths.py` (adherence-tier) resolves every script
path the archive tooling will actually cp/invoke to a real file on disk — the
build-script cp list, the archived Makefile prerequisites, and their agreement.
A future move that strands a path now fails a test. Mutation-proven: repointing
either the cp list or a Makefile prereq at a pre-reorg flat path fails the
guard.

## Gates

`make lint` (166 passed) and `make check-fast` (945 passed) green, `UV_NO_SYNC=1`.

## Ticket

Closed and archived on-branch (`tickets/closed/0261-…erg`), so the merge closes
nothing — `Ticket: none` per project convention for an on-branch close (a
`**Ticket:**` line at an already-archived ticket makes erg-pr-merge bounce).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)