### PR TITLE
tickets: 0305 API DOI resolution (corpus v2) + 0306 manuscript claim correction

### DIFF
--- a/tickets/0305-corpus-v2-resolve-ref-oa-id-dois.erg
+++ b/tickets/0305-corpus-v2-resolve-ref-oa-id-dois.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Corpus v2: resolve catalog-stage ref_oa_id references to DOIs via OpenAlex API
+Created: 2026-07-23
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-23T16:30Z HDMX-coding-agent created author decision (session 2026-07-23): do it in corpus v2, not v1.1.x
+
+--- body ---
+## Context
+
+Ticket 0300 (PR #1093) merged the catalog-stage OpenAlex references into
+citations.csv as a fallback layer. Those ~172k edges carry a `ref_oa_id`
+(OpenAlex work ID) but an empty `ref_doi`, so they count in per-document
+reference totals yet stay invisible to every DOI-joined analysis
+(co-citation, refined_citations, the traditions figure). 0300 deliberately
+preserved the intra-corpus (source_doi, ref_doi) edge set byte-identical so
+v1-frozen analyses remain valid — resolving DOIs breaks that freeze, which
+is why the author scoped this to corpus v2, where numbers are re-baselined
+anyway (keydocs layer 0304, GROBID v1.1.2).
+
+Cost is modest: OpenAlex API is free, ~50 IDs per batch request → ~3,500
+calls, well under the polite-pool daily quota. Many refs will have no DOI
+(reports, chapters, old literature) — that residue is expected, not a
+failure.
+
+## Relevant files
+
+- `scripts/corpus_merge_citations.py` — where catalog-stage edges enter
+- `data/catalogs/openalex_citations.csv` — the ref_oa_id-bearing layer
+- `scripts/harvest/` enrich-cache idioms — reuse caching + polite_get
+
+## Actions
+
+1. Batch-resolve distinct ref_oa_id values via the OpenAlex works endpoint
+   (~50 per call), cached as JSONL (resumable, like other enrich caches).
+2. Fill ref_doi on catalog-stage rows where a DOI exists; leave others.
+3. Re-run the merge + align stages; record before/after counts (edges
+   entering the DOI-joined graph).
+4. Runs AFTER the 0304 harvest, BEFORE the final data-paper corpus numbers.
+
+## Test
+
+- Red first: a resolution-cache unit test (mapping applied, missing DOIs
+  left empty, dedup against existing (source_doi, ref_doi) pairs).
+
+## Verification
+
+- [ ] Resolution cache committed via DVC; run report saved
+- [ ] Before/after edge counts reported; no duplicate (source_doi, ref_doi)
+
+## Invariants
+
+- v1 analyses stay frozen: this lands in the corpus-v2 lineage only.
+- No hand-curated data; polite API use.
+
+## Exit criteria
+
+- [ ] ref_oa_id references resolved where a DOI exists; citations.csv v2
+      carries them with ref_doi filled
+- [ ] Corpus-v2 analytic graph includes the resolved edges

--- a/tickets/0306-manuscript-three-traditions-claim-correction.erg
+++ b/tickets/0306-manuscript-three-traditions-claim-correction.erg
@@ -1,0 +1,71 @@
+%erg 0.1
+Title: Manuscript: qualify the three-traditions claim for 1990-2007 after contemporaneous-citers check
+Created: 2026-07-23
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-23T16:35Z HDMX-coding-agent created author request (session 2026-07-23) — correction of the already-submitted paper
+
+--- body ---
+## Context
+
+The Œconomia manuscript (v2.0.5 resubmitted 2026-07-21, awaiting editor)
+states that three intellectual traditions exist in the 1990-2007 period,
+supported by the co-citation figure/appendix A.5. Exploration during the
+RDJ-26561 revision (session 2026-07-23) showed the canonical analysis uses
+pre-2007 REFERENCES cited by the FULL 1990-2024 corpus. Restricting citing
+documents to <= 2007 (480 citers, 6,155 pairs), only two traditions
+separate (pricing; CDM); no community contains the institutionalist anchors
+(North, DiMaggio, Finnemore). The third tradition's co-citation signature
+appears retrospective — post-crystallization literature rereading the
+UNFCCC period — which nuances the claim but arguably strengthens the
+thesis (retrospective construction of the object).
+
+Pending input before drafting: the figure-exploration report on (a) the
+<= 2008 variant, (b) inspection of burden-sharing literature in unlabeled
+communities (the absence may reflect badly chosen anchors, not absent
+literature — check Ringius, Rose, Tol, Grubb, den Elzen, Meyer, etc.),
+(c) projection of canonical communities onto the contemporaneous graph.
+
+## Relevant files
+
+- `deliverables/manuscript/manuscript.qmd` ~line 114 and appendix A.5
+- `scripts/_pre2007_traditions.py` — canonical method (full-corpus citers)
+- Exploration scripts/figures in the 0286 exploration worktree (to be
+  archived or re-derived): fig_traditions_pre2007_citers.png and pre-2008
+  variants
+
+## Actions
+
+1. Wait for the exploration report (anchors check, pre-2008 variant,
+   projection); author arbitrates the interpretation.
+2. Draft the manuscript correction: state explicitly that the co-citation
+   evidence identifies pre-2007 references as seen by the full corpus, and
+   qualify the contemporaneous existence of the third tradition (practice
+   vs citation signature), with the sparsity caveat.
+3. Route: autonomous prose change to a submitted manuscript goes through
+   branch + PR for author arbitration (rules/git.md prose workpackages).
+   Coordinate timing with the editor process (v2.0.5 under review — the
+   correction may wait for the next revision round unless author decides
+   otherwise).
+
+## Test
+
+- Prose adherence tests stay green; no positive-phrasing pins (CI polarity
+  rule).
+
+## Verification
+
+- [ ] Corrected claim consistent with the corroboration framing
+      (writing.md: detection corroborates, never discovers)
+
+## Invariants
+
+- Do not overclaim in the other direction either: absence in the sparse
+  contemporaneous graph is not proof of absence (480 citers).
+
+## Exit criteria
+
+- [ ] Author-approved wording landed on a manuscript branch/PR, or an
+      explicit decision to fold it into the next Œconomia revision round


### PR DESCRIPTION
**Ticket:** none

Files two tickets decided in today's interactive session:
- 0305 — resolve catalog-stage ref_oa_id references to DOIs via OpenAlex API, corpus-v2 lineage (author decision; keeps 0300's v1 freeze intact).
- 0306 — qualify the manuscript's three-traditions-in-1990-2007 claim after the contemporaneous-citers check (needs-human; waits on the figure-exploration report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)