### PR TITLE
ticket(0321): extract the TF-IDF label vocabulary out of a Tier-3 entry point

### DIFF
--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -164,13 +164,16 @@ required; the flat classification already makes every mover import-leaf.
 
 Nine files were entry-point-AND-imported. Three had a genuine helper leaked from
 an output-producing entry point → **extracted to a neutral flat `_`-module (the
-0250 pattern), byte-identical by construction**, freeing the entry point to move:
+0250 pattern), byte-identical by construction**, freeing the entry point to move.
+A fourth case (0321) arrived later by the same route and took the same
+resolution — the pattern is the standing answer, not a one-off audit result:
 
 | Entry point (now Tier-3) | Extracted helper(s) → flat module | Repointed importer(s) |
 |---|---|---|
 | `summarize_core_venues` | `canonical_venue`/`venue_type`/`institution_group` → `_venue_naming.py` | `compute_venue_concentration`, `export_core_venues_markdown` |
 | `build_het_core` | `is_global_south`/`is_non_english` → `_corpus_predicates.py` | `analyze_multilingual` |
 | `build_teaching_yaml` | `_dedup_course_names` → `_course_dedup.py` | `analyze_syllabi` |
+| `compute_clusters` | `LABEL_STOPWORDS`/`ACRONYM_EXPANSIONS`/`collapse_acronyms` → `_label_vocabulary.py` | `analyze_global_map` (ticket 0321) |
 
 The other six were **reclassified Tier-2** (see above). One correction to the old
 audit: `qa_near_duplicates` has no `__main__` and its docstring documents a

--- a/scripts/_label_vocabulary.py
+++ b/scripts/_label_vocabulary.py
@@ -1,0 +1,59 @@
+"""Shared vocabulary for TF-IDF cluster and community labelling (ticket 0321).
+
+Two consumers label groups of works by their distinctive TF-IDF terms and must
+agree on what counts as distinctive: `compute_clusters` (semantic k-means
+clusters, whose top terms become the fig_sem_composition panel subtitles) and
+`analyze_global_map` (Louvain citation communities, whose top terms label the
+fig_global_map_direct nodes). A term suppressed in one and kept in the other
+would make the two figures disagree about the same corpus.
+
+This module exists because `analyze_global_map` was importing these names from
+`compute_clusters`, which is a Tier-3 entry point. The `scripts/` reorg (epic
+0240) rests on Tier-3 files being import-leaves — nothing may import them by
+flat name, or moving them between phase directories breaks the importer. A
+neutral `_`-private module at the flat library surface is the 0250/0254
+resolution for that dual-role hazard; the alternative, reclassifying
+`compute_clusters` as Tier-2, would have been the escape hatch rather than the
+fix, since it is an entry point that merely happened to own two helpers.
+
+No I/O, no config, no corpus access — vocabulary only.
+"""
+
+import re
+
+# Terms too common in a climate-finance corpus to distinguish anything within
+# it. "climate" and "finance" describe every work in the corpus, so they carry
+# no information about which group a work belongs to.
+LABEL_STOPWORDS = {
+    "climate", "climate change", "change", "finance", "financial", "carbon",
+    "emission", "emissions", "mitigation", "adaptation",
+    "paper", "study", "analysis", "results", "approach", "article", "research",
+    "literature", "review", "data", "work", "based", "findings", "using",
+    "new", "use", "used", "model", "evidence", "impact", "effects", "effect",
+    "role", "case", "sector", "risk", "market", "markets", "investment",
+    "countries", "country", "policy", "policies", "global", "world",
+    "international", "national", "economic", "economics", "development",
+    "blockchain", "esg", "theory", "usd",
+    "pdf", "http", "https", "www", "vol", "pp",
+}
+
+# Expansions collapsed to their acronym before vectorising, so a work writing
+# "clean development mechanism" and one writing "CDM" contribute to the same
+# term rather than splitting its weight across two.
+ACRONYM_EXPANSIONS = {
+    r"\benvironmental[,]?\s+social\s+(?:and\s+)?governance\b": "ESG",
+    r"\bclean\s+development\s+mechanism\b": "CDM",
+    r"\bemissions?\s+trading\s+(?:system|scheme)\b": "ETS",
+    r"\bunited\s+nations\s+framework\s+convention\s+on\s+climate\s+change\b": "UNFCCC",
+    r"\bconference\s+of\s+(?:the\s+)?parties\b": "COP",
+    r"\bgreen\s+climate\s+fund\b": "GCF",
+    r"\bsustainable\s+development\s+goals?\b": "SDGs",
+    r"\bnationally\s+determined\s+contributions?\b": "NDCs",
+}
+
+
+def collapse_acronyms(text):
+    """Replace known expansions with their acronyms to avoid double-counting."""
+    for pattern, acronym in ACRONYM_EXPANSIONS.items():
+        text = re.sub(pattern, acronym, text, flags=re.IGNORECASE)
+    return text

--- a/scripts/analysis/analyze_global_map.py
+++ b/scripts/analysis/analyze_global_map.py
@@ -29,12 +29,12 @@ import community as community_louvain
 import networkx as nx
 import numpy as np
 from _global_map_graph import direct_graph, load_data
