### PR TITLE
ticket(0316): phase secrets out of the project .env (author policy)

### DIFF
--- a/tickets/0316-phase-secrets-out-of-project-env.erg
+++ b/tickets/0316-phase-secrets-out-of-project-env.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: Phase secrets out of the project .env — local config only
+Created: 2026-07-24
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-24T21:05Z HDMX-coding-agent created (author policy, OpenRouter key incident)
+
+--- body ---
+## Context
+
+Author policy (2026-07-24): the project `.env` holds legitimate local
+configuration only (paths, MAILTO, feature toggles) — no secrets. Secrets
+live in the harness env (`~/.claude/.env`). The policy surfaced when a
+refreshed OpenRouter key was correctly placed in the harness env while the
+pipeline kept reading the dead key from the project `.env` (and a stale
+shell-ambient copy shadowed even that).
+
+Current secret-shaped vars still in the project `.env`:
+`AGENT_GH_TOKEN`, `OPENALEX_API_KEY`, `S2_API_KEY`.
+(`OPENROUTER_API_KEY` already removed.)
+
+## Actions
+
+1. Decide the load mechanism: chain env files in Make/dvc invocations
+   (`--env-file $HOME/.claude/.env --env-file .env`) or a small
+   `load_secrets()` helper in pipeline_io that reads the harness env with
+   ambient-wins-never semantics (the shadowing trap above).
+2. Move the three remaining secrets to `~/.claude/.env`; delete from the
+   project `.env`; update `.env.example` if present.
+3. Verify every consumer (harvest scripts, gh identity in .githooks,
+   summarize_abstracts, external-peer-review skill) resolves its secret
+   from the new location; document in AGENTS.md or architecture notes.
+
+## Verification
+
+- [ ] `grep -iE 'KEY|TOKEN|SECRET' .env` shows no credential vars
+- [ ] `make corpus` stages needing APIs run green on padme
+- [ ] Worktree creation (.worktreeinclude copies .env) still yields a
+      working environment without copying secrets into worktrees
+
+## Exit criteria
+
+- [ ] Project .env contains local configuration only; all secrets resolve
+      from the harness env in every execution context


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0316-phase-secrets-out-of-project-env.erg

Files the author's secrets policy as a work item: project .env = local config only; secrets resolve from the harness env. Triggered by today's OpenRouter key incident (refreshed key unread because the pipeline read the project copy, with ambient shadowing on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)