### PR TITLE
chore: track the run reports from the 0297 corpus regeneration

### DIFF
--- a/data/catalogs/run_reports.dvc
+++ b/data/catalogs/run_reports.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: c37e0f4c1cf0d8b15122d0b3ec003482.dir
-  size: 57049
-  nfiles: 130
+- md5: 42bc3e29ab25f7aa1ffb2cd687b41472.dir
+  size: 59970
+  nfiles: 139
   hash: md5
   path: run_reports


### PR DESCRIPTION
**Ticket:** none
**Ticket-ref:** tickets/closed/0297-corpus-language-null-rate-regression.erg

Pointer-only follow-up to #1136. The 0297 corpus regeneration wrote nine new
Phase-1 QA run reports (`corpus_align`, `enrich_citations` ×2,
`enrich_language` ×2, `summarize_abstracts` ×3), taking the DVC-tracked
directory from 130 to 139 files (57,049 → 59,970 bytes). `dvc commit` recorded
them and `dvc push` sent them to the padme remote; this lands the matching
pointer.

Why it matters: without it, git keeps the old `c37e0f4c…` hash while the newer
run reports sit on the remote unreferenced, so a fresh `dvc pull` on doudou
would restore the pre-regeneration set.

No code, no corpus data — three lines of `data/catalogs/run_reports.dvc`.

Note: the directory was already dirty before this session started, so a few of
the 9 predate the regeneration and necessarily ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
