### PR TITLE
fix(0265): plot_ncc_alluvial reads cluster_labels.json alongside --input

### DIFF
--- a/scripts/analysis/compute_regression_hashes.py
+++ b/scripts/analysis/compute_regression_hashes.py
@@ -144,6 +144,19 @@ REGISTRY: list[dict] = [
         ],
     },
     {
+        # NCC-format alluvial variant. Registered so the cluster_labels.json
+        # path bug (ticket 0265 — read from --input dir, not DERIVED_TABLES_DIR)
+        # stays caught by the harness, like its plot_fig_alluvial sibling.
+        "name": "plot_ncc_alluvial",
+        "script": "figures/plot_ncc_alluvial.py",
+        "args": ["--output", "deliverables/_shared/figures/fig_ncc_alluvial.png",
+                 "--input", "data/derived/tables/tab_alluvial.csv"],
+        "deps": ["compute_clusters"],
+        "outputs": [
+            "deliverables/_shared/figures/fig_ncc_alluvial.png",
+        ],
+    },
+    {
         "name": "plot_fig_breakpoints",
         "script": "figures/plot_fig_breakpoints.py",
         "args": ["--output", "deliverables/_shared/figures/fig_breakpoints.png",

--- a/scripts/figures/plot_ncc_alluvial.py
+++ b/scripts/figures/plot_ncc_alluvial.py
@@ -216,18 +216,23 @@ def main():
     _apply_ncc_style()
 
     # --- Load data ---
+    # --input takes precedence for the alluvial CSV; cluster_labels.json is
+    # written by compute_clusters to the same directory, so derive its path the
+    # same way rather than hardcoding DERIVED_TABLES_DIR (ticket 0265).
     if io_args.input:
         alluvial_data = pd.read_csv(io_args.input[0], index_col=0)
+        labels_dir = os.path.dirname(io_args.input[0])
     else:
         alluvial_data = pd.read_csv(
             os.path.join(DERIVED_TABLES_DIR, "tab_alluvial.csv"), index_col=0,
         )
+        labels_dir = DERIVED_TABLES_DIR
     alluvial_data.columns = alluvial_data.columns.astype(int)
     period_labels = alluvial_data.index.tolist()
     n_periods = len(period_labels)
     n_clusters = len(alluvial_data.columns)
 
-    with open(os.path.join(DERIVED_TABLES_DIR, "cluster_labels.json")) as f:
+    with open(os.path.join(labels_dir, "cluster_labels.json")) as f:
         cluster_labels_raw = json.load(f)
     cluster_labels = {int(k): v for k, v in cluster_labels_raw.items()}
 

--- a/tests/fixtures/smoke/golden_hashes.json
+++ b/tests/fixtures/smoke/golden_hashes.json
@@ -29,5 +29,8 @@
   },
   "plot_fig_breakpoints": {
     "deliverables/_shared/figures/fig_breakpoints.png": "1883b4db7f5a77b058bc6ccef7a81a13889796ccaa06006b3fe945e3ee26608e"
+  },
+  "plot_ncc_alluvial": {
+    "deliverables/_shared/figures/fig_ncc_alluvial.png": "e334214390a7bebd2f140c6f2e9f5523db1c53588bcdaed5ed10d958e5da9696"
   }
 }

