### PR TITLE
trim(0274): drop the Source column from the paper's variables table

### DIFF
--- a/deliverables/_shared/tables/tab_variables.md
+++ b/deliverables/_shared/tables/tab_variables.md
@@ -1,36 +1,36 @@
-| Group | Variable | Type | Description | Source |
-|:----|:------|:----|:-------------------------|:---------|
-| Record identity | `source` | string | Primary source catalog for the record's metadata (highest-priority contributing source) | source catalogs, merged by catalog_merge.py |
-|  | `source_id` | string | Identifier in the primary source (e.g. OpenAlex work ID) | source catalogs, merged by catalog_merge.py |
-|  | `doi` | string, nullable | Digital Object Identifier, when available | source catalogs, merged by catalog_merge.py |
-| Bibliographic metadata | `title` | string | Title of the work | source catalogs, merged by catalog_merge.py |
-|  | `first_author` | string, nullable | First author name | source catalogs, merged by catalog_merge.py |
-|  | `all_authors` | string, nullable | Full author list, separator-joined | source catalogs, merged by catalog_merge.py |
-|  | `year` | integer | Publication year | source catalogs, merged by catalog_merge.py |
-|  | `journal` | string, nullable | Publication venue (journal, publisher, or repository) | source catalogs, merged by catalog_merge.py |
-|  | `language` | string, nullable | Language code (ISO 639-1), detected and normalised | enrichment (enrich_* scripts) |
-|  | `keywords` | string, nullable | Keywords, semicolon-separated | source catalogs, merged by catalog_merge.py |
-|  | `categories` | string, nullable | Subject categories / concepts from the source catalog | source catalogs, merged by catalog_merge.py |
-|  | `cited_by_count` | integer | Citation count (OpenAlex, as of the collection date) | source catalogs, merged by catalog_merge.py |
-|  | `affiliations` | string, nullable | Author affiliations, when available | source catalogs, merged by catalog_merge.py |
-| Provenance flags | `from_openalex` | boolean | Provenance flag: found in OpenAlex | source catalogs, merged by catalog_merge.py |
-|  | `from_istex` | boolean | Provenance flag: found in ISTEX | source catalogs, merged by catalog_merge.py |
-|  | `from_bibcnrs` | boolean | Provenance flag: found in bibCNRS | source catalogs, merged by catalog_merge.py |
-|  | `from_scispace` | boolean | Provenance flag: found via SciSpace | source catalogs, merged by catalog_merge.py |
-|  | `from_grey` | boolean | Provenance flag: grey-literature source | source catalogs, merged by catalog_merge.py |
-|  | `from_teaching` | boolean | Provenance flag: teaching canon (syllabi) | source catalogs, merged by catalog_merge.py |
-|  | `from_unfccc` | boolean | Provenance flag: curated UNFCCC key document (absent from corpus builds predating this pipeline stage) | curated key-documents layer (catalog_keydocs.py, corpus v2) |
-|  | `from_oecd` | boolean | Provenance flag: curated OECD key document (absent from corpus builds predating this pipeline stage) | curated key-documents layer (catalog_keydocs.py, corpus v2) |
-|  | `abstract_provenance` | string, nullable | Provenance of the abstract text for curated key documents: `curated`, `reconstructed:lead`, or `reconstructed:exec_summary`; empty elsewhere (absent from corpus builds predating this pipeline stage) | curated key-documents layer (catalog_keydocs.py, corpus v2) |
-|  | `keywords_provenance` | string, nullable | Provenance of the keywords for curated key documents: `extracted` or `generated:lexicon`; empty elsewhere (absent from corpus builds predating this pipeline stage) | curated key-documents layer (catalog_keydocs.py, corpus v2) |
-|  | `source_count` | integer | Number of sources that contributed the record (sum of the provenance flags) | source catalogs, merged by catalog_merge.py |
-| Curation metadata | `abstract_status` | string | Status of the (undistributed) abstract: `original`, `reconstructed` (from OpenAlex inverted index or ISTEX fulltext), `generated` (LLM summary of an oversized abstract), `too_long`, or `missing` | enrichment (enrich_* scripts) |
-|  | `near_duplicate_group` | integer, nullable | Group identifier for near-identical content published under several DOIs; null for ungrouped works | quality filtering (corpus_filter.py) |
-|  | `semantic_outlier_dist` | float, nullable | Distance to the corpus embedding centroid, computed for the semantic-outlier flag (absent from corpus builds predating this pipeline stage) | quality filtering (corpus_filter.py) |
-|  | `in_v1` | boolean | Version tracking: work present in the v1.0 submission corpus (absent from corpus builds predating this pipeline stage) | quality filtering (corpus_filter.py) |
-|  | `is_flagged` | boolean | Any quality flag raised; the refined subset is `df[~df['is_flagged'] | df['is_protected']]` | quality filtering (corpus_filter.py) |
-|  | `flag_reason` | string | Comma-separated list of raised quality flags (missing_metadata, no_abstract_irrelevant, title_blacklist, citation_isolated_old, semantic_outlier, llm_irrelevant); empty when unflagged | quality filtering (corpus_filter.py) |
-|  | `is_protected` | boolean | Protection from removal (key papers kept despite flags) | quality filtering (corpus_filter.py) |
-|  | `protection_reason` | string, nullable | Why the work is protected (citation count, seed list, ...) (absent from corpus builds predating this pipeline stage) | quality filtering (corpus_filter.py) |
+| Group | Variable | Type | Description |
+|:----|:------|:----|:-------------------------------|
+| Record identity | `source` | string | Primary source catalog for the record's metadata (highest-priority contributing source) |
+|  | `source_id` | string | Identifier in the primary source (e.g. OpenAlex work ID) |
+|  | `doi` | string, nullable | Digital Object Identifier, when available |
+| Bibliographic metadata | `title` | string | Title of the work |
+|  | `first_author` | string, nullable | First author name |
+|  | `all_authors` | string, nullable | Full author list, separator-joined |
+|  | `year` | integer | Publication year |
+|  | `journal` | string, nullable | Publication venue (journal, publisher, or repository) |
+|  | `language` | string, nullable | Language code (ISO 639-1), detected and normalised |
+|  | `keywords` | string, nullable | Keywords, semicolon-separated |
+|  | `categories` | string, nullable | Subject categories / concepts from the source catalog |
+|  | `cited_by_count` | integer | Citation count (OpenAlex, as of the collection date) |
+|  | `affiliations` | string, nullable | Author affiliations, when available |
+| Provenance flags | `from_openalex` | boolean | Provenance flag: found in OpenAlex |
+|  | `from_istex` | boolean | Provenance flag: found in ISTEX |
+|  | `from_bibcnrs` | boolean | Provenance flag: found in bibCNRS |
+|  | `from_scispace` | boolean | Provenance flag: found via SciSpace |
+|  | `from_grey` | boolean | Provenance flag: grey-literature source |
+|  | `from_teaching` | boolean | Provenance flag: teaching canon (syllabi) |
+|  | `from_unfccc` | boolean | Provenance flag: curated UNFCCC key document (absent from corpus builds predating this pipeline stage) |
+|  | `from_oecd` | boolean | Provenance flag: curated OECD key document (absent from corpus builds predating this pipeline stage) |
+|  | `abstract_provenance` | string, nullable | Provenance of the abstract text for curated key documents: `curated`, `reconstructed:lead`, or `reconstructed:exec_summary`; empty elsewhere (absent from corpus builds predating this pipeline stage) |
+|  | `keywords_provenance` | string, nullable | Provenance of the keywords for curated key documents: `extracted` or `generated:lexicon`; empty elsewhere (absent from corpus builds predating this pipeline stage) |
+|  | `source_count` | integer | Number of sources that contributed the record (sum of the provenance flags) |
+| Curation metadata | `abstract_status` | string | Status of the (undistributed) abstract: `original`, `reconstructed` (from OpenAlex inverted index or ISTEX fulltext), `generated` (LLM summary of an oversized abstract), `too_long`, or `missing` |
+|  | `near_duplicate_group` | integer, nullable | Group identifier for near-identical content published under several DOIs; null for ungrouped works |
+|  | `semantic_outlier_dist` | float, nullable | Distance to the corpus embedding centroid, computed for the semantic-outlier flag (absent from corpus builds predating this pipeline stage) |
+|  | `in_v1` | boolean | Version tracking: work present in the v1.0 submission corpus (absent from corpus builds predating this pipeline stage) |
+|  | `is_flagged` | boolean | Any quality flag raised; the refined subset is `df[~df['is_flagged'] | df['is_protected']]` |
+|  | `flag_reason` | string | Comma-separated list of raised quality flags (missing_metadata, no_abstract_irrelevant, title_blacklist, citation_isolated_old, semantic_outlier, llm_irrelevant); empty when unflagged |
+|  | `is_protected` | boolean | Protection from removal (key papers kept despite flags) |
+|  | `protection_reason` | string, nullable | Why the work is protected (citation count, seed list, ...) (absent from corpus builds predating this pipeline stage) |
 
