### PR TITLE
tickets: 0296 Phase-1 run-report coverage map (roar sweep, deferred)

### DIFF
--- a/tickets/0296-phase-1-run-report-coverage-map-counts-l.erg
+++ b/tickets/0296-phase-1-run-report-coverage-map-counts-l.erg
@@ -1,0 +1,42 @@
+%erg 0.1
+Title: Phase-1 run-report coverage map: counts logged but not persisted (class ticket, instrument on demand)
+Created: 2026-07-22
+Author: HDMX-coding-agent
+Label: deferred
+
+--- log ---
+2026-07-22T12:37Z HDMX-coding-agent created
+
+--- body ---
+
+## Context
+
+Roar sweep after PR #1082 (ticket 0284): the referee asked for dedup counts
+that existed only in `log.info` lines, forcing instrumentation + a stage
+rerun mid-R&R. The same latent shape exists in 16 Phase-1 scripts — they log
+row/removal counts but never call `save_run_report`, so their numbers are
+not pipeline-traceable if a manuscript ever needs them:
+
+catalog_bibcnrs, catalog_grey, catalog_istex, catalog_openalex,
+catalog_scispace, catalog_scopus, catalog_semanticscholar, corpus_filter,
+corpus_migrate_citations_cache, corpus_ref_match, enrich_embeddings,
+enrich_join, enrich_openalex_keywords (scripts/harvest/);
+corpus_merge_citations, enrich_dois, qa_near_duplicates (scripts/).
+
+This is deliberately NOT "instrument all 16 now" — that is speculative
+(YAGNI). It is the coverage map so the next referee/prose need for a
+Phase-1 number starts here instead of rediscovering the gap.
+
+## Actions (on demand, per script actually needed)
+
+1. When a manuscript or response letter needs a number from one of these
+   scripts, instrument that script only, per the catalog_merge pattern
+   (flat counters dict + save_run_report; PR #1082).
+2. Rerun offline where inputs are archived (byte-compare the data output
+   to prove reporting-only), else coordinate a padme run.
+
+## Exit criteria
+
+- [ ] Every Phase-1 number cited in a deliverable traces to an archived
+      run report (checked per need, not en masse); ticket closes when the
+      R&R cycle ends with no uncovered need remaining


### PR DESCRIPTION
Roar-sweep follow-up from the 284/285/282 raid (PRs #1079/#1080/#1082).

Files one deferred class ticket: 16 Phase-1 scripts log counts without `save_run_report`, the latent shape that forced mid-R&R instrumentation in 0284 (referee remark R1-12). The ticket is a coverage map with an instrument-on-demand policy, not a bulk mandate.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)