### PR TITLE
ticket(0321): record the no-CI decision in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Autonomous execution using test-driven development. The inner cycle is:
 
 Use `make check-fast` during development, `make check` before opening a PR. Makefile truth: prerequisites and targets must match each script's actual file reads and writes.
 
+**There is no CI.** This repo has no `.github/workflows/`, by decision (ticket 0321, 2026-07-27). Nothing runs the suite on push or on a pull request: `make check` is a purely local gate, and a green main is only ever whatever the last session verified on its own machine. Two consequences. Run `make check` yourself before opening a PR — no forge job will do it for you. And never read a merged PR as proof that main is green: when a full `make check` surfaces failures your branch did not cause, they belong to main, and they get their own ticket.
+
 ### Verify
 Gate each PR before merging via `/verify <pr-number>`. The skill runs the full loop:
 

--- a/tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
+++ b/tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T08:10Z HDMX-coding-agent created
 2026-07-27T08:17Z HDMX-coding-agent note surfaced by a full `make check` on branch t0317-temporal-coverage; both failures are in files that branch does not touch. This repo has no CI workflows, so `make check` is a purely local gate and main's redness went unseen.
+2026-07-27T11:50Z HDMX-coding-agent note actions 1-2 landed via PR #1128 and PR #1130, both merged with a non-closing Ticket-ref because action 3 was still open. Verified on main b91b7446: ruff clean, test_script_classification 2 passed.
+2026-07-27T11:50Z HDMX-coding-agent note author arbitrated action 3: no CI, the local-only gate is deliberate. Recorded in AGENTS.md and in the Decision section.
 
 --- body ---
 ## Context
@@ -66,7 +68,19 @@ the file in `RECLASSIFIED_DUAL_ROLE` and `docs/repo-layout.md`.
 - `conception/` is exploration code, but it is still linted — the fix is a
   scoped per-file ignore with a reason, not removing it from ruff's reach.
 
+## Decision — no CI (author, 2026-07-27)
+
+The local-only gate is deliberate. This repo will not grow a
+`.github/workflows/`; `make check` before a PR stays the whole gate, run by
+whoever opens the PR. Recorded in `AGENTS.md` beside the existing
+`make check-fast` / `make check` instruction, with the two consequences a
+session needs to act on: nobody else runs the suite for you, and a merged PR
+is no evidence that main is green.
+
 ## Exit criteria
 
-- [ ] ruff clean and the dual-role import resolved
-- [ ] An explicit decision recorded on CI vs local-only gating
+- [x] ruff clean and the dual-role import resolved
+      (PR #1128 ruff; PR #1130 extracted the TF-IDF label vocabulary out of
+      the Tier-3 entry point — extraction, not an allowlist widening)
+- [x] An explicit decision recorded on CI vs local-only gating
+      (author 2026-07-27: no CI; see the Decision section and `AGENTS.md`)

--- a/tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
+++ b/tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-07-27T08:17Z HDMX-coding-agent note surfaced by a full `make check` on branch t0317-temporal-coverage; both failures are in files that branch does not touch. This repo has no CI workflows, so `make check` is a purely local gate and main's redness went unseen.
 2026-07-27T11:50Z HDMX-coding-agent note actions 1-2 landed via PR #1128 and PR #1130, both merged with a non-closing Ticket-ref because action 3 was still open. Verified on main b91b7446: ruff clean, test_script_classification 2 passed.
 2026-07-27T11:50Z HDMX-coding-agent note author arbitrated action 3: no CI, the local-only gate is deliberate. Recorded in AGENTS.md and in the Decision section.
+2026-07-27T12:09Z HDMX-coding-agent note verification run on main b91b7446: make check exits 0, pytest tests/ 1828 passed 22 skipped 0 failed in 3m42s. Main is green; 0297 and 0320 stay open on their substance.
 
 --- body ---
 ## Context
@@ -59,8 +60,12 @@ the file in `RECLASSIFIED_DUAL_ROLE` and `docs/repo-layout.md`.
 
 ## Verification
 
-- [ ] `make check` on a clean main shows only the corpus-data failures tracked
-      by 0297 and 0320
+- [x] `make check` on a clean main shows only the corpus-data failures tracked
+      by 0297 and 0320 — better than that on main b91b7446 (2026-07-27):
+      `make check` exits 0, `pytest tests/` reports 1828 passed, 22 skipped,
+      0 failed in 3m42s. The 0320 failure went with PR #1131; the 0297 one
+      cleared through the #1134 / #1138 merges. Both tickets stay open: a
+      green suite is not evidence their substantive work is done.
 
 ## Invariants
 

--- a/tickets/closed/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
+++ b/tickets/closed/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg
@@ -2,6 +2,7 @@
 Title: main is red: 8 ruff findings and a tier-3 dual-role import from the 2026-07-24 merges
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1139
 
 --- log ---
 2026-07-27T08:10Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 2026-07-27T11:50Z HDMX-coding-agent note author arbitrated action 3: no CI, the local-only gate is deliberate. Recorded in AGENTS.md and in the Decision section.
 2026-07-27T12:09Z HDMX-coding-agent note verification run on main b91b7446: make check exits 0, pytest tests/ 1828 passed 22 skipped 0 failed in 3m42s. Main is green; 0297 and 0320 stay open on their substance.
 
+2026-07-27T12:10Z HDMX-coding-agent closed — autoclosed — PR #1139
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes the last open action of 0321. Actions 1 and 2 (ruff clean, Tier-3 dual-role import) landed via #1128 and #1130, both merged with a non-closing `Ticket-ref` because the CI-vs-local-gate ruling was still outstanding.

The author ruled on 2026-07-27: **no CI.** The local-only gate is deliberate; this repo will not grow a `.github/workflows/`. `AGENTS.md` now says so beside the existing `make check-fast` / `make check` instruction, with the two consequences a session has to act on — nobody else runs the suite for you, and a merged PR is no evidence that main is green.

Verified on main `b91b7446`:
- `uv run ruff check .` → All checks passed
- `tests/test_script_classification.py` → 2 passed

Doc- and ticket-only diff; no code touched.

**Ticket:** tickets/0321-main-is-red-8-ruff-findings-and-a-tier-3.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)