### PR TITLE
tickets(0339, 0340, 0341): file the 0325 sweep for unescaped markup emitters

### DIFF
--- a/tickets/0339-markdown-pipe-table-emitters-interpolate.erg
+++ b/tickets/0339-markdown-pipe-table-emitters-interpolate.erg
@@ -1,0 +1,93 @@
+%erg 0.1
+Title: Markdown pipe-table emitters interpolate free-text journal names unescaped
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T12:09Z HDMX-coding-agent created
+2026-07-27T12:15Z HDMX-coding-agent note found by the 0325 roar sweep for the same defect class. Latent, not currently firing: every row in the shipped tab_venues.md carries its five cells, because no pipe-bearing venue sits in today's top-N.
+
+--- body ---
+## Context
+
+Ticket 0325 fixed an emitter that interpolated values into a Markdown pipe
+table without escaping `|`, so the deposited codebook published its
+reconstruction recipe truncated at the pipe. The sweep for that defect class
+found two more emitters with the same shape, both interpolating a **journal
+name** — free text straight from the bibliographic corpus.
+
+The corpus really does contain the dangerous character. In
+`refined_works.csv`, 10 `journal` values and 14 `title` values carry a literal
+`|`, all bilingual names joined with a pipe:
+
+```
+International Development Policy | Revue internationale de politique de développement
+Journal of Corporate Finance Research / Корпоративные Финансы | ISSN 2073-0438
+```
+
+Nothing is corrupted today: the venues selected for the manuscript table
+happen to be pipe-free. It fires on the first corpus rebuild that promotes one
+of those venues into the top-N — silently, because a Markdown renderer drops
+the overflowing cell rather than erroring.
+
+## Root cause
+
+Same as 0325: a script builds markup by string interpolation and does not
+escape what the markup treats as syntax.
+
+- `scripts/figures/export_tab_venues.py:120` —
+  `f"| {r['lean']} | {r['journal']} "` — `journal` is raw `refined_works.csv`
+  text, no canonicalisation. Its output is `{{< include >}}`d by
+  `deliverables/manuscript/manuscript.qmd:331` (and the fr variant at
+  `manuscript-Gide.qmd:226`), so this instance reaches a rendered manuscript.
+- `scripts/figures/export_core_venues_markdown.py:107` —
+  `f"| {venue} | {count} | {vtype} |"`. `venue` is `venue_canonical`, which
+  passes through `canonical_venue()` in `scripts/_venue_naming.py` — but that
+  function returns the **raw journal string** when no rule matches
+  (`_venue_naming.py:59`), so an uncurated name flows straight through.
+  Dormant for now: the table has a Makefile target (`Makefile:330`) but no
+  `.qmd` includes it yet.
+
+## Relevant files
+
+- `scripts/figures/export_tab_venues.py` — the reachable, rendered instance
+- `scripts/figures/export_core_venues_markdown.py` — the dormant instance
+- `scripts/_venue_naming.py` — `canonical_venue()`'s raw fallback
+- `scripts/_deposit_variables.py` — `markdown_cell()`, the escaping already
+  written for 0325; extract it rather than writing a third copy
+
+## Actions
+
+1. Lift `markdown_cell()` out of `_deposit_variables.py` into a neutral module
+   both emitters can import, keeping its prose/code-span split — CommonMark
+   reads a backslash as an escape in prose but literally inside a code span,
+   so one blanket rule corrupts one side. 0325's commit message records the
+   three candidate rules and how each fails.
+2. Route every free-text cell in both emitters through it.
+3. Leave numeric and curated-label columns alone; escaping them is noise.
+
+## Test
+
+Red first, and on the **rendered** table rather than the emitted source — the
+lesson of 0325 is that a source-level assertion cannot see this. Build a
+one-row table from a venue named
+`International Development Policy | Revue internationale`, render it through
+pandoc's GFM reader, and assert the row still has five `<td>` cells with the
+venue name whole. `tests/test_rendered_table_fidelity.py` carries the pattern.
+
+## Verification
+
+- [ ] A pipe-bearing venue renders as one cell in both tables
+- [ ] Regenerating `tab_venues.md` from the current corpus is a no-op — no
+      pipe-bearing venue is in today's top-N, so the fix must not churn it
+- [ ] One escaping implementation, imported by all three call sites
+
+## Invariants
+
+- `make check` passes; the manuscript still renders.
+- Numeric columns keep their formatting (`:.0f`).
+
+## Exit criteria
+
+- [ ] No Markdown-table emitter interpolates free text without escaping
+- [ ] The escaping rule lives in one place, pinned by a rendered test

