### PR TITLE
chore(0321): ruff clean — unblock test_ruff_clean on main

### DIFF
--- a/conception/exploration-sem-vs-citation/explore_semantic_vs_citation.py
+++ b/conception/exploration-sem-vs-citation/explore_semantic_vs_citation.py
@@ -17,8 +17,12 @@ import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
-from sklearn.metrics import (adjusted_rand_score, normalized_mutual_info_score,
-                             silhouette_samples, silhouette_score)
+from sklearn.metrics import (
+    adjusted_rand_score,
+    normalized_mutual_info_score,
+    silhouette_samples,
+    silhouette_score,
+)
 
 sys.path.insert(0, "scripts")
 sys.path.insert(0, "libs/openalex-corpus/src")
@@ -36,9 +40,12 @@ def figure_communities(figure_name):
         reg = yaml.safe_load(f)
     return {int(cid): (reg["concepts"][k]["label"], reg["concepts"][k]["color"])
             for cid, k in reg["figures"].get(figure_name, {}).items()}
-from pipeline_loaders import (load_refined_citations, load_refined_embeddings,
-                              load_refined_works)
 from openalex_corpus.text import normalize_doi
+from pipeline_loaders import (
+    load_refined_citations,
+    load_refined_embeddings,
+    load_refined_works,
+)
 
 
 def main():

--- a/conception/exploration-sem-vs-citation/explore_v1_clusters_vs_citation.py
+++ b/conception/exploration-sem-vs-citation/explore_v1_clusters_vs_citation.py
@@ -6,8 +6,6 @@ Per-work assignment for the paper partition = nearest committed v1 centroid
 KMeans geometry of compute_clusters.py. No figure output.
 """
 
-import json
-import os
 import sys
 from collections import Counter
 
@@ -22,10 +20,12 @@ sys.path.insert(0, "scripts")
 sys.path.insert(0, "libs/openalex-corpus/src")
 
 import yaml
-
 from openalex_corpus.text import normalize_doi
-from pipeline_loaders import (BASE_DIR, load_refined_citations,
-                              load_refined_embeddings, load_refined_works)
+from pipeline_loaders import (
+    load_refined_citations,
+    load_refined_embeddings,
+    load_refined_works,
+)
 
 RANDOM_STATE = 42
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ select = [
 "scripts/utils.py" = ["F401", "E402"]
 "scripts/harvest/catalog_syllabi.py" = ["F401"]
 "scripts/analysis/compute_clustering_comparison.py" = ["F401"]
+# Salvaged exploration kept as the provenance of the two-structurations claim
+# (PR #1124). Its main() is the script that was actually run; splitting it to
+# satisfy a length threshold would make the file no longer that script, which
+# defeats the reason it is committed. Length ignored, everything else enforced.
+"conception/exploration-sem-vs-citation/explore_semantic_vs_citation.py" = ["PLR0915"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/scripts/analysis/analyze_global_map.py
+++ b/scripts/analysis/analyze_global_map.py
@@ -31,10 +31,10 @@ import numpy as np
 from _global_map_graph import direct_graph, load_data
 from compute_clusters import LABEL_STOPWORDS, _collapse_acronyms
 from openalex_corpus.embedding import is_boilerplate_abstract
-from sklearn.feature_extraction.text import TfidfVectorizer
 from pipeline_loaders import load_analysis_config
 from scipy.sparse import csr_matrix
 from script_io_args import parse_io_args, validate_io
+from sklearn.feature_extraction.text import TfidfVectorizer
 from utils import get_logger
 
 log = get_logger("analyze_global_map")


### PR DESCRIPTION
**Ticket-ref:** tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg

Partial fix for 0321 — the lint half. Does not close it: the
`compute_clusters` → `analyze_global_map` dual-role import and the CI-vs-local
gate decision remain open. (0321's ticket file is filed in #1127, so it is not
on this branch yet.)

`main` has been failing `tests/test_ruff.py::test_ruff_clean` since the
2026-07-24 merges. Eight findings, all in files those merges touched:

| Rule | Where | Fix |
|---|---|---|
| I001 ×4 | both `conception/exploration-sem-vs-citation/` scripts, `analyze_global_map.py` | autofix |
| F401 ×3 | `explore_v1_clusters_vs_citation.py` — `json`, `os`, `pipeline_loaders.BASE_DIR` | autofix |
| PLR0915 | `explore_semantic_vs_citation.py::main` (92 > 80) | scoped per-file ignore |

The three removed imports appear nowhere else in their file (`grep` count 0);
all three edited files re-parse.

**The one judgement call.** `explore_semantic_vs_citation.py` is salvaged
exploration, committed as the provenance of the two-structurations claim
(#1124). Its `main()` *is* the script that was run. Splitting it to satisfy a
length threshold would make the file no longer that script, defeating the
reason it is in the repo. So: a per-file ignore naming `PLR0915` alone, with
the reason in `pyproject.toml`. Every other rule still applies to it.

Also sets `git remote origin` to the current URL — the repo moved to
`climate-finance-het` and every push was printing a redirect warning.

## Verification

- `uv run ruff check .` → All checks passed
- `tests/test_ruff.py` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
