### PR TITLE
tickets: roar follow-ups — orphan istex_refs layer (0302), consumption contract test (0303), tracker 0274 children

### DIFF
--- a/tickets/0274-rdj26561-rr-round-1-tracker.erg
+++ b/tickets/0274-rdj26561-rr-round-1-tracker.erg
@@ -9,6 +9,8 @@ Author: HDMX-coding-agent
 2026-07-20T11:00Z HDMX-coding-agent note author approved UN-system corpus expansion — added 0288, R1-06 now covered by 0281+0288
 2026-07-21T08:00Z HDMX-coding-agent note added 0289 (author request): verify comparison to prior bibliometric mappings
 
+2026-07-22T15:05Z HDMX-coding-agent note children 0300/0301 filed (PR #1086): artifact corrections for R1-13/R1-12; 0277/0276 log notes carry the corrected numbers
+
 --- body ---
 ## Context
 
@@ -39,6 +41,8 @@ remarks; coverage check clean at filing time).
 - 0283 — response letter: point-by-point reply and summary of revisions (ED-05)
 - 0284 — per-procedure dedup removal counts artifact (R1-12)
 - 0285 — per-document reference-count distribution artifact (R1-13)
+- 0300 — merge catalog-stage OpenAlex refs; corrects 0285's zero-ref headline 41.5% -> ~22.1% (R1-13)
+- 0301 — dedup error-rate estimates as citable artifact (R1-12)
 - 0286 — citation-network figure: author decision, implement or decline (R1-14) [needs-human]
 - 0287 — corpus CSV layout: restructure or document, author decision (R1-19) [needs-human]
 - 0288 — corpus v2: curated international-institution key-documents layer, UNFCCC + OECD DAC sub-lists (R1-06) — critical path: blocks final corpus numbers

--- a/tickets/0302-corpus-merge-istex-refs-csv-into-citatio.erg
+++ b/tickets/0302-corpus-merge-istex-refs-csv-into-citatio.erg
@@ -1,0 +1,40 @@
+%erg 0.1
+Title: Corpus: merge istex_refs.csv into citations.csv or declare it out-of-scope
+Created: 2026-07-22
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-22T16:39Z HDMX-coding-agent created from roar sweep of 0300's class (dropped harvest layer)
+
+--- body ---
+## Context
+
+Roar sweep after PR #1086 (ticket 0300: catalog-stage OpenAlex references
+never merged into citations.csv) looked for the same class — a harvested
+reference layer no merge consumes. One sibling found: `catalog_istex.py`
+writes `data/catalogs/istex_refs.csv` (15.5 MB, "cited references with
+DOIs", declared in dvc.yaml), and nothing reads it — `corpus_merge_citations.py`
+merges only the enrich caches (crossref, openalex, GROBID, ref_matches).
+
+Mitigating fact: ISTEX-sourced docs show only 5.2% zero-references (their
+refs arrive via the OpenAlex/Crossref path), so the impact is enrichment
+(possibly richer DOI'd edges), not a counting hole like 0300. It may also be
+legitimate to declare the layer out-of-scope — decide, don't let it dangle.
+
+## Actions
+
+1. Compare a sample of istex_refs edges against the merged citations.csv for
+   the same source DOIs: measure incremental edges.
+2. If material: map istex_refs into REFS_COLUMNS in corpus_merge_citations.py
+   (with dedup on (source_doi, ref_doi)) alongside 0300's fix.
+3. If immaterial: document the out-of-scope decision in the script docstring
+   and in 0303's contract-test allowlist.
+
+## Test
+
+- Covered by 0303's contract test once the decision is recorded.
+
+## Exit criteria
+
+- [ ] istex_refs.csv is either merged or explicitly declared out-of-scope
+      with the incremental-edge measurement recorded here

--- a/tickets/0303-contract-test-every-harvested-reference.erg
+++ b/tickets/0303-contract-test-every-harvested-reference.erg
@@ -1,0 +1,38 @@
+%erg 0.1
+Title: Contract test: every harvested reference layer feeds corpus_merge_citations or is declared out-of-scope
+Created: 2026-07-22
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-22T16:39Z HDMX-coding-agent created from roar step 4 (class guard: two dropped-layer instances, 0300 + 0302)
+
+--- body ---
+## Context
+
+The class now has two instances: 0300 (openalex_citations.csv harvested at
+catalog stage, skipped by the enrich done-check, never merged) and 0302
+(istex_refs.csv produced and never read). The shape: a reference-edge
+producer writes a layer that corpus_merge_citations.py does not consume, and
+nothing fails. A per-PR gate cannot catch this — the defect is a MISSING
+consumption edge in the pipeline graph, visible only repo-wide.
+
+## Actions
+
+1. Add an adherence-tier contract test: enumerate reference-layer artifacts
+   (producers writing `*_refs.csv` / `*_citations.csv` under CATALOGS_DIR,
+   plus the enrich caches) and assert each is either (a) an input of
+   corpus_merge_citations.py, (b) the merged output itself, or (c) named in
+   an explicit out-of-scope allowlist with a reason string.
+2. Seed the allowlist with the 0302 decision if istex_refs stays out.
+3. Same test asserts the enrich done-check sources (files that mark a DOI
+   "done") are a subset of the merge inputs — the 0300 mechanism, pinned.
+
+## Test
+
+- The contract test itself; prove its teeth by temporarily removing a merge
+  input from the consumption list (mutation check, then revert).
+
+## Exit criteria
+
+- [ ] Adherence test in tests/, green on main, teeth proven by mutation
+- [ ] Done-check/merge-input subset relation pinned


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0302-corpus-merge-istex-refs-csv-into-citatio.erg
Ticket-ref: tickets/0303-contract-test-every-harvested-reference.erg
Ticket-ref: tickets/0274-rdj26561-rr-round-1-tracker.erg

Roar wrap-up of PR #1086. The sweep for 0300's defect class (a harvested reference layer no merge consumes) found one sibling — `istex_refs.csv`, produced by `catalog_istex.py`, read by nothing (0302). Two instances give the bug a class shape, so 0303 files the standing adherence contract test (every reference layer feeds `corpus_merge_citations.py` or sits in an explicit out-of-scope allowlist; done-check sources ⊆ merge inputs). Tracker 0274 now lists children 0300/0301 per the tracking-ticket convention.

Filing-only PR: no code changes; `erg check` PASS (293 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)