### PR TITLE
ticket(0326): C2ST smoke tests were 45% of the suite — add --n-perm override

### DIFF
--- a/scripts/compute_null_model.py
+++ b/scripts/compute_null_model.py
@@ -131,6 +131,16 @@ def main():
         default=-1,
         help="Parallel workers for CPU path (-1 = all cores, 1 = sequential)",
     )
+    parser.add_argument(
+        "--n-perm",
+        type=int,
+        default=None,
+        help=(
+            "Override divergence.permutation.n_perm for this run. Omit to use "
+            "the configured value. Intended for smoke tests, which need the "
+            "script to run end-to-end, not a publishable null distribution"
+        ),
+    )
     args = parser.parse_args(extra)
 
     method_name = args.method
@@ -143,6 +153,18 @@ def main():
         )
 
     cfg = load_analysis_config()
+    # Single override point: every permutation backend reads n_perm from
+    # cfg["divergence"]["permutation"], so setting it here covers all methods
+    # without threading a parameter through each backend's signature. Logged
+    # loudly because a null distribution computed at a test-sized n_perm is
+    # not publishable, and silence is how it would end up in a figure.
+    if args.n_perm is not None:
+        cfg["divergence"]["permutation"]["n_perm"] = args.n_perm
+        log.warning(
+            "n_perm OVERRIDDEN to %d (config value ignored) — smoke/debug run, "
+            "not a publishable null distribution",
+            args.n_perm,
+        )
     log.info("=== Null model: %s (channel=%s) ===", method_name, channel)
 
     # Load existing divergence CSV for year/window pairs

--- a/tests/test_null_model.py
+++ b/tests/test_null_model.py
@@ -1059,3 +1059,39 @@ class TestBackendComparison:
         assert z_gpu == pytest.approx(z_cpu, rel=0.5), (
             f"Z-scores differ by >50%%: CPU={z_cpu:.2f}, GPU={z_gpu:.2f}"
         )
+
+
+# ---------------------------------------------------------------------------
+# --n-perm override (ticket 0326)
+# ---------------------------------------------------------------------------
+
+
+class TestNPermOverride:
+    """A smoke test must be able to prove the contract without production cost.
+
+    Measured 2026-07-27: the two C2ST smoke tests in test_null_model_c2st.py
+    were 462s of a 1,037s serial suite — 45% — because they invoke
+    compute_null_model.py with no way to lower n_perm, so a fixture-sized run
+    still trains a classifier 500 times per window. The statistical properties
+    are already covered by the cheap unit tests in that file; the smoke test's
+    job is only that the script runs end-to-end and writes a valid artifact.
+    """
+
+    def test_cli_exposes_n_perm(self):
+        """The override exists and mirrors the --n-jobs pattern."""
+        path = os.path.join(SCRIPTS_DIR, "compute_null_model.py")
+        with open(path) as fh:
+            src = fh.read()
+        assert '"--n-perm"' in src, "compute_null_model.py must expose --n-perm"
+
+    def test_n_perm_defaults_to_config_when_absent(self):
+        """Omitting the flag must leave the configured value untouched — a
+        production run may never silently use a test-sized permutation count."""
+        path = os.path.join(SCRIPTS_DIR, "compute_null_model.py")
+        with open(path) as fh:
+            src = fh.read()
+        assert "default=None" in src
+        assert "args.n_perm is not None" in src, (
+            "the override must be conditional, so the config default stands "
+            "whenever the flag is not passed"
+        )

--- a/tests/test_null_model_c2st.py
+++ b/tests/test_null_model_c2st.py
@@ -343,6 +343,15 @@ class TestC2STNullModelSmoke:
             str(null_out),
             "--div-csv",
             str(div_out),
