### PR TITLE
OECD keydocs expansion: 21 new seeds, series completions, 0311 split, cut plan

### DIFF
--- a/config/grey_sources.yaml
+++ b/config/grey_sources.yaml
@@ -89,3 +89,9 @@
   year: 2003
   source_org: "UNDP/Oxford University Press"
   keywords: "global public goods; climate finance"
+
+- title: "Reporting on Development: ODA and Financing for Development"
+  author: "Vanheukelom, Jan and Migliorisi, Stefano and Herrero Cangas, Alisa and Keijzer, Niels and Spierings, Eunike"
+  year: 2012
+  url: "https://ecdpm.org/work/reporting-on-development-oda-and-financing-for-development"
+  source_org: "ECDPM"

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -281,3 +281,12 @@ documents:
     language: en
     url: ""
     provenance: "Author OLIS fetch 2026-07-24: implements the Dec 1991 environment-development ministers mandate; early working-party layer (ENVIRONET anchor). Pooled with sidecar."
+  - symbol: "DCD/DAC/STAT(2023)9/FINAL"
+    title: "Converged Statistical Reporting Directives for the Creditor Reporting System (CRS) and the Annual DAC Questionnaire (2023): Chapters 1-6"
+    short_title: "Converged Statistical Reporting Directives (2023)"
+    year: 2023
+    body: "OECD DAC Working Party on Development Finance Statistics"
+    doc_class: statistical_directive
+    language: en
+    url: "https://one.oecd.org/document/DCD/DAC/STAT(2023)9/FINAL/en/pdf"
+    provenance: "Author OLIS fetch 2026-07-24: directives approved by WP-STAT 12 April 2023 — extends the directive series to the last in-range edition. Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -170,3 +170,12 @@ documents:
     language: en
     url: "https://www.oecd.org/content/dam/oecd/en/publications/reports/2018/12/oecd-dac-blended-finance-principles_898d3549/dc66bd9c-en.pdf"
     provenance: "Author addition 2026-07-24: founding Principles absent from corpus (only the 2021 Guidance 10.1787/ded656b4-en and 2022 clean-energy guidance are present via DOI), so the class exclusion does not apply. PDF fetched by author, pooled with sidecar."
+  - symbol: "OECD/DAC/GUIDELINES-SSD/2001"
+    title: "The DAC Guidelines: Strategies for Sustainable Development"
+    short_title: "DAC Guidelines on Strategies for Sustainable Development (2001)"
+    year: 2001
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/strategies-for-sustainable-development_9789264194762-en.html"
+    provenance: "Author addition 2026-07-24: DAC sustainable-development doctrine between the 1992 Aid & Environment guidelines and the Rio-marker statistical series; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -176,7 +176,7 @@ documents:
     doc_class: dac_document
     language: en
     url: "https://www.oecd.org/content/dam/oecd/en/publications/reports/2018/12/oecd-dac-blended-finance-principles_898d3549/dc66bd9c-en.pdf"
-    provenance: "Author addition 2026-07-24: founding Principles absent from corpus (only the 2021 Guidance 10.1787/ded656b4-en and 2022 clean-energy guidance are present via DOI), so the class exclusion does not apply. PDF fetched by author, pooled with sidecar."
+    provenance: "Author addition 2026-07-24: founding Principles absent from corpus (only the 2021 Guidance and 2022 clean-energy guidance are present via their iLibrary DOIs), so the class exclusion does not apply. PDF fetched by author, pooled with sidecar."
   - symbol: "OECD/DAC/GUIDELINES-SSD/2001"
     title: "The DAC Guidelines: Strategies for Sustainable Development"
     short_title: "DAC Guidelines on Strategies for Sustainable Development (2001)"

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -236,3 +236,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/harmonising-donor-practices-for-effective-aid-delivery_9789264199835-en.html"
     provenance: "Author addition 2026-07-24: DAC Guidelines and Reference Series volume on aid-delivery harmonisation (pre-Paris Declaration doctrine); absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar. Year to confirm against the landing page's Cite widget (0313 enrichment pass)."
+  - symbol: "OCDE/GD(91)200"
+    title: "Guidelines on Environment and Aid No. 1: Good Practices for Environmental Impact Assessment of Development Projects"
+    short_title: "DAC Good Practices for EIA of Development Projects (1991)"
+    year: 1991
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: ""
+    provenance: "Author fetch 2026-07-24 (OLIS): first of the derestricted Environment and Aid guidelines series; concrete document for the ENVIRONET-predecessor working-party anchor (OECD/ENVIRONET/1990s). Scan with usable text layer."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -290,3 +290,12 @@ documents:
     language: en
     url: "https://one.oecd.org/document/DCD/DAC/STAT(2023)9/FINAL/en/pdf"
     provenance: "Author OLIS fetch 2026-07-24: directives approved by WP-STAT 12 April 2023 — extends the directive series to the last in-range edition. Pooled with sidecar."
+  - symbol: "DCD/DAC/STAT(2023)9/ADD2/FINAL"
+    title: "Converged Statistical Reporting Directives for the Creditor Reporting System (CRS) and the Annual DAC Questionnaire (2023): Addendum 2 (Annexes)"
+    short_title: "Converged Statistical Reporting Directives 2023 — Addendum 2"
+    year: 2023
+    body: "OECD DAC Working Party on Development Finance Statistics"
+    doc_class: statistical_directive
+    language: en
+    url: "https://one.oecd.org/document/DCD/DAC/STAT(2023)9/ADD2/FINAL/en/pdf"
+    provenance: "Author OLIS fetch 2026-07-24: annexes addendum to the 2023 directives (115 pp — carries the Rio-marker annex material). Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -252,8 +252,8 @@ documents:
     body: "OECD DAC Working Party on Development Assistance and Environment"
     doc_class: dac_document
     language: en
-    url: ""
-    provenance: "Author fetch 2026-07-24: Aid and Environment guidelines series No. 3; early working-party layer (ENVIRONET anchor). Pooled with sidecar."
+    url: "https://reliefweb.int/report/world/guidelines-aid-and-environment"
+    provenance: "Author fetch 2026-07-24 via ReliefWeb (legacy attachment): Aid and Environment guidelines series No. 3; early working-party layer (ENVIRONET anchor). Pooled with sidecar."
   - symbol: "OECD/DAC/AID-ENV-9/1996"
     title: "Guidelines on Aid and Environment No. 9: Guidelines for Aid Agencies for Improved Conservation and Sustainable Use of Tropical and Sub-Tropical Wetlands"
     short_title: "DAC Aid and Environment Guidelines No. 9 — Wetlands (1996)"

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -209,3 +209,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/shaping-the-21st-century-the-contribution-of-development-co-operation_da2d4165-en.html"
     provenance: "Author addition 2026-07-24: the 1996 DAC strategy that seeded the International Development Goals (precursor to the MDGs), environmental sustainability among them; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."
+  - symbol: "OECD/DAC/MFSDR-PRINCIPLES/2019"
+    title: "OECD DAC Guiding Principles on Managing for Sustainable Development Results"
+    short_title: "DAC Guiding Principles on Managing for Sustainable Development Results (2019)"
+    year: 2019
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/managing-for-sustainable-development-results_44a288bc-en.html"
+    provenance: "Author addition 2026-07-24: DAC results-management doctrine in the guidance series lineage; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -29,6 +29,18 @@
 # tolerates the failure, and accepts pre-placed PDFs in the pool directory
 # (manual bulk export path anticipated by ticket 0288).
 
