### PR TITLE
test(0263): classify golden S3/S4 (GPU-only) and A.5 needle (math-mode lag)

### DIFF
--- a/tests/test_golden_values.py
+++ b/tests/test_golden_values.py
@@ -32,6 +32,18 @@ ALL_METHODS = sorted(METHODS.keys())
 # intentionally padme-only (@pytest.mark.slow). See ticket 0123 for investigation.
 ATOL = 1e-6
 
+# S3/S4 follow the torch backend, so their goldens only reproduce on GPU.
+# Measured on doudou (CPU, 2026-07-22, ticket 0263): S3 shifts every value
+# by up to 1.8e-3 (random-projection path), S4 drifts 2/32 values by ~6e-6.
+# Environmental, not code drift — skip on CPU instead of failing forever.
+GPU_SENSITIVE_METHODS = {"S3_sliced_wasserstein", "S4_frechet"}
+try:
+    import torch
+
+    GPU_AVAILABLE = torch.cuda.is_available()
+except ImportError:
+    GPU_AVAILABLE = False
+
 from conftest import run_compute as _run_compute
 
 
@@ -41,6 +53,12 @@ class TestGoldenValues:
 
     @pytest.mark.parametrize("method", ALL_METHODS)
     def test_method_matches_golden(self, method, tmp_path):
+        if method in GPU_SENSITIVE_METHODS and not GPU_AVAILABLE:
+            pytest.skip(
+                f"{method}: goldens are padme GPU outputs; CPU deviates "
+                "(tickets 0123, 0263)"
+            )
+
         golden_path = os.path.join(GOLDEN_DIR, f"tab_div_{method}.csv")
         if not os.path.exists(golden_path):
             pytest.skip(f"Golden CSV not found: {golden_path}")

--- a/tests/test_separation_provenance.py
+++ b/tests/test_separation_provenance.py
@@ -72,7 +72,7 @@ def test_a5_prose_matches_committed_csv():
     """Every figure the A.5 bullet cites equals the committed CSV value.
 
     Node and edge counts exact; share and null mean at two decimals; z to
-    the nearest integer (the prose writes 'z ≈ N'); permutation count exact.
+    the nearest integer (the prose writes '$z \approx N$'); permutation count exact.
     """
     row = _louvain_share_row()
     bullet = _a5_bullet()
@@ -93,7 +93,7 @@ def test_a5_prose_matches_committed_csv():
         f"{n_edges} edges",
         f"share {observed:.2f}",
         f"null of {null_mean:.2f}",
-        f"z ≈ {round(z_score)},",
+        f"$z \\approx {round(z_score)}$,",
         f"N = {n_perm} permutations",
     ]
     for needle in checks:

--- a/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
+++ b/tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg
@@ -9,6 +9,8 @@ Label: deferred
 
 2026-07-15T13:58Z HDMX-coding-agent label deferred
 2026-07-22T09:10Z HDMX-coding-agent note lair full-suite run on doudou: 59 failed, 4 errors, 1507 passed (27m38s); clusters seen include missing derived artifacts (test_corpus_table_export) and subprocess script failures (subsampling ribbon, venue concentration) — still in this ticket's scope
+2026-07-22T11:05Z HDMX-coding-agent note cluster 3 CLASSIFIED env-only (hardware): reran both golden tests on doudou — S3 shifts 96/96 values, max abs 1.8e-3 / max rel 10% (torch CPU vs CUDA random-projection path); S4 shifts 2/32 values by max 6.4e-6, barely over ATOL=1e-6. Magnitudes match the documented ticket-0123 CPU-vs-GPU signature; padme runs are deterministic and match goldens per the test header. Not code drift. Gate applied: test_golden_values.py now skips S3/S4 when torch.cuda is unavailable
+2026-07-22T11:20Z HDMX-coding-agent note NEW cluster 6 CLASSIFIED test-lag: test_separation_provenance::test_a5_prose_matches_committed_csv broke when panel commit 524b6678 (2026-07-20) set the A.5 z-value in math mode ($z \approx 25$); CSV numbers still match the prose. Needle updated to the math-mode form
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket-ref: tickets/0263-triage-2026-07-11-make-check-slow-tier-f.erg

Starts the 0263 triage — two failure classes classified and gated, ticket stays open (clusters 1, 2, 4, 5 remain):

**Cluster 3 — golden values S3/S4: environmental (hardware), not drift.**
Measured on doudou: S3 shifts 96/96 values, max abs 1.8e-3 / max rel 10% (torch CPU vs CUDA random-projection path); S4 shifts 2/32 values by 6.4e-6 vs ATOL 1e-6. Matches the CPU-vs-GPU signature documented in the test header (ticket 0123); padme runs are deterministic against goldens. Fix: capability skip when `torch.cuda` is unavailable — the padme-only intent was previously only a comment. Verified: S3/S4 skip with reason on doudou, control method S2_energy still runs and passes.

**New cluster 6 — A.5 provenance needle: test-lag, not data mismatch.**
`test_a5_prose_matches_committed_csv` broke when panel commit 524b6678 (2026-07-20) set the z-value in math mode (`$z \approx 25$`). CSV values still match the prose (z 25.299 → 25). Fix: needle updated to the math-mode form; test passes again.

Gates: make lint 154 green; check-fast now 946 passed (the A.5 red was its only failure); erg check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)