### PR TITLE
chore: file follow-up tickets 0272/0273 from raid 265 /gaze sweep

### DIFF
--- a/tickets/0272-extract-shared-derive-companion-path-hel.erg
+++ b/tickets/0272-extract-shared-derive-companion-path-hel.erg
@@ -14,7 +14,8 @@ so that a secondary file read (`cluster_labels.json`) is derived relative to
 `--input` rather than hardcoded to `DERIVED_TABLES_DIR`. Ticket 0265 (PR #1063)
 applied the identical fix to `plot_ncc_alluvial.py`. The `/gaze` review on
 PR #1063 (two independent cleanup agents — reuse and altitude — converged on
-this) flagged that the pattern is now a verbatim triplicate:
+this) flagged that the pattern is now a verbatim duplicate between two of the
+three fixed call sites:
 
 ```python
 if io_args.input:
@@ -23,15 +24,25 @@ else:
     labels_dir = DERIVED_TABLES_DIR
 ```
 
-repeated across `scripts/figures/plot_fig_alluvial.py`,
-`scripts/figures/plot_fig2_composition.py`, and
-`scripts/figures/plot_ncc_alluvial.py`.
+repeated verbatim in `scripts/figures/plot_fig_alluvial.py` and
+`scripts/figures/plot_ncc_alluvial.py`. `scripts/figures/plot_fig2_composition.py`
+is the third fixed call site but is differently shaped: it resolves labels via
+its own `_resolve_cluster_labels(labels_arg, csv_path, has_input)` helper (a
+three-way `--labels` / `--input`-relative / fixed-default chain that falls
+through to `load_cluster_labels()` — the ticket-0273 target function — as its
+final default), not the two-way `if/else` above. **This ticket's scope is the
+two verbatim call sites; `plot_fig2_composition.py`'s `_resolve_cluster_labels`
+is out of scope for the shared-helper extraction** (its resolution order and
+`--labels` override are not one-line-reducible to `derive_companion_path()`
+without changing behavior) — note it here only as adjacent context, not a
+third extraction target. (Corrected 2026-07-17, `/gaze` PR #1064 review: the
+original "verbatim triplicate" framing was inaccurate for this file.)
 
 ## Relevant files
 
 - `scripts/figures/plot_fig_alluvial.py`
-- `scripts/figures/plot_fig2_composition.py`
 - `scripts/figures/plot_ncc_alluvial.py`
+- `scripts/figures/plot_fig2_composition.py` — adjacent, out of scope (see Context)
 - `scripts/script_io_args.py` (or `scripts/utils.py`) — natural home for a
   shared helper
 
@@ -39,27 +50,28 @@ repeated across `scripts/figures/plot_fig_alluvial.py`,
 
 1. Add a `derive_companion_path(io_args, default_dir)` (or similar) helper to
    the shared I/O module.
-2. Replace the three verbatim copies with calls to the helper.
+2. Replace the two verbatim copies (`plot_fig_alluvial.py`,
+   `plot_ncc_alluvial.py`) with calls to the helper.
 3. No behavior change — same fallback semantics in every call site.
 
 ## Test
 