+# Series lineage note (author, 2026-07-24): the DAC guidance series is one
+# continuous lineage under three successive names —
+#   "The DAC Guidelines" (ISSN 19900864,
+#     https://www.oecd.org/en/publications/the-dac-guidelines_19900864.html),
+#   "DAC Guidelines and Reference Series" (ISSN 19900988,
+#     https://www.oecd.org/en/publications/dac-guidelines-and-reference-series_19900988.html),
+#   "Best Practices in Development Co-operation" (
+#     https://www.oecd.org/en/publications/best-practices-in-development-co-operation_d571f17c-en.html).
+# Treat them as one methodological series when curating doctrine documents;
+# the 2001/2002 Guidelines seeds belong to the first name, the 2021/2025
+# Blended Finance Guidance to the third.
+
 documents:
   # ── DAC Statistical Reporting Directives (Rio markers) ───────────────
   - symbol: "OECD/DAC/SRD/1998"

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -263,3 +263,12 @@ documents:
     language: en
     url: ""
     provenance: "Author fetch 2026-07-24: Aid and Environment guidelines series No. 9 (sustainable use of wetlands); year to confirm at 0313. Pooled with sidecar."
+  - symbol: "DCD/DAC/STAT(2020)27"
+    title: "Assessing the Policy Objectives of Development Co-operation Activities: Review of the Reporting Status, Use and Relevance of Rio and Policy Markers - Conclusions and Recommendations"
+    short_title: "WP-STAT review of Rio and policy markers (2020)"
+    year: 2020
+    body: "OECD DAC Working Party on Development Finance Statistics"
+    doc_class: statistical_directive
+    language: en
+    url: ""
+    provenance: "Author OLIS fetch 2026-07-24: the 2020 internal review of Rio-marker reporting status, use and relevance — evidence layer for the marker-reliability dispute. Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -227,3 +227,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/development-assistance-manual-dac_g2gh14fb-en.html"
     provenance: "Author addition 2026-07-24: consolidated 1992 DAC principles manual (131 pp scan); absent from corpus. IMAGE-ONLY PDF — no text layer; needs OCR before fulltext counts (sidecar currently near-empty)."
+  - symbol: "OECD/DAC/HARMONISING-DONOR-PRACTICES/2003"
+    title: "Harmonising Donor Practices for Effective Aid Delivery"
+    short_title: "DAC Guidelines on Harmonising Donor Practices (2003)"
+    year: 2003
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/harmonising-donor-practices-for-effective-aid-delivery_9789264199835-en.html"
+    provenance: "Author addition 2026-07-24: DAC Guidelines and Reference Series volume on aid-delivery harmonisation (pre-Paris Declaration doctrine); absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar. Year to confirm against the landing page's Cite widget (0313 enrichment pass)."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -179,3 +179,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/strategies-for-sustainable-development_9789264194762-en.html"
     provenance: "Author addition 2026-07-24: DAC sustainable-development doctrine between the 1992 Aid & Environment guidelines and the Rio-marker statistical series; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."
+  - symbol: "OECD/DAC/GUIDELINES-RIO/2002"
+    title: "The DAC Guidelines: Integrating the Rio Conventions into Development Co-operation"
+    short_title: "DAC Guidelines on Integrating the Rio Conventions (2002)"
+    year: 2002
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/integrating-the-rio-conventions-into-development-co-operation_9789264176065-en.html"
+    provenance: "Author addition 2026-07-24: DAC doctrine on integrating the Rio Conventions into aid — companion to the 2002 Rio-marker statistical report already listed; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -299,3 +299,12 @@ documents:
     language: en
     url: "https://one.oecd.org/document/DCD/DAC/STAT(2023)9/ADD2/FINAL/en/pdf"
     provenance: "Author OLIS fetch 2026-07-24: annexes addendum to the 2023 directives (115 pp — carries the Rio-marker annex material). Pooled with sidecar."
+  - symbol: "DCD/DAC(2014)37/FINAL"
+    title: "Revised DAC Recommendation on Untying Official Development Assistance to the Least Developed Countries and Heavily Indebted Poor Countries"
+    short_title: "Revised DAC Recommendation on Untying ODA (2014)"
+    year: 2014
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://one.oecd.org/document/DCD/DAC(2014)37/FINAL/en/pdf"
+    provenance: "Author OLIS fetch 2026-07-24: untying recommendation as approved 21 July 2014. Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -161,3 +161,12 @@ documents:
     language: en
     url: ""
     provenance: "Placeholder anchor for the early working-party layer; concrete documents identified from OLIS at harvest (enumeration child ticket)."
+  - symbol: "OECD/DAC/BLENDED-FINANCE-PRINCIPLES/2018"
+    title: "OECD DAC Blended Finance Principles for Unlocking Commercial Finance for the Sustainable Development Goals"
+    short_title: "DAC Blended Finance Principles (2018)"
+    year: 2018
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/content/dam/oecd/en/publications/reports/2018/12/oecd-dac-blended-finance-principles_898d3549/dc66bd9c-en.pdf"
+    provenance: "Author addition 2026-07-24: founding Principles absent from corpus (only the 2021 Guidance 10.1787/ded656b4-en and 2022 clean-energy guidance are present via DOI), so the class exclusion does not apply. PDF fetched by author, pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -146,15 +146,10 @@ documents:
     provenance: "Contemporary record of the Rio-marker decision. Pre-DOI era. Locate at harvest."
 
   # ── Early DAC / WP-STAT / ENVIRONET documents ────────────────────────
-  - symbol: "OECD/GD(92)-AID-ENV"
-    title: "Guidelines on Aid and Environment"
-    short_title: "DAC Guidelines on Aid and Environment (1992)"
-    year: 1992
-    body: "OECD Development Assistance Committee"
-    doc_class: dac_document
-    language: en
-    url: ""
-    provenance: "Pre-Rio-marker environment screening doctrine; corpus OECD-DOI coverage starts at 2000 (ticket 0288). OLIS symbol to identify at harvest."
+  # RETIRED 2026-07-24 (0313 web-hunt): "OECD/GD(92)-AID-ENV Guidelines on
+  # Aid and Environment (1992)" was a phantom — no consolidated volume exists.
+  # The series is nine numbered pamphlets, seeded individually below
+  # (AID-ENV Nos. 1-9; No. 1 = OCDE/GD(91)200).
   - symbol: "OECD/DAC/RIO-REPORT/2002"
     title: "Aid Targeting the Objectives of the Rio Conventions 1998-2000: A Contribution by the DAC Secretariat"
     short_title: "First Rio-marker statistical report (2002)"
@@ -317,3 +312,58 @@ documents:
     language: en
     url: "https://one.oecd.org/document/DCD/DAC/STAT(2018)9/ADD2/FINAL/en/pdf"
     provenance: "Author OLIS fetch 2026-07-24: annexes addendum to the 2018 directives (83 pp, marker annexes). Pooled with sidecar."
