### PR TITLE
tickets(0263): defer make-check slow-tier triage

### DIFF
--- a/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
+++ b/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
@@ -2,10 +2,12 @@
 Title: Triage 2026-07-11 make-check slow-tier failures on doudou
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Label: deferred
 
 --- log ---
 2026-07-11T14:36Z HDMX-coding-agent created
 
+2026-07-15T13:58Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- Add `Label: deferred` to ticket 0263 (make-check slow-tier failure triage on doudou)

## Why
Confirmed 0263 is not needed for the Œconomia resubmission: it's not
referenced by the R&R tracking tickets (0133/0152), and the flagged
golden-value metrics (S3_sliced_wasserstein, S4_frechet) belong to the
divergence zoo for the companion structural-change paper, not the
manuscript's reported cosine/Jensen–Shannon breaks. Deferring it out of
the ready queue behind the active version-ladder work.

**Ticket-ref:** tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg

## Test plan
- [x] `erg check tickets/` passes (254 tickets)