-- Existing tests for the three call sites (including
+- Existing tests for the two call sites (including
   `tests/test_ncc_alluvial_labels_path.py` from ticket 0265) must continue to
   pass unchanged — this is a pure refactor.
 - Add a small unit test for the helper itself.
 
 ## Verification
 
-- [ ] Helper extracted and used by all three call sites
+- [ ] Helper extracted and used by both call sites
 - [ ] `make check-fast` and `make lint` stay green
 
 ## Invariants
 
-- Pure refactor — no output-path or fallback-behavior change for any of the
-  three scripts.
+- Pure refactor — no output-path or fallback-behavior change for either
+  script.
 
 ## Exit criteria
 
-- [ ] One shared helper, three call sites reduced to a one-line call each
-- [ ] All pre-existing tests for the three scripts still pass
+- [ ] One shared helper, two call sites reduced to a one-line call each
+- [ ] All pre-existing tests for the two scripts still pass

--- a/tickets/0272-extract-shared-derive-companion-path-hel.erg
+++ b/tickets/0272-extract-shared-derive-companion-path-hel.erg
@@ -1,0 +1,65 @@
+%erg 0.1
+Title: Extract shared derive_companion_path() helper for --input-relative secondary-file reads
+Created: 2026-07-17
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-17T14:01Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Ticket 0262 (PR #1049) fixed `plot_fig_alluvial.py` and `plot_fig2_composition.py`
+so that a secondary file read (`cluster_labels.json`) is derived relative to
+`--input` rather than hardcoded to `DERIVED_TABLES_DIR`. Ticket 0265 (PR #1063)
+applied the identical fix to `plot_ncc_alluvial.py`. The `/gaze` review on
+PR #1063 (two independent cleanup agents — reuse and altitude — converged on
+this) flagged that the pattern is now a verbatim triplicate:
+
+```python
+if io_args.input:
+    labels_dir = os.path.dirname(io_args.input[0])
+else:
+    labels_dir = DERIVED_TABLES_DIR
+```
+
+repeated across `scripts/figures/plot_fig_alluvial.py`,
+`scripts/figures/plot_fig2_composition.py`, and
+`scripts/figures/plot_ncc_alluvial.py`.
+
+## Relevant files
+
+- `scripts/figures/plot_fig_alluvial.py`
+- `scripts/figures/plot_fig2_composition.py`
+- `scripts/figures/plot_ncc_alluvial.py`
+- `scripts/script_io_args.py` (or `scripts/utils.py`) — natural home for a
+  shared helper
+
+## Actions
+
+1. Add a `derive_companion_path(io_args, default_dir)` (or similar) helper to
+   the shared I/O module.
+2. Replace the three verbatim copies with calls to the helper.
+3. No behavior change — same fallback semantics in every call site.
+
+## Test
+
+- Existing tests for the three call sites (including
+  `tests/test_ncc_alluvial_labels_path.py` from ticket 0265) must continue to
+  pass unchanged — this is a pure refactor.
+- Add a small unit test for the helper itself.
+
+## Verification
+
+- [ ] Helper extracted and used by all three call sites
+- [ ] `make check-fast` and `make lint` stay green
+
+## Invariants
+
+- Pure refactor — no output-path or fallback-behavior change for any of the
+  three scripts.
+
+## Exit criteria
+
+- [ ] One shared helper, three call sites reduced to a one-line call each
+- [ ] All pre-existing tests for the three scripts still pass

--- a/tickets/0273-load-cluster-labels-ignores-input-reads.erg
+++ b/tickets/0273-load-cluster-labels-ignores-input-reads.erg
@@ -1,0 +1,68 @@
+%erg 0.1
+Title: load_cluster_labels() ignores --input, reads cluster_labels.json from fixed path
+Created: 2026-07-17
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-17T14:02Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Ticket 0262 (PR #1049) and ticket 0265 (PR #1063) fixed the same bug shape
+(secondary file `cluster_labels.json` hardcoded to `DERIVED_TABLES_DIR`,
+ignoring `--input`) in three inline call sites: `plot_fig_alluvial.py`,
+`plot_fig2_composition.py`, `plot_ncc_alluvial.py`. The `/gaze` altitude
+review on PR #1063 flagged a fourth, structurally different instance:
+`load_cluster_labels()` in `scripts/pipeline_loaders.py:230` reads from a
+fixed module-level `_CLUSTER_LABELS_PATH` constant unconditionally — no
+`io_args`/`--input` parameter at all — and is called by
+`scripts/figures/plot_heatmap_communities_clusters.py`.
+
+Unlike the three fixed instances, this one does not raise on a miss: it
+`warnings.warn`s and silently falls back to generic `"Cluster N"` labels.
+That makes it a worse instance of the bug class in one sense (wrong output
+with no error, not a crash) even though it is invisible to a naive
+"does it raise" test.
+
+## Relevant files
+
+- `scripts/pipeline_loaders.py` — `load_cluster_labels()`, ~line 230
+- `scripts/figures/plot_heatmap_communities_clusters.py` — sole call site,
+  ~line 255 (`cluster_short = load_cluster_labels()`)
+- `scripts/figures/plot_ncc_alluvial.py` — reference fix pattern (ticket 0265)
+
+## Actions
+
+1. Give `load_cluster_labels()` an optional path/labels-dir parameter so
+   callers with a redirected `--input` can pass the companion directory,
+   mirroring the `labels_dir` pattern from ticket 0265.
+2. Update `plot_heatmap_communities_clusters.py` to pass its `--input`-derived
+   directory through.
+3. Consider whether the silent generic-label fallback should stay a warning
+   or become a hard error when `--input` is explicitly given (a test harness
+   redirecting `--input` almost certainly expects the labels to be found,
+   not silently swapped for placeholders).
+
+## Test
+
+- A test that calls `load_cluster_labels()` (or runs
+  `plot_heatmap_communities_clusters.py`) with `--input` pointing at a tmp
+  directory containing `cluster_labels.json`, asserting the real labels are
+  used, not the generic `"Cluster N"` fallback.
+
+## Verification
+
+- [ ] Fix applied and confirmed against a redirected `--input` directory
+- [ ] `make check-fast` and `make lint` stay green
+
+## Invariants
+
+- No behavior change for the default (no `--input`) invocation path.
+
+## Exit criteria
+
+- [ ] `load_cluster_labels()` (or its caller) resolves `cluster_labels.json`
+      relative to `--input` when given
+- [ ] Regression coverage exists so this bug class cannot silently reappear
+      here


### PR DESCRIPTION
## Summary
- Ticket 0265 (PR #1063) fixed `plot_ncc_alluvial.py`'s hardcoded `DERIVED_TABLES_DIR` read for `cluster_labels.json`, mirroring the fix already applied to `plot_fig_alluvial.py`/`plot_fig2_composition.py` in ticket 0262.
- `/gaze`'s simplify pass on PR #1063 converged on two related instances of the same bug class outside that PR's scope, filed here as atomic follow-ups:
  - **0272** — extract a shared `derive_companion_path()` helper (now a third verbatim duplicate across three scripts).
  - **0273** — `load_cluster_labels()` in `pipeline_loaders.py` has the same `--input`-ignoring bug via a shared loader (used by `plot_heatmap_communities_clusters.py`), with a worse failure mode: silent fallback to generic labels instead of a crash.

This PR only adds the two ticket files — no code changes.

## Test plan
- [x] `erg validate` passes on both new tickets
- [x] `erg check tickets/` passes (260 tickets)

Ticket-ref: tickets/0272
Ticket-ref: tickets/0273

🤖 Generated with [Claude Code](https://claude.com/claude-code)