### PR TITLE
fix: 0283 log conflict markers from #1099 merge resolution

### DIFF
--- a/tickets/0283-datapaper-response-letter-resubmission.erg
+++ b/tickets/0283-datapaper-response-letter-resubmission.erg
@@ -4,9 +4,6 @@ Created: 2026-07-20
 Author: HDMX-coding-agent
 Blocked-by: 0276
 Blocked-by: 0277
-Blocked-by: 0278
-Blocked-by: 0280
-Blocked-by: 0281
 Blocked-by: 0286
 Blocked-by: 0288
 
@@ -23,12 +20,9 @@ Blocked-by: 0288
 2026-07-23T13:47Z HDMX-coding-agent note blocker 0275 closed — Blocked-by removed.
 2026-07-23T13:57Z HDMX-coding-agent note blocker 0279 closed — Blocked-by removed.
 2026-07-23T14:27Z HDMX-coding-agent note blocker 0287 closed — Blocked-by removed.
-<<<<<<< HEAD
-2026-07-23T15:22Z HDMX-coding-agent note blocker 0280 closed — Blocked-by removed.
-=======
 2026-07-23T15:19Z HDMX-coding-agent note blocker 0281 closed — Blocked-by removed.
 2026-07-23T15:21Z HDMX-coding-agent note blocker 0278 closed — Blocked-by removed.
->>>>>>> origin/main
+2026-07-23T15:22Z HDMX-coding-agent note blocker 0280 closed — Blocked-by removed.
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** none

The #1099 conflict resolution only handled the first hunk; the log-section hunk landed on main with raw conflict markers (erg check red). Restores the three blocker-close log lines in chronological order. Header Blocked-by lines (0276/0277/0286/0288) were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)