--- a/tickets/0340-standing-guard-every-generated-markdown.erg
+++ b/tickets/0340-standing-guard-every-generated-markdown.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Standing guard: every generated Markdown table row has its declared cell count
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Blocked-by: 0339
+
+--- log ---
+2026-07-27T12:09Z HDMX-coding-agent created
+2026-07-27T12:16Z HDMX-coding-agent note filed by the 0325 roar sweep. The class has now produced three instances (0325's codebook, and both emitters in 0339), which is what earns a standing test rather than a third point fix.
+
+--- body ---
+## Context
+
+Three emitters have now shipped the same defect: a free-text value carrying a
+`|` interpolated into a Markdown pipe table, where the renderer silently drops
+the overflowing cell. 0325 fixed one in the deposited codebook; 0339 fixes two
+more. Each was caught by a human or an agent reading output, never by a test.
+
+A per-PR review gate cannot catch the fourth. The class needs a standing test
+that fails when *any* generated table in the tree has a malformed row —
+including one produced by an emitter nobody thought to check.
+
+This ticket is deliberately separate from 0339 (roar step 4: a regression
+guard for a class is not bundled into the fix PR).
+
+## Actions
+
+1. Discover the generated Markdown tables from the Makefile rather than a
+   hardcoded list — a hardcoded list is exactly what lets the next emitter
+   escape. `tests/test_phase_layout.py` already parses Make targets; reuse
+   that approach. See memory `feedback_autodiscovery_class_guard`.
+2. For each such artifact on disk, parse its pipe tables and assert every body
+   row splits into the same number of cells as its header, honouring `\|`
+   escapes.
+3. Skip artifacts absent on the machine (DVC-gated) rather than failing —
+   several tables need corpus data.
+
+## Test
+
+The guard *is* the test. Make it red first by pointing it at a fixture table
+containing an unescaped `|` in a cell and confirming it fails, then at the
+escaped version and confirming it passes. Without that step the guard can pass
+vacuously — e.g. by finding no files.
+
+## Verification
+
+- [ ] The guard fails on a deliberately malformed fixture
+- [ ] It passes on the current tree
+- [ ] It discovers tables from the Makefile, so a new emitter is covered
+      without editing the test
+- [ ] Marked `adherence` or fast — it reads files, runs nothing
+
+## Invariants
+
+- No corpus data required; skips cleanly where artifacts are absent.
+- `make check-fast` stays under its budget.
+
+## Exit criteria
+
+- [ ] A single test covers every generated Markdown table in the tree
+- [ ] Adding an emitter without escaping fails that test

--- a/tickets/0341-interactive-corpus-hover-text-interpolat.erg
+++ b/tickets/0341-interactive-corpus-hover-text-interpolat.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Interactive corpus hover text interpolates title and journal into raw HTML unescaped
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T12:09Z HDMX-coding-agent created
+2026-07-27T12:17Z HDMX-coding-agent note filed by the 0325 roar sweep. The tell is that two sibling scripts already do this correctly, so it is an inconsistency rather than an unconsidered case.
+
+--- body ---
+## Context
+
+The 0325 sweep looked for values interpolated into markup without escaping.
+`scripts/figures/plot_interactive_corpus.py` builds Plotly hover text as raw
+HTML — deliberate `<b>`, `<br>`, `<i>` tags — and interpolates `title_short`,
+`first_author`, and `journal_short` straight in (lines ~233-239, 265-268,
+298-305), writing `deliverables/_shared/figures/interactive_core_corpus.html`.
+
+Title and journal are free bibliographic text. An `&` or a `<` in either
+corrupts the hover box the same way an unescaped `|` corrupts a table cell.
+Ampersands in journal names are ordinary ("Energy Research & Social Science").
+
+What makes this worth fixing rather than noting: `plot_genealogy_html.py` and
+`plot_alluvial_html.py` already call `html.escape()` on every free-text field
+before interpolation. The convention exists in this codebase; one script
+departs from it.
+
+## Relevant files
+
+- `scripts/figures/plot_interactive_corpus.py` — the three interpolation sites
+- `scripts/figures/plot_genealogy_html.py` — correct: escapes before building
+- `scripts/figures/plot_alluvial_html.py` — correct, same pattern
+
+## Actions
+
+1. Apply `html.escape()` to `title_short`, `first_author`, and
+   `journal_short` at each hover-text site, matching the sibling scripts.
+2. Leave the intentional `<b>`/`<br>`/`<i>` structure tags alone — escape the
+   interpolated values, not the template.
+
+## Test
+
+Assert that a record whose title contains `&` and `<` produces hover text in
+which those characters appear escaped while the structural tags survive
+unescaped. A unit test on the hover-text builder is enough here: unlike the
+LaTeX and pipe-table cases, the corruption is visible in the emitted string,
+because the escaping and the markup live in the same layer.
+
+## Verification
+
+- [ ] A title containing `&` and `<` survives into the rendered hover box
+- [ ] `<b>`/`<br>`/`<i>` still render as markup
+- [ ] The figure still builds
+
+## Invariants
+
+- `make check` passes; the interactive figure regenerates.
+
+## Exit criteria
+
+- [ ] All three HTML-emitting figure scripts escape free text the same way


### PR DESCRIPTION
Ticket: none

Sweep filings from `/roar` after ticket 0325 merged (PR #1137). Tickets only — no code changes.

0325 fixed two emitters that build markup by string interpolation without escaping what the markup treats as syntax. The sweep looked for the same shape across `scripts/`.

**0339 — two more Markdown pipe-table emitters interpolate a raw journal name.** `export_tab_venues.py:120` (whose output is `{{< include >}}`d by the manuscript) and `export_core_venues_markdown.py:107` (via `canonical_venue()`'s raw fallback at `_venue_naming.py:59`). The corpus really carries the character: 10 `journal` values and 14 `title` values in `refined_works.csv` contain a literal `|`, all bilingual names joined with a pipe. Nothing is corrupted today — the shipped `tab_venues.md` rows all carry their five cells, because no pipe-bearing venue is in the current top-N. It fires on the first corpus rebuild that promotes one.

**0340 — standing guard for the class.** Three instances now (0325's codebook plus 0339's two), each caught by someone reading output rather than by a test. Filed separately from the fix per the roar step-4 rule, and Makefile-discovered so the next emitter is covered without editing the test.

**0341 — the same class in HTML.** `plot_interactive_corpus.py` interpolates title, author, and journal into raw Plotly hover markup, while `plot_genealogy_html.py` and `plot_alluvial_html.py` already call `html.escape()`. An inconsistency against an established convention.

`erg check`: PASS (322 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)