### PR TITLE
tickets: close reorg trackers 0225 + 0223 (grand reorg complete)

### DIFF
--- a/tickets/closed/0223-repo-layout-reorg.erg
+++ b/tickets/closed/0223-repo-layout-reorg.erg
@@ -3,6 +3,7 @@ Title: Repo layout reorg — tidy the top level in three stages (data, code, pro
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: Repo-layout grand reorg complete. All three workstream children closed: DATA (0224), CODE (0225), PROSE (0226). Top level tidied across the three stages. Remaining reorg-adjacent item is seed 0229 (shared harvest/index to libs/ for AEDIST), deferred/consumer-gated — tracked independently, not part of 0223's exit.
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Label: deferred
 2026-07-10T09:49Z HDMX-coding-agent label deferred
 2026-07-10T10:07Z note author-adjudicated 2026-07-10: deliverables/ RATIFIED, src/ DECLINED (keep libs/ for cross-repo), AEDIST shared harvest/index → 0229
 2026-07-10T00:00Z HDMX-coding-agent note child 0226 (prose) closed via PR #1002; child 0225 (code) fanned out into integer sub-children 0239-0242 (0225 is now a sub-tracker). This tracker closes when 0225 closes. All parked behind the Œconomia R&R.
+2026-07-11T10:44Z HDMX-coding-agent closed — Repo-layout grand reorg complete. All three workstream children closed: DATA (0224), CODE (0225), PROSE (0226). Top level tidied across the three stages. Remaining reorg-adjacent item is seed 0229 (shared harvest/index to libs/ for AEDIST), deferred/consumer-gated — tracked independently, not part of 0223's exit.
 --- body ---
 ## Context
 Top level reached 43 entries with two flat mega-directories: `scripts/` (173

--- a/tickets/closed/0225-reorg-code.erg
+++ b/tickets/closed/0225-reorg-code.erg
@@ -3,6 +3,7 @@ Title: Reorg workstream — code (scripts/ by phase; shared harvest/index → li
 Created: 2026-07-10
 Author: HDMX-coding-agent
 Label: deferred
+Closed: Code reorg workstream complete. Exit criteria met: 0239/0240/0241/0242 all closed (scripts/ regrouped by phase: 45 flat Tier-2 + figures/harvest/analysis/qa subdirs; import model unified on source roots; guards subdir-safe). Spin-offs 0248/0250/0253-0261 landed under the 0240 epic. libs/ harvest+index delegated to seed 0229 (consumer-gated on AEDIST), not a 0225 exit criterion.
 
 --- log ---
 2026-07-10T00:00Z HDMX-coding-agent created
@@ -12,6 +13,7 @@ Label: deferred
 2026-07-10T00:00Z HDMX-coding-agent note strip stale Blocked-by 0223 — the edge encoded "wait for layout ratification", discharged 2026-07-10 (0223 log: deliverables/ RATIFIED, src/ DECLINED). 0223 is a tracking parent that stays open until this child closes, so child-blocked-by-parent was an inverted/cyclic edge (0226, same edge, was executed and merged regardless). Ticket stays deferred: parked behind the Œconomia R&R per 0223 scheduling.
 2026-07-10T00:00Z HDMX-coding-agent note split into integer children 0239-0242 (author directive); 0225 now a sub-tracker. Fixed .mk scope: all 5 analysis .mk relocate (was 3); render/manuscript .mk already per-deliverable via 0237; root zoo.mk is Phase-2-pure (render split out by 0237) but name-clashes with deliverables/zoo/zoo.mk → rename on relocation.
 2026-07-11T06:52Z HDMX-coding-agent note 0239/0242/0248/0250 closed. 0240 (the high-risk 173-file move) decomposed into an EPIC with de-risked children: 0253 (import-path model), 0254 (entry-point/library classification audit), 0255-0258 (phase-subdir moves: figures/harvest/analysis/qa), 0241 (5 extractions, re-pointed Blocked-by 0257), 0259 (RANDOM_STATE seed hygiene). Two-tier rule + relative-source-root import model baked in (author-approved 2026-07-11). 0240 stays open as the epic tracker.
+2026-07-11T10:44Z HDMX-coding-agent closed — Code reorg workstream complete. Exit criteria met: 0239/0240/0241/0242 all closed (scripts/ regrouped by phase: 45 flat Tier-2 + figures/harvest/analysis/qa subdirs; import model unified on source roots; guards subdir-safe). Spin-offs 0248/0250/0253-0261 landed under the 0240 epic. libs/ harvest+index delegated to seed 0229 (consumer-gated on AEDIST), not a 0225 exit criterion.
 --- body ---
 ## Context
 Second stage of the top-level tidy (tracker `0223`). `scripts/` holds 173 flat


### PR DESCRIPTION
Closes the two reorg parent trackers now that all their children are done.

- **0225 (code sub-tracker)** — exit criteria met: 0239/0240/0241/0242 closed; scripts/ regrouped by phase. libs/ delegated to seed 0229.
- **0223 (grand tracker)** — all three workstreams closed: DATA (0224), CODE (0225), PROSE (0226).
- **0229 stays OPEN** — deferred seed (shared harvest/index → libs/ for AEDIST), consumer-gated, needs AEDIST requirements before Execute.

Both closed+archived on-branch; `erg check` PASS (251 tickets).

**Ticket:** none