### PR TITLE
tickets(roar): file 0264 — Gide variant spelling/voice diverged from 0243

### DIFF
--- a/tickets/0264-gide-conference-variant-sync-or-diverge.erg
+++ b/tickets/0264-gide-conference-variant-sync-or-diverge.erg
@@ -1,0 +1,63 @@
+%erg 0.1
+Title: Gide conference variant: sync or diverge from 0243 voice decisions
+Created: 2026-07-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-15T11:59Z HDMX-coding-agent created
+
+--- body ---
+
+## Context
+
+Ticket 0243's D1-D4 voice-alignment kickoff (PR #1016) settled and mechanized
+three of the four decisions for `deliverables/manuscript/manuscript.qmd`:
+Oxford British spelling (D2), restrained hedging register (D3), and a
+no-generation-scaffolding guard (D1's mechanical half). A roar-step-3 sweep
+for the same anti-pattern in sibling deliverables found that
+`deliverables/manuscript/manuscript-Gide.qmd` — the Charles Gide conference
+variant, forked from the same manuscript (`architecture.md`) — still carries
+34 Cambridge British (-ise/-isation) tokens against 1 Oxford token, i.e. it
+was untouched by the 0243 mechanization and is now spelling-inconsistent
+with its sibling.
+
+## Relevant files
+
+- `deliverables/manuscript/manuscript-Gide.qmd` — the conference variant
+- `deliverables/manuscript/manuscript.qmd` — now Oxford British (0243 D2)
+- `conception/0243-voice-alignment-kickoff.md` — the settled D1-D4 decisions
+  (git history on the now-merged `t0243-voice-alignment-prep` branch)
+
+## Actions
+
+1. Author decides: does the Gide variant inherit the manuscript's D1-D4 voice
+   decisions (spelling, hedging register, person), or does a conference talk
+   legitimately keep its own register, independent of the journal article's?
+2. If sync: apply the same mechanical D2 spelling conversion (and any D3/D1
+   guards judged applicable) to `manuscript-Gide.qmd`.
+3. If diverge: record the decision (one line, editorial brief or this
+   ticket's log) so a future sweep doesn't re-flag it as an oversight.
+
+## Test
+
+- No red step required — this is a decide-then-maybe-mechanically-apply
+  ticket, not new code. If Action 2 is taken, `test_no_ise_spelling_variants`
+  (or a Gide-scoped sibling test) is the regression guard, following the
+  pattern in `tests/test_manuscript_prose.py` (ticket 0243, commit
+  `manuscript(0243): D2 —  Oxford British spelling`).
+
+## Verification
+
+- [ ] Decision recorded (sync or diverge), with rationale
+- [ ] If sync: `manuscript-Gide.qmd` -ise-family token count is 0 (mirroring
+      `manuscript.qmd`'s guard)
+
+## Invariants
+
+- No factual, numerical, or citation change to either manuscript.
+- `make check-fast` / `make lint` stay green.
+
+## Exit criteria
+
+- [ ] Sync-or-diverge decision made and recorded
+- [ ] If sync: mechanical conversion applied, guarded by a test, green CI


### PR DESCRIPTION
## Summary
- roar step-3 sweep after merging PR #1016 (ticket 0243 D1-D4 mechanization) found `manuscript-Gide.qmd` untouched: 34 Cambridge British (-ise/-isation) tokens against 1 Oxford token, now spelling-inconsistent with its sibling `manuscript.qmd`.
- Files ticket 0264 for the author to decide: sync the Gide conference variant to the same voice decisions, or deliberately diverge (a conference talk may legitimately keep its own register).

Ticket-ref: tickets/0264-gide-conference-variant-sync-or-diverge.erg