+            # A smoke test asks "does the script run end-to-end and write a
+            # valid artifact", not "is this null distribution publishable".
+            # At the configured n_perm=500 these two tests trained a C2ST
+            # classifier 500 times per window and cost 462s — 45% of the whole
+            # serial suite (measured 2026-07-27, ticket 0326). The statistical
+            # properties are covered by the unit tests above, which use the
+            # backends directly.
+            "--n-perm",
+            "3",
         ]
         res = subprocess.run(
             cmd,

--- a/tickets/0325-variables-table-drops-the-negation-latex.erg
+++ b/tickets/0325-variables-table-drops-the-negation-latex.erg
@@ -1,0 +1,94 @@
+%erg 0.1
+Title: Variables table drops the negation: LaTeX esc() eats the tilde, publishing an inverted filter recipe
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T10:21Z HDMX-coding-agent created
+2026-07-27T12:25Z HDMX-coding-agent note found by the external peer-review panel (openai/gpt-5.5, grinchy persona), which read the RENDERED PDF and flagged that the paper gives two different filter expressions. Verified: the source is correct in both places, the PDF is not. Child of 0274 — resubmission-blocking.
+
+--- body ---
+## Context
+
+The data paper documents how to reproduce the refined subset from the
+deposited CSV. It prints that recipe twice, and the rendered PDF disagrees
+with itself:
+
+| Where | Renders as |
+|---|---|
+| §3 prose | `df[~df['is_flagged'] \| df['is_protected']]` — correct |
+| Table 4 (`@tbl-variables`) | `df[ df['is_flagged'] \| df['is_protected']]` — **negation gone** |
+
+A reader following Table 4 selects the complement: the flagged-and-unprotected
+works that were *removed*, not the 33,344 that were kept. In a data paper
+whose contribution is the dataset, the documented recipe for reconstructing
+the advertised subset is about as load-bearing as text gets.
+
+**The source is correct.** Both `deliverables/data-paper/data-paper.qmd` and
+`scripts/_deposit_variables.py` carry the tilde. The corruption happens at
+render.
+
+## Root cause
+
+`render_markdown_table()` in `scripts/_deposit_variables.py` emits raw LaTeX
+(a `longtable` inside a ```` ```{=latex} ```` block). Its `esc()` helper
+escapes only `&`, `%`, `#`, `_`. So in a LaTeX table cell:
+
+- `~` is a **non-breaking space** — `df[~df[` becomes `df[ df[`
+- `` ` `` is an **opening quote** — the code span renders as quoted prose
+
+Both are LaTeX doing exactly what LaTeX does with unescaped input. Nothing is
+broken upstream; the emitter is incomplete.
+
+Audit of all 32 deposit variables for characters `esc()` does not handle:
+
+- `is_flagged` — `~` and backticks. **Semantic corruption.**
+- `abstract_provenance`, `keywords_provenance`, `abstract_status` — backticks
+  only. Cosmetic: code literals render as quoted prose.
+
+## Relevant files
+
+- `scripts/_deposit_variables.py` — `render_markdown_table()` and `esc()`
+- `scripts/figures/export_variables_table.py` — thin wrapper, no escaping
+- `deliverables/_shared/tables/tab_variables.md` — the generated artifact
+- `deliverables/_shared/tables/codebook.md` — check whether the deposited
+  codebook takes the same path and is corrupted the same way
+
+## Actions
+
+1. Extend `esc()` to the LaTeX specials it currently ignores: `\` (first, or
+   it double-escapes the others), `~`, `^`, `$`, `{`, `}`. Use
+   `\textasciitilde{}` / `\textasciicircum{}` / `\textbackslash{}`.
+2. Render markdown backtick spans as `\texttt{...}` rather than letting them
+   become quotes, so a code literal in a description reads as code.
+3. Check `codebook.md` for the same defect — it documents the same column and
+   ships inside the Zenodo deposit.
+4. Re-render and diff the PDF's Table 4 against §3's prose: the two
+   expressions must be character-identical.
+
+## Test
+
+- Red first: assert that the rendered `tab_variables.md` contains no bare `~`
+  or backtick inside the LaTeX block, and that the `is_flagged` row's
+  expression matches the one in `data-paper.qmd` exactly.
+- Stronger, and the one that would have caught this: extract the text of the
+  built PDF and assert the two filter expressions are identical. A source-level
+  test cannot see a rendering bug — that is the whole lesson here.
+
+## Verification
+
+- [ ] PDF Table 4 and §3 print the same expression, tilde intact
+- [ ] The three cosmetic backtick cases render as code, not quotes
+- [ ] The deposited codebook carries the correct recipe
+
+## Invariants
+
+- The deposited CSV's documented reconstruction recipe must reproduce exactly
+  {{< meta corpus_total >}} works.
+- No weakening of the deposit contract: `export_deposit.py` enforces the same
+  variable list at write time and must stay in agreement.
+
+## Exit criteria
+
+- [ ] Every deposit-variable description survives LaTeX rendering unaltered
+- [ ] A guard compares the rendered artifact, not only the source

--- a/tickets/0326-c2st-smoke-tests-run-production-sized-pe.erg
+++ b/tickets/0326-c2st-smoke-tests-run-production-sized-pe.erg
@@ -1,0 +1,70 @@
+%erg 0.1
+Title: C2ST smoke tests run production-sized permutations: 45% of the serial suite in two tests
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Closed: fixed on t0326-c2st-smoke-perm-override — --n-perm override, 462s -> 12.1s
+
+--- log ---
+2026-07-27T12:40Z HDMX-coding-agent created
+2026-07-27T12:45Z HDMX-coding-agent closed — --n-perm CLI override added; the two smoke tests pass --n-perm 3; measured 462s -> 12.1s, 125 tests green in the null-model/divergence suites, ruff clean.
+
+--- body ---
+## Context
+
+Measuring where `make check` spends its time (author request, 2026-07-27):
+a serial full run is 1,037s over 1,804 tests, and **two tests are 462s of
+it — 45%**:
+
+- `TestC2STNullModelSmoke::test_compute_produces_output[C2ST_lexical]` 236.6s
+- `TestC2STNullModelSmoke::test_compute_produces_output[C2ST_embedding]` 225.1s
+
+The other ten tests in the same file cost 2.4s combined. Tier totals:
+integration 929.3s (89.6%), slow 78.4s, fast 15.0s over 1,116 tests,
+adherence 14.4s. The fast tier has nothing to reclaim; the cost is one file.
+
+Cause: both tests invoke `compute_null_model.py` end-to-end with no way to
+lower `n_perm`, so a fixture-sized smoke run still trains a C2ST classifier
+`divergence.permutation.n_perm = 500` times per window. The subprocess timeout
+is 300s and the run was reaching 236s of it.
+
+A smoke test's contract is that the script runs end-to-end and writes a valid
+artifact. The statistical properties (AUC in range, null near chance,
+reproducibility, schema) are already covered by the ten cheap unit tests in
+the same file, which drive the backends directly and cost ~0.3s each.
+
+## Resolution
+
+`--n-perm` on `compute_null_model.py`, mirroring the existing `--n-jobs`:
+
+- `default=None`, so omitting it leaves the configured value untouched — a
+  production run can never silently inherit a test-sized permutation count.
+- Applied as a single assignment into `cfg["divergence"]["permutation"]`
+  after `load_analysis_config()`. Every permutation backend reads that key,
+  so one line covers all methods with no signature threading.
+- Logs at WARNING when overridden. A null distribution at n_perm=3 is not
+  publishable, and silence is how it would reach a figure.
+
+The two smoke tests pass `--n-perm 3`.
+
+## Measured
+
+- The two tests: 462s -> 12.1s (38x).
+- Expected serial suite: 1,037s -> ~590s.
+- `tests/test_null_model_c2st.py` + `test_null_model.py` + `test_divergence.py`:
+  125 passed. `ruff check` clean.
+
+## Note for the workpackage split (author, 2026-07-27)
+
+These are exploratory tests belonging to the method-zoo / multilayer
+deliverable, not to the data paper. Under a phase taxonomy they read as
+"Phase 2 analysis" and look common; under the per-deliverable taxonomy the
+author ratified, they are one deliverable's private work and should not run
+when the data paper is touched. That distinction is the split's job, not this
+ticket's — recorded here because this file is the clearest example of why the
+per-deliverable model is the right one.
+
+## Exit criteria
+
+- [x] The smoke tests prove the end-to-end contract without production compute
+- [x] Omitting --n-perm leaves the configured value in force
+- [x] An overridden run says so, loudly

--- a/tickets/0326-c2st-smoke-tests-run-production-sized-pe.erg
+++ b/tickets/0326-c2st-smoke-tests-run-production-sized-pe.erg
@@ -2,11 +2,10 @@
 Title: C2ST smoke tests run production-sized permutations: 45% of the serial suite in two tests
 Created: 2026-07-27
 Author: HDMX-coding-agent
-Closed: fixed on t0326-c2st-smoke-perm-override — --n-perm override, 462s -> 12.1s
 
 --- log ---
 2026-07-27T12:40Z HDMX-coding-agent created
-2026-07-27T12:45Z HDMX-coding-agent closed — --n-perm CLI override added; the two smoke tests pass --n-perm 3; measured 462s -> 12.1s, 125 tests green in the null-model/divergence suites, ruff clean.
+2026-07-27T12:45Z HDMX-coding-agent note fix landed — --n-perm CLI override added; the two smoke tests pass --n-perm 3; measured 462s -> 12.1s, 125 tests green in the null-model/divergence suites, ruff clean.
 
 --- body ---
 ## Context

--- a/tickets/closed/0326-c2st-smoke-tests-run-production-sized-pe.erg
+++ b/tickets/closed/0326-c2st-smoke-tests-run-production-sized-pe.erg
@@ -2,11 +2,13 @@
 Title: C2ST smoke tests run production-sized permutations: 45% of the serial suite in two tests
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1132
 
 --- log ---
 2026-07-27T12:40Z HDMX-coding-agent created
 2026-07-27T12:45Z HDMX-coding-agent note fix landed — --n-perm CLI override added; the two smoke tests pass --n-perm 3; measured 462s -> 12.1s, 125 tests green in the null-model/divergence suites, ruff clean.
 
+2026-07-27T10:57Z HDMX-coding-agent closed — autoclosed — PR #1132
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0326-c2st-smoke-tests-run-production-sized-pe.erg

Measured where `make check` spends its time. A serial full run is **1,037s over 1,804 tests**, and **two tests are 462s of it — 45%**:

| Test | Before |
|---|---:|
| `TestC2STNullModelSmoke::test_compute_produces_output[C2ST_lexical]` | 236.6s |
| `TestC2STNullModelSmoke::test_compute_produces_output[C2ST_embedding]` | 225.1s |
| the other 10 tests in that file, combined | 2.4s |

Tier totals: integration 929.3s (89.6%) · slow 78.4s · **fast 15.0s over 1,116 tests** · adherence 14.4s. The fast tier has nothing to reclaim — the cost is one file.

## Cause

Both invoke `compute_null_model.py` end-to-end with no way to lower `n_perm`, so a *fixture-sized* smoke run still trains a C2ST classifier `divergence.permutation.n_perm = 500` times per window — reaching 236s of its own 300s subprocess timeout.

A smoke test's contract is that the script runs and writes a valid artifact. AUC range, null-near-chance, reproducibility and schema are already covered by the ten unit tests in the same file, which drive the backends directly at ~0.3s each.

## Fix

`--n-perm` on `compute_null_model.py`, mirroring the existing `--n-jobs`:

- **`default=None`** — omitting it leaves the configured value in force, so a production run can never silently inherit a test-sized count.
- **One assignment** into `cfg["divergence"]["permutation"]` after `load_analysis_config()`. Every permutation backend reads that key, so a single line covers all methods with no signature threading.
- **WARNING when overridden.** A null distribution at n_perm=3 is not publishable; silence is how it would reach a figure.

## Verification

- **462s → 12.1s** (38×), measured
- 125 passed across `test_null_model_c2st.py` + `test_null_model.py` + `test_divergence.py`
- `ruff check` clean
- Red-tested: both guards failed before the change (`--n-perm` absent, conditional absent)
- Expected serial suite **1,037s → ~590s**

## Note

These are the method-zoo deliverable's *exploratory* tests. Under a phase taxonomy they read as "Phase 2 analysis" and look common; under the per-deliverable workpackage model they are one deliverable's private work and should not run when the data paper is touched. That is the split's job, not this PR's — recorded because this file is the clearest argument for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)