### PR TITLE
fix(0297): reconnect the langdetect pass — 4.04% -> 0.15% null language

### DIFF
--- a/scripts/harvest/enrich_join.py
+++ b/scripts/harvest/enrich_join.py
@@ -148,24 +148,40 @@ def _apply_abstract_caches(df, cache_dir):
 
 
 def _apply_language_cache(df, cache_dir):
-    """Normalize language codes and fill missing from cache."""
+    """Normalize language codes and fill missing from the two language caches.
+
+    Caches are consulted in order of authority: `language_resolved.csv` holds
+    what OpenAlex reports, `language_detected.csv` the local langdetect
+    fallback for works OpenAlex has no language for. Reading only the first
+    left every locally-detected language on the floor (ticket 0297).
+    """
     df["language"] = df["language"].apply(normalize_lang)
-    lang_cache = _load_csv_cache(
+    resolved_cache = _load_csv_cache(
         os.path.join(cache_dir, "language_resolved.csv"), "key", "language")
+    detected_cache = _load_csv_cache(
+        os.path.join(cache_dir, "language_detected.csv"), "key", "language")
 
     applied = 0
+    from_detected = 0
     for idx in df.index:
         if _is_missing(df.at[idx, "language"]):
             doi = normalize_doi(df.at[idx, "doi"])
             sid = str(df.at[idx, "source_id"])
-            lang = lang_cache.get(doi, "") if doi else ""
-            if not lang:
-                lang = lang_cache.get(sid, "")
+            lang = ""
+            for cache in (resolved_cache, detected_cache):
+                lang = cache.get(doi, "") if doi else ""
+                if not lang:
+                    lang = cache.get(sid, "")
+                if lang:
+                    if cache is detected_cache:
+                        from_detected += 1
+                    break
             if lang:
                 df.at[idx, "language"] = lang
                 applied += 1
-    log.info("Language cache: applied %d (cache has %d entries)",
-             applied, len(lang_cache))
+    log.info("Language caches: applied %d (%d from langdetect); "
+             "resolved=%d, detected=%d entries",
+             applied, from_detected, len(resolved_cache), len(detected_cache))
     return applied
 
 

--- a/scripts/harvest/enrich_language.py
+++ b/scripts/harvest/enrich_language.py
@@ -261,11 +261,33 @@ def pass1_apply_cache(df, cache):
 
 # --- Pass 2: local text detection ---
 
-def pass2_local_detect(df):
+def _cache_key(df, idx):
+    """Cache key for a row: normalized DOI when present, else source_id.
+
+    Mirrors the lookup order in enrich_join._apply_language_cache, which
+    tries the DOI first and falls back to source_id. Returns "" when the
+    row offers neither (nothing to key on, so nothing is cached).
+    """
+    if "doi" in df.columns and pd.notna(df.at[idx, "doi"]):
+        doi = normalize_doi(df.at[idx, "doi"])
+        if doi:
+            return doi
+    if "source_id" in df.columns and pd.notna(df.at[idx, "source_id"]):
+        return str(df.at[idx, "source_id"])
+    return ""
+
+
+def pass2_local_detect(df, cache=None):
     """Fill remaining null language values using langdetect on title+abstract.
 
     Also flags nonsensical existing values (codes not in ISO 639-1).
     Returns number of records filled.
+
+    When `cache` is a dict, each detection is also recorded in it, keyed the
+    way enrich_join looks values up: by normalized DOI when there is one,
+    else by source_id. Without this the detections die with the process —
+    the script is cache-only since #428, so an in-memory fill reaches
+    nothing (ticket 0297).
     """
     filled = 0
     for idx in df.index:
@@ -290,6 +312,10 @@ def pass2_local_detect(df):
         if detected and is_valid_iso639_1(detected):
             df.at[idx, "language"] = detected
             filled += 1
+            if cache is not None:
+                key = _cache_key(df, idx)
+                if key:
+                    cache[key] = detected
 
     return filled
 
@@ -379,10 +405,14 @@ def main():
 
     # --- Pass 2: local text detection ---
     log.info("Pass 2: local text detection (langdetect)")
-    filled_pass2 = pass2_local_detect(df)
+    detected_cache = load_cache("language_detected")
+    filled_pass2 = pass2_local_detect(df, detected_cache)
+    save_cache("language_detected", detected_cache)
     counters["pass2_filled"] = filled_pass2
+    counters["pass2_cached"] = len(detected_cache)
     null_after_pass2 = int(df["language"].isna().sum())
-    log.info("Pass 2 filled %d, remaining null: %d", filled_pass2, null_after_pass2)
+    log.info("Pass 2 filled %d, remaining null: %d (cache: %d entries)",
+             filled_pass2, null_after_pass2, len(detected_cache))
 
     # Cache-only: enrich_join.py applies caches to the monolith (#428)
 

--- a/tests/test_enrich_language.py
+++ b/tests/test_enrich_language.py
@@ -259,6 +259,70 @@ class TestPass2LocalDetect:
         assert df.loc[0, "language"] == "en"
 
 
+# ---------- pass2 cache persistence (ticket 0297) ----------
+
+class TestPass2Persistence:
+    """pass2 detections must survive the process.
+
+    The #428 refactor made enrich_language cache-only: enrich_join applies
+    the caches to the monolith. Pass 1 saved language_resolved.csv, but
+    pass 2's langdetect results were only written to the in-memory frame
+    and discarded on exit — so 4.1% of the corpus stayed null (ticket 0297).
+    """
+
+    def test_records_detections_in_cache(self):
+        """A detection is recorded in the caller's cache dict."""
+        from enrich_language import pass2_local_detect
+        df = pd.DataFrame({
+            "doi": ["10.1234/a"],
+            "source_id": ["W001"],
+            "language": [None],
+            "title": ["Climate Finance"],
+            "abstract": ["Climate finance refers to local, national, or transnational "
+                         "financing that seeks to support mitigation and adaptation "
+                         "actions addressing climate change."],
+        })
+        cache = {}
+        filled = pass2_local_detect(df, cache)
+        assert filled == 1
+        assert cache == {"10.1234/a": "en"}
+
+    def test_cache_keyed_by_source_id_without_doi(self):
+        """Records without a DOI are keyed by source_id, as enrich_join looks up."""
+        from enrich_language import pass2_local_detect
+        df = pd.DataFrame({
+            "doi": [None],
+            "source_id": ["W002"],
+            "language": [None],
+            "title": ["Climate finance refers to local national or transnational financing"],
+            "abstract": [None],
+        })
+        cache = {}
+        pass2_local_detect(df, cache)
+        assert cache == {"W002": "en"}
+
+    def test_cache_optional(self):
+        """Existing callers that pass no cache still work."""
+        from enrich_language import pass2_local_detect
+        df = pd.DataFrame({
+            "language": [None],
+            "title": ["Climate Finance"],
+            "abstract": ["Climate finance refers to local, national, or transnational "
+                         "financing that seeks to support mitigation and adaptation."],
+        })
+        assert pass2_local_detect(df) == 1
+
+    def test_main_saves_detected_cache(self):
+        """main() persists pass-2 results to the language_detected cache."""
+        path = os.path.join(HARVEST_DIR, "enrich_language.py")
+        with open(path) as f:
+            source = f.read()
+        assert 'save_cache("language_detected"' in source, (
+            "pass-2 detections are computed but never persisted — "
+            "enrich_join cannot apply them (ticket 0297)"
+        )
+
+
 # ---------- DVC pipeline integration ----------
 
 class TestDVCStage:

--- a/tests/test_join_enrichments.py
+++ b/tests/test_join_enrichments.py
@@ -156,6 +156,67 @@ def test_join_applies_language_cache(enrichment_dir):
     assert bib_row["language"] == "de"
 
 
+def test_join_applies_detected_language_cache(enrichment_dir, tmp_path):
+    """The langdetect cache fills what OpenAlex could not (ticket 0297).
+
+    language_resolved.csv holds OpenAlex answers, including empty ones for
+    works OpenAlex has no language for. language_detected.csv holds the
+    local langdetect fallback. The join must consult both, or every
+    locally-detected language is silently dropped.
+    """
+    from enrich_join import join_enrichments
+
+    cache_dir = enrichment_dir / "enrich_cache"
+    # OpenAlex knows nothing about IST002's language: an empty answer.
+    pd.DataFrame({
+        "key": ["10.1234/b"],
+        "language": [""],
+    }).to_csv(cache_dir / "language_resolved.csv", index=False)
+    pd.DataFrame({
+        "key": ["10.1234/b", "BIB003"],
+        "language": ["fr", "de"],
+    }).to_csv(cache_dir / "language_detected.csv", index=False)
+
+    output_path = enrichment_dir / "enriched_works.csv"
+    join_enrichments(
+        unified_path=str(enrichment_dir / "unified_works.csv"),
+        output_path=str(output_path),
+        cache_dir=str(cache_dir),
+    )
+
+    result = pd.read_csv(output_path)
+    ist_row = result[result["source_id"] == "IST002"].iloc[0]
+    assert ist_row["language"] == "fr", "detected-language cache not applied (by DOI)"
+    bib_row = result[result["source_id"] == "BIB003"].iloc[0]
+    assert bib_row["language"] == "de", "detected-language cache not applied (by source_id)"
+
+
+def test_join_prefers_openalex_over_detection(enrichment_dir):
+    """When OpenAlex has an answer, the langdetect guess does not override it."""
+    from enrich_join import join_enrichments
+
+    cache_dir = enrichment_dir / "enrich_cache"
+    pd.DataFrame({
+        "key": ["10.1234/b"],
+        "language": ["fr"],
+    }).to_csv(cache_dir / "language_resolved.csv", index=False)
+    pd.DataFrame({
+        "key": ["10.1234/b"],
+        "language": ["es"],
+    }).to_csv(cache_dir / "language_detected.csv", index=False)
+
+    output_path = enrichment_dir / "enriched_works.csv"
+    join_enrichments(
+        unified_path=str(enrichment_dir / "unified_works.csv"),
+        output_path=str(output_path),
+        cache_dir=str(cache_dir),
+    )
+
+    result = pd.read_csv(output_path)
+    ist_row = result[result["source_id"] == "IST002"].iloc[0]
+    assert ist_row["language"] == "fr"
+
+
 def test_join_preserves_existing_values(enrichment_dir):
     """Existing non-null values are not overwritten by caches."""
     from enrich_join import join_enrichments

--- a/tickets/0297-corpus-language-null-rate-regression.erg
+++ b/tickets/0297-corpus-language-null-rate-regression.erg
@@ -7,6 +7,10 @@ Author: HDMX-coding-agent
 2026-07-22T16:40Z HDMX-coding-agent created author request during 0289 review (failure known for weeks, now tracked)
 2026-07-22T16:40Z HDMX-coding-agent note inherits cluster 2 from closed triage ticket 0263 — same 4.1% (1743/42916) on doudou AND padme, so a corpus property, not local staleness; after backfill on padme, finish with make corpus-sync on doudou
 
+2026-07-27T11:03Z HDMX-coding-agent note root cause: #428 made enrich_language cache-only but only pass 1's language_resolved.csv was wired into enrich_join; pass 2's langdetect results were filled in memory and discarded, and the stale language_detected.csv (1555 valid entries) was never read by anyone
+2026-07-27T11:03Z HDMX-coding-agent note verified on live corpus read-only: join now applies both caches, 1615 languages recovered from langdetect, null rate 4.04% -> 0.15% (65/43179)
+2026-07-27T11:04Z HDMX-coding-agent note order-insensitive: pass 2 on raw unified_works (real DVC order, 2271 detections) and on the joined frame both yield 65/43179 = 0.15%; english-majority test also improves 87.89% -> 91.56% (floor 75%)
+2026-07-27T11:04Z HDMX-coding-agent note code fix verified read-only against live corpus; remaining step is the corpus regeneration itself (make corpus-enrich on padme primary checkout, cache-warm) so ticket stays OPEN past the code PR
 --- body ---
 ## Context
 
@@ -32,6 +36,33 @@ with newly ingested sources whose records carry no language field.
    (langdetect or the pipeline's existing detector), or fetch the field
    from the source API where available.
 3. Rerun the acceptance test; corpus back under 2%.
+
+## Root cause (found 2026-07-27)
+
+Not newly-ingested sources, as the Context above guessed — the nulls are
+spread across every source (openalex 1427, bibcnrs 209, scispace 64,
+teaching 41, grey 2). The langdetect pass was silently disconnected:
+
+- `enrich_language.pass2_local_detect` filled the DataFrame in memory and
+  returned a count. The #428 refactor made the script cache-only, with
+  `enrich_join` applying caches to the monolith, but nothing ever wrote
+  pass 2's detections to a cache — they died with the process.
+- `enrich_join._apply_language_cache` read only `language_resolved.csv`
+  (pass 1, OpenAlex). So even the `language_detected.csv` sitting on disk
+  with 1,555 valid detections was read by nobody.
+
+Pass 1 alone cannot close the gap: OpenAlex returns an empty language for
+most of these works (851 of 2,347 cached keys are non-empty), which is
+precisely why the langdetect fallback exists.
+
+## Remaining step
+
+The code fix is verified read-only against the live corpus, but
+`enriched_works.csv` on disk still carries the old 4.04% until the
+pipeline re-runs. Run `make corpus-enrich` on padme's **primary
+checkout** (not a worktree — DVC data and lock live there) after the code
+PR merges; the caches are warm, so the join is the only stage with real
+work. Then `make corpus-validate`.
 
 ## Test
 


### PR DESCRIPTION
**Ticket-ref:** tickets/0297-corpus-language-null-rate-regression.erg

`test_language_null_rate_below_2_percent` has been red for weeks at 4.1%
null language against a < 2% contract. The Context in 0297 guessed newly
ingested sources; that was wrong. The nulls are spread across every source
(openalex 1427, bibcnrs 209, scispace 64, teaching 41, grey 2), and the real
cause is that the langdetect pass has been disconnected from the pipeline
since the #428 refactor.

## What broke

`#428` made `enrich_language` cache-only: each enrichment writes its own
cache, and `enrich_join` applies the caches to the monolith. Two halves of
that contract were never wired for pass 2:

- `pass2_local_detect` filled the DataFrame in memory and returned a count.
  Nothing persisted the detections, so they died with the process.
- `_apply_language_cache` read only `language_resolved.csv` (pass 1,
  OpenAlex). So `language_detected.csv` — already on disk with **1,555
  valid detections** — was read by nobody.

Pass 1 cannot cover for this: OpenAlex reports no language for most of
these works (only 851 of 2,347 cached keys are non-empty), which is exactly
why the local fallback exists.

## The fix

- `enrich_language` loads, extends, and saves `language_detected.csv`
  around pass 2. Keys come from `_cache_key` — normalized DOI, else
  `source_id` — matching the lookup order in the join. Loading first makes
  the pass incremental like every other enrichment here.
- `enrich_join` consults both caches in authority order: OpenAlex wins,
  langdetect fills only what OpenAlex left empty. The log line now reports
  how many came from langdetect, so a future silent drop shows up in the
  run report rather than only in the acceptance test months later.

Rejected alternative: let `enrich_language` write the works CSV directly,
as it did before #428. That reintroduces two writers of the monolith, which
is the thing #428 separated.

## Verification

Read-only against the live padme corpus (real `unified_works.csv` + real
caches, scratch output — the DVC corpus was not touched):

| | null language | English majority |
|---|---|---|
| before | 1,743 / 43,179 = **4.04%** | 87.89% |
| after | 65 / 43,179 = **0.15%** | 91.56% |

The join recovers **1,615** languages that were previously dropped.
English majority rises well clear of its 75% floor, so no collateral break.

Measured under both orderings, since the DVC stage runs pass 2 on raw
`unified_works.csv` (before the join backfills DOIs and abstracts) while a
naive check would run it on the joined frame. Pass 2 on raw unified yields
2,271 detections; both paths land on the same 65 / 43,179. The fix is
order-insensitive.

Test suite: fast tier 1,119 passed. `tests/test_enrich_language.py` +
`tests/test_join_enrichments.py` 52 passed. The cache parameter is optional,
so the three pre-existing pass-2 tests pass unchanged.

## Why the ticket stays open (`Ticket-ref:`, not `Ticket:`)

This PR fixes the code. The on-disk `enriched_works.csv` still carries the
old 4.04% until the pipeline re-runs, so 0297's exit criterion is not met by
merging. The remaining step is `make corpus-enrich` on padme's **primary
checkout** — DVC data and lock live there, not in a worktree — then
`make corpus-validate`. The caches are warm, so the join is the only stage
with real work.

## Out of scope

`make lint` has two failures on this branch that are **pre-existing on
main** and untouched by this diff: `test_ruff_clean` (I001/F401 in
`scripts/analysis/analyze_global_map.py` and
`conception/exploration-sem-vs-citation/`) and
`test_no_tier3_entry_point_is_imported` (`compute_clusters` imported by
`analyze_global_map`). Ruff is clean on all four files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
