### PR TITLE
chore: close R&R trackers 0133/0156 — v2.0.5 resubmitted

### DIFF
--- a/deliverables/corpus-report/corpus-report.qmd
+++ b/deliverables/corpus-report/corpus-report.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Corpus Construction and Data Quality"
-subtitle: "Companion to 'Inventing Climate Finance' (submitted to *Oeconomia*)"
+subtitle: "Companion to 'Climate Finance: Birth of an Economic Aggregate' (revised and resubmitted to *Oeconomia*)"
 author: "Minh Ha-Duong"
 date: "2026-04-14"
 metadata-files: [../_shared/technical-report-vars.yml]

--- a/tickets/closed/0133-oeconomia-r-r-resubmission-tracking-tick.erg
+++ b/tickets/closed/0133-oeconomia-r-r-resubmission-tracking-tick.erg
@@ -2,7 +2,7 @@
 Title: Oeconomia R&R — resubmission tracking ticket
 Created: 2026-06-18
 Author: HDMX-coding-agent
-Blocked-by: 0156
+Closed: resubmission delivered 2026-07-21: 61/61 remarks author-signed in the 0152 ledger, letter + anonymous manuscript uploaded via the Revisions form, deposits Zenodo 10.5281/zenodo.21476165 + HAL hal-05558422v2 online, tag v1.1-oeconomia-revised; v-trackers 0154/0156 closed
 
 --- log ---
 2026-06-18T06:33Z HDMX-coding-agent created
@@ -12,6 +12,8 @@ Blocked-by: 0156
 
 2026-06-23T09:09Z HDMX-coding-agent note blocker 0154 closed — Blocked-by removed.
 2026-06-24T17:44Z HDMX-coding-agent note blocker 0155 closed — Blocked-by removed.
+2026-07-22T08:07Z HDMX-coding-agent note blocker 0156 closed — Blocked-by removed.
+2026-07-22T08:07Z HDMX-coding-agent closed — resubmission delivered 2026-07-21: 61/61 remarks author-signed in the 0152 ledger, letter + anonymous manuscript uploaded via the Revisions form, deposits Zenodo 10.5281/zenodo.21476165 + HAL hal-05558422v2 online, tag v1.1-oeconomia-revised; v-trackers 0154/0156 closed
 --- body ---
 ## Context
 Œconomia (Delcey, managing ed.) returned the manuscript "History of climate

--- a/tickets/closed/0156-v2-0-5-implementation-version-tracker.erg
+++ b/tickets/closed/0156-v2-0-5-implementation-version-tracker.erg
@@ -2,6 +2,7 @@
 Title: v2.0.5 implementation — version tracker
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: integration review done 2026-07-22: all children closed (0134-0143, 0152, 0153, 0162, 0171, 0172), resubmitted to Oeconomia 2026-07-21, make check green on merged main, nine-member panel + gaze APPROVED on the final PR, union sweep fixed the corpus-report companion subtitle
 
 --- log ---
 2026-06-18T08:50Z HDMX-coding-agent created
@@ -24,6 +25,7 @@ Author: HDMX-coding-agent
 2026-07-09T13:01Z HDMX-coding-agent note blocker 0162 closed — Blocked-by removed.
 2026-07-20T13:31Z HDMX-coding-agent note blocker 0152 closed — Blocked-by removed.
 2026-07-21T15:23Z HDMX-coding-agent note blocker 0153 closed — Blocked-by removed.
+2026-07-22T08:07Z HDMX-coding-agent closed — integration review done 2026-07-22: all children closed (0134-0143, 0152, 0153, 0162, 0171, 0172), resubmitted to Oeconomia 2026-07-21, make check green on merged main, nine-member panel + gaze APPROVED on the final PR, union sweep fixed the corpus-report companion subtitle
 --- body ---
 ## Context
 Version-milestone tracker for **v2.0.5 — implementation** (research → writing →


### PR DESCRIPTION
Ticket: none

(0156 and 0133 closed and archived on this branch; close commits ride the PR.)

Integration review (roar step 8, all children closed):
- Children of 0156 all closed: 0134–0143, 0152 (61/61 rows author-signed), 0153 (deposits + platform), 0162, 0171, 0172.
- Full suite: make check green on merged main (2026-07-21); prose suite 30/30 after the pin retirement (author decision, 0269).
- Exit criteria: resubmitted via the Œconomia Revisions form 2026-07-21; Zenodo 10.5281/zenodo.21476165 and HAL hal-05558422v2 online; tag v1.1-oeconomia-revised.
- Union sweep for the retitle class: fixed the corpus-report companion subtitle; the ESHET slides/outline keep the March title deliberately (accepted talk title — author's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)