### PR TITLE
tickets(lair): file 0262 + 0263 — make-check failures found at wrap-up

### DIFF
--- a/tickets/0262-fix-regression-harness-paths-broken-by-0.erg
+++ b/tickets/0262-fix-regression-harness-paths-broken-by-0.erg
@@ -1,0 +1,64 @@
+%erg 0.1
+Title: Fix regression harness paths broken by 0240 scripts reorg
+Created: 2026-07-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-11T14:36Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+All 10 tests/test_regression.py tests fail on main ("<name> produced no
+outputs"), discovered by the 2026-07-11 /lair full `make check` (log:
+~/.local/share/rtk/tee/1783780386_make_check.log). Root cause is the 0240
+scripts/ reorg, ninth surface of the relocation class
+(project_file_relocation_move_surface memory):
+
+1. `compute_regression_hashes.py` moved from `scripts/` to `scripts/analysis/`,
+   so its `ROOT` (derived from `__file__`, line ~39) now resolves one level too
+   deep: `SCRIPTS_DIR` = `<repo>/scripts/scripts`.
+2. Even with ROOT fixed, the REGISTRY entries (lines ~50-150) hold pre-reorg
+   flat basenames (`compute_breakpoints.py`, `plot_fig1_bars.py`,
+   `build_het_core.py`, ...) — the scripts now live under `scripts/analysis/`
+   and `scripts/figures/`.
+
+Verified: resolving `SCRIPTS_DIR / entry["script"]` finds 0 of 10 registry
+scripts on current main. Invisible to check-fast (regression tests are slow
+tier) and to per-move greps during 0240 (the registry stores basenames, not
+`scripts/`-prefixed paths, so path-sweep greps missed them).
+
+## Relevant files
+
+- `scripts/analysis/compute_regression_hashes.py` — ROOT constant + REGISTRY script fields
+- `tests/test_regression.py` — the 10 failing consumers
+- `tests/fixtures/smoke/` — fixtures the harness runs against
+
+## Actions
+
+1. Red test first (fast tier, no data): assert every REGISTRY entry's
+   `SCRIPTS_DIR / script` exists on disk. Fails 10/10 today.
+2. Fix ROOT for the new location (or anchor on git toplevel), repoint the 10
+   REGISTRY `script` fields to their subdir paths.
+3. Run the 10 test_regression tests to confirm green (goldens should match —
+   the scripts themselves are unchanged, only the launcher lost them).
+
+## Test
+
+- New guard: `test_regression.py` (or harness module test) — every REGISTRY
+  script path exists. Red on current main.
+
+## Verification
+
+- [ ] Guard test red before fix, green after
+- [ ] `uv run pytest tests/test_regression.py` 10/10 pass
+- [ ] `make check-fast` and `make lint` stay green
+
+## Invariants
+
+- Golden hashes unchanged — this is a launcher fix, not a behaviour change.
+
+## Exit criteria
+
+- [ ] All 10 test_regression tests pass on main
+- [ ] Fast-tier guard prevents silent registry-path rot on future moves

--- a/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
+++ b/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
@@ -1,0 +1,52 @@
+%erg 0.1
+Title: Triage 2026-07-11 make-check slow-tier failures on doudou
+Created: 2026-07-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-11T14:36Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 2026-07-11 /lair full `make check` on doudou (main @ 315be9e1, log:
+~/.local/share/rtk/tee/1783780386_make_check.log) surfaced 19 failures + 4
+errors. Ten are root-caused (regression harness, ticket 0262). The remaining
+nine failures + four errors need triage: environmental (doudou data/compute
+state) vs real. None is release-blocking on its face, but the golden-value
+pair is unclassified and could hide numeric drift.
+
+Clusters, with observed messages:
+
+1. `test_corpus_table_export` (4 ERRORS) — Missing
+   `deliverables/_shared/tables/tab_corpus_sources.csv` ("run
+   export_corpus_table.py first"). Generated, untracked; likely just not built
+   here. Decide: build in test fixture, mark differently, or accept.
+2. `test_corpus_acceptance::test_language_null_rate_below_2_percent` — null
+   rate 4.1% (1743/42916) vs <2% expected. Local corpus predates the language
+   backfill? Re-check after v1.1.2 lands and `make corpus-sync`.
+3. `test_golden_values` S3_sliced_wasserstein + S4_frechet — AssertionError
+   (mismatch vs golden). UNCLASSIFIED: lib-version/hardware sensitivity on
+   doudou, or genuine drift. Highest-priority triage of this ticket.
+4. `test_null_model_c2st` (2) — subprocess.TimeoutExpired on the CPU-only
+   machine. Budget vs machine mismatch; consider a longer timeout or slow-tier
+   gating by capability.
+5. `test_fetch_parallel` (3) + `test_bib_doi_title` (1) — FileNotFoundError on
+   tmp/cache paths; environment or fixture setup, possibly flaky.
+
+## Actions
+
+1. Re-run each cluster on padme (data-complete, GPU) after 0262 merges.
+2. Classify each: env-only (document/gate), flaky (fix fixture), or real (fix
+   or re-ticket per cluster; atomic tickets).
+3. For cluster 3, byte-compare S3/S4 outputs on both machines to separate
+   hardware sensitivity from drift.
+
+## Verification
+
+- [ ] Each of the 5 clusters has a logged disposition
+- [ ] `make check` green on padme, or every residual red maps to an open ticket
+
+## Exit criteria
+
+- [ ] No unclassified `make check` failure remains on either machine


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0262-fix-regression-harness-paths-broken-by-0.erg
Ticket-ref: tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg

Files two tickets from the /lair step-9 full `make check` (19 failed + 4 errors on main):

- **0262** (root-caused): the 0240 scripts/ reorg broke `compute_regression_hashes.py` twice over — its `ROOT` constant now resolves to `scripts/scripts/` and all 10 REGISTRY entries hold pre-reorg flat basenames. All of `tests/test_regression.py` fails. Fix spec + red-test-first guard included.
- **0263**: triage of the remaining 9 failures + 4 errors (missing generated table, corpus language nulls at 4.1% mid-v1.1.2, golden S3/S4 mismatch of unknown polarity, C2ST CPU timeouts, fetch/bib fixture errors) — classify env vs real on padme.

Filing only; no fix in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)