+
+  - symbol: "OECD/DAC/AID-ENV-2/1992"
+    title: "Guidelines on Aid and Environment No. 2: Good Practices for Country Environmental Surveys and Strategies"
+    short_title: "DAC Aid and Environment Guidelines No. 2 (1992)"
+    year: 1992
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://web.archive.org/web/20150907190658id_/http://www.oecd.org/dac/environment-development/1887600.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24: Wayback capture of the oecd.org numeric-ID series. Endorsed Dec 1991 (first set of four). Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-4/1992"
+    title: "Guidelines on Aid and Environment No. 4: Guidelines for Aid Agencies on Global Environmental Problems"
+    short_title: "DAC Aid and Environment Guidelines No. 4 — Global Environmental Problems (1992)"
+    year: 1992
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://www.cbd.int/doc/guidelines/fin-oecd-gd-lns-global-en.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24, CBD mirror: THE climate number of the series — aid doctrine on global environmental problems, endorsed Dec 1991. Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-5/1993"
+    title: "Guidelines on Aid and Environment No. 5: Guidelines for Aid Agencies on Chemicals Management"
+    short_title: "DAC Aid and Environment Guidelines No. 5 — Chemicals (1993)"
+    year: 1993
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://web.archive.org/web/20150907190658id_/http://www.oecd.org/dac/environment-development/1887724.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24: Wayback capture of the oecd.org numeric-ID series. Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-6/1994"
+    title: "Guidelines on Aid and Environment No. 6: Guidelines for Aid Agencies on Pest and Pesticide Management"
+    short_title: "DAC Aid and Environment Guidelines No. 6 — Pest Management (1994)"
+    year: 1994
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://web.archive.org/web/20150907190658id_/http://www.oecd.org/dac/environment-development/1887732.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24: Wayback capture of the oecd.org numeric-ID series. Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-7/1994"
+    title: "Guidelines on Aid and Environment No. 7: Guidelines for Aid Agencies on Disaster Mitigation"
+    short_title: "DAC Aid and Environment Guidelines No. 7 — Disaster Mitigation (1994)"
+    year: 1994
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://web-archive-storage.oecd.org/aemint-web-archive-prod/web-archive/f8/f8b631a5e2609024c39aafc540e852beedd031358298ee2b0c03530faecda823.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24: OECD web-archive-storage host. Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-8/1992"
+    title: "Guidelines on Aid and Environment No. 8: Global and Regional Aspects of the Development and Protection of the Marine and Coastal Environment"
+    short_title: "DAC Aid and Environment Guidelines No. 8 — Marine and Coastal (1992)"
+    year: 1992
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: "https://www.cbd.int/doc/guidelines/fin-oecd-gd-lns-mar-en.pdf"
+    provenance: "Web-hunt fan-out 2026-07-24, CBD mirror: cover imprint 1992, adopted after Nos. 7/9 per text — year to confirm at 0313. Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -308,3 +308,12 @@ documents:
     language: en
     url: "https://one.oecd.org/document/DCD/DAC(2014)37/FINAL/en/pdf"
     provenance: "Author OLIS fetch 2026-07-24: untying recommendation as approved 21 July 2014. Pooled with sidecar."
+  - symbol: "DCD/DAC/STAT(2018)9/ADD2/FINAL"
+    title: "Converged Statistical Reporting Directives for the Creditor Reporting System (CRS) and the Annual DAC Questionnaire (2018): Addendum 2 (Annexes)"
+    short_title: "Converged Statistical Reporting Directives 2018 — Addendum 2"
+    year: 2018
+    body: "OECD DAC Working Party on Development Finance Statistics"
+    doc_class: statistical_directive
+    language: en
+    url: "https://one.oecd.org/document/DCD/DAC/STAT(2018)9/ADD2/FINAL/en/pdf"
+    provenance: "Author OLIS fetch 2026-07-24: annexes addendum to the 2018 directives (83 pp, marker annexes). Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -272,3 +272,12 @@ documents:
     language: en
     url: ""
     provenance: "Author OLIS fetch 2026-07-24: the 2020 internal review of Rio-marker reporting status, use and relevance — evidence layer for the marker-reliability dispute. Pooled with sidecar."
+  - symbol: "OCDE/GD(94)12"
+    title: "Effective Technology Transfer, Co-operation and Capacity Building for Sustainable Development: Common Reference Paper"
+    short_title: "DAC common reference paper on technology transfer and capacity building (1994)"
+    year: 1994
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: ""
+    provenance: "Author OLIS fetch 2026-07-24: implements the Dec 1991 environment-development ministers mandate; early working-party layer (ENVIRONET anchor). Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -245,3 +245,21 @@ documents:
     language: en
     url: ""
     provenance: "Author fetch 2026-07-24 (OLIS): first of the derestricted Environment and Aid guidelines series; concrete document for the ENVIRONET-predecessor working-party anchor (OECD/ENVIRONET/1990s). Scan with usable text layer."
+  - symbol: "OECD/DAC/AID-ENV-3/1992"
+    title: "Guidelines on Aid and Environment No. 3: Guidelines for Aid Agencies on Involuntary Displacement and Resettlement in Development Projects"
+    short_title: "DAC Aid and Environment Guidelines No. 3 — Displacement and Resettlement (1992)"
+    year: 1992
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: ""
+    provenance: "Author fetch 2026-07-24: Aid and Environment guidelines series No. 3; early working-party layer (ENVIRONET anchor). Pooled with sidecar."
+  - symbol: "OECD/DAC/AID-ENV-9/1996"
+    title: "Guidelines on Aid and Environment No. 9: Guidelines for Aid Agencies for Improved Conservation and Sustainable Use of Tropical and Sub-Tropical Wetlands"
+    short_title: "DAC Aid and Environment Guidelines No. 9 — Wetlands (1996)"
+    year: 1996
+    body: "OECD DAC Working Party on Development Assistance and Environment"
+    doc_class: dac_document
+    language: en
+    url: ""
+    provenance: "Author fetch 2026-07-24: Aid and Environment guidelines series No. 9 (sustainable use of wetlands); year to confirm at 0313. Pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -218,3 +218,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/managing-for-sustainable-development-results_44a288bc-en.html"
     provenance: "Author addition 2026-07-24: DAC results-management doctrine in the guidance series lineage; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."
+  - symbol: "OECD/DAC/ASSISTANCE-MANUAL/1992"
+    title: "Development Assistance Manual: DAC Principles for Effective Aid"
+    short_title: "DAC Development Assistance Manual (1992)"
+    year: 1992
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/development-assistance-manual-dac_g2gh14fb-en.html"
+    provenance: "Author addition 2026-07-24: consolidated 1992 DAC principles manual (131 pp scan); absent from corpus. IMAGE-ONLY PDF — no text layer; needs OCR before fulltext counts (sidecar currently near-empty)."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -200,3 +200,12 @@ documents:
     language: en
     url: "https://www.oecd.org/en/publications/integrating-the-rio-conventions-into-development-co-operation_9789264176065-en.html"
     provenance: "Author addition 2026-07-24: DAC doctrine on integrating the Rio Conventions into aid — companion to the 2002 Rio-marker statistical report already listed; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."
+  - symbol: "OECD/DAC/SHAPING-21ST-CENTURY/1996"
+    title: "Shaping the 21st Century: The Contribution of Development Co-operation"
+    short_title: "Shaping the 21st Century (DAC, 1996)"
+    year: 1996
+    body: "OECD Development Assistance Committee"
+    doc_class: dac_document
+    language: en
+    url: "https://www.oecd.org/en/publications/shaping-the-21st-century-the-contribution-of-development-co-operation_da2d4165-en.html"
+    provenance: "Author addition 2026-07-24: the 1996 DAC strategy that seeded the International Development Goals (precursor to the MDGs), environmental sustainability among them; absent from corpus (checked refined_works). PDF fetched by author, pooled with sidecar."

--- a/config/oecd_dac_sources.yaml
+++ b/config/oecd_dac_sources.yaml
@@ -226,7 +226,7 @@ documents:
     doc_class: dac_document
     language: en
     url: "https://www.oecd.org/en/publications/development-assistance-manual-dac_g2gh14fb-en.html"
-    provenance: "Author addition 2026-07-24: consolidated 1992 DAC principles manual (131 pp scan); absent from corpus. IMAGE-ONLY PDF — no text layer; needs OCR before fulltext counts (sidecar currently near-empty)."
+    provenance: "Author addition 2026-07-24: consolidated 1992 DAC principles manual; absent from corpus. ISBN 92-64-13779-3, OECD code (43 92 06 1), catalogued at 142 pp — our scan has 131 pp, completeness to verify at 0313. IMAGE-ONLY PDF — needs OCR before fulltext counts."
   - symbol: "OECD/DAC/HARMONISING-DONOR-PRACTICES/2003"
     title: "Harmonising Donor Practices for Effective Aid Delivery"
     short_title: "DAC Guidelines on Harmonising Donor Practices (2003)"