-: Variables of `climate_finance_corpus.csv`, by logical group. The table is generated from the deposit column contract (`scripts/_deposit_variables.py`), which the export script enforces at write time. {#tbl-variables}
+: Variables of `climate_finance_corpus.csv`, by logical group. Generated from the deposit column contract (`scripts/_deposit_variables.py`); per-source provenance, allowed values, and missingness are in the deposited codebook. {#tbl-variables}

--- a/scripts/_deposit_variables.py
+++ b/scripts/_deposit_variables.py
@@ -228,8 +228,8 @@ def transform(df):
 def render_markdown_table() -> str:
     """Render the contract as a Quarto pipe table with caption and label."""
     lines = [
-        "| Group | Variable | Type | Description | Source |",
-        "|:----|:------|:----|:-------------------------|:---------|",
+        "| Group | Variable | Type | Description |",
+        "|:----|:------|:----|:-------------------------------|",
     ]
     prev_group = None
     for v in DEPOSIT_VARIABLES:
@@ -237,13 +237,14 @@ def render_markdown_table() -> str:
             " (absent from corpus builds predating this pipeline stage)"
         group = v.group if v.group != prev_group else ""
         prev_group = v.group
-        lines.append(f"| {group} | `{v.name}` | {v.type} | {desc} | {v.source} |")
+        lines.append(f"| {group} | `{v.name}` | {v.type} | {desc} |")
     lines += [
         "",
-        ": Variables of `climate_finance_corpus.csv`, by logical group. The "
-        "table is generated from the deposit column contract "
-        "(`scripts/_deposit_variables.py`), which the export script enforces "
-        "at write time. {#tbl-variables}",
+        ": Variables of `climate_finance_corpus.csv`, by logical group. "
+        "Generated from the deposit column contract "
+        "(`scripts/_deposit_variables.py`); per-source provenance, allowed "
+        "values, and missingness are in the deposited codebook. "
+        "{#tbl-variables}",
     ]
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0274-rdj26561-rr-round-1-tracker.erg

Author request during the copyedit checkpoint: the paper's variables table loses its Source column (a third of its rendered width); the deposited codebook keeps full provenance and the caption points there. Related tests green (33 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)