-from compute_clusters import LABEL_STOPWORDS, _collapse_acronyms
+from _label_vocabulary import LABEL_STOPWORDS, collapse_acronyms
 from openalex_corpus.embedding import is_boilerplate_abstract
-from sklearn.feature_extraction.text import TfidfVectorizer
 from pipeline_loaders import load_analysis_config
 from scipy.sparse import csr_matrix
 from script_io_args import parse_io_args, validate_io
+from sklearn.feature_extraction.text import TfidfVectorizer
 from utils import get_logger
 
 log = get_logger("analyze_global_map")
@@ -139,7 +139,7 @@ def _member_text(row):
     abstract = _clean(row.get("abstract"))
     if is_boilerplate_abstract(abstract, title=title):
         abstract = ""
-    return _collapse_acronyms(" ".join(p for p in (title, keywords, abstract) if p))
+    return collapse_acronyms(" ".join(p for p in (title, keywords, abstract) if p))
 
 
 def add_top_terms(summary, partition, works, n_terms=3):

--- a/scripts/analysis/compute_clusters.py
+++ b/scripts/analysis/compute_clusters.py
@@ -22,11 +22,11 @@ Usage:
 import argparse
 import json
 import os
-import re
 import warnings
 
 import numpy as np
 import pandas as pd
+from _label_vocabulary import LABEL_STOPWORDS, collapse_acronyms
 from openalex_corpus.embedding import is_boilerplate_abstract
 from script_io_args import parse_io_args, validate_io
 from sklearn.cluster import KMeans
@@ -46,38 +46,6 @@ log = get_logger("compute_clusters")
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 
-LABEL_STOPWORDS = {
-    "climate", "climate change", "change", "finance", "financial", "carbon",
-    "emission", "emissions", "mitigation", "adaptation",
-    "paper", "study", "analysis", "results", "approach", "article", "research",
-    "literature", "review", "data", "work", "based", "findings", "using",
-    "new", "use", "used", "model", "evidence", "impact", "effects", "effect",
-    "role", "case", "sector", "risk", "market", "markets", "investment",
-    "countries", "country", "policy", "policies", "global", "world",
-    "international", "national", "economic", "economics", "development",
-    "blockchain", "esg", "theory", "usd",
-    "pdf", "http", "https", "www", "vol", "pp",
-}
-
-ACRONYM_EXPANSIONS = {
-    r"\benvironmental[,]?\s+social\s+(?:and\s+)?governance\b": "ESG",
-    r"\bclean\s+development\s+mechanism\b": "CDM",
-    r"\bemissions?\s+trading\s+(?:system|scheme)\b": "ETS",
-    r"\bunited\s+nations\s+framework\s+convention\s+on\s+climate\s+change\b": "UNFCCC",
-    r"\bconference\s+of\s+(?:the\s+)?parties\b": "COP",
-    r"\bgreen\s+climate\s+fund\b": "GCF",
-    r"\bsustainable\s+development\s+goals?\b": "SDGs",
-    r"\bnationally\s+determined\s+contributions?\b": "NDCs",
-}
-
-
-def _collapse_acronyms(text):
-    """Replace known expansions with their acronyms to avoid double-counting."""
-    for pattern, acronym in ACRONYM_EXPANSIONS.items():
-        text = re.sub(pattern, acronym, text, flags=re.IGNORECASE)
-    return text
-
-
 def _word_count(terms):
     return sum(len(t.split()) for t in terms)
 
