### PR TITLE
ticket(0263): close triage — residual language-null handed off to 0297

### DIFF
--- a/tickets/0297-corpus-language-null-rate-regression.erg
+++ b/tickets/0297-corpus-language-null-rate-regression.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-22T16:40Z HDMX-coding-agent created author request during 0289 review (failure known for weeks, now tracked)
+2026-07-22T16:40Z HDMX-coding-agent note inherits cluster 2 from closed triage ticket 0263 — same 4.1% (1743/42916) on doudou AND padme, so a corpus property, not local staleness; after backfill on padme, finish with make corpus-sync on doudou
 
 --- body ---
 ## Context

--- a/tickets/closed/0263-triage-2026-07-11-make-check-slow-tier-f.erg
+++ b/tickets/closed/0263-triage-2026-07-11-make-check-slow-tier-f.erg
@@ -3,6 +3,7 @@ Title: Triage 2026-07-11 make-check slow-tier failures on doudou
 Created: 2026-07-11
 Author: HDMX-coding-agent
 Label: deferred
+Closed: all clusters dispositioned across waves 1-3 (PRs #1075/#1076/#1078); sole residual (cluster 2, language null rate 4.1%) handed off to ticket 0297
 
 --- log ---
 2026-07-11T14:36Z HDMX-coding-agent created
@@ -14,6 +15,7 @@ Label: deferred
 2026-07-22T12:35Z HDMX-coding-agent note wave-2 dispositions: cluster 1 (corpus_table_export) env — untracked Make artifact, fixture now skips when not built; cluster 4 (c2st x2) env — 300s subprocess budget is GPU-sized, smoke class now skips without CUDA; cluster 5 split: bib_doi_title was a REAL bug (qa_bib_doi.py _REPO_ROOT two dirnames deep after the 0255 move to scripts/qa/, fixed, 14/14 pass incl. Crossref) and fetch_parallel env — bs4 lives in the corpus dependency group absent from the doudou env, module now importorskips. NEW cluster 7 (subsampling_ribbon x2, venue_concentration x1) rule-violation — subprocess env lacked source_root_env(), passed only under make's exported PYTHONPATH; fixed per 0253. Side finding: uv sync removed the stale openalex-corpus wheel (installed from a deleted worktree path), surfacing a mypy Any-hole; mypy_path now carries the source roots. Remaining open: cluster 2 (language null rate, blocked on v1.1.2) and the padme full run
 2026-07-22T14:05Z HDMX-coding-agent note padme run done (334 commits pulled + uv sync first): 3 failed / 1573 passed in 10m46. (a) language_null_rate 4.1% fails on padme too — cluster 2 is a corpus-v1.1.1 property, not doudou staleness; still blocked on v1.1.2. (b) content-tree guard hit ~200 pre-0226 leftovers, archived to ~/attic-content-pre0226-20260722 on padme — env, cleared. (c) parameterize_works_paths CLI: same missing-source_root_env class as cluster 7, was masked everywhere by the stale openalex-corpus wheel until uv sync purged it; a doudou census then showed 38 failures across 9 files. Class-level fix: conftest now exports the source roots on PYTHONPATH for the whole test session, closing current and future instances (210/210 pass)
 2026-07-22T14:40Z HDMX-coding-agent note FINAL both-machine state after waves 1-3 (PRs #1075, #1076, #1078): padme make check on main@wave3 = 1 failed / 1575 passed (10m36) — sole residual is cluster 2 language_null_rate (4.1% vs 2%), a corpus-v1.1.1 property on both machines, unblocked by the v1.1.2 language backfill then `make corpus-sync` on doudou. Every other cluster has a logged disposition and its gate/fix merged. Verification boxes satisfiable on v1.1.2 landing; keep open until the language recheck goes green
+2026-07-22T16:38Z HDMX-coding-agent closed — all clusters dispositioned across waves 1-3 (PRs #1075/#1076/#1078); sole residual (cluster 2, language null rate 4.1%) handed off to ticket 0297
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: none

Closes and archives the 0263 make-check triage ticket on-branch (the close
commit rides this PR, hence no **Ticket:** close claim for erg-pr-merge).

- All five original clusters plus the two discovered mid-triage have logged
  dispositions; fixes and gates merged in waves 1–3 (PRs #1075, #1076, #1078).
- Final both-machine state: padme `make check` = 1 failed / 1575 passed; the
  sole red is `test_language_null_rate_below_2_percent` (4.1% vs <2%), a
  corpus-v1.1.1/v2-extension property identical on doudou and padme.
- That residual now has its own dedicated ticket 0297 (filed during the 0289
  review, renumbered from 0295); this PR adds the cross-reference note in
  0297 carrying the both-machine evidence and the padme→doudou sync step.

Per the follow-up-lets-parent-close convention: the parent triage closes now
instead of idling until the v1.1.2 language backfill lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)