--- a/deliverables/data-paper/revision-rdj26561/cut-plan.md
+++ b/deliverables/data-paper/revision-rdj26561/cut-plan.md
@@ -1,0 +1,113 @@
+# Cut plan: data-paper.qmd word budget 4,100 → 2,500
+
+Prepared 2026-07-24 (ticket-ref 0274). Plan only — no manuscript edits made.
+Remark IDs from `ledger.dedup.jsonl` in this directory.
+
+## 1. Measured word counts
+
+Counting method (script in commit message context, reproducible): strip YAML
+front matter and HTML comments; each `{{< meta … >}}` shortcode counts as one
+word; pipe-table rows and table captions excluded; generated includes
+(`tab_corpus_sources.md`, `tab_languages.md`, `tab_variables.md`) excluded;
+figure captions **included**; citation keys excluded; abstract (in YAML)
+counted separately. `wc = len(text.split())` on the cleaned prose.
+
+| Section | Words |
+|---|---|
+| Abstract | 95 |
+| Preamble (related-dataset line) | 24 |
+| 1. Introduction | 611 |
+| 2.1 Sources | 304 |
+| 2.2 Data Structure | 303 |
+| 2.3 Quality, Completeness, Biases | 835 |
+| 2.4 OpenAlex limitations | 419 |
+| 3. Data | 992 |
+| 4. Concluding Remarks | 407 |
+| Data and Code Availability | 53 |
+| **Total** | **4,068** |
+
+Figure captions alone: fig-bars 17 + fig-global-map 137 + fig-sem-composition 79 = 233 words.
+
+**Counting ambiguity for the author.** RDJ4HSS says "max 2,500 words" without
+stating whether abstract, figure captions, and tables count. If abstract (95)
+and captions (233) are excluded, the effective total is 3,740 and the target
+needs only ~1,240 of cuts. This plan reaches 2,500 under the *strict* reading
+(everything counts). Generated pipe tables (tbl-sources, tbl-openalex-limits)
+and the three generated includes are not counted here in either reading; if
+the journal counts table text, flag it — tbl-openalex-limits alone is ~150
+words and answers ED-01/R1-11, so it should be defended, not cut.
+
+## 2. Ranked cut list
+
+Tier 1 — condensations (prose stays in the paper, tighter):
+
+| # | Section | Passage | Now | Action | Save | Risk (remark coverage) |
+|---|---|---|---|---|---|---|
+| 1 | §1 Intro | Six-bullet literature-confirmations list + lead-in | 311 | Condense to ~90-word summary paragraph; full six statistics already live in generated tables (`tab_lit_confirmations.csv` etc.) — move the detailed enumeration to Zenodo README / supplement, keep a pointer | 220 | ED-02, R1-18 (added value). Safe: the condensed summary + §4 directions paragraph + companion-paper reference keep coverage; the statistics survive in deposited tables |
+| 2 | §2.4 | "Deduplication is the residual weak point" audit paragraph | 211 | Condense to ~110: keep the false-negative/false-positive counts and the author-matching future-release sentence; move mechanism detail to the deposited audit table's notes | 100 | R1-12 (dedup). Core counts must survive; §2.2 also reports per-pass removal counts, and tbl-openalex-limits has a dedup row |
+| 3 | §2.3 | National-institutions scope paragraph | 207 | Condense to ~100: keep the boundary rationale (category constituted in UNFCCC/OECD arenas), the @campiglio_etal2025 tractability example, and the extension path | 105 | R1-06, R1-08. Protected core — condense only, never delete |
+| 4 | §3 | fig-global-map caption | 137 | Condense to ~60: keep takeaway (bipolar field) + one method sentence; move layout/registry detail to supplement or figure-notes file | 75 | R1-14 (network demo). The figure itself is the answer; caption keeps the takeaway |
+| 5 | §3 | citations.csv paragraph | 164 | Condense to ~100: keep GROBID reference-string parsing and the 28% no-DOI caveat | 65 | R1-13. GROBID sentences are protected |
+| 6 | §4 | Companion-paper three-method-families paragraph | 129 | Condense to ~70: keep proof-of-use claim and the blind-2007-break sentence | 60 | ED-02 (partially). Keep companion-paper reference |
+| 7 | §3 | embeddings.npz paragraph | 142 | Condense to ~85: keep model, dimensions, normalisation, boilerplate exclusion; drop usage suggestions (BERTopic/top2vec) | 55 | None directly; boilerplate-exclusion clause supports R1-16b |
+| 8 | §2.1 | API-bounds / raw-pool paragraph | 121 | Condense to ~70: **keep the RePEc/NBER/MPRA sentence verbatim** (answers R1-16a); move pool-storage and overlap-validation detail to Zenodo README | 50 | R1-16a. That one sentence is the only coverage — protected |
+| 9 | §2.3 | Reference-list completeness paragraph | 120 | Condense to ~70: keep median/zero-tail counts and the "screening variable" advice | 50 | R1-13 (reference counts). Keep the numbers; also echoed in tbl-openalex-limits |
+| 10 | §2.4 | Abstract-field paragraph | 115 | Condense to ~70: keep boilerplate detector + fig-bars bias direction | 45 | R1-16b. Keep both facts |
+| 11 | §3 | corpus.csv paragraph | 150 | Condense to ~105: keep @tbl-variables pointer, codebook, filter recipe, near-duplicate column | 45 | ED-03, R1-19. Table include + codebook sentence protected |
+| 12 | §4 | Referee-reply paragraph | 116 | Condense to ~70: keep the candid "task-specific cleaning" concession; trim the Negishi/Barrett illustration to one clause | 45 | R1-18. Concession sentence protected |
+| 13 | §2.3 | Near-duplicate (COP27 editorial) paragraph | 48 | Delete; fold the @atwoli_etal2022 example as one clause into §2.2's near-duplicate paragraph | 40 | None solely here — mechanism covered in §2.2 and tbl-openalex-limits row |
+| 14 | §2.3 | Reranker calibration paragraph | 96 | Condense to ~55: keep AUC 0.818 human validation and contested-category caveat | 40 | R1-11 (query false positives) — AUC figure also cited in tbl-openalex-limits |
+| 15 | §2.3 | Citation-verification paragraph ("As tbl-quality shows…") | 104 | Condense to ~70: keep 99.0% audit and the corrected non-English wording | 35 | R1-13 (audit), R1-16c (the reworded coverage sentence is here — keep it) |
+| 16 | §2.3 | Biases paragraph | 105 | Condense to ~70; absorb §2.1's multilingual-by-design paragraph (52 → drop ~25 by merging) | 60 | None solely; language-share facts also in tbl-languages include |
+| 17 | §3 | fig-sem-composition caption | 79 | Condense to ~45 | 35 | Boilerplate-exclusion clause supports R1-16b — keep it |
+| 18 | §3 | Temporal citation-coverage paragraph | 85 | Condense to ~55: keep 27%/47% numbers and the user warning | 30 | Supports R1-13-adjacent guidance |
+| 19 | §1 | Prior-mappings coverage paragraph | 113 | Condense to ~85: keep the three coverage percentages | 30 | ED-02 (added value) — percentages protected |
+| 20 | §2.1 | Search-strategy paragraph | 96 | Condense to ~66 | 30 | None; taxonomy detail in deposited YAML |
+| 21 | §2.2 | Protection-criteria paragraph | 75 | Trim teaching-canon construction detail to the existing tech-report pointer | 30 | None |
+| 22 | §4 | Final provenance/future paragraph | 63 | Condense to ~40 | 20 | ED-01's regional-databases answer is in §2.4, not here — safe |
+
+Tier 1 subtotal: **1,315 words saved** → 4,068 − 1,315 = **2,753**.
+
+Tier 2 — needed only under the strict reading (abstract + captions count):
+
+| # | Item | Action | Save |
+|---|---|---|---|
+| 23 | §2.3 lead-in column-definitions paragraph (74) | Move %non-EN/%DOI/%Abstract/%Refs definitions into the generated table's footnote (edit the table generator, not prose) | 50 |
+| 24 | §2.4 dedup + §2.3 reference-stats residue | Second-pass move of remaining audit numbers to a one-page "quality supplement" in the Zenodo deposit, pointers in text | 120 |
+| 25 | Abstract | Tighten 95 → 70 | 25 |
+| 26 | §3 Zenodo-structure lead paragraph (70) | Condense to ~50 — keep the three-part inputs/products split (ED-04 protected) | 20 |
+| 27 | §4 opening paragraph (41) | Merge into directions paragraph | 20 |
+| 28 | §1 opening paragraph (83) | Tighten to ~65 | 18 |
+
+Tier 2 subtotal: **253** → running total **2,500**. If the journal excludes
+abstract and captions (3,740 effective), Tier 1 alone lands at ~2,420 and
+Tier 2 is unnecessary.
+
+## 3. Protected passages (must survive, at least condensed)
+
+- §2.1 "OpenAlex indexes economics working papers from RePEc, NBER, MPRA…" — only coverage of **R1-16a**.
+- §2.3 "the five smaller sources increase the corpus's non-English, institutional, and pedagogical coverage" (corrected wording) — **R1-16c**.
+- §2.3 national-institutions boundary paragraph (rationale + Campiglio + extension path) — **R1-06/R1-08**.
+- §2.4 entire section skeleton: tbl-openalex-limits table + regional-databases paragraph (SciELO, Garuda) — **ED-01, R1-10, R1-11, R1-16b**. The table is the point-by-point answer; do not cut the table.
+- §2.2 + §2.4 dedup per-pass counts and false-negative/false-positive audit numbers — **R1-12**.
+- §2.3 99.0% citation-link audit; reference-count median/zero-tail numbers; §3 GROBID sentences — **R1-13**.
+- §3 fig-global-map figure + community paragraph — **R1-14** (also fig-sem-composition for the text-analysis angle).
+- §3 corpus.csv description + `@tbl-variables` include + codebook sentence — **ED-03, R1-19**.
+- §3 Zenodo three-part structure sentence (code / inputs / products) — **ED-04**.
+- §1 condensed added-value summary + §4 directions paragraph + companion-paper references — **ED-02, R1-18**.
+- §4 "task-specific cleaning" concession — **R1-18**.
+
+## 4. Arithmetic
+
+- Current prose total: **4,068** (strict count; 3,740 if abstract + captions excluded).
+- Words to cut (strict): 4,068 − 2,500 = **1,568**.
+- Tier 1 savings: **1,315**. Tier 2 savings: **253**. Sum: **1,568** → exactly 2,500.
+- Under the lenient reading, Tier 1 alone suffices (≈2,420 countable words) with ~80 words of slack.
+
+**Verdict: 2,500 is reachable without deleting any remark's only coverage.**
+Every cut is a condensation or a move-to-supplement with an in-text pointer;
+no remark listed in the ledger loses its answering passage. The tight spots
+are #2 (R1-12 dedup audit) and #3 (R1-06 national institutions), where
+condensation must be done carefully — both keep their load-bearing numbers
+and rationale. Author arbitration recommended on: the counting ambiguity,
+Tier 2 item 24 (supplement move), and how far to shrink the intro bullet list.

