### PR TITLE
chore(skills): update-publist — correct bib path and git-repo status

### DIFF
--- a/.claude/skills/update-publist/SKILL.md
+++ b/.claude/skills/update-publist/SKILL.md
@@ -11,10 +11,10 @@ Update the author's BibTeX database and archive on HAL. Covers all scientific pr
 
 ## Source of truth
 
-- **BibTeX file**: `~/CNRS/html/src/Ha-Duong.bib`
-- **Build**: `make` in `~/CNRS/html/src` (generates `index.html`)
-- **Deploy**: `make sync` in `~/CNRS/html` (FTP to ouvaton.coop)
-- Not a git repo — edits are direct.
+- **BibTeX file**: `~/CNRS/html/Ha-Duong.bib` (repo root, not `src/`)
+- **Build**: `make` in `~/CNRS/html/src` (generates `../index.html`)
+- **Deploy**: `make sync` in `~/CNRS/html` (validates HTML, then FTP to ouvaton.coop)
+- `~/CNRS/html` IS a git repo: commit directly on its main, one commit per logical change; `index.html` is gitignored. Check `git status` before editing — the author may have uncommitted changes in `Ha-Duong.bib`; keep his hunks and yours in separate commits (stage per hunk if needed).
 
 ## BibTeX entry type rules
 


### PR DESCRIPTION
Ticket: none

Two stale facts fixed in .claude/skills/update-publist/SKILL.md:
- BibTeX source is `~/CNRS/html/Ha-Duong.bib` (repo root), not `~/CNRS/html/src/`.
- `~/CNRS/html` is a git repo ("Not a git repo — edits are direct" was wrong); documents direct-commit-on-main convention and the per-hunk staging protocol when the author has concurrent uncommitted edits.

Both discrepancies hit during the 2026-07-22 RCE-reclassification session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)