### PR TITLE
chore(0153): close — resubmission deposited (Zenodo, HAL, tag, platform)

### DIFF
--- a/tickets/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/0156-v2-0-5-implementation-version-tracker.erg
@@ -2,7 +2,6 @@
 Title: v2.0.5 implementation — version tracker
 Created: 2026-06-18
 Author: HDMX-coding-agent
-Blocked-by: 0153
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
@@ -24,6 +23,7 @@ Blocked-by: 0153
 2026-07-09T13:01Z HDMX-coding-agent note blocker 0134 closed — Blocked-by removed.
 2026-07-09T13:01Z HDMX-coding-agent note blocker 0162 closed — Blocked-by removed.
 2026-07-20T13:31Z HDMX-coding-agent note blocker 0152 closed — Blocked-by removed.
+2026-07-21T15:23Z HDMX-coding-agent note blocker 0153 closed — Blocked-by removed.
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →

--- a/tickets/closed/0153-resubmission-rebuild-verify-version-bump.erg
+++ b/tickets/closed/0153-resubmission-rebuild-verify-version-bump.erg
@@ -2,6 +2,7 @@
 Title: resubmission rebuild verify version-bump and Zenodo HAL deposit
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: all actions done 2026-07-21: re-anon confirmed, make check green, Zenodo new version 10.5281/zenodo.21476165, HAL hal-05558422v2 SWORD-accepted (moderation pending), tag v1.1-oeconomia-revised pushed, author resubmitted on the Oeconomia platform
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
@@ -11,6 +12,7 @@ Author: HDMX-coding-agent
 2026-07-08T09:00Z HDMX-coding-agent note Blocked-by 0152 + 0162 restored: removing 0155 left the final step unblocked, visible as ready to autonomous sweeps. 0162 transitively carries 0134→0171→0172; 0152 must accompany the deposit.
 2026-07-09T13:01Z HDMX-coding-agent note blocker 0162 closed — Blocked-by removed.
 2026-07-20T13:31Z HDMX-coding-agent note blocker 0152 closed — Blocked-by removed.
+2026-07-21T15:23Z HDMX-coding-agent closed — all actions done 2026-07-21: re-anon confirmed, make check green, Zenodo new version 10.5281/zenodo.21476165, HAL hal-05558422v2 SWORD-accepted (moderation pending), tag v1.1-oeconomia-revised pushed, author resubmitted on the Oeconomia platform
 --- body ---
 ## Context
 v2.0.5 final step. Package and deposit the revised manuscript.


### PR DESCRIPTION
Ticket: none

(0153 was closed and archived on this branch — the close commit rides the PR; nothing for the merge hook to close.)

Close-out of the v2.0.5 final step. All actions complete: re-anonymization (long since), make check green on merged main, Zenodo new version 10.5281/zenodo.21476165, HAL hal-05558422v2 accepted via SWORD (moderation pending), submission branch tagged v1.1-oeconomia-revised, platform resubmission done by the author on 2026-07-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)