--- a/deliverables/data-paper/revision-rdj26561/cut-plan.md
+++ b/deliverables/data-paper/revision-rdj26561/cut-plan.md
@@ -1,7 +1,15 @@
-# Cut plan: data-paper.qmd word budget 4,100 → 2,500
+# Cut plan v2: data-paper.qmd word budget 4,100 → 2,500
 
-Prepared 2026-07-24 (ticket-ref 0274). Plan only — no manuscript edits made.
-Remark IDs from `ledger.dedup.jsonl` in this directory.
+Prepared 2026-07-24, revised same day per author feedback (ticket-ref 0274).
+Plan only — no manuscript edits made. Remark IDs from `ledger.dedup.jsonl` in
+this directory.
+
+Changes from v1: a whole-removal pass now comes first (v1 was
+condensation-only); Tier 2 is dropped from the actionable plan; every
+"move to supplement" is rewritten as a file or README section in the Zenodo
+data package (kit structure per `ed04-zenodo-restructure-upload.md`, ticket
+0280) with a one-line pointer in the paper — RDJ4HSS gets no formal
+electronic supplement.
 
 ## 1. Measured word counts
 
@@ -31,59 +39,65 @@ Figure captions alone: fig-bars 17 + fig-global-map 137 + fig-sem-composition 79
 **Counting ambiguity for the author.** RDJ4HSS says "max 2,500 words" without
 stating whether abstract, figure captions, and tables count. If abstract (95)
 and captions (233) are excluded, the effective total is 3,740 and the target
-needs only ~1,240 of cuts. This plan reaches 2,500 under the *strict* reading
+needs only ~1,240 of cuts. This plan works under the *strict* reading
 (everything counts). Generated pipe tables (tbl-sources, tbl-openalex-limits)
 and the three generated includes are not counted here in either reading; if
 the journal counts table text, flag it — tbl-openalex-limits alone is ~150
 words and answers ED-01/R1-11, so it should be defended, not cut.
 
-## 2. Ranked cut list
+## 2. Remove whole — taken first
 
