### PR TITLE
ticket(0336): Flag 5 semantic isolation is silently skipped on every run

### DIFF
--- a/tickets/0323-data-paper-narrate-langdetect-inferred-l.erg
+++ b/tickets/0323-data-paper-narrate-langdetect-inferred-l.erg
@@ -2,12 +2,12 @@
 Title: Data paper: narrate langdetect-inferred language tags in prose, as abstract reconstruction already is
 Created: 2026-07-27
 Author: HDMX-coding-agent
-Blocked-by: 0297
 
 --- log ---
 2026-07-27T10:09Z HDMX-coding-agent created
 2026-07-27T10:12Z HDMX-coding-agent note child of 0274. Surfaced by the independent review of PR #1129, then sharpened: the reviewer read this as an inherited gap ("disclosure lives only in the codebook, consistent with prior practice"). It is not. data-paper.qmd:122 already narrates abstract reconstruction in prose. Language would be the ONE derived field with no prose narration, and that gap is created by 0297 rather than inherited.
 
+2026-07-27T11:24Z HDMX-coding-agent note unblocked: 0297 closed and the corpus regenerated on padme 2026-07-27. Real figures from enriched_works.csv language_provenance: 40644 source, 850 openalex, 1620 detected:langdetect, 65 empty (of 43179). refined_works.csv: 33344 rows, 9 null
 --- body ---
 ## Context
 

--- a/tickets/0336-flag5-semantic-isolation-silently-skipped.erg
+++ b/tickets/0336-flag5-semantic-isolation-silently-skipped.erg
@@ -1,0 +1,104 @@
+%erg 0.1
+Title: Flag 5 (semantic isolation) is silently skipped on every corpus filter run
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T11:30Z HDMX-coding-agent created found during the 0297 corpus regeneration on padme
+
+--- body ---
+## Context
+
+`corpus_filter.py` computes six flags to decide what leaves the corpus.
+Flag 5 (semantic isolation, embedding-based) never runs: it needs the
+embeddings matrix to align positionally with the row subset it rebuilds, and
+the two have diverged.
+
+Observed during the ticket-0297 corpus regeneration (2026-07-27):
+
+```
+WARNING   Embedding size mismatch (38736 vs 33057), skipping.
+INFO        Flag 5: skipped (no embeddings)
+```
+
+Measured against the current corpus:
+
+- `enrich_embeddings` writes **38,736** vectors to `data/catalogs/embeddings.npz`
+- `_load_embeddings` in `corpus_filter.py` rebuilds its own subset —
+  `abstract` non-null and longer than 50 chars, **and** `year` within
+  `config/analysis.yaml periodization.year_min..year_max` (1990–2024) — giving
+  **33,057** rows
+- `len(embeddings) != len(emb_df)` therefore always holds, so the function
+  returns `(None, None, False)` and the caller skips the flag
+
+The abstract filter alone yields 36,476 rows; the year window removes a
+further 3,419. So the two stages disagree on both criteria, not one.
+
+This is not staleness and not a DVC ordering artifact. `extend` does not
+declare `embeddings.npz` as a dependency, so DVC never re-runs it when
+embeddings change, and re-running `extend` after `enrich_embeddings` does not
+help — the counts differ regardless of order. The corpus filter has been
+running with five of six flags for as long as the row sets have diverged.
+
+## Why it matters
+
+A skipped flag is not a neutral default: it means no paper is ever excluded
+for semantic isolation, so `refined_works.csv` retains works Flag 5 was
+designed to drop. Any count or figure derived from the refined corpus
+reflects a five-flag filter while the codebook and the data paper describe
+six. The failure is a `log.warning`, so it never breaks a build.
+
+## Relevant files
+
+- `scripts/harvest/corpus_filter.py` — `_load_embeddings()` (the mismatch and
+  the silent `return None, None, False`), and the Flag 5 call site
+- `scripts/harvest/enrich_embeddings.py` — decides which rows get embedded
+- `config/analysis.yaml` — `periodization.year_min` / `year_max`
+- `dvc.yaml` — `extend` stage deps (no `embeddings.npz`)
+
+## Actions
+
+1. Decide which row set is authoritative. Options, to be arbitrated:
+   a. Embed exactly the Flag 5 subset (add the year window to
+      `enrich_embeddings`) — narrows the embeddings used elsewhere, so check
+      every other consumer of `embeddings.npz` first.
+   b. Keep embeddings broad and have Flag 5 **join by key** (`source_id` or
+      DOI) instead of relying on positional alignment. Preferred on the face
+      of it: positional alignment between two independently-filtered frames is
+      the underlying fragility, and a join removes the whole class.
+2. Implement the chosen option.
+3. Declare `embeddings.npz` as a dep of the `extend` stage in `dvc.yaml` so
+   the flag cannot silently go stale again.
+4. Re-run `make corpus-filter-all` and record how `refined_works.csv` changes
+   — this will move the corpus row count, so it needs author sign-off before
+   any downstream figure or table is regenerated.
+
+## Test
+
+Red first: a unit test that builds a works frame plus an embeddings matrix
+whose row sets differ, and asserts Flag 5 still evaluates (rather than
+returning `skipped`) once the join replaces positional alignment. Add a guard
+test asserting `_load_embeddings` never silently returns "no embeddings" for a
+corpus that does have embeddings — a `log.warning` swallowing a dead flag is
+what hid this.
+
+## Verification
+
+- [ ] Flag 5 reports a real count in the extend log, not `skipped`
+- [ ] `embeddings.npz` is a declared dep of `extend` in `dvc.yaml`
+- [ ] The change in `refined_works.csv` row count is measured and recorded
+- [ ] `make check` passes
+
+## Invariants
+
+- No weakening of the acceptance thresholds.
+- `make corpus`/`corpus-sync` only, never bare `dvc repro`; padme->doudou
+  data direction.
+- Changing the corpus composition affects every downstream count: do not
+  regenerate figures or tables until the author has signed off on the new
+  row count.
+
+## Exit criteria
+
+- Flag 5 evaluates on every run, its effect on the corpus is measured and
+  signed off, and a guard prevents it from silently going dead again.