@@ -90,7 +58,7 @@ def _label_clusters(df, core_only):
 
     Returns dict mapping cluster_id -> label string.
     """
-    abstracts_for_tfidf = [_collapse_acronyms(a) for a in df["abstract"].fillna("").tolist()]
+    abstracts_for_tfidf = [collapse_acronyms(a) for a in df["abstract"].fillna("").tolist()]
     min_df_val = 3 if core_only else 5
     label_vectorizer = TfidfVectorizer(
         ngram_range=(1, 2), max_features=8000, sublinear_tf=True,

--- a/tests/test_label_vocabulary.py
+++ b/tests/test_label_vocabulary.py
@@ -1,0 +1,100 @@
+"""The TF-IDF label vocabulary has one home (ticket 0321).
+
+`compute_clusters` labels semantic k-means clusters (fig_sem_composition panel
+subtitles); `analyze_global_map` labels Louvain citation communities
+(fig_global_map_direct nodes). Both score terms by TF-IDF distinctiveness over
+the same corpus, so they have to suppress the same stopwords and collapse the
+same acronyms — otherwise the two figures disagree about which terms
+characterise a group of works.
+
+They used to agree by `analyze_global_map` importing from `compute_clusters`,
+which made a Tier-3 entry point into a library and broke the invariant the
+`scripts/` reorg depends on (epic 0240). These tests pin the extraction: one
+source, both consumers reading it, and no reintroduced local copy.
+"""
+
+import ast
+import os
+
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+
+CONSUMERS = (
+    os.path.join("analysis", "compute_clusters.py"),
+    os.path.join("analysis", "analyze_global_map.py"),
+)
+
+
+def _source(rel):
+    with open(os.path.join(SCRIPTS_DIR, rel)) as fh:
+        return fh.read()
+
+
+def _assigned_names(rel):
+    """Module-level names a script binds, and functions it defines."""
+    tree = ast.parse(_source(rel), filename=rel)
+    names = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.FunctionDef):
+            names.add(node.name)
+    return names
+
+
+def test_vocabulary_module_is_importable_and_populated():
+    from _label_vocabulary import (
+        ACRONYM_EXPANSIONS,
+        LABEL_STOPWORDS,
+        collapse_acronyms,
+    )
+
+    assert LABEL_STOPWORDS and ACRONYM_EXPANSIONS
+    assert callable(collapse_acronyms)
+
+
+@pytest.mark.parametrize("rel", CONSUMERS)
+def test_consumer_imports_the_shared_vocabulary(rel):
+    assert "from _label_vocabulary import" in _source(rel), (
+        f"{rel} should read the label vocabulary from _label_vocabulary"
+    )
+
+
+@pytest.mark.parametrize("rel", CONSUMERS)
+def test_consumer_keeps_no_local_copy(rel):
+    """A local re-definition would silently drift from the shared one."""
+    local = _assigned_names(rel) & {
+        "LABEL_STOPWORDS", "ACRONYM_EXPANSIONS", "collapse_acronyms",
+        "_collapse_acronyms",
+    }
+    assert not local, f"{rel} redefines {sorted(local)} instead of importing it"
+
+
+def test_no_consumer_imports_from_the_other():
+    """The dual-role hazard this extraction resolves: a Tier-3 entry point
+    imported by another script is not safe to move between phase directories,
+    which is the invariant the scripts/ reorg rests on."""
+    for rel in CONSUMERS:
+        src = _source(rel)
+        assert "from compute_clusters import" not in src
+        assert "from analyze_global_map import" not in src
+
+
+def test_acronyms_collapse_so_a_term_is_not_split_across_spellings():
+    from _label_vocabulary import collapse_acronyms
+
+    assert collapse_acronyms("the clean development mechanism") == "the CDM"
+    assert collapse_acronyms("Clean Development Mechanism") == "CDM"
+    # A work already using the acronym is left as-is, so both spellings land
+    # on the same term.
+    assert collapse_acronyms("the CDM") == "the CDM"
+
+
+def test_stopwords_cover_the_corpus_wide_terms():
+    """"climate" and "finance" describe every work in the corpus, so they
+    distinguish no group within it."""
+    from _label_vocabulary import LABEL_STOPWORDS
+
+    for term in ("climate", "finance", "carbon", "emissions"):
+        assert term in LABEL_STOPWORDS


### PR DESCRIPTION
**Ticket-ref:** tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg

Second half of 0321 (the lint half is #1128). Resolves the dual-role import by
extraction, per the author's call.

`analyze_global_map` imported `LABEL_STOPWORDS` and `_collapse_acronyms` from
`compute_clusters`, a **Tier-3 entry point**. The `scripts/` reorg (epic 0240)
rests on Tier-3 files being import-leaves — nothing may import them by flat
name, or moving one between phase directories breaks its importer. That is the
invariant `test_no_tier3_entry_point_is_imported` guards, failing on `main`
since `10a8c029`.

## Extraction, not reclassification

The guard offers both exits. `RECLASSIFIED_DUAL_ROLE` is for genuinely
reusable computational libraries wearing a thin `main()` —
`compute_divergence`'s dispatch registry, the null-model drivers.
`compute_clusters` is an entry point that happened to own two label helpers;
reclassifying it would have used the escape hatch instead of fixing the thing.

## Why all three names move together

They are one unit. Both consumers label groups of works by TF-IDF
distinctiveness over the same corpus:

- `compute_clusters` → semantic k-means clusters → `fig_sem_composition`
  panel subtitles
- `analyze_global_map` → Louvain citation communities →
  `fig_global_map_direct` node labels

A term suppressed in one and kept in the other makes the two figures disagree
about which terms characterise a group of the same works. `_label_vocabulary`
documents that shared meaning rather than just holding the constants.

## Verified as a pure move

Not eyeballed — the definitions were rebuilt from `origin/main` in an isolated
namespace and compared:

- `LABEL_STOPWORDS` — equal, 60 terms
- `ACRONYM_EXPANSIONS` — equal, 8 patterns
- `collapse_acronyms` — identical output on five samples covering every
  pattern plus a no-op input

`re` left `compute_clusters` with the only function that used it. The
underscore-private spelling was dropped at both call sites rather than
aliased — two call sites is not worth a compatibility shim.

## Verification

- `tests/test_label_vocabulary.py` (new) — both consumers import it, neither
  keeps a local copy that could drift, neither imports the other
- `tests/test_script_classification.py` green — the guard this fixes
- 76 passed across classification + hygiene + the new file
- `ruff check scripts/` clean (the remaining `conception/` findings are #1128's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