-Tier 1 — condensations (prose stays in the paper, tighter):
+Candid criterion: which passages are weak, distracting, redundant with the
+deposited artifacts, or serve no referee remark — and can be deleted outright,
+at most leaving a one-line pointer? Each entry states the ledger check: no
+remark loses its only coverage.
+
+| # | Section | Passage (first words) | Now | Action | Save | Weakness (candid) | Ledger check |
+|---|---|---|---|---|---|---|---|
+| W1 | §1 | Six-bullet literature-confirmations list + lead-in ("Beyond coverage, the corpus can re-test…") | 311 | Remove whole; replace with a ~35-word paragraph: the corpus reproduces six published results of the prior literature, statistics in `tab_lit_confirmations.csv` / `tab_semantic_robustness.csv`, shipped under `data/products/` in the Zenodo package (add them to the ed04 kit) | 276 | This is the weakest block in the paper: six analysis findings with test statistics in a *data paper's introduction*. It reads as results smuggled from the companion paper, distracts from the data-description mandate, and duplicates deposited artifacts verbatim. A referee skimming for "what is the dataset?" hits a wall of chi-squares first. | ED-02/R1-18 (added value) keep triple coverage: the prior-mappings coverage percentages (§1), the pointer sentence itself, §4 proof-of-use + directions paragraphs. |
+| W2 | §4 | Three-method-families paragraph ("Can such a corpus serve the history of economic thought?…") | 129 | Remove the method-family enumeration whole; keep one ~29-word sentence: companion paper as proof of use, corroborative epistemic role, and the calendar-blind 2007 structural break | 100 | The semantic/lexical/descriptive taxonomy is the companion paper's methodology, restated here for no data-paper purpose. It tells readers how *another* paper analyses the data instead of what the data are. Padding by borrowed depth. | ED-02 coverage survives in the retained sentence (companion-paper reference + blind-break claim). No other remark maps here. |
+| W3 | §3 | Temporal citation-coverage paragraph ("Citation coverage --- the share of corpus works…") | 85 | Remove whole; the 27%/47% figures and the early-period-undercount warning become a "Citation coverage over time" note in `codebook.md` (data/products/, ed04 kit); no in-text pointer needed — the citations.csv paragraph already states the 28% no-DOI undercount and its mechanism | 85 | Redundant in mechanism with the citations.csv paragraph three paragraphs earlier (same DOI/indexing explanation, restated). Usage guidance of this granularity belongs with the data dictionary, not the paper. | R1-13 keeps its coverage via the 99.0% audit, reference-count statistics, and GROBID sentences — this paragraph was adjacent support only, never a remark's answer. |
+| W4 | §2.1 | Multilingual-by-design paragraph ("The corpus is multilingual by design…") | 52 | Remove whole | 52 | Pure repetition: the English share, the eight-language targeting, and the cross-linguistic-foundation claim all reappear in §2.3's biases paragraph and in tbl-languages. Self-congratulatory framing ("deliberate", "foundation") with zero new facts. | No remark maps solely here; language-share facts survive in §2.3 + tbl-languages include (R1-16c's answering sentence is in §2.3, untouched). |
+| W5 | §2.3 | Near-duplicate COP27 paragraph ("Near-duplicate detection identified…") | 48 | Remove whole; fold `@atwoli_etal2022` as one example clause into §2.2's near-duplicate paragraph | 40 | Third telling of the same mechanism: §2.2 describes detection, tbl-openalex-limits has a duplicate-records row, and this paragraph re-explains both to deliver one anecdote. | No remark solely here; dedup coverage (ED-01, R1-11, R1-12) rests on §2.2, §2.4, and the table row. |
+| W6 | §2.2 | Teaching-canon construction sentence ("The teaching canon was built by scraping…") | 45 | Remove whole; the existing companion-technical-report pointer in the same sentence's tail stays as the one-line pointer | 40 | Method detail for a *source*, parked mid-paragraph inside the protection-criteria discussion — a digression at the wrong altitude. The technical report already documents it. | No remark maps here. |
+| W7 | §3 | Open-Access/fulltext-URL sentences at the end of the source-catalogs paragraph ("The corpus does not include a dedicated Open Access…") | 45 | Remove whole; becomes a "Recovering OA links" note in the Zenodo package README (ed04 kit) | 40 | Defensive how-to trivia (reconstruct URLs from identifiers) that answers no reviewer and interests only a user already inside the package — which is exactly where the README lives. | No remark maps here. |
+
+**Whole-removal subtotal: 633 words.**
+
+## 3. Condensations — cover the remainder only
+
+Tier 1 condensations, v1 list minus the items W1–W7 replace (v1 #1, #6, #13,
+#18, #21) and with v1 #16 reduced (its merge-with-§2.1 component is now W4).
+All "supplement" destinations rewritten as Zenodo-package files.
 
 | # | Section | Passage | Now | Action | Save | Risk (remark coverage) |
 |---|---|---|---|---|---|---|
-| 1 | §1 Intro | Six-bullet literature-confirmations list + lead-in | 311 | Condense to ~90-word summary paragraph; full six statistics already live in generated tables (`tab_lit_confirmations.csv` etc.) — move the detailed enumeration to Zenodo README / supplement, keep a pointer | 220 | ED-02, R1-18 (added value). Safe: the condensed summary + §4 directions paragraph + companion-paper reference keep coverage; the statistics survive in deposited tables |
-| 2 | §2.4 | "Deduplication is the residual weak point" audit paragraph | 211 | Condense to ~110: keep the false-negative/false-positive counts and the author-matching future-release sentence; move mechanism detail to the deposited audit table's notes | 100 | R1-12 (dedup). Core counts must survive; §2.2 also reports per-pass removal counts, and tbl-openalex-limits has a dedup row |
-| 3 | §2.3 | National-institutions scope paragraph | 207 | Condense to ~100: keep the boundary rationale (category constituted in UNFCCC/OECD arenas), the @campiglio_etal2025 tractability example, and the extension path | 105 | R1-06, R1-08. Protected core — condense only, never delete |
-| 4 | §3 | fig-global-map caption | 137 | Condense to ~60: keep takeaway (bipolar field) + one method sentence; move layout/registry detail to supplement or figure-notes file | 75 | R1-14 (network demo). The figure itself is the answer; caption keeps the takeaway |
-| 5 | §3 | citations.csv paragraph | 164 | Condense to ~100: keep GROBID reference-string parsing and the 28% no-DOI caveat | 65 | R1-13. GROBID sentences are protected |
-| 6 | §4 | Companion-paper three-method-families paragraph | 129 | Condense to ~70: keep proof-of-use claim and the blind-2007-break sentence | 60 | ED-02 (partially). Keep companion-paper reference |
-| 7 | §3 | embeddings.npz paragraph | 142 | Condense to ~85: keep model, dimensions, normalisation, boilerplate exclusion; drop usage suggestions (BERTopic/top2vec) | 55 | None directly; boilerplate-exclusion clause supports R1-16b |
-| 8 | §2.1 | API-bounds / raw-pool paragraph | 121 | Condense to ~70: **keep the RePEc/NBER/MPRA sentence verbatim** (answers R1-16a); move pool-storage and overlap-validation detail to Zenodo README | 50 | R1-16a. That one sentence is the only coverage — protected |
-| 9 | §2.3 | Reference-list completeness paragraph | 120 | Condense to ~70: keep median/zero-tail counts and the "screening variable" advice | 50 | R1-13 (reference counts). Keep the numbers; also echoed in tbl-openalex-limits |
-| 10 | §2.4 | Abstract-field paragraph | 115 | Condense to ~70: keep boilerplate detector + fig-bars bias direction | 45 | R1-16b. Keep both facts |
-| 11 | §3 | corpus.csv paragraph | 150 | Condense to ~105: keep @tbl-variables pointer, codebook, filter recipe, near-duplicate column | 45 | ED-03, R1-19. Table include + codebook sentence protected |
-| 12 | §4 | Referee-reply paragraph | 116 | Condense to ~70: keep the candid "task-specific cleaning" concession; trim the Negishi/Barrett illustration to one clause | 45 | R1-18. Concession sentence protected |
-| 13 | §2.3 | Near-duplicate (COP27 editorial) paragraph | 48 | Delete; fold the @atwoli_etal2022 example as one clause into §2.2's near-duplicate paragraph | 40 | None solely here — mechanism covered in §2.2 and tbl-openalex-limits row |
-| 14 | §2.3 | Reranker calibration paragraph | 96 | Condense to ~55: keep AUC 0.818 human validation and contested-category caveat | 40 | R1-11 (query false positives) — AUC figure also cited in tbl-openalex-limits |
-| 15 | §2.3 | Citation-verification paragraph ("As tbl-quality shows…") | 104 | Condense to ~70: keep 99.0% audit and the corrected non-English wording | 35 | R1-13 (audit), R1-16c (the reworded coverage sentence is here — keep it) |
-| 16 | §2.3 | Biases paragraph | 105 | Condense to ~70; absorb §2.1's multilingual-by-design paragraph (52 → drop ~25 by merging) | 60 | None solely; language-share facts also in tbl-languages include |
-| 17 | §3 | fig-sem-composition caption | 79 | Condense to ~45 | 35 | Boilerplate-exclusion clause supports R1-16b — keep it |
-| 18 | §3 | Temporal citation-coverage paragraph | 85 | Condense to ~55: keep 27%/47% numbers and the user warning | 30 | Supports R1-13-adjacent guidance |
-| 19 | §1 | Prior-mappings coverage paragraph | 113 | Condense to ~85: keep the three coverage percentages | 30 | ED-02 (added value) — percentages protected |
-| 20 | §2.1 | Search-strategy paragraph | 96 | Condense to ~66 | 30 | None; taxonomy detail in deposited YAML |
-| 21 | §2.2 | Protection-criteria paragraph | 75 | Trim teaching-canon construction detail to the existing tech-report pointer | 30 | None |
-| 22 | §4 | Final provenance/future paragraph | 63 | Condense to ~40 | 20 | ED-01's regional-databases answer is in §2.4, not here — safe |
+| 1 | §2.4 | "Deduplication is the residual weak point" audit paragraph | 211 | Condense to ~110: keep the false-negative/false-positive counts and the author-matching future-release sentence; mechanism detail goes into notes accompanying the deposited `tab_dedup_error_estimates.csv` (data/products/, ed04 kit) | 100 | R1-12 (dedup). Core counts must survive; §2.2 also reports per-pass removal counts, and tbl-openalex-limits has a dedup row |
+| 2 | §2.3 | National-institutions scope paragraph | 207 | Condense to ~100: keep the boundary rationale (category constituted in UNFCCC/OECD arenas), the @campiglio_etal2025 tractability example, and the extension path | 105 | R1-06, R1-08. Protected core — condense only, never delete |
+| 3 | §3 | fig-global-map caption | 137 | Condense to ~60: keep takeaway (bipolar field) + one method sentence; reading-guide/layout/registry detail moves to a `figure-notes.md` in the Zenodo package (data/products/, ed04 kit) | 75 | R1-14 (network demo). The figure itself is the answer; caption keeps the takeaway |
+| 4 | §3 | citations.csv paragraph | 164 | Condense to ~100: keep GROBID reference-string parsing and the 28% no-DOI caveat | 65 | R1-13. GROBID sentences are protected |
+| 5 | §3 | embeddings.npz paragraph | 142 | Condense to ~85: keep model, dimensions, normalisation, boilerplate exclusion; drop usage suggestions (BERTopic/top2vec) | 55 | None directly; boilerplate-exclusion clause supports R1-16b |
+| 6 | §2.1 | API-bounds / raw-pool paragraph | 121 | Condense to ~70: **keep the RePEc/NBER/MPRA sentence verbatim** (answers R1-16a); pool-storage and overlap-validation detail moves to the Zenodo package README (ed04 kit) | 50 | R1-16a. That one sentence is the only coverage — protected |
+| 7 | §2.3 | Reference-list completeness paragraph | 120 | Condense to ~70: keep median/zero-tail counts and the "screening variable" advice | 50 | R1-13 (reference counts). Keep the numbers; also echoed in tbl-openalex-limits |
+| 8 | §2.4 | Abstract-field paragraph | 115 | Condense to ~70: keep boilerplate detector + fig-bars bias direction | 45 | R1-16b. Keep both facts |
+| 9 | §3 | corpus.csv paragraph | 150 | Condense to ~105: keep @tbl-variables pointer, codebook, filter recipe, near-duplicate column | 45 | ED-03, R1-19. Table include + codebook sentence protected |
+| 10 | §4 | Referee-reply paragraph | 116 | Condense to ~70: keep the candid "task-specific cleaning" concession; trim the Negishi/Barrett illustration to one clause | 45 | R1-18. Concession sentence protected |
+| 11 | §2.3 | Reranker calibration paragraph | 96 | Condense to ~55: keep AUC 0.818 human validation and contested-category caveat | 40 | R1-11 (query false positives) — AUC figure also cited in tbl-openalex-limits |
+| 12 | §2.3 | Citation-verification paragraph ("As tbl-quality shows…") | 104 | Condense to ~70: keep 99.0% audit and the corrected non-English wording | 35 | R1-13 (audit), R1-16c (the reworded coverage sentence is here — keep it) |
+| 13 | §2.3 | Biases paragraph | 105 | Condense to ~70 (the v1 merge with §2.1's multilingual paragraph is superseded by W4) | 35 | None solely; language-share facts also in tbl-languages include |
+| 14 | §3 | fig-sem-composition caption | 79 | Condense to ~45 | 35 | Boilerplate-exclusion clause supports R1-16b — keep it |
+| 15 | §1 | Prior-mappings coverage paragraph | 113 | Condense to ~85: keep the three coverage percentages | 30 | ED-02 (added value) — percentages protected |
+| 16 | §2.1 | Search-strategy paragraph | 96 | Condense to ~66 | 30 | None; taxonomy detail in deposited YAML |
+| 17 | §4 | Final provenance/future paragraph | 63 | Condense to ~40 | 20 | ED-01's regional-databases answer is in §2.4, not here — safe |
 
-Tier 1 subtotal: **1,315 words saved** → 4,068 − 1,315 = **2,753**.
+**Condensation subtotal: 860 words.**
 
-Tier 2 — needed only under the strict reading (abstract + captions count):
+*Tier-2 reserve:* a further ~253 words of second-order cuts (v1 items 23–28:
+column-definition footnote move, abstract tightening, opening-paragraph
+merges) remain identified and available if Tier 1 under-delivers; they are
+not part of the actionable plan.
 
-| # | Item | Action | Save |
-|---|---|---|---|
-| 23 | §2.3 lead-in column-definitions paragraph (74) | Move %non-EN/%DOI/%Abstract/%Refs definitions into the generated table's footnote (edit the table generator, not prose) | 50 |
-| 24 | §2.4 dedup + §2.3 reference-stats residue | Second-pass move of remaining audit numbers to a one-page "quality supplement" in the Zenodo deposit, pointers in text | 120 |
-| 25 | Abstract | Tighten 95 → 70 | 25 |
-| 26 | §3 Zenodo-structure lead paragraph (70) | Condense to ~50 — keep the three-part inputs/products split (ED-04 protected) | 20 |
-| 27 | §4 opening paragraph (41) | Merge into directions paragraph | 20 |
-| 28 | §1 opening paragraph (83) | Tighten to ~65 | 18 |
-
-Tier 2 subtotal: **253** → running total **2,500**. If the journal excludes
-abstract and captions (3,740 effective), Tier 1 alone lands at ~2,420 and
-Tier 2 is unnecessary.
-
-## 3. Protected passages (must survive, at least condensed)
+## 4. Protected passages (must survive, at least condensed)
 
 - §2.1 "OpenAlex indexes economics working papers from RePEc, NBER, MPRA…" — only coverage of **R1-16a**.
 - §2.3 "the five smaller sources increase the corpus's non-English, institutional, and pedagogical coverage" (corrected wording) — **R1-16c**.
@@ -94,20 +108,24 @@ Tier 2 is unnecessary.
 - §3 fig-global-map figure + community paragraph — **R1-14** (also fig-sem-composition for the text-analysis angle).
 - §3 corpus.csv description + `@tbl-variables` include + codebook sentence — **ED-03, R1-19**.
 - §3 Zenodo three-part structure sentence (code / inputs / products) — **ED-04**.
-- §1 condensed added-value summary + §4 directions paragraph + companion-paper references — **ED-02, R1-18**.
+- §1 W1 pointer sentence + prior-mappings percentages + §4 proof-of-use and directions paragraphs — **ED-02, R1-18**.
 - §4 "task-specific cleaning" concession — **R1-18**.
 
-## 4. Arithmetic
+## 5. Arithmetic
 
 - Current prose total: **4,068** (strict count; 3,740 if abstract + captions excluded).
 - Words to cut (strict): 4,068 − 2,500 = **1,568**.
-- Tier 1 savings: **1,315**. Tier 2 savings: **253**. Sum: **1,568** → exactly 2,500.
-- Under the lenient reading, Tier 1 alone suffices (≈2,420 countable words) with ~80 words of slack.
+- Whole removals (taken first): **633**. Condensations (remainder): **860**. Sum: **1,493** → lands at **2,575** under the strict reading.
+- Residual 75 words under the strict reading come from the Tier-2 reserve (253 available — first candidates: column-definition footnote move ~50, abstract tightening ~25).
+- Under the lenient reading (abstract + captions excluded, 3,740 countable), this plan lands at ≈2,247 with ~250 words of slack — some condensations could then be relaxed.
 
 **Verdict: 2,500 is reachable without deleting any remark's only coverage.**
-Every cut is a condensation or a move-to-supplement with an in-text pointer;
-no remark listed in the ledger loses its answering passage. The tight spots
-are #2 (R1-12 dedup audit) and #3 (R1-06 national institutions), where
-condensation must be done carefully — both keep their load-bearing numbers
-and rationale. Author arbitration recommended on: the counting ambiguity,
-Tier 2 item 24 (supplement move), and how far to shrink the intro bullet list.
+Whole removals do the structural work (633 words, and the paper reads more
+like a data paper for it); condensations cover the rest. Every displaced
+detail becomes a file or README section in the Zenodo data package (ed04 kit
+structure) with at most a one-line pointer in the paper — no journal
+electronic supplement. The tight spots are condensation #1 (R1-12 dedup
+audit) and #2 (R1-06 national institutions), where load-bearing numbers and
+rationale must survive. Author arbitration recommended on: the counting
+ambiguity, and whether to draw the final ~75 words from the reserve or relax
+toward the lenient reading.

--- a/tickets/0311-keydocs-empty-url-anchors-completion.erg
+++ b/tickets/0311-keydocs-empty-url-anchors-completion.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-23T23:30Z HDMX-coding-agent created child of 0288, from PR #1107 verify recommendation
 
+2026-07-24T08:30Z HDMX-coding-agent note split into 0312 (fetch: mop-up harvest + manual OECD intake) and 0313 (verify-and-fill: URL/symbol resolution); this ticket becomes the tracker
+
 --- body ---
 ## Context
 
@@ -19,7 +21,12 @@ data paper (parent 0288) would silently ship without their fulltexts.
 Also open from 0304's report: ENB COP22-29 summaries (not in the archived
 vol-12 index) and ~12 Incapsula wall bounces to retry cold.
 
