### PR TITLE
fix(0240): close epic — integration fixup (venues.mk + archive README)

### DIFF
--- a/build/templates/README-datapaper.md
+++ b/build/templates/README-datapaper.md
@@ -59,8 +59,8 @@ paper's figure and tables. They illustrate how to work with the dataset:
 | Script | Output | What it does |
 |--------|--------|--------------|
 | `scripts/plot_fig_bars.py` | `fig_bars.png` | Annual publication volume bar chart |
-| `scripts/export_corpus_table.py` | `tab_corpus_sources.md` | Per-source quality and completeness table |
-| `scripts/export_language_table.py` | `tab_languages.md` | Language distribution table |
+| `scripts/figures/export_corpus_table.py` | `tab_corpus_sources.md` | Per-source quality and completeness table |
+| `scripts/figures/export_language_table.py` | `tab_languages.md` | Language distribution table |
 
 ## License
 

--- a/data/catalogs/catalogs
+++ b/data/catalogs/catalogs
@@ -1,0 +1,1 @@
+/home/haduong/CNRS/projets/actifs/climate-finance-het/data/catalogs

--- a/scripts/analysis/venues.mk
+++ b/scripts/analysis/venues.mk
@@ -28,6 +28,6 @@ $(VENUE_TABLE): scripts/analysis/compute_venue_concentration.py scripts/analysis
 
 # ── Figure ────────────────────────────────────────────────────────────────
 
-$(VENUE_FIG): scripts/plot_venue_concentration.py scripts/plot_style.py scripts/utils.py \
+$(VENUE_FIG): scripts/figures/plot_venue_concentration.py scripts/plot_style.py scripts/utils.py \
 		$(VENUE_TABLE) $(DERIVED)/tab_breakpoints.csv
 	$(PYTHON) $< --output $@ --input $(VENUE_TABLE) $(DERIVED)/tab_breakpoints.csv

--- a/tickets/closed/0240-reorg-code-2-scripts-by-phase.erg
+++ b/tickets/closed/0240-reorg-code-2-scripts-by-phase.erg
@@ -3,12 +3,14 @@ Title: EPIC — reorg scripts/ by dataflow phase (two-tier move, relative source
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: Epic complete: scripts/ regrouped by dataflow phase. All 10 children merged (0253 import-model incl CI/CD/container robustness; 0254 classification+gate; 0259 seed->config; 0260 subdir-safe guards; 0255-0258 the four phase moves; 0241 extractions reconciled; 0261 archive cp-loop). Result: scripts/ root = 45 flat Tier-2 modules + phase subdirs figures/62 harvest/25 analysis/34 qa/11 (=132 movers). Integration review: recipe-identity per move, all guards green (import-path/classification/layering/phase-layout/arch/discovery/archive-paths), make lint 166 + check-fast 948 on combined main; union sweep found+fixed one dangling build ref (venues.mk plot_venue_concentration) + 2 archive-README provenance refs. dvc.lock refreshes on next dvc repro; full make clean && make all data build is the author's supervised acceptance (pure refactor validated by recipe-identity, not a data rebuild).
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
 2026-07-10T00:00Z HDMX-coding-agent note split from 0225 (code workstream) as an integer child; the high-risk stage (173-file move, import-path churn). Parked behind the Œconomia R&R per 0223.
 2026-07-11T06:52Z HDMX-coding-agent note decomposed into an EPIC TRACKER with de-risked children (author-approved architecture, 2026-07-11): two-tier move (only pure entry points move; library modules stay flat) + relative-source-root import model. Children 0253-0259 filed; 0241 re-pointed to Blocked-by 0257 (the analysis move) instead of this tracker. This ticket is now a tracker with NO Blocked-by — children encode real prerequisites only, never blocked-by the tracker.
 
+2026-07-11T10:10Z HDMX-coding-agent closed — Epic complete: scripts/ regrouped by dataflow phase. All 10 children merged (0253 import-model incl CI/CD/container robustness; 0254 classification+gate; 0259 seed->config; 0260 subdir-safe guards; 0255-0258 the four phase moves; 0241 extractions reconciled; 0261 archive cp-loop). Result: scripts/ root = 45 flat Tier-2 modules + phase subdirs figures/62 harvest/25 analysis/34 qa/11 (=132 movers). Integration review: recipe-identity per move, all guards green (import-path/classification/layering/phase-layout/arch/discovery/archive-paths), make lint 166 + check-fast 948 on combined main; union sweep found+fixed one dangling build ref (venues.mk plot_venue_concentration) + 2 archive-README provenance refs. dvc.lock refreshes on next dvc repro; full make clean && make all data build is the author's supervised acceptance (pure refactor validated by recipe-identity, not a data rebuild).
 --- body ---
 ## Epic goal
 `scripts/` holds 173 flat files that are really a **library plus a set of entry


### PR DESCRIPTION
Final integration fixup + close for the **0240 scripts/-by-phase reorg epic**.

## Integration review found
A repo-wide union sweep (the multi-PR-one-file discipline) caught a dangling build ref the individual-move greps + green `check-fast` missed:
- `scripts/analysis/venues.mk:31` referenced `scripts/plot_venue_concentration.py` at its old flat path (moved to `scripts/figures/` by 0255) — a real dangling `make` prerequisite. **Fixed.**
- `build/templates/README-datapaper.md` ×2 stale `export_*` provenance rows. **Fixed.**
- (`dvc.lock` self-heals on next `dvc repro`; `tickets/closed/*` are immutable history; `test_archive_script_paths.py` cite is a benign docstring.)

## Epic result
`scripts/` root = **45 flat Tier-2** modules + phase subdirs (figures 62 / harvest 25 / analysis 34 / qa 11 = 132 movers). All 10 children merged + independently verified. `make lint` 166 + `check-fast` 948 green on combined main; recipe-identity per move; all guards green.

Full `make clean && make all` data build is the author's supervised acceptance (pure refactor validated by recipe-identity, not a data rebuild).

**Ticket:** none (0240 closed+archived on-branch)