--- a/tests/test_ncc_alluvial_labels_path.py
+++ b/tests/test_ncc_alluvial_labels_path.py
@@ -1,0 +1,70 @@
+"""plot_ncc_alluvial.py must read cluster_labels.json alongside --input.
+
+Regression pin for ticket 0265: the script gated its primary tab_alluvial.csv
+read on --input but read the secondary cluster_labels.json unconditionally from
+the module-level DERIVED_TABLES_DIR constant. When --input redirects the data
+elsewhere (test harness, companion-paper variant), the labels file was looked
+up in the wrong place. This is the same bug shape fixed for plot_fig_alluvial.py
+and plot_fig2_composition.py in ticket 0262 (PR #1049).
+
+The test points --input at a tmp directory holding both files and points
+CLIMATE_FINANCE_DATA (hence DERIVED_TABLES_DIR) at an EMPTY tree. Buggy code
+falls back to DERIVED_TABLES_DIR, fails to find cluster_labels.json, and exits
+non-zero. Fixed code derives the labels dir from the --input path and succeeds.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from _source_roots import source_root_env
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+SCRIPT = os.path.join(SCRIPTS_DIR, "figures", "plot_ncc_alluvial.py")
+
+# Minimal valid alluvial table: period (index) x cluster columns 0..3, counts.
+_ALLUVIAL_CSV = (
+    "period,0,1,2,3\n"
+    "1990-2006,10,5,3,2\n"
+    "2007-2014,4,12,6,8\n"
+    "2015-2025,2,7,15,9\n"
+)
+_CLUSTER_LABELS = {"0": "Finance", "1": "Policy", "2": "Adaptation", "3": "Markets"}
+
+
+@pytest.mark.integration
+def test_cluster_labels_read_from_input_dir(tmp_path):
+    """--input redirects both tab_alluvial.csv and cluster_labels.json reads."""
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    (input_dir / "tab_alluvial.csv").write_text(_ALLUVIAL_CSV)
+    (input_dir / "cluster_labels.json").write_text(json.dumps(_CLUSTER_LABELS))
+
+    # DERIVED_TABLES_DIR resolves under CLIMATE_FINANCE_DATA/derived/tables.
+    # Point it at an EMPTY tree: a buggy fallback there cannot find the labels.
+    empty_data = tmp_path / "empty_data"
+    (empty_data / "derived" / "tables").mkdir(parents=True)
+
+    output = tmp_path / "fig_ncc_alluvial.png"
+    env = source_root_env({
+        **os.environ,
+        "CLIMATE_FINANCE_DATA": str(empty_data),
+        "MPLBACKEND": "Agg",
+        "SOURCE_DATE_EPOCH": "0",
+    })
+    result = subprocess.run(
+        [
+            sys.executable, SCRIPT,
+            "--output", str(output),
+            "--input", str(input_dir / "tab_alluvial.csv"),
+        ],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        "plot_ncc_alluvial.py failed with --input redirected away from "
+        f"DERIVED_TABLES_DIR (labels not read alongside --input?):\n{result.stderr}"
+    )
+    assert output.exists(), "expected output figure was not written"

--- a/tickets/closed/0265-plot-ncc-alluvial-hardcoded-cluster-labels.erg
+++ b/tickets/closed/0265-plot-ncc-alluvial-hardcoded-cluster-labels.erg
@@ -2,10 +2,12 @@
 Title: plot_ncc_alluvial.py reads cluster_labels.json from hardcoded DERIVED_TABLES_DIR, ignoring --input
 Created: 2026-07-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1063
 
 --- log ---
 2026-07-15T16:40Z HDMX-coding-agent created
 
+2026-07-17T13:53Z HDMX-coding-agent closed — autoclosed — PR #1063
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`scripts/figures/plot_ncc_alluvial.py` gated its primary `tab_alluvial.csv` read
on `--input` but read the secondary `cluster_labels.json` unconditionally from
the module-level `DERIVED_TABLES_DIR` constant. When `--input` redirects the data
elsewhere (test harness, companion-paper variant), the labels file was looked up
in the wrong place. This is the third instance of the bug shape fixed for
`plot_fig_alluvial.py` and `plot_fig2_composition.py` in ticket 0262 (PR #1049);
the `roar` sweep after that PR found this un-fixed sibling.

## Changes

1. **Fix** (`plot_ncc_alluvial.py`): when `--input` is given, derive
   `labels_dir = os.path.dirname(io_args.input[0])`; otherwise fall back to
   `DERIVED_TABLES_DIR`. Identical pattern to the `plot_fig_alluvial.py`
   reference fix. The default (no `--input`) path is unchanged, so the real
   `make` build (`--input data/derived/tables/tab_alluvial.csv`) behaves exactly
   as before. `tab_core_shares.csv` stays hardcoded + `os.path.exists`-guarded,
   matching the reference (intentional, out of scope).

2. **Standalone regression test** (`tests/test_ncc_alluvial_labels_path.py`,
   `@pytest.mark.integration`): runs the script with `--input` at a tmp dir
   holding both files and `CLIMATE_FINANCE_DATA` pointed at an empty tree, so a
   buggy fallback to `DERIVED_TABLES_DIR` crashes. Confirmed red on the buggy
   code (`FileNotFoundError` at the labels read), green after the fix.

3. **Regression harness** (`compute_regression_hashes.py` REGISTRY + golden):
   registered `plot_ncc_alluvial` (Wave 2, deps `compute_clusters`, `--input`
   redirected) so this bug class stays caught by the harness like its two
   siblings — closing the gap the ticket names (this script was invisible to the
   regression suite). Golden regenerated surgically: only the new
   `fig_ncc_alluvial.png` hash was added; existing baselines verified unchanged
   (`--check` green before and after) and deterministic across two same-machine
   runs.

## TDD

Red (test) → green (fix) → refactor (REGISTRY), one commit each.

## Verification

- `ruff check` clean on all changed files.
- New standalone test + `test_regression_plot_ncc_alluvial` + infra guards pass.
- `make check-fast` / `make lint`: the only failures are **pre-existing,
  causally disjoint** manuscript-workpackage reds — `test_cited_works_available`
  (`michalopoulos2017` unallowlisted, added in `0d096444`) and 7
  `test_manuscript_prose` content assertions. My diff touches none of
  `deliverables/`, `config/`, or the prose tests; all are present on
  `origin/main` independent of this branch.

**Ticket:** tickets/0265-plot-ncc-alluvial-hardcoded-cluster-labels.erg