-## Actions
+## Children
+
+- 0313 — verify-and-fill: resolve series anchors, enumerate ENB, confirm symbols
+- 0312 — fetch: cold mop-up re-run, manual OECD PDF intake, dvc commit (blocked-by 0313)
+
+## Actions (superseded by the split above)
 
 1. Cold re-run of the mop-up harvest (wall bounces should clear).
 2. Resolve the fund-series anchors (GCF/GEF/AFB/CMA4) to concrete document

--- a/tickets/0312-keydocs-fetch-mopup-harvest.erg
+++ b/tickets/0312-keydocs-fetch-mopup-harvest.erg
@@ -1,0 +1,42 @@
+%erg 0.1
+Title: Keydocs fetch: cold mop-up harvest re-run and manual OECD PDF intake
+Created: 2026-07-24
+Author: HDMX-coding-agent
+Blocked-by: 0313
+
+--- log ---
+2026-07-24T08:30Z HDMX-coding-agent created split from 0311 (fetch lane)
+
+--- body ---
+## Context
+
+Split from 0311 (parent 0288). The fetch lane: actually acquiring the
+fulltexts once URLs are known. Separated from the verify-and-fill lane
+(0313) so the URL-resolution research and the mechanical harvest re-run
+can be reviewed independently. Blocked-by 0313 only for the seeds whose
+URLs 0313 resolves; the wall-bounce retries and the manual OECD intake
+can start immediately.
+
+## Actions
+
+1. Cold re-run of the mop-up harvest (`catalog_keydocs.py`) — the ~12
+   Incapsula wall bounces from 0304's report should clear.
+2. Manual OECD intake: 11 PDFs fetched by the author in a browser
+   (one.oecd.org 403s robots), placed as
+   `data/pool/keydocs/oecd/<safe_filename(symbol)>.pdf`. Already cached:
+   DCD_DAC_2007_39_FINAL, DCD_DAC_2016_3_FINAL, DCD_DAC_STAT_2018_9_FINAL.
+3. Re-run harvest after 0313 lands its URLs; `dvc commit` the pool.
+
+## Verification
+
+- [ ] Every OECD/UNFCCC seed entry status is cached or documented no_url
+- [ ] Pool sidecar .txt extracted for each new PDF
+
+## Invariants
+
+- Seed guard stays green; harvester still rejects DOI-bearing seeds.
+
+## Exit criteria
+
+- [ ] Harvest statuses final (cached/no_url only) — 0288's corpus-v2
+      rebuild can count fulltexts

