### PR TITLE
tickets(0330, 0331): file the silent-dependency-skip sweep from the merge wave

### DIFF
--- a/tickets/0323-data-paper-narrate-langdetect-inferred-l.erg
+++ b/tickets/0323-data-paper-narrate-langdetect-inferred-l.erg
@@ -2,10 +2,10 @@
 Title: Data paper: narrate langdetect-inferred language tags in prose, as abstract reconstruction already is
 Created: 2026-07-27
 Author: HDMX-coding-agent
-Blocked-by: 0297
 
 --- log ---
 2026-07-27T10:09Z HDMX-coding-agent created
+2026-07-27T11:15Z HDMX-coding-agent note unblocked: 0297 closed via PR #1129 (merge wave 2026-07-27); stale Blocked-by removed
 2026-07-27T10:12Z HDMX-coding-agent note child of 0274. Surfaced by the independent review of PR #1129, then sharpened: the reviewer read this as an inherited gap ("disclosure lives only in the codebook, consistent with prior practice"). It is not. data-paper.qmd:122 already narrates abstract reconstruction in prose. Language would be the ONE derived field with no prose narration, and that gap is created by 0297 rather than inherited.
 
 --- body ---

--- a/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
+++ b/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
@@ -1,0 +1,123 @@
+%erg 0.1
+Title: diptest is undeclared so the Hartigan dip test never runs
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T11:02Z HDMX-coding-agent created
+2026-07-27T11:10Z HDMX-coding-agent note Found by the roar sweep after PR #1127 (ticket 0314) hard-guarded the same class at Flag 6
+
+--- body ---
+## Context
+
+Ticket 0314 (merged as PR #1127) turned a silently-skipped pipeline stage into
+a hard error: when `torch` is not importable, `filter_flags_llm.py` now raises
+instead of logging "Flag 6 skipped" and shipping an inflated corpus. The
+post-merge sweep for the same class found one more live instance.
+
+`scripts/analysis/analyze_bimodality.py` imports `diptest` inside a
+`try/except ImportError` and, on failure, emits `log.info("diptest package not
+available, skipping Hartigan's dip test")` and continues. But `diptest` appears
+nowhere in `pyproject.toml` or `uv.lock` — it is not a declared dependency, in
+any group or extra. The import therefore always fails, and the dip test has
+never run in this project.
+
+The consequence is visible in the committed artifact. Every row of
+`data/derived/tables/tab_bimodality.csv` carries an empty `dip_pvalue`:
+
+    embedding           | dip_pvalue = ''  | delta_bic = 1350
+    tfidf_lexical       | dip_pvalue = ''  | delta_bic = 15984
+    unsupervised_PC3    | dip_pvalue = ''  | delta_bic = 1398
+    embedding_1990-2006 | dip_pvalue = ''  | delta_bic = 19
+    embedding_2007-2014 | dip_pvalue = ''  | delta_bic = -59
+    embedding_2015-2024 | dip_pvalue = ''  | delta_bic = 1118
+
+Meanwhile the module docstring advertises the file as containing "Dip test
+p-values, GMM BIC, pole paper counts".
+
+Blast radius is bounded, and no published number is wrong.
+`compute_vars.py::bimodality_stats` reads only `n_efficiency_pole`,
+`n_accountability_pole`, `n_both_poles`, `delta_bic`, `bic_1comp`, `bic_2comp`,
+`embedding_lexical_corr`, and `explained_variance`. It never reads
+`dip_pvalue`, so no manuscript variable derives from the empty column. This is
+a dead advertised output, not a corrupted result — filed at normal severity
+rather than as a correctness emergency.
+
+For contrast, `scripts/_divergence_backend.py` was checked and is not an
+instance: `torch` is a declared extra (`cpu` / `cu130`), the NumPy path is a
+speed fallback producing the same numbers, and `get_backend()` already raises
+`RuntimeError` when the config asks for CUDA and it is absent. That is the
+pattern this ticket wants at the diptest joint.
+
+## Relevant files
+
+- `scripts/analysis/analyze_bimodality.py` — the swallowed ImportError in
+  `_test_bimodality()`, and the per-period `dip_pvalue is not None` guard below it
+- `pyproject.toml` — where the dependency is missing
+- `data/derived/tables/tab_bimodality.csv` — the artifact with the empty column
+- `scripts/analysis/compute_vars.py::bimodality_stats` — the consumer that
+  bounds the blast radius
+- `scripts/filter_flags_llm.py` — the reference hard-guard from ticket 0314
+
+## Decision required
+
+Two defensible resolutions; the author picks.
+
+1. Declare and enforce. Add `diptest` to the appropriate dependency group,
+   `uv lock`, and convert the `except ImportError` into a `raise RuntimeError`
+   in the ticket-0314 idiom (name the install command, name the opt-out flag).
+   The dip test then runs and the column becomes real. Costs a dependency;
+   gains the second bimodality statistic the docstring already promises.
+2. Drop the column. Remove the diptest branch, the `dip_p` field, and the
+   docstring claim. No new dependency; the table stops advertising something it
+   never delivered.
+
+Option 1 is the recommendation: the GMM delta-BIC is a single line of evidence
+for a load-bearing claim (bimodality of the axis score), and Hartigan's dip is
+the standard independent check on exactly that. But it changes what the analysis
+reports, so it is the author's call, not the agent's.
+
+## Test
+
+Red step, and it holds under either option:
+
+    def test_bimodality_dip_column_is_not_silently_empty():
+        """Ticket 0330. Either the dip test runs, or the column is gone."""
+        df = pd.read_csv(TABLES_DIR / "tab_bimodality.csv")
+        if "dip_pvalue" in df.columns:
+            assert df["dip_pvalue"].notna().any(), (
+                "dip_pvalue present but empty in every row - "
+                "diptest is not installed and the skip is silent"
+            )
+
+Fails today (column present, all-empty); passes under either resolution. Mark
+it `slow` if it reads the real derived table.
+
+## Verification
+
+- [ ] The test above is red on current main before the fix
+- [ ] Option 1: `uv run python -c "import diptest"` succeeds, and a regenerated
+      `tab_bimodality.csv` has non-empty `dip_pvalue`
+- [ ] Option 2: no `dip` reference remains in `analyze_bimodality.py`, and the
+      docstring no longer promises dip p-values
+- [ ] No `log.info(... "not available" ...)` remains on a dependency-missing
+      path in this file
+
+## Invariants
+
+- `compute_vars.py::bimodality_stats` emits identical values for every variable
+  it currently produces. This ticket must not move a manuscript number —
+  byte-compare the vars output before and after.
+- `make check-fast` and `make lint` stay green.
+
+## Exit criteria
+
+- [ ] The choice between option 1 and option 2 is recorded in this ticket's log
+- [ ] The chosen resolution is implemented and the test above passes
+- [ ] No silent dependency-missing skip remains in `analyze_bimodality.py`
+
+## See also
+
+- 0314 (closed, PR #1127) — the same class, hard-guarded at Flag 6
+- 0331 — the standing class guard, so the next undeclared import is caught
+  mechanically instead of by a post-merge sweep

--- a/tickets/0331-no-guard-on-undeclared-third-party-impor.erg
+++ b/tickets/0331-no-guard-on-undeclared-third-party-impor.erg
@@ -1,0 +1,123 @@
+%erg 0.1
+Title: no guard on undeclared third-party imports in scripts/
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Blocked-by: 0330
+
+--- log ---
+2026-07-27T11:02Z HDMX-coding-agent created
+2026-07-27T11:12Z HDMX-coding-agent note Class-level follow-up to 0330; the same defect already shipped once in libs/ (0211)
+
+--- body ---
+## Context
+
+This defect class has now bitten twice, in two different code trees, and both
+times a human reading code caught it rather than a test.
+
+- Ticket 0211, in `libs/openalex-corpus`: the package declared only `pandas`
+  while `crawl.py` imported `requests`. The shared dev env already had
+  `requests`, so a 25-test suite stayed green over a broken clean install.
+  Fixed in #956 and guarded afterwards by
+  `tests/test_openalex_corpus_installability.py`.
+- Ticket 0330, in `scripts/`: `analyze_bimodality.py` imports `diptest`, which
+  is declared nowhere. Because the import sits in a `try/except ImportError`
+  that logs at INFO and continues, nothing was ever red — the Hartigan dip test
+  simply never ran, and shipped an empty column in a Make-wired table.
+
+The 0211 guard is scoped to the path package only: it builds a throwaway venv,
+installs `libs/openalex-corpus`, and imports its submodules. It says nothing
+about `scripts/`, which is where the bulk of the pipeline lives and where 0330
+happened. The tree with the most code has the least coverage.
+
+The warm shared dev env is what hides both: it accumulates packages from every
+extra and group ever installed, so an undeclared import resolves at author time
+and fails only for a fresh clone, a CI container, or a reproducibility-archive
+consumer. That last case matters most — the Phase-4 archives exist so a third
+party can rebuild the analysis.
+
+## Relevant files
+
+- `tests/test_openalex_corpus_installability.py` — the existing guard; the
+  model to generalise, and the precedent for making it mutation-proof
+- `pyproject.toml` — dependency groups and extras that form the declared set
+- `scripts/**/*.py` — the unguarded tree (Phase 1 and Phase 2)
+- `conception/**/*.py` — decide whether in or out of scope (see below)
+
+## Actions
+
+1. Enumerate every module-level and function-level `import X` /
+   `from X import ...` across `scripts/`, using `ast`, not regex. The 0330
+   instance is a function-local import inside a `try`, so a module-header-only
+   scan would have missed it.
+2. Partition each imported name into stdlib (`sys.stdlib_module_names`),
+   first-party (resolvable under the `scripts` or `libs/openalex-corpus/src`
+   source roots), or third-party.
+3. Assert every third-party name maps to a distribution declared in
+   `pyproject.toml`, across dependencies, optional extras, and dependency
+   groups alike. Import name and distribution name differ often enough
+   (`sklearn`/`scikit-learn`, `yaml`/`PyYAML`, `community`/`python-louvain`)
+   that a mapping table or `importlib.metadata.packages_distributions()` is
+   required; a bare name comparison produces false positives on day one.
+4. Give the test an explicit, commented allowlist for any deliberate optional
+   import, so adding one is a visible decision rather than a silent pass.
+
+## Decisions to settle while implementing
+
+- Scope. `scripts/` is certainly in. `conception/` holds salvaged exploration
+  scripts kept as provenance (see the `PLR0915` per-file ignore added in
+  PR #1128) and is arguably out — archived one-shot runs, not pipeline code.
+  Recommendation: `scripts/` only, with `conception/` excluded and the reason
+  recorded in the test docstring.
+- Tier. Pure `ast` parsing plus a `pyproject.toml` read needs no heavy import
+  and no subprocess, so the fast tier fits; it is also a contract check, which
+  makes `adherence` defensible. Recommendation: `adherence`, beside the ruff and
+  hygiene guards it resembles.
+
+## Test
+
+The guard is itself the deliverable, so it needs a mutation-proof companion in
+the 0211 style — a test proving the guard would have caught the historical
+defect:
+
+    @pytest.mark.adherence
+    def test_undeclared_import_guard_catches_a_planted_import(tmp_path):
+        """Ticket 0331. Plant an undeclared import; the scanner must flag it."""
+        planted = tmp_path / "fake_script.py"
+        planted.write_text("def f():\n    import diptest\n    return diptest\n")
+        undeclared = scan_for_undeclared_imports([planted], declared=DECLARED)
+        assert "diptest" in undeclared
+
+Note the function-local placement: that is exactly the 0330 shape, and a
+scanner reading only module headers fails this test, which is the point.
+
+## Verification
+
+- [ ] Run the scanner against current main; every name it reports is either a
+      genuine undeclared import or gets a justified allowlist entry
+- [ ] The `diptest` instance from 0330 is reported before 0330 is fixed
+- [ ] The planted-import test fails if the scanner is downgraded to a
+      module-header-only or regex implementation
+- [ ] `make lint` stays green once the allowlist is settled
+
+## Invariants
+
+- No production script changes in this ticket — it adds a test and, at most, an
+  allowlist. The `diptest` resolution itself belongs to 0330.
+- Test-suite runtime does not regress; the fast tier stays within its budget.
+
+## Exit criteria
+
+- [ ] A guard exists that fails when a `scripts/` module imports a third-party
+      package absent from `pyproject.toml`
+- [ ] It parses with `ast` and catches function-local imports inside
+      `try/except ImportError`
+- [ ] Its mutation-proof companion test is present and meaningful
+- [ ] Scope (`conception/` in or out) and tier are recorded in the test docstring
+
+## See also
+
+- 0330 — the instance that prompted this; fix it first so the guard lands green
+- 0211 (closed, PR #956) — the same class in `libs/`, and the narrow-scope guard
+  this one generalises
+- 0314 (closed, PR #1127) — the adjacent rule that a missing dependency must
+  fail loudly rather than skip a stage


### PR DESCRIPTION
Post-merge roar sweep for the anti-pattern PR #1127 (ticket 0314) fixed:
a missing optional dependency that silently disables an analysis whose output
feeds a deliverable.

## What the sweep found

**One genuine instance — ticket 0330.** `scripts/analysis/analyze_bimodality.py`
imports `diptest` inside a `try/except ImportError` that logs at INFO and
continues. `diptest` is declared nowhere in `pyproject.toml` or `uv.lock`, so
the import has always failed and Hartigan's dip test has never run. Every row
of the committed `data/derived/tables/tab_bimodality.csv` carries an empty
`dip_pvalue`, while the module docstring advertises the file as containing
"Dip test p-values".

Blast radius is bounded and **no manuscript number is wrong**:
`compute_vars.py::bimodality_stats` reads `delta_bic`, the BIC pair, the pole
counts, the correlation and the explained variance — never `dip_pvalue`. So
this is a dead advertised output, not a corrupted result. The ticket leaves the
resolution to the author (declare the dependency and hard-fail in the 0314
idiom, or drop the column), because option 1 changes what the analysis reports.

**One non-instance, checked and cleared.** `scripts/_divergence_backend.py`'s
torch fallback is fine: torch is a declared extra (`cpu` / `cu130`), the NumPy
path is a speed fallback producing identical numbers, and `get_backend()`
already raises `RuntimeError` when the config asks for CUDA and it is absent —
that is precisely the pattern 0330 wants. The other ~20 `"skipping"` log lines
across `scripts/` are data-conditional guards (too few texts, empty
neighborhood, no citations file), not dependency degradation.

## Why a class guard too — ticket 0331

This defect has now shipped twice in two trees, caught both times by a human
reading code rather than by a test:

- **0211** (`libs/openalex-corpus`): declared only `pandas` while `crawl.py`
  imported `requests`. Fixed in #956 and guarded by
  `tests/test_openalex_corpus_installability.py`.
- **0330** (`scripts/`): the diptest case above.

That existing guard is scoped to the path package only. `scripts/` — the bulk
of the pipeline — has none. The warm shared dev env is what hides it: an
undeclared import resolves at author time and fails only for a fresh clone, a
CI container, or a Phase-4 reproducibility-archive consumer. 0331 specifies an
`ast`-based scanner (module-header greps would have missed 0330's
function-local import) plus a mutation-proof planted-import companion test in
the 0211 style. `Blocked-by: 0330` so it lands green.

## Also

Drops `Blocked-by: 0297` from ticket 0323 — stale since PR #1129 closed 0297 in
the same merge wave. `erg check` was reporting it as a warning; the tree is now
clean at 318 tickets, 0 warnings.

## Verification

- `erg check tickets/` — PASS, 318 tickets, 0 warnings
- Tickets only; no production code touched.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)