### PR TITLE
File corpus-integrity guard tickets 0314/0315

### DIFF
--- a/tickets/0314-filter-flag6-hard-guard.erg
+++ b/tickets/0314-filter-flag6-hard-guard.erg
@@ -1,0 +1,38 @@
+%erg 0.1
+Title: Filter stage: hard-fail when Flag 6 (semantic relevance) cannot run
+Created: 2026-07-24
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-24T16:20Z HDMX-coding-agent created from corpus-v2 rebuild incident
+
+--- body ---
+## Context
+
+During the 2026-07-24 corpus-v2 rebuild, the filter stage ran in an env
+without torch/sentence-transformers. Flag 6 (semantic relevance) logged
+"Flag 6 skipped … no candidates scored" as a WARNING and the stage exited 0,
+shipping a refined corpus inflated by 5,840 wrongly-retained works
+(38,166 instead of 33,344). The defect was caught only because the number
+swung between passes and was chased by hand (PR #1116 diagnosis).
+
+A silently-degraded corpus is worse than a failed build: every downstream
+number (paper, letter, deposit) inherits the inflation unnoticed.
+
+## Actions
+
+1. In the filter script, make an unrunnable Flag 6 a hard error (exit
+   non-zero), with the remediation in the message (uv sync --group corpus
+   --extra cpu|cu130; PYTHONPATH via make).
+2. Audit sibling flags for the same skip-and-continue pattern; same
+   treatment for any flag whose absence changes corpus membership.
+
+## Test
+
+- Unit: filter invoked with torch unavailable (mock import failure) exits
+  non-zero and names Flag 6 in the error.
+
+## Exit criteria
+
+- [ ] Filter cannot exit 0 with a membership-affecting flag skipped
+- [ ] make check green

--- a/tickets/0315-feather-cache-mtime-invalidation.erg
+++ b/tickets/0315-feather-cache-mtime-invalidation.erg
@@ -1,0 +1,37 @@
+%erg 0.1
+Title: pipeline_loaders: Feather cache must invalidate on CSV mtime
+Created: 2026-07-24
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-24T16:20Z HDMX-coding-agent created from corpus-v2 rebuild incident (bit twice on 2026-07-24)
+
+--- body ---
+## Context
+
+The corpus loaders accelerate CSV reads via Feather sidecars but never
+compare their mtime to the source CSV. During the 2026-07-24 corpus-v2
+rebuild, April-dated Feather caches shadowed the freshly rebuilt CSVs and
+crashed the sem6 build with inconsistent data; the fix (manual cache
+rebuild via the Make feather targets) had to be re-discovered mid-run —
+and the same trap had already bitten earlier the same day. Any analysis
+run between a corpus rebuild and a manual cache refresh silently reads
+the OLD corpus.
+
+## Actions
+
+1. In pipeline_loaders, when a Feather sidecar is older than its source
+   CSV, ignore it and regenerate (or fail with a clear message if
+   regeneration is not possible in context).
+2. Cover load_refined_works / load_refined_citations / any loader with a
+   Feather fast path.
+
+## Test
+
+- Unit: touch the CSV newer than the Feather; loader returns CSV content
+  (or regenerates), never the stale Feather.
+
+## Exit criteria
+
+- [ ] A rebuilt CSV can never be shadowed by an older Feather sidecar
+- [ ] make check green


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0314-filter-flag6-hard-guard.erg
Ticket-ref: tickets/0315-feather-cache-mtime-invalidation.erg

Two defects surfaced by today's corpus-v2 rebuild (diagnosis on PR #1116): the filter's Flag 6 skips silently when torch is absent (inflated corpus, exit 0), and Feather caches never invalidate on CSV mtime (stale corpus reads). Filing only — fixes are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)