### PR TITLE
chore: STATE refresh 2026-07-11 (post-0252 lair)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-Last updated: 2026-07-11T06:55Z
+Last updated: 2026-07-11T14:10Z
 
 ## Current goal
 
@@ -12,16 +12,19 @@ until resubmitted.
 ### Also open (details live in the tickets)
 - **0243** voice alignment — author decisions on draft PR #1016.
 - **0244** AI-generated includes — author marker review.
-- **0252** hygiene sweep (.dvc pointers, dead branch) · **0026** method paper.
+- **0026** method paper.
 - Harness PR #472 (reuse gate + supervisor doctrine) awaits author review.
 
 ## Status
-<!-- generated 2026-07-11T06:55Z -->
-**Tickets:** 4 ready · 42 blocked — `erg ready tickets/` for full list
+<!-- generated 2026-07-11T14:10Z -->
+
+**Tickets:** 3 ready · 37 blocked — `erg ready tickets/` for full list
 **Recent commits:**
-  de07787c ticket(0251): close and archive — guard landed, gates green
-  caa2e2ed ticket(0248): close and archive — .mk discovery unified, PR #1019
-  fe53ba8b ticket(0242): close and archive — backward arrow severed, PR #1017
+  0b97e620 Merge pull request #1038 from MinhHaDuong/t252-hygiene-dvc-pointers
+  e0800ca0 ticket(0252): close and archive — PR #1038
+  25fdf157 test(0252): mark symlink guard integration — subprocess tier rule
+  7623c744 ticket(0252): log extended branch-sweep decisions
+  32688f21 ticket(0252): log author decisions — branch deleted, orphan pointers kept
 
 ## Corpus (v1.1.1)
 
@@ -30,9 +33,8 @@ until resubmitted.
 
 ## Health
 
-check-fast 954 + lint 152 green (wrong-namespace guard 0251 in). 0246 was a
-false alarm: make is exit-faithful, a `| tail` pipe swallowed the exit code.
-2026-07-10/11 night regime + morning: 8 PRs merged, 6 tickets closed.
+check-fast 945 + lint 167 green (0252 in: symlink guard, 3 stale DVC
+pointers dropped, 4 dead branches removed).
 
 ## Next actions
 

--- a/STATE.md
+++ b/STATE.md
@@ -12,7 +12,6 @@ until resubmitted.
 ### Also open (details live in the tickets)
 - **0243** voice alignment — author decisions on draft PR #1016.
 - **0244** AI-generated includes — author marker review.
-- **0026** method paper.
 - Harness PR #472 (reuse gate + supervisor doctrine) awaits author review.
 
 ## Status


### PR DESCRIPTION
Ticket: none

Routine /lair STATE refresh: status regenerated, 0252 pruned from active list (closed via PR #1038), health numbers updated to today's runs (check-fast 945, lint 167), history lines pruned to meet the 40-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)