### PR DESCRIPTION
**Ticket:** none
**Ticket-ref:** tickets/0336-flag5-semantic-isolation-silently-skipped.erg
**Ticket-ref:** tickets/0323-data-paper-narrate-langdetect-inferred-l.erg

Ticket-store fallout from the 0297 corpus regeneration on padme (data landed
in #1136). No code changes.

## 0336 — Flag 5 is silently dead (new)

`corpus_filter.py` computes six flags to decide what leaves the corpus. Flag 5
(semantic isolation) has been returning `skipped` on every run:

```
WARNING   Embedding size mismatch (38736 vs 33057), skipping.
INFO        Flag 5: skipped (no embeddings)
```

`enrich_embeddings` writes **38,736** vectors; `_load_embeddings` rebuilds its
own subset — abstract > 50 chars **and** year within
`periodization.year_min..year_max` (1990–2024) — giving **33,057** rows, then
requires exact positional alignment. The abstract filter alone yields 36,476,
so the two stages disagree on both criteria.

Structural, not stale: `extend` does not declare `embeddings.npz` as a
dependency, and the counts differ regardless of run order. My first reading of
the warning was that DVC had merely ordered `extend` before
`enrich_embeddings`; measuring it disproved that.

Consequence: no paper is ever excluded for semantic isolation, so the refined
corpus reflects a five-flag filter while the codebook and data paper describe
six — and the failure is a `log.warning`, so no build ever broke.

Filed rather than fixed inline, deliberately. The remedy changes
`refined_works.csv`'s row count, which is an author sign-off unit and moves
every downstream count; and the choice between narrowing the embeddings or
replacing positional alignment with a key join is a design call, not a
mechanical one. The ticket records both options and marks the join as
preferable, since positional alignment between two independently-filtered
frames is the underlying fragility.

## 0323 — unblocked with real numbers

`erg check` flagged `Blocked-by: 0297` as stale once 0297 closed. 0323's body
said the inferred-language count was meaningless before the corpus rebuild;
the rebuild has now happened, so the log entry carries the figures it needs:
40,644 `source`, 850 `openalex`, **1,620 `detected:langdetect`**, 65 empty, of
43,179. `erg check` is clean again (317 tickets, no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
