### PR TITLE
ticket(0343): move project secrets to the keystore, select via KEYS=

### DIFF
--- a/tickets/0343-move-project-secrets-to-the-keystore-and.erg
+++ b/tickets/0343-move-project-secrets-to-the-keystore-and.erg
@@ -1,0 +1,119 @@
+%erg 0.1
+Title: Move project secrets to the keystore and select them via KEYS=
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T12:11Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Two live credentials leaked into terminal output and a session transcript on
+2026-07-27 (an OpenAI key, then an OpenRouter key while investigating the
+first). Neither leak was a scrubbing failure; both came from credentials being
+**ambient** in processes that had no business holding them.
+
+The harness side is fixed. `~/.claude/.env` no longer contains any secret
+literal: it holds a single `KEYS=` line, and every value is read from
+`~/.config/keys/<provider>.env` by the selection mechanism in
+`~/.claude/scripts/bash-env.sh`. Entry forms are `provider`, `provider:VAR`,
+and `provider:SRC=DST` (rename on export). Default-deny: an unlisted provider
+is not loaded.
+
+This project was migrated only as far as the OpenRouter identity. `.env` now
+carries:
+
+    KEYS=openrouter:OPENROUTER_API_KEY_CLIMATEFINANCE=OPENROUTER_API_KEY
+
+so `scripts/filter_flags_llm.py` reads the plain name while the project
+authenticates as itself. Before this, every process on the machine received the
+*aedist* project's OpenRouter key under the unsuffixed name — this project was
+billing to another project's identity by accident.
+
+Three secrets remain as literals in `.env` and should follow the same path:
+`AGENT_GH_TOKEN`, `OPENALEX_API_KEY`, `S2_API_KEY`. `~/.config/keys/github.env`
+already exists, so `AGENT_GH_TOKEN` may already be duplicated there — check
+before copying, and if the values differ, that divergence is itself the finding.
+
+Why it matters beyond tidiness: a literal in `.env` is exported into every
+process the session spawns, including test subprocesses that print what they
+find on failure. That is exactly how both leaks happened. A `KEYS=` entry is
+read in an isolated subshell and exported only under the name requested.
+
+## Relevant files
+
+- `.env` — project env (git-ignored). Holds the three remaining literals and the
+  `KEYS=` line. **Never commit its contents to a ticket, log, or PR.**
+- `~/.config/keys/*.env` — the keystore, mode 0700. `github.env`, `openalex.env`,
+  `semanticscholar.env` already exist.
+- `~/.claude/scripts/bash-env.sh` — the loader. Read the header comment for the
+  `KEYS=` grammar and the trusted/untrusted split before editing anything.
+- `scripts/filter_flags_llm.py` — the only project consumer of
+  `OPENROUTER_API_KEY` found by grep.
+- `.claude/rules/git.md` — documents `AGENT_GH_TOKEN` as coming from `.env`;
+  update if the source changes.
+- `.worktreeinclude` — copies `.env` into every worktree, so the migration must
+  keep worktrees working.
+
+## Actions
+
+1. Inventory: for each of `AGENT_GH_TOKEN`, `OPENALEX_API_KEY`, `S2_API_KEY`,
+   determine whether the keystore already holds the value, and whether it
+   matches. Compare by hash — never print a value.
+2. For any absent from the keystore, add it to the right provider file
+   (`github.env`, `openalex.env`, `semanticscholar.env`), mode 0600.
+3. Extend the `KEYS=` line in `.env` to select all four credentials, renaming
+   where the consuming code expects a different name.
+4. Delete the three literals from `.env`.
+5. Verify every consumer still resolves its credential, from a worktree as well
+   as from the repo root.
+6. Update `.claude/rules/git.md` if `AGENT_GH_TOKEN`'s documented source moved.
+
+## Test
+
+Red first: an adherence test asserting `.env` carries no secret literal.
+
+    tests/test_env_has_no_secret_literals.py
+
+Assert that every assignment in `.env` is either a non-secret setting
+(`CLIMATE_FINANCE_DATA`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`) or the `KEYS=`
+line — i.e. no value that looks like a credential (length over ~20 with no
+whitespace, or matching a known key prefix). Mark `@pytest.mark.adherence`.
+
+The test must **fail on the current `.env`** before the migration, and pass
+after. It must not print any value it rejects: report the variable NAME only.
+A test that echoes what it found is the defect this ticket exists to prevent.
+
+Skip cleanly (not fail) when `.env` is absent, so a fresh clone and CI-less
+checkouts do not report a false defect.
+
+## Verification
+
+- [ ] `.env` contains no secret literal; only `KEYS=` and non-secret settings
+- [ ] Each migrated value exists exactly once, in `~/.config/keys/`, mode 0600
+- [ ] `scripts/filter_flags_llm.py` resolves `OPENROUTER_API_KEY` to the
+      CLIMATEFINANCE identity — verified by hash comparison, never by printing
+- [ ] Agent git operations still authenticate with `AGENT_GH_TOKEN`
+- [ ] The same checks pass from inside a worktree (`.worktreeinclude` path)
+- [ ] `tests/test_env_has_no_secret_literals.py` fails on the pre-migration
+      `.env` and passes after
+
+## Invariants
+
+- No credential value appears in any file this ticket commits, in any test
+  output, or in any PR description. Names and hashes only.
+- `~/.config/keys/` stays the single store. Do not reintroduce a second copy
+  "for convenience" — the duplication is what made rotation unreliable.
+- The harness must keep resolving `OPENROUTER_API_KEY` to its own IDH key;
+  this project's selection must not leak into `~/.claude/.env`.
+- No CI here (AGENTS.md, ticket 0321): run `make check` locally before the PR.
+
+## Exit criteria
+
+`.env` holds no secret material, every credential resolves from the keystore
+for both the repo root and a worktree, and the adherence test guarding this is
+green and demonstrated red on the pre-migration file.
+
+Out of scope: rotating the two exposed keys (harness-side, author's action) and
+the `~/.claude` loader itself, which is already migrated.


### PR DESCRIPTION
Files ticket 0343. No code change.

## Why

Two live credentials reached a terminal and a session transcript on 2026-07-27
(an OpenAI key, then an OpenRouter key while investigating the first). Neither
was a scrubbing failure. Both were **ambient** credentials held by processes
with no need of them — which is what a literal in `.env` guarantees: it is
exported into every spawned process, including test subprocesses that print
what they find when an assertion fails.

## Already done inline (not in this PR)

`.env` now carries a `KEYS=` line selecting
`OPENROUTER_API_KEY_CLIMATEFINANCE` and renaming it to the plain name
`scripts/filter_flags_llm.py` reads. That one was not merely untidy but wrong:
every process on the machine was receiving the *aedist* project's OpenRouter
key under the unsuffixed name, so this project was billing to another project's
identity by accident. Verified by hash: repo root now resolves to
CLIMATEFINANCE, the harness to its own IDH key.

## What the ticket covers

`AGENT_GH_TOKEN`, `OPENALEX_API_KEY`, `S2_API_KEY` are still literals in
`.env`. Filed rather than fixed inline because `AGENT_GH_TOKEN` gates the
machine user's ability to push — worth a red/green cycle behind a guard, not a
same-session edit.

Test spec is deliberately strict on one point: the adherence guard reports
variable **names** only, never values. A guard that echoes the credential it
rejects would reproduce the exact defect it exists to prevent.

## Verification

- `erg check tickets/` — PASS (320 tickets)
- ticket id 0343 confirmed free on `origin/main`
- no credential value appears in the ticket, this PR, or the commit message

Ticket-ref: tickets/0343-move-project-secrets-to-the-keystore-and.erg

Ticket: none

(This PR *files* 0343; the work it describes is not done, so it must not close.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
