### PR TITLE
ticket(0297): persist pass-2 language detections, with provenance

### DIFF
--- a/scripts/_deposit_variables.py
+++ b/scripts/_deposit_variables.py
@@ -133,6 +133,13 @@ DEPOSIT_VARIABLES: list[Variable] = [
              "or `generated:lexicon`; empty elsewhere", _KEYDOCS,
              required=False, group=_PROV,
              allowed_values="extracted, generated:lexicon, empty"),
+    Variable("language_provenance", "string, nullable",
+             "How the language code was obtained: `source` (carried by the "
+             "source catalog), `openalex` (backfilled from the OpenAlex API), "
+             "or `detected:langdetect` (inferred from title and abstract); "
+             "empty where no language could be established", _ENRICH,
+             required=False, group=_PROV,
+             allowed_values="source, openalex, detected:langdetect, empty"),
     Variable("source_count", "integer",
              "Number of sources that contributed the record (sum of the "
              "provenance flags)", _MERGE, group=_PROV,

--- a/scripts/harvest/enrich_join.py
+++ b/scripts/harvest/enrich_join.py
@@ -148,25 +148,56 @@ def _apply_abstract_caches(df, cache_dir):
 
 
 def _apply_language_cache(df, cache_dir):
-    """Normalize language codes and fill missing from cache."""
-    df["language"] = df["language"].apply(normalize_lang)
-    lang_cache = _load_csv_cache(
-        os.path.join(cache_dir, "language_resolved.csv"), "key", "language")
+    """Normalize language codes and fill missing from the two language caches.
 
-    applied = 0
+    Order matters: `language_resolved` holds values *sourced* from OpenAlex,
+    `language_detected` holds values *inferred* by langdetect from title and
+    abstract (ticket 0297). Sourced wins; inference only fills what is still
+    null afterwards, and every inferred value is disclosed in
+    `language_provenance` so a deposited language tag never hides how it was
+    obtained. Mirrors abstract_provenance / keywords_provenance.
+    """
+    df["language"] = df["language"].apply(normalize_lang)
+    resolved = _load_csv_cache(
+        os.path.join(cache_dir, "language_resolved.csv"), "key", "language")
+    detected = _load_csv_cache(
+        os.path.join(cache_dir, "language_detected.csv"), "key", "language")
+
+    # Anything already present before either cache is applied came with the
+    # record from its source catalog.
+    provenance = pd.Series("", index=df.index, dtype=object)
+    provenance[~df["language"].apply(_is_missing)] = "source"
+
+    def _lookup(cache, doi, sid):
+        lang = cache.get(doi, "") if doi else ""
+        return lang or cache.get(sid, "")
+
+    applied_resolved = applied_detected = 0
     for idx in df.index:
-        if _is_missing(df.at[idx, "language"]):
-            doi = normalize_doi(df.at[idx, "doi"])
-            sid = str(df.at[idx, "source_id"])
-            lang = lang_cache.get(doi, "") if doi else ""
-            if not lang:
-                lang = lang_cache.get(sid, "")
-            if lang:
-                df.at[idx, "language"] = lang
-                applied += 1
-    log.info("Language cache: applied %d (cache has %d entries)",
-             applied, len(lang_cache))
-    return applied
+        if not _is_missing(df.at[idx, "language"]):
+            continue
+        doi = normalize_doi(df.at[idx, "doi"])
+        sid = str(df.at[idx, "source_id"])
+
+        lang = _lookup(resolved, doi, sid)
+        if lang:
+            df.at[idx, "language"] = lang
+            provenance.at[idx] = "openalex"
+            applied_resolved += 1
+            continue
+
+        lang = _lookup(detected, doi, sid)
+        if lang:
+            df.at[idx, "language"] = lang
+            provenance.at[idx] = "detected:langdetect"
+            applied_detected += 1
+
+    df["language_provenance"] = provenance
+    log.info(
+        "Language caches: applied %d sourced (%d entries) + %d detected (%d entries)",
+        applied_resolved, len(resolved), applied_detected, len(detected),
+    )
+    return applied_resolved + applied_detected
 
 
 def _apply_summaries(df, cache_dir):

--- a/scripts/harvest/enrich_join.py
+++ b/scripts/harvest/enrich_join.py
@@ -18,7 +18,7 @@ import os
 
 import pandas as pd
 from openalex_corpus.text import normalize_doi
-from pipeline_text import normalize_lang
+from pipeline_text import is_valid_iso639_1, normalize_lang
 from utils import CATALOGS_DIR, get_logger, save_csv
 
 log = get_logger("enrich_join")
@@ -163,10 +163,19 @@ def _apply_language_cache(df, cache_dir):
     detected = _load_csv_cache(
         os.path.join(cache_dir, "language_detected.csv"), "key", "language")
 
-    # Anything already present before either cache is applied came with the
-    # record from its source catalog.
+    def _needs_filling(val):
+        """Missing, or present but not a real ISO 639-1 code.
+
+        A code the codebook calls ISO 639-1 but that no standard recognises
+        ('ua', 'sh') is not usable data; pass 2 already re-detects those, and
+        treating them as present would discard the correction (ticket 0297).
+        """
+        return _is_missing(val) or not is_valid_iso639_1(val)
+
+    # Anything usable before either cache is applied came with the record
+    # from its source catalog.
     provenance = pd.Series("", index=df.index, dtype=object)
-    provenance[~df["language"].apply(_is_missing)] = "source"
+    provenance[~df["language"].apply(_needs_filling)] = "source"
 
     def _lookup(cache, doi, sid):
         lang = cache.get(doi, "") if doi else ""
@@ -174,7 +183,7 @@ def _apply_language_cache(df, cache_dir):
 
     applied_resolved = applied_detected = 0
     for idx in df.index:
-        if not _is_missing(df.at[idx, "language"]):
+        if not _needs_filling(df.at[idx, "language"]):
             continue
         doi = normalize_doi(df.at[idx, "doi"])
         sid = str(df.at[idx, "source_id"])

--- a/scripts/harvest/enrich_join.py
+++ b/scripts/harvest/enrich_join.py
@@ -172,19 +172,19 @@ def _apply_language_cache(df, cache_dir):
         """
         return _is_missing(val) or not is_valid_iso639_1(val)
 
-    # Anything usable before either cache is applied came with the record
-    # from its source catalog.
+    # One pass over the column answers both questions: the rows that do NOT
+    # need filling already carried a usable code from their source catalog,
+    # and the rest are exactly the loop's work list (a few thousand of ~28k).
+    needs_filling = df["language"].apply(_needs_filling).astype(bool)
     provenance = pd.Series("", index=df.index, dtype=object)
-    provenance[~df["language"].apply(_needs_filling)] = "source"
+    provenance[~needs_filling] = "source"
 
     def _lookup(cache, doi, sid):
         lang = cache.get(doi, "") if doi else ""
         return lang or cache.get(sid, "")
 
     applied_resolved = applied_detected = 0
-    for idx in df.index:
-        if not _needs_filling(df.at[idx, "language"]):
-            continue
+    for idx in df.index[needs_filling.to_numpy()]:
         doi = normalize_doi(df.at[idx, "doi"])
         sid = str(df.at[idx, "source_id"])
 

--- a/scripts/harvest/enrich_language.py
+++ b/scripts/harvest/enrich_language.py
@@ -6,7 +6,10 @@ Two-pass pipeline:
            then query by openalex_id for records without DOIs.
   Pass 2 — Local text detection: langdetect on title+abstract for remaining nulls.
 
-Cache: data/catalogs/enrich_cache/language_resolved.csv
+Caches (one per pass, kept apart so enrich_join can tell a sourced language
+from an inferred one — see language_provenance):
+  Pass 1 — data/catalogs/enrich_cache/language_resolved.csv
+  Pass 2 — data/catalogs/enrich_cache/language_detected.csv
 
 Usage:
     uv run python scripts/enrich_language.py [--dry-run]

--- a/scripts/harvest/enrich_language.py
+++ b/scripts/harvest/enrich_language.py
@@ -261,11 +261,24 @@ def pass1_apply_cache(df, cache):
 
 # --- Pass 2: local text detection ---
 
-def pass2_local_detect(df):
+def pass2_local_detect(df, cache=None):
     """Fill remaining null language values using langdetect on title+abstract.
 
     Also flags nonsensical existing values (codes not in ISO 639-1).
     Returns number of records filled.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Works frame; mutated in place.
+    cache : dict | None
+        When given, each detection is recorded as {key: lang} using the same
+        key convention enrich_join resolves by — normalised DOI first, else
+        source_id. This script is cache-only (it never writes the works CSV
+        back), so without this the detections die with the process: that was
+        ticket 0297, ~1,500 results recomputed and discarded every run.
+        Undetectable rows are left out entirely rather than cached empty.
+
     """
     filled = 0
     for idx in df.index:
@@ -290,6 +303,11 @@ def pass2_local_detect(df):
         if detected and is_valid_iso639_1(detected):
             df.at[idx, "language"] = detected
             filled += 1
+            if cache is not None:
+                doi = normalize_doi(df.at[idx, "doi"]) if pd.notna(df.at[idx, "doi"]) else ""
+                key = doi or (str(df.at[idx, "source_id"]) if "source_id" in df.columns else "")
+                if key:
+                    cache[key] = detected
 
     return filled
 
@@ -379,12 +397,20 @@ def main():
 
     # --- Pass 2: local text detection ---
     log.info("Pass 2: local text detection (langdetect)")
-    filled_pass2 = pass2_local_detect(df)
+    detected_cache = load_cache("language_detected")
+    filled_pass2 = pass2_local_detect(df, detected_cache)
     counters["pass2_filled"] = filled_pass2
     null_after_pass2 = int(df["language"].isna().sum())
     log.info("Pass 2 filled %d, remaining null: %d", filled_pass2, null_after_pass2)
 
-    # Cache-only: enrich_join.py applies caches to the monolith (#428)
+    # Cache-only: enrich_join.py applies caches to the monolith (#428).
+    # Pass 2 gets its OWN cache, kept apart from pass 1's language_resolved:
+    # pass 1 carries values sourced from OpenAlex, pass 2 carries values
+    # inferred by langdetect. Merging them would make an inferred tag
+    # indistinguishable from a sourced one in a deposited dataset — the
+    # distinction enrich_join turns into language_provenance (ticket 0297).
+    save_cache("language_detected", detected_cache)
+    log.info("Detected-language cache: %d entries", len(detected_cache))
 
     elapsed = time.time() - t0
     counters.update({

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -56,6 +56,8 @@ RefinedWorksSchema = DataFrameSchema(
         "from_oecd": Column(str, nullable=True, required=False),
         "abstract_provenance": Column(str, nullable=True, required=False),
         "keywords_provenance": Column(str, nullable=True, required=False),
+        # Set by enrich_join from the two language caches (ticket 0297).
+        "language_provenance": Column(str, nullable=True, required=False),
         "source_count": Column(str, nullable=True),
         "abstract_status": Column(str, nullable=True),
         "near_duplicate_group": Column(str, nullable=True),

--- a/tests/test_enrich_language.py
+++ b/tests/test_enrich_language.py
@@ -413,3 +413,50 @@ class TestPass2Persistence:
         """The existing call sites and tests pass no cache."""
         from enrich_language import pass2_local_detect
         assert pass2_local_detect(self._one_english_row()) == 1
+
+
+class TestInvalidCodesAreReplaced:
+    """An invalid ISO 639-1 code is as bad as a missing one.
+
+    Pass 2 already re-detects rows whose language is a non-ISO code ('ua',
+    'sh' — 5 such rows in the current corpus). That correction hit the same
+    wall as the null backfill: enrich_join only filled rows it considered
+    *missing*, so a corrected code never reached the monolith and the deposit
+    kept shipping codes the codebook says are ISO 639-1.
+    """
+
+    def test_join_treats_an_invalid_code_as_missing(self, tmp_path):
+        import sys as _sys
+        _sys.path.insert(0, os.path.join(SCRIPTS_DIR, "harvest"))
+        from enrich_join import _apply_language_cache
+
+        cache_dir = tmp_path / "enrich_cache"
+        cache_dir.mkdir()
+        pd.DataFrame([{"key": "10.1/a", "language": "uk"}]).to_csv(
+            cache_dir / "language_detected.csv", index=False)
+
+        df = pd.DataFrame({
+            "language": ["ua"],       # not ISO 639-1
+            "doi": ["10.1/a"],
+            "source_id": ["W1"],
+        })
+        _apply_language_cache(df, str(cache_dir))
+        assert df.loc[0, "language"] == "uk"
+        assert df.loc[0, "language_provenance"] == "detected:langdetect"
+
+    def test_a_valid_code_is_left_alone(self, tmp_path):
+        import sys as _sys
+        _sys.path.insert(0, os.path.join(SCRIPTS_DIR, "harvest"))
+        from enrich_join import _apply_language_cache
+
+        cache_dir = tmp_path / "enrich_cache"
+        cache_dir.mkdir()
+        pd.DataFrame([{"key": "10.1/a", "language": "en"}]).to_csv(
+            cache_dir / "language_detected.csv", index=False)
+
+        df = pd.DataFrame({
+            "language": ["fr"], "doi": ["10.1/a"], "source_id": ["W1"],
+        })
+        _apply_language_cache(df, str(cache_dir))
+        assert df.loc[0, "language"] == "fr"
+        assert df.loc[0, "language_provenance"] == "source"

--- a/tests/test_enrich_language.py
+++ b/tests/test_enrich_language.py
@@ -342,3 +342,74 @@ class TestScriptStructure:
 
     def test_uses_enrich_cache(self):
         assert "enrich_cache" in self.source
+
+
+# ---------- Pass 2 must persist, not just mutate (ticket 0297) ----------
+
+
+class TestPass2Persistence:
+    """Pass 2's detections have to survive the process.
+
+    The bug this class exists for: pass2_local_detect mutated the in-memory
+    frame, main() never wrote that frame back (the script is cache-only, per
+    its own comment), and pass 2 wrote to no cache. So ~1,500 langdetect
+    results were recomputed and discarded on every run, and enriched_works.csv
+    kept 1,743 null languages (4.0%) against a <2% contract — of which 1,579
+    had a title and 1,306 had an abstract, i.e. exactly the population pass 2
+    is for.
+
+    The pre-existing TestPass2LocalDetect tests all passed throughout, because
+    they assert the in-memory mutation. These assert the persisted artifact.
+    """
+
+    def _one_english_row(self):
+        return pd.DataFrame({
+            "language": [None],
+            "title": ["Climate Finance"],
+            "abstract": ["Climate finance refers to local, national, or transnational "
+                         "financing that seeks to support mitigation and adaptation "
+                         "actions addressing climate change."],
+            "doi": ["10.1/a"],
+            "source_id": ["W1"],
+        })
+
+    def test_detections_are_recorded_in_the_cache(self):
+        from enrich_language import pass2_local_detect
+        cache = {}
+        df = self._one_english_row()
+        filled = pass2_local_detect(df, cache)
+        assert filled == 1
+        assert cache, "pass 2 detected a language but recorded it nowhere"
+        assert "en" in cache.values()
+
+    def test_cache_is_keyed_the_way_the_join_looks_it_up(self):
+        """enrich_join resolves by normalised DOI first, then source_id."""
+        from enrich_language import pass2_local_detect
+        cache = {}
+        pass2_local_detect(self._one_english_row(), cache)
+        assert cache.get("10.1/a") == "en"
+
+    def test_falls_back_to_source_id_when_no_doi(self):
+        from enrich_language import pass2_local_detect
+        cache = {}
+        df = self._one_english_row()
+        df.loc[0, "doi"] = None
+        pass2_local_detect(df, cache)
+        assert cache.get("W1") == "en"
+
+    def test_undetectable_rows_are_not_cached(self):
+        """A row langdetect cannot resolve must leave no cache entry, so the
+        join does not later fill it with an empty string."""
+        from enrich_language import pass2_local_detect
+        cache = {}
+        df = pd.DataFrame({
+            "language": [None], "title": [""], "abstract": [""],
+            "doi": ["10.1/z"], "source_id": ["W9"],
+        })
+        pass2_local_detect(df, cache)
+        assert cache == {}
+
+    def test_cache_argument_is_optional(self):
+        """The existing call sites and tests pass no cache."""
+        from enrich_language import pass2_local_detect
+        assert pass2_local_detect(self._one_english_row()) == 1

--- a/tests/test_enrich_language.py
+++ b/tests/test_enrich_language.py
@@ -460,3 +460,48 @@ class TestInvalidCodesAreReplaced:
         _apply_language_cache(df, str(cache_dir))
         assert df.loc[0, "language"] == "fr"
         assert df.loc[0, "language_provenance"] == "source"
+
+    def test_a_row_neither_cache_knows_stays_null(self, tmp_path):
+        """No cache entry, no invention: the language stays null and the
+        provenance column says nothing rather than claiming a source."""
+        import sys as _sys
+        _sys.path.insert(0, os.path.join(SCRIPTS_DIR, "harvest"))
+        from enrich_join import _apply_language_cache
+
+        cache_dir = tmp_path / "enrich_cache"
+        cache_dir.mkdir()
+        pd.DataFrame([{"key": "10.1/other", "language": "en"}]).to_csv(
+            cache_dir / "language_resolved.csv", index=False)
+        pd.DataFrame([{"key": "10.1/elsewhere", "language": "fr"}]).to_csv(
+            cache_dir / "language_detected.csv", index=False)
+
+        df = pd.DataFrame({
+            "language": [None], "doi": ["10.1/a"], "source_id": ["W1"],
+        })
+        _apply_language_cache(df, str(cache_dir))
+        assert pd.isna(df.loc[0, "language"])
+        assert df.loc[0, "language_provenance"] == ""
+
+    def test_an_uncorrected_invalid_code_is_left_as_is(self, tmp_path):
+        """When neither cache can correct a non-ISO code, the join leaves it
+        untouched — it does not blank it, and it does not label it 'source'.
+        Documents the residual population the null-rate contract tolerates."""
+        import sys as _sys
+        _sys.path.insert(0, os.path.join(SCRIPTS_DIR, "harvest"))
+        from enrich_join import _apply_language_cache
+
+        cache_dir = tmp_path / "enrich_cache"
+        cache_dir.mkdir()
+        pd.DataFrame([{"key": "10.1/other", "language": "en"}]).to_csv(
+            cache_dir / "language_resolved.csv", index=False)
+        pd.DataFrame([{"key": "10.1/elsewhere", "language": "uk"}]).to_csv(
+            cache_dir / "language_detected.csv", index=False)
+
+        df = pd.DataFrame({
+            "language": ["ua"],       # not ISO 639-1
+            "doi": ["10.1/a"],
+            "source_id": ["W1"],
+        })
+        _apply_language_cache(df, str(cache_dir))
+        assert df.loc[0, "language"] == "ua"
+        assert df.loc[0, "language_provenance"] == ""

--- a/tickets/closed/0297-corpus-language-null-rate-regression.erg
+++ b/tickets/closed/0297-corpus-language-null-rate-regression.erg
@@ -2,11 +2,13 @@
 Title: Corpus language null rate at 4.1% — acceptance test red for weeks
 Created: 2026-07-22
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1129
 
 --- log ---
 2026-07-22T16:40Z HDMX-coding-agent created author request during 0289 review (failure known for weeks, now tracked)
 2026-07-22T16:40Z HDMX-coding-agent note inherits cluster 2 from closed triage ticket 0263 — same 4.1% (1743/42916) on doudou AND padme, so a corpus property, not local staleness; after backfill on padme, finish with make corpus-sync on doudou
 
+2026-07-27T10:57Z HDMX-coding-agent closed — autoclosed — PR #1129
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0297-corpus-language-null-rate-regression.erg

The language null rate has sat at 4.0% against a <2% contract for weeks, and
the count never moved: **exactly 1,743 nulls before and after the corpus-v2
rebuild**, with the three new v2 sources (UNFCCC, OECD, ISTEX) contributing
zero of them. That stability was the clue. This is not a source that skips
language — it is a step that never lands.

## Root cause

`enrich_language.py` is cache-only by design: it never writes the works CSV
back, and `enrich_join.py` applies its caches to the monolith. Pass 1 obeys
that, saving to `language_resolved`. **Pass 2 did not.** `pass2_local_detect`
mutated the in-memory frame, `main()` logged `Pass 2 filled N`, and the frame
was dropped on return — its own comment says "Cache-only", but pass 2 wrote to
no cache. Roughly 1,500 langdetect results were computed and discarded on
every single run.

The leftover population matches exactly: of the 1,743 nulls, 1,579 have a
title and 1,306 have an abstract — precisely what pass 2 is for. Only 164 have
no title at all, the irreducible floor. By source: OpenAlex 1,427 (82% of all
nulls), bibCNRS 209 (**90% of that source's 233 rows**), SciSpace 66,
teaching 42.

**Why the tests missed it.** `TestPass2LocalDetect` asserts the in-memory
mutation, which always worked. The new `TestPass2Persistence` asserts the
persisted artifact.

## The fix, and one design decision

Pass 2 now writes to its **own** cache, deliberately not merged into pass 1's:

| Cache | Values |
|---|---|
| `language_resolved` | **sourced** from the OpenAlex API |
| `language_detected` | **inferred** by langdetect from title + abstract |

Merging them would make an inferred tag indistinguishable from a sourced one
inside a deposited dataset — in a data paper about data quality, whose referee
probed exactly this. Today every language value in the corpus is sourced;
this change introduces inferred ones, so it needs disclosure.

`enrich_join` applies sourced first, inferred only to what remains null, and
records which in a new `language_provenance` column (`source` / `openalex` /
`detected:langdetect`), declared in the deposit contract alongside the
existing `abstract_provenance` and `keywords_provenance` — the precedent this
follows.

## Expected effect

~4.0% → ~0.4%, every filled value carrying how it was obtained.

## Note on running it

`make corpus` guards on `main`, so the rebuild that realises this cannot run
from the branch. The caches are being warmed now (`enrich_language.py` writes
only to `enrich_cache/`, which is gitignored and not a DVC output), so the
rebuild after merge is cheap. **`lang_english_pct` and `tab_languages` will
move** — this needs to land before the response letter quotes them, not after.

## Verification

- `tests/test_enrich_language.py` — 41 passed, incl. 5 new persistence tests
  red-tested before the fix
- 176 passed across the enrich/deposit/codebook suites
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

