### PR TITLE
fix(0262): repoint regression harness at post-0240 script paths

### DIFF
--- a/scripts/analysis/compute_regression_hashes.py
+++ b/scripts/analysis/compute_regression_hashes.py
@@ -34,7 +34,7 @@ log = get_logger("compute_regression_hashes")
 # Paths
 # ---------------------------------------------------------------------------
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent
 FIXTURE_DIR = ROOT / "tests" / "fixtures" / "smoke"
 GOLDEN_PATH = FIXTURE_DIR / "golden_hashes.json"
 SCRIPTS_DIR = ROOT / "scripts"
@@ -50,7 +50,7 @@ REGISTRY: list[dict] = [
     # --- Wave 1: independent (no deps, run in parallel) ---
     {
         "name": "compute_breakpoints",
-        "script": "compute_breakpoints.py",
+        "script": "analysis/compute_breakpoints.py",
         "args": ["--output", "data/derived/tables/tab_breakpoints.csv"],
         "deps": [],
         "outputs": [
@@ -59,7 +59,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "compute_breakpoint_robustness",
-        "script": "compute_breakpoints.py",
+        "script": "analysis/compute_breakpoints.py",
         "args": ["--output", "data/derived/tables/tab_breakpoint_robustness.csv",
                  "--robustness"],
         "deps": [],
@@ -69,7 +69,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "compute_clusters",
-        "script": "compute_clusters.py",
+        "script": "analysis/compute_clusters.py",
         "args": ["--output", "data/derived/tables/tab_alluvial.csv"],
         "deps": [],
         "outputs": [
@@ -79,7 +79,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "plot_fig1_bars",
-        "script": "plot_fig1_bars.py",
+        "script": "figures/plot_fig1_bars.py",
         "args": ["--output", "deliverables/_shared/figures/fig_bars.png"],
         "deps": [],
         "outputs": [
@@ -88,7 +88,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "plot_fig1_bars_v1",
-        "script": "plot_fig1_bars.py",
+        "script": "figures/plot_fig1_bars.py",
         "args": [
             "--output", "deliverables/_shared/figures/fig_bars_v1.png",
             "--v1-only",
@@ -100,7 +100,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "build_het_core",
-        "script": "build_het_core.py",
+        "script": "analysis/build_het_core.py",
         "args": ["--output", "tests/fixtures/smoke/catalogs/het_mostcited_50.csv"],
         "deps": [],
         "outputs": [
@@ -113,7 +113,7 @@ REGISTRY: list[dict] = [
     # harness never touches real deliverables/.
     {
         "name": "plot_fig2_breaks",
-        "script": "plot_fig2_breaks.py",
+        "script": "figures/plot_fig2_breaks.py",
         "args": ["--output", "deliverables/_shared/figures/fig_breaks.png",
                  "--input", "data/derived/tables/tab_breakpoints.csv"],
         "deps": ["compute_breakpoints"],
@@ -123,7 +123,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "plot_fig2_composition",
-        "script": "plot_fig2_composition.py",
+        "script": "figures/plot_fig2_composition.py",
         "args": [
             "--output", "deliverables/_shared/figures/fig_composition.png",
             "--input", "data/derived/tables/tab_alluvial.csv",
@@ -135,7 +135,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "plot_fig_alluvial",
-        "script": "plot_fig_alluvial.py",
+        "script": "figures/plot_fig_alluvial.py",
         "args": ["--output", "deliverables/_shared/figures/fig_alluvial.png",
                  "--input", "data/derived/tables/tab_alluvial.csv"],
         "deps": ["compute_clusters"],
@@ -145,7 +145,7 @@ REGISTRY: list[dict] = [
     },
     {
         "name": "plot_fig_breakpoints",
-        "script": "plot_fig_breakpoints.py",
+        "script": "figures/plot_fig_breakpoints.py",
         "args": ["--output", "deliverables/_shared/figures/fig_breakpoints.png",
                  "--input", "data/derived/tables/tab_breakpoints.csv",
                  "data/derived/tables/tab_breakpoint_robustness.csv",
@@ -169,12 +169,20 @@ REGISTRY: list[dict] = [
 
 def _smoke_env() -> dict[str, str]:
     """Environment dict for deterministic smoke runs."""
+    source_roots = os.pathsep.join([
+        str(SCRIPTS_DIR),
+        str(ROOT / "libs" / "openalex-corpus" / "src"),
+    ])
     return {
         **os.environ,
         "CLIMATE_FINANCE_DATA": str(FIXTURE_DIR),
         "PYTHONHASHSEED": "0",
         "SOURCE_DATE_EPOCH": "0",
         "MPLBACKEND": "Agg",
+        "PYTHONPATH": os.pathsep.join(
+            [source_roots, os.environ["PYTHONPATH"]]
+            if os.environ.get("PYTHONPATH") else [source_roots]
+        ),
     }
 
 

--- a/scripts/figures/plot_fig2_composition.py
+++ b/scripts/figures/plot_fig2_composition.py
@@ -48,6 +48,26 @@ def _format_tfidf_line(terms_str, max_terms=9, line_width=35):
     return textwrap.fill(flat, width=line_width, max_lines=2, placeholder="…")
 
 
+def _resolve_cluster_labels(labels_arg, csv_path, has_input):
+    """Load cluster labels: --labels, then alongside --input, then default.
+
+    cluster_labels.json is written by compute_clusters.py to the same
+    --output dir as the alluvial CSV, so when --input is given (and no
+    explicit --labels) look there before falling back to the module-level
+    default location.
+    """
+    labels_path = labels_arg
+    if labels_path is None and has_input:
+        candidate = os.path.join(os.path.dirname(csv_path), "cluster_labels.json")
+        if os.path.exists(candidate):
+            labels_path = candidate
+    if labels_path:
+        import json
+        with open(labels_path) as f:
+            return {int(k): v for k, v in json.load(f).items()}
+    return load_cluster_labels()
+
+
 def main():
     io_args, extra = parse_io_args()
     validate_io(output=io_args.output)
@@ -75,12 +95,7 @@ def main():
     pct = df.div(totals, axis=0) * 100
 
     # Load TF-IDF labels for subtitles
-    if args.labels:
-        import json
-        with open(args.labels) as f:
-            raw_labels = {int(k): v for k, v in json.load(f).items()}
-    else:
-        raw_labels = load_cluster_labels()
+    raw_labels = _resolve_cluster_labels(args.labels, csv_path, bool(io_args.input))
 
     # Order clusters: declining first (top-left), growing last (bottom-right)
     share_change = pct.iloc[-1] - pct.iloc[0]

--- a/scripts/figures/plot_fig_alluvial.py
+++ b/scripts/figures/plot_fig_alluvial.py
@@ -187,17 +187,21 @@ def main():
         label_file = "cluster_labels.json"
 
     # --- Load tables ---
-    # --input takes precedence over default path for the alluvial CSV
+    # --input takes precedence over default path for the alluvial CSV; the
+    # cluster labels file lives alongside it (both written by compute_clusters
+    # to the same --output directory), so derive its path the same way.
     if io_args.input:
         alluvial_data = pd.read_csv(io_args.input[0], index_col=0)
+        labels_dir = os.path.dirname(io_args.input[0])
     else:
         alluvial_data = pd.read_csv(os.path.join(DERIVED_TABLES_DIR, tab_al), index_col=0)
+        labels_dir = DERIVED_TABLES_DIR
     alluvial_data.columns = alluvial_data.columns.astype(int)
     period_labels = alluvial_data.index.tolist()
     n_periods = len(period_labels)
     n_clusters = len(alluvial_data.columns)
 
-    with open(os.path.join(DERIVED_TABLES_DIR, label_file)) as f:
+    with open(os.path.join(labels_dir, label_file)) as f:
         cluster_labels_raw = json.load(f)
     cluster_labels = {int(k): v for k, v in cluster_labels_raw.items()}
 

--- a/tests/fixtures/smoke/golden_hashes.json
+++ b/tests/fixtures/smoke/golden_hashes.json
@@ -22,10 +22,10 @@
     "deliverables/_shared/figures/fig_breaks.png": "029a3856aa189131690be860e7f749f997109165b60d8e6266c8ea8b34ecfbd6"
   },
   "plot_fig2_composition": {
-    "deliverables/_shared/figures/fig_composition.png": "53c0c8aebd8d6cca5199bf3424469eb4f68e1b6b90b1fcc7cac3f76cab6879b4"
+    "deliverables/_shared/figures/fig_composition.png": "832900f2e4b4b8b6dc0f9c77dd53780fc9826fd82b57c0b01f9d8a9afcccef2c"
   },
   "plot_fig_alluvial": {
-    "deliverables/_shared/figures/fig_alluvial.png": "368bc3e7aaff8d5dc3d876608a1e313ef8e0f3c8447f494742b69edac336817f"
+    "deliverables/_shared/figures/fig_alluvial.png": "4e29b7aa82d220df0769c0a7c15e178e52d7425a1a17dde703d468e8059b3190"
   },
   "plot_fig_breakpoints": {
     "deliverables/_shared/figures/fig_breakpoints.png": "1883b4db7f5a77b058bc6ccef7a81a13889796ccaa06006b3fe945e3ee26608e"

--- a/tests/fixtures/smoke/golden_hashes.json
+++ b/tests/fixtures/smoke/golden_hashes.json
@@ -22,7 +22,7 @@
     "deliverables/_shared/figures/fig_breaks.png": "029a3856aa189131690be860e7f749f997109165b60d8e6266c8ea8b34ecfbd6"
   },
   "plot_fig2_composition": {
-    "deliverables/_shared/figures/fig_composition.png": "832900f2e4b4b8b6dc0f9c77dd53780fc9826fd82b57c0b01f9d8a9afcccef2c"
+    "deliverables/_shared/figures/fig_composition.png": "8784ff61f2a529763bad6c22e210522084a1af65f6977077e0131b45db2bd58f"
   },
   "plot_fig_alluvial": {
     "deliverables/_shared/figures/fig_alluvial.png": "4e29b7aa82d220df0769c0a7c15e178e52d7425a1a17dde703d468e8059b3190"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -160,6 +160,21 @@ class TestRegressionInfra:
             "remove it along with _stage_intermediates"
         )
 
+    def test_registry_script_paths_exist(self):
+        """Every REGISTRY script must resolve on disk under SCRIPTS_DIR.
+
+        Guards against silent registry-path rot when scripts/ is reorganized
+        (ticket 0262: the 0240 scripts/ reorg moved every registered script
+        into a subdirectory, but REGISTRY kept flat pre-reorg basenames)."""
+        from compute_regression_hashes import SCRIPTS_DIR
+        missing = [
+            entry["name"] for entry in REGISTRY
+            if not (SCRIPTS_DIR / entry["script"]).exists()
+        ]
+        assert not missing, (
+            f"REGISTRY scripts not found under {SCRIPTS_DIR}: {missing}"
+        )
+
     def test_wave2_registry_entries_have_input_args(self):
         """Wave 2 scripts (with deps) must pass --input in their REGISTRY args,
         so the harness can point them at the tmp directory directly."""

--- a/tickets/closed/0262-fix-regression-harness-paths-broken-by-0.erg
+++ b/tickets/closed/0262-fix-regression-harness-paths-broken-by-0.erg
@@ -62,12 +62,15 @@ tier) and to per-move greps during 0240 (the registry stores basenames, not
 - Golden hashes unchanged for 8/10 scripts. **Deviation**: 2 entries
   (`plot_fig_alluvial`, `plot_fig2_composition`) were regenerated. Root cause:
   fixing the SCRIPTS_DIR/REGISTRY path bug uncovered a second, independent
-  pre-existing defect — `plot_fig_alluvial.py` read `cluster_labels.json` from
-  a hardcoded `DERIVED_TABLES_DIR` instead of alongside its `--input` CSV
-  (both written to the same `--output` dir by `compute_clusters.py`), so it
-  crashed (`FileNotFoundError`) whenever Wave 2 actually ran under the smoke
-  harness — verified by isolating the fix and confirming the crash reproduces
-  on the pre-existing code once paths are otherwise correct. Wave 2 has never
+  pre-existing defect — both `plot_fig_alluvial.py` and
+  `plot_fig2_composition.py` resolved `cluster_labels.json` from a hardcoded
+  `DERIVED_TABLES_DIR` instead of alongside their `--input` CSV (both written
+  to the same `--output` dir by `compute_clusters.py`). The former crashed
+  (`FileNotFoundError`) whenever Wave 2 actually ran under the smoke harness;
+  the latter silently fell back to placeholder `"Cluster N"` labels via
+  `load_cluster_labels()`'s warn-and-fallback path — caught in `/review-pr`'s
+  red-team pass, independently reproduced, and fixed the same way (derive the
+  labels path from `--input`'s directory when given). Wave 2 has never
   successfully completed in this harness before (masked entirely by the
   SCRIPTS_DIR bug this ticket fixes), so the 2 stale goldens were never
   validated against real deterministic output; regenerating them via

--- a/tickets/closed/0262-fix-regression-harness-paths-broken-by-0.erg
+++ b/tickets/closed/0262-fix-regression-harness-paths-broken-by-0.erg
@@ -2,9 +2,11 @@
 Title: Fix regression harness paths broken by 0240 scripts reorg
 Created: 2026-07-11
 Author: HDMX-coding-agent
+Closed: 10/10 test_regression tests pass; guard test added; make check-fast + make lint green
 
 --- log ---
 2026-07-11T14:36Z HDMX-coding-agent created
+2026-07-15T16:10Z HDMX-coding-agent closed — 10/10 test_regression tests pass; guard test added; make check-fast + make lint green
 
 --- body ---
 ## Context
@@ -50,15 +52,34 @@ tier) and to per-move greps during 0240 (the registry stores basenames, not
 
 ## Verification
 
-- [ ] Guard test red before fix, green after
-- [ ] `uv run pytest tests/test_regression.py` 10/10 pass
-- [ ] `make check-fast` and `make lint` stay green
+- [x] Guard test red before fix, green after (`test_registry_script_paths_exist`,
+      `tests/test_regression.py`)
+- [x] `uv run pytest tests/test_regression.py` 10/10 pass (23/23 including infra tests)
+- [x] `make check-fast` and `make lint` stay green
 
 ## Invariants
 
-- Golden hashes unchanged — this is a launcher fix, not a behaviour change.
+- Golden hashes unchanged for 8/10 scripts. **Deviation**: 2 entries
+  (`plot_fig_alluvial`, `plot_fig2_composition`) were regenerated. Root cause:
+  fixing the SCRIPTS_DIR/REGISTRY path bug uncovered a second, independent
+  pre-existing defect — `plot_fig_alluvial.py` read `cluster_labels.json` from
+  a hardcoded `DERIVED_TABLES_DIR` instead of alongside its `--input` CSV
+  (both written to the same `--output` dir by `compute_clusters.py`), so it
+  crashed (`FileNotFoundError`) whenever Wave 2 actually ran under the smoke
+  harness — verified by isolating the fix and confirming the crash reproduces
+  on the pre-existing code once paths are otherwise correct. Wave 2 has never
+  successfully completed in this harness before (masked entirely by the
+  SCRIPTS_DIR bug this ticket fixes), so the 2 stale goldens were never
+  validated against real deterministic output; regenerating them via
+  `--update-golden` reflects the harness actually working for the first time,
+  not an intentional analysis change. Diff confirmed scoped to exactly these
+  2 hash entries in `tests/fixtures/smoke/golden_hashes.json`.
+- Also fixed: `_smoke_env()` didn't put `scripts` + `libs/openalex-corpus/src`
+  on `PYTHONPATH` for the subprocess — previously masked because each script's
+  own directory (`scripts/`) coincided with the `script_io_args` import root;
+  the 0240 reorg moved scripts into subdirectories, breaking that coincidence.
 
 ## Exit criteria
 
-- [ ] All 10 test_regression tests pass on main
-- [ ] Fast-tier guard prevents silent registry-path rot on future moves
+- [x] All 10 test_regression tests pass on main
+- [x] Fast-tier guard prevents silent registry-path rot on future moves


### PR DESCRIPTION
## Summary

- Fixes `ROOT`/`SCRIPTS_DIR` in `compute_regression_hashes.py` (was resolving one directory too deep after the script itself moved into `scripts/analysis/`) and repoints all 10 `REGISTRY` script paths to their post-0240 `scripts/analysis/`/`scripts/figures/` subdirectories.
- Fixes `_smoke_env()` to put `scripts/` + `libs/openalex-corpus/src` on `PYTHONPATH` for the subprocess — the reorg broke a previously-implicit coincidence where a script's own directory doubled as the `script_io_args` import root.
- Fixes `plot_fig_alluvial.py` and `plot_fig2_composition.py` to read `cluster_labels.json` alongside their `--input` CSV instead of a hardcoded `DERIVED_TABLES_DIR` — the former crashed as soon as Wave 2 could actually run (which it never had before, in this harness); the latter silently fell back to placeholder labels (caught in `/review-pr`'s red-team pass).
- Regenerates golden hashes for exactly the 2 scripts (`plot_fig_alluvial`, `plot_fig2_composition`) whose Wave 2 run had never previously completed — see the ticket's Invariants section for the full justification. The other 8 goldens are byte-identical.
- Adds `test_registry_script_paths_exist` as a fast-tier guard against future registry/script-path drift.

## Test plan

- [x] New guard test (`test_registry_script_paths_exist`) red before the fix, green after
- [x] `uv run pytest tests/test_regression.py` — 23/23 pass (10 regression + 13 infra/redirect)
- [x] `make check-fast` — 946 passed, 10 skipped
- [x] `make lint` — 169 passed, 5 skipped
- [x] `/verify-adherence` — PASS (one non-blocking nit noted in the review, not gating)

Ticket: none — 0262 was closed on-branch (see `tickets/closed/0262-...erg`'s Closed: header and log entry in this PR's diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)