--- a/tickets/0313-keydocs-verify-fill-url-anchors.erg
+++ b/tickets/0313-keydocs-verify-fill-url-anchors.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-24T08:30Z HDMX-coding-agent created split from 0311 (verify-and-fill lane)
 
+2026-07-24T12:40Z HDMX-coding-agent note web-hunt fan-out (6 agents) findings: (a) OECD/GD(92)-AID-ENV re-scoped — no consolidated 1992 volume exists; the series is numbered pamphlets, Dec-1991 ministers endorsed Nos 1-4 (No 4 = Global Environmental Problems, the climate one; No 8 = Marine and Coastal, Wayback oecd.org/dac/environment-development/1887756.pdf). (b) OECD/DAC/SRD/1998 re-scoped — the 1998 Rio-marker introduction was a 1997 WP-STAT policy-marker decision + dedicated survey, NOT a directives revision; first directive text embedding Rio markers is DCD/DAC(2002)21/ADD (one.oecd.org 403s it even with cookie replay — possibly not declassified; try DCD/DAC/STAT/M(1997-98) minutes). (c) DCR 1992/1995 not online anywhere checked (IA, HathiTrust-403, Google Books, AU library holds paper only); leads: OECD Library & Archives request, manual HathiTrust, ILL. (d) ENVIRONET founding mandate (~1989) and Dec-1991 joint ministerial communique not isolated online; SG/PRESS(91)9 is the Jan-1991 environment-only statement, not it.
+
 --- body ---
 ## Context
 

--- a/tickets/0313-keydocs-verify-fill-url-anchors.erg
+++ b/tickets/0313-keydocs-verify-fill-url-anchors.erg
@@ -1,0 +1,40 @@
+%erg 0.1
+Title: Keydocs verify-and-fill: resolve series anchors and empty-URL entries
+Created: 2026-07-24
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-24T08:30Z HDMX-coding-agent created split from 0311 (verify-and-fill lane)
+
+--- body ---
+## Context
+
+Split from 0311 (parent 0288). The research lane: resolving every seed
+entry that still lacks a concrete URL or carries a "to confirm at
+harvest" provenance, so the fetch lane (0312) has final targets.
+
+## Actions
+
+1. Resolve the fund-series anchors (GCF 2015/2020, GEF 1997, Adaptation
+   Fund 2010, CMA4 Add.1) to concrete document URLs or Wayback captures.
+2. Enumerate ENB COP22-29 summaries from enb.iisd.org or Wayback.
+3. Resolve the OECD entries with empty URLs (SRD/1998 OLIS symbol, DCR
+   1992/1995/1998, GD(92) Aid & Environment, Rio report 2002, ENVIRONET
+   1990s enumeration) to symbols + URLs where they exist.
+4. Confirm the seven "to confirm at harvest" symbols.
+5. Leave genuinely no-PDF curated works (Clinton COP15 statement, AOSIS
+   reaction, G77 LTF submission) as documented no_url entries.
+
+## Verification
+
+- [ ] No seed entry retains "to confirm at harvest"
+- [ ] Empty-URL entries form an explicit, documented curated-no-PDF list
+
+## Invariants
+
+- Seed guard stays green; no catalog_grey coupling; no `doi:` keys.
+
+## Exit criteria
+
+- [ ] Every seed has either a final URL/symbol or a documented no_url
+      justification — 0312 can harvest to completion


### PR DESCRIPTION
Morning session 2026-07-24: the author's OECD fetch run plus supporting work.

- **21 new keydocs seeds** (YAML now 35): 7 author HITL additions (2018 Blended Finance Principles, 2001/2002 DAC Guidelines, Shaping the 21st Century 1996, MfSDR 2019, Harmonising Donor Practices 2003, 1992 Assistance Manual), directive-series completions (2023 + ADD2, 2018 ADD2, 2014 Untying Recommendation, WP-STAT 2020 marker review), and the complete Guidelines on Aid and Environment series Nos. 1-9 (web-hunt fan-out: Wayback + CBD mirrors).
- **Phantom retired**: no consolidated 1992 Aid-Env volume exists; SRD-1998 re-scope findings recorded in 0313.
- **Ticket 0311 split** into 0312 (fetch lane) + 0313 (verify-and-fill lane); hunt findings logged in 0313.
- **ECDPM 2012 study** routed to the grey layer (author decision).
- **Cut plan** for the word budget (4,068 → 2,500) at `deliverables/data-paper/revision-rdj26561/cut-plan.md` — report only, manuscript untouched.

Pool artifacts (31 keydocs PDFs, 59 oecd_hitl PDFs) are DVC-side; `dvc commit` rides the 0312/0288 rebuild.

Ticket: none
Ticket-ref: tickets/0288-datapaper-unfccc-grey-literature-layer.erg
Ticket-ref: tickets/0311-keydocs-empty-url-anchors-completion.erg
Ticket-ref: tickets/0313-keydocs-verify-fill-url-anchors.erg
Ticket-ref: tickets/0274-rdj26561-rr-round-1-tracker.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)