### PR TITLE
chore(0279): variables-table note — corpus-v2 provenance columns

### DIFF
--- a/tickets/0279-datapaper-variables-table-csv-usability.erg
+++ b/tickets/0279-datapaper-variables-table-csv-usability.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-20T09:00Z HDMX-coding-agent created
 2026-07-20T10:00Z HDMX-coding-agent note split the R1-19 CSV-restructure decision into 0287; this ticket delivers the variables table (ED-03)
+2026-07-23T00:30Z HDMX-coding-agent note corpus-v2 layer merged (PR #1085): the variables table must cover 4 new refined_works columns — from_unfccc, from_oecd, abstract_provenance (values: curated / reconstructed:lead / reconstructed:exec_summary), keywords_provenance (extracted / generated:lexicon) — and the abstract_status value 'reconstructed'
 
 --- body ---
 ## Context


### PR DESCRIPTION
Propagates the corpus-v2 data-contract change (PR #1085) into ticket 0279: the variables table / codebook must document from_unfccc, from_oecd, abstract_provenance, keywords_provenance, and the reconstructed abstract_status value.

Ticket-ref: tickets/0279-datapaper-variables-table-csv-usability.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)