### PR TITLE
fix(0330): declare diptest and hard-guard its import — the dip test now runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "rapidfuzz",
     "pot>=0.9.0",
     "dcor>=0.6.1",
+    "diptest>=0.10.0",
     "ruptures>=1.1.9",
     "pybursts>=0.1.1",
     "python-louvain",

--- a/scripts/analysis/analyze_bimodality.py
+++ b/scripts/analysis/analyze_bimodality.py
@@ -4,11 +4,12 @@ Method:
 - Define efficiency and accountability pole vocabularies
 - Compute pole centroids in embedding space
 - Project all papers onto efficiency↔accountability axis
-- Test bimodality (GMM BIC, dip test if available, KDE)
+- Test bimodality (GMM BIC, Hartigan's dip test, KDE)
 - Validate with TF-IDF and keyword co-occurrence
 
 Produces:
-- data/derived/tables/tab_bimodality.csv: Dip test p-values, GMM BIC, pole paper counts
+- data/derived/tables/tab_bimodality.csv: Dip test p-values (embedding axis,
+  overall and per period), GMM BIC, pole paper counts
 - <derived>/tab_pole_papers.csv: Per-paper score and pole assignment (analysis intermediate)
 - data/derived/tables/tab_axis_detection.csv: Unsupervised TF-IDF components and alignment to pole axis
 
@@ -355,18 +356,39 @@ def _gmm_delta_bic(scores):
 
 
 def _test_bimodality(df, periods):
-    """Step 4: GMM BIC + optional dip test, overall and per-period."""
+    """Step 4: GMM BIC + Hartigan's dip test, overall and per-period.
+
+    Both statistics are mandatory. They are not redundant: delta-BIC asks
+    whether one Gaussian fits badly, which a skewed unimodal distribution
+    answers "yes" to just as readily as a two-humped one, and it grows with n.
+    The dip statistic tests unimodality itself, nonparametrically, on a scale
+    that does not inflate with n. Dropping either one leaves the
+    two-communities claim resting on a proxy (ticket 0330).
+    """
     scores = df["axis_score"].values
     bic1, bic2, delta_bic = _gmm_delta_bic(scores)
     log.info("GMM BIC: 1-component=%.0f, 2-component=%.0f, dBIC=%.0f", bic1, bic2, delta_bic)
 
-    dip_pvalue = None
     try:
         import diptest
-        dip_stat, dip_pvalue = diptest.diptest(scores)
-        log.info("Hartigan's dip test: statistic=%.4f, p=%.4f", dip_stat, dip_pvalue)
-    except ImportError:
-        log.info("diptest package not available, skipping Hartigan's dip test")
+    except ImportError as exc:
+        # Hard error, not a warning (tickets 0314, 0330). This branch used to
+        # log "not available" and continue, shipping a tab_bimodality.csv whose
+        # dip_pvalue column was empty in every row while the module docstring
+        # advertised dip p-values. A failed build is recoverable; a table that
+        # quietly under-reports its own evidence is not. No opt-out flag here,
+        # unlike Flag 6's --skip-llm: diptest is a small pure wheel with no
+        # install burden to escape, so skipping it would never be deliberate.
+        raise RuntimeError(
+            "Hartigan's dip test cannot run: diptest is not importable. "
+            "Refusing to continue, because skipping it silently ships an empty "
+            "dip_pvalue column next to a docstring that promises one. Install "
+            "it with `uv sync`, and make sure the source roots are on "
+            "PYTHONPATH - `make` exports them, a bare shell does not."
+        ) from exc
+
+    dip_stat, dip_pvalue = diptest.diptest(scores)
+    log.info("Hartigan's dip test: statistic=%.4f, p=%.4f", dip_stat, dip_pvalue)
 
     period_stats = []
     for period_label, (y_start, y_end) in periods.items():
@@ -377,16 +399,13 @@ def _test_bimodality(df, periods):
                                  "delta_bic": None, "dip_p": None})
             continue
         _, _, dbic = _gmm_delta_bic(pscores)
-        dp = None
-        if dip_pvalue is not None:
-            try:
-                _, dp = diptest.diptest(pscores)
-            except (ValueError, RuntimeError):
-                pass
+        # No try/except around the per-period call. The n >= 20 guard above
+        # already covers the degenerate inputs diptest rejects, so a raise here
+        # is a real defect and must surface rather than blank one period.
+        _, dp = diptest.diptest(pscores)
         period_stats.append({"period": period_label, "n": len(pscores),
                              "delta_bic": dbic, "dip_p": dp})
-        log.info("%s (n=%d): dBIC=%.0f%s", period_label, len(pscores), dbic,
-                 (", dip p=%.4f" % dp) if dp is not None else "")
+        log.info("%s (n=%d): dBIC=%.0f, dip p=%.4f", period_label, len(pscores), dbic, dp)
 
     return bic1, bic2, delta_bic, dip_pvalue, period_stats
 

--- a/tests/test_bimodality_dip.py
+++ b/tests/test_bimodality_dip.py
@@ -16,6 +16,7 @@ Two guards, deliberately split:
 Same class as ticket 0314 (Flag 6 without torch), which PR #1127 hard-guarded.
 """
 
+import ast
 import os
 import re
 
@@ -39,6 +40,25 @@ def test_diptest_is_a_declared_dependency():
     )
 
 
+def _swallowing_import_handlers(source):
+    """Yield line numbers of `except ImportError` blocks that do not re-raise.
+
+    Catching ImportError is legitimate — the ticket-0314 idiom does it to
+    replace a bare ModuleNotFoundError with an actionable message. What is not
+    legitimate is a handler that returns control to the caller, because the run
+    then continues with a degraded result. So the guard is on the *swallow*,
+    not on the catch.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        caught = ast.dump(node.type) if node.type is not None else "bare"
+        if node.type is not None and "ImportError" not in caught:
+            continue
+        if not any(isinstance(child, ast.Raise) for child in ast.walk(node)):
+            yield node.lineno
+
+
 @pytest.mark.adherence
 def test_diptest_import_failure_is_a_hard_error():
     """A missing dependency must stop the run, not downgrade the output.
@@ -52,9 +72,11 @@ def test_diptest_import_failure_is_a_hard_error():
     assert "import diptest" in source, (
         "test is stale: analyze_bimodality.py no longer imports diptest"
     )
-    assert not re.search(r"except\s+ImportError", source), (
-        "analyze_bimodality.py swallows an ImportError - a missing diptest "
-        "must raise, not log and continue with an empty dip_pvalue column"
+    swallowed = list(_swallowing_import_handlers(source))
+    assert not swallowed, (
+        f"analyze_bimodality.py swallows an ImportError at line(s) {swallowed} "
+        "- a missing diptest must raise, not log and continue with an empty "
+        "dip_pvalue column"
     )
     assert not re.search(r"log\.\w+\([^)]*not available", source), (
         "analyze_bimodality.py announces a missing dependency at log level and "

--- a/tests/test_bimodality_dip.py
+++ b/tests/test_bimodality_dip.py
@@ -1,0 +1,82 @@
+"""Hartigan's dip test must actually run — no silent dependency-missing skip.
+
+Ticket 0330. `analyze_bimodality.py` wrapped `import diptest` in a try/except
+that logged "not available" and continued, while `diptest` was declared in
+neither `pyproject.toml` nor `uv.lock`. The import therefore always failed and
+`dip_pvalue` was empty in every row of `tab_bimodality.csv`, next to a module
+docstring advertising "Dip test p-values".
+
+Two guards, deliberately split:
+
+- The source guard runs everywhere, including a clean checkout with no corpus.
+  It is the one that stays meaningful in CI.
+- The artifact guard needs the real derived table and so only runs on a machine
+  that has built it (padme).
+
+Same class as ticket 0314 (Flag 6 without torch), which PR #1127 hard-guarded.
+"""
+
+import os
+import re
+
+import pandas as pd
+import pytest
+from utils import BASE_DIR, DERIVED_TABLES_DIR
+
+SCRIPT = os.path.join(BASE_DIR, "scripts", "analysis", "analyze_bimodality.py")
+PYPROJECT = os.path.join(BASE_DIR, "pyproject.toml")
+
+
+@pytest.mark.adherence
+def test_diptest_is_a_declared_dependency():
+    """An import the pipeline depends on must be declared, not hoped for."""
+    with open(PYPROJECT, encoding="utf-8") as fh:
+        pyproject = fh.read()
+    assert re.search(r'^\s*"diptest', pyproject, re.MULTILINE), (
+        "diptest is imported by analyze_bimodality.py but declared nowhere in "
+        "pyproject.toml - the import fails on every machine and the dip test "
+        "never runs"
+    )
+
+
+@pytest.mark.adherence
+def test_diptest_import_failure_is_a_hard_error():
+    """A missing dependency must stop the run, not downgrade the output.
+
+    The failure mode this pins is not a crash but a plausible wrong artifact:
+    a table shipping an empty column that its own docstring advertises.
+    """
+    with open(SCRIPT, encoding="utf-8") as fh:
+        source = fh.read()
+
+    assert "import diptest" in source, (
+        "test is stale: analyze_bimodality.py no longer imports diptest"
+    )
+    assert not re.search(r"except\s+ImportError", source), (
+        "analyze_bimodality.py swallows an ImportError - a missing diptest "
+        "must raise, not log and continue with an empty dip_pvalue column"
+    )
+    assert not re.search(r"log\.\w+\([^)]*not available", source), (
+        "analyze_bimodality.py announces a missing dependency at log level and "
+        "carries on; the run must stop instead"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.path.exists(os.path.join(DERIVED_TABLES_DIR, "tab_bimodality.csv")),
+    reason="tab_bimodality.csv not built",
+)
+def test_bimodality_dip_column_is_not_silently_empty():
+    """Either the dip test ran, or the column is gone. Never present-and-empty.
+
+    Written to hold under both resolutions the ticket weighed, so it survives a
+    later decision to drop the statistic.
+    """
+    df = pd.read_csv(os.path.join(DERIVED_TABLES_DIR, "tab_bimodality.csv"))
+    if "dip_pvalue" not in df.columns:
+        return
+    assert df["dip_pvalue"].notna().any(), (
+        "dip_pvalue is present but empty in every row - diptest is not "
+        "installed and the skip is silent"
+    )

--- a/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
+++ b/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T11:02Z HDMX-coding-agent created
 2026-07-27T11:10Z HDMX-coding-agent note Found by the roar sweep after PR #1127 (ticket 0314) hard-guarded the same class at Flag 6
+2026-07-27T14:05Z minh decision Option 1 (declare and enforce). Option 2 rejected: dropping the column hides the question instead of answering it, leaving the two-communities claim resting on delta-BIC alone
+2026-07-27T14:05Z HDMX-coding-agent note Statistical stakes recorded below under "Why option 1"; the per-period delta-BIC/n confound found while explaining them is out of scope here
 
 --- body ---
 ## Context
@@ -76,6 +78,36 @@ Option 1 is the recommendation: the GMM delta-BIC is a single line of evidence
 for a load-bearing claim (bimodality of the axis score), and Hartigan's dip is
 the standard independent check on exactly that. But it changes what the analysis
 reports, so it is the author's call, not the agent's.
+
+## Decision: option 1 (author, 2026-07-27)
+
+Option 2 was rejected as evasive. The settled reasoning:
+
+Delta-BIC is a model-selection number, not a test of two modes. It answers "is
+one Gaussian a bad fit?", and a two-component mixture wins that comparison for a
+skewed or heavy-tailed *unimodal* distribution just as readily as for a genuinely
+two-humped one — a two-Gaussian mixture is itself unimodal unless the component
+means separate by roughly more than 2 sigma, which the script never checks. It
+also has no scale: the likelihood gain grows with n while the penalty grows with
+log n, so at n=29675 any small departure from normality yields a large number.
+
+Hartigan's dip statistic is the largest vertical distance between the empirical
+CDF and the nearest unimodal CDF. Its null is exactly the hypothesis at issue —
+one mode, any shape, no Gaussian assumption — and the statistic does not inflate
+with n. The two fail differently: delta-BIC's false-positive mode
+(non-Gaussian but single-humped) is what dip is immune to.
+
+The manuscript's existing corroboration is thinner than it reads. The TF-IDF
+layer is a different *representation* scored on the same pole vocabularies and
+judged by the *same* statistic, with the two axis scores correlated at r=0.77.
+Independence there is on the data axis, not the method axis. Dip supplies the
+missing one.
+
+This is a falsification risk, taken deliberately. At n=29675 the dip test has
+real power, so a non-rejection would be a finding: it would mean delta_bic=1350
+was detecting non-Gaussianity rather than two modes, and section 5.3 of
+multilayer-detection.qmd would need rewriting. That possibility is the reason to
+run it, not a reason to drop the column.
 
 ## Test
 

--- a/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
+++ b/tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-07-27T11:10Z HDMX-coding-agent note Found by the roar sweep after PR #1127 (ticket 0314) hard-guarded the same class at Flag 6
 2026-07-27T14:05Z minh decision Option 1 (declare and enforce). Option 2 rejected: dropping the column hides the question instead of answering it, leaving the two-communities claim resting on delta-BIC alone
 2026-07-27T14:05Z HDMX-coding-agent note Statistical stakes recorded below under "Why option 1"; the per-period delta-BIC/n confound found while explaining them is out of scope here
+2026-07-27T14:16Z HDMX-coding-agent note Dip test ran for the first time: p=1.0000 overall, 0.9943/0.9942/1.0000 per period. The falsification risk landed. Result section below; manuscript arbitration is the author's, not this ticket's
 
 --- body ---
 ## Context
@@ -108,6 +109,39 @@ real power, so a non-rejection would be a finding: it would mean delta_bic=1350
 was detecting non-Gaussianity rather than two modes, and section 5.3 of
 multilayer-detection.qmd would need rewriting. That possibility is the reason to
 run it, not a reason to drop the column.
+
+## Result (2026-07-27)
+
+The dip test ran for the first time. It does not reject unimodality anywhere:
+
+    method                | n      | delta_bic | dip p
+    embedding (overall)   | 29675  |      1355 | 1.0000
+    embedding_1990–2006   |  1613  |        20 | 0.9943
+    embedding_2007–2014   |  7399  |       -60 | 0.9942
+    embedding_2015–2024   | 20663  |      1119 | 1.0000
+
+The dip statistic is 0.00098, roughly six times *below* the 1/sqrt(n) scale of
+the null reference, so this is not a borderline non-rejection at low power.
+
+Diagnostic run on the same axis scores explains the disagreement, and it is the
+failure mode named in the decision above rather than a surprise:
+
+    axis_score:  n=29675  skew=0.591  excess kurtosis=1.114
+    fitted 2-component GMM (the model delta_bic prefers):
+      comp A: w=0.617  mu=-0.0271  sd=0.0751
+      comp B: w=0.383  mu=+0.0546  sd=0.1154
+      standardised separation = 0.839 sigma  (two humps need ~2)
+      modes in the fitted mixture density = 1
+
+The two-component mixture that wins the BIC comparison is itself unimodal. It
+wins because the axis score is skewed and leptokurtic, and a second Gaussian
+absorbs that better than one Gaussian does. delta_bic=1355 is measuring
+departure from normality, not two communities.
+
+This bears on section 5.3 of deliverables/multilayer/multilayer-detection.qmd,
+which reads the same numbers as a bimodal structure. That is manuscript prose
+and therefore the author's arbitration, not this ticket's: no prose was
+touched here. See the follow-up ticket for the arbitration.
 
 ## Test
 

--- a/tickets/0331-no-guard-on-undeclared-third-party-impor.erg
+++ b/tickets/0331-no-guard-on-undeclared-third-party-impor.erg
@@ -2,12 +2,12 @@
 Title: no guard on undeclared third-party imports in scripts/
 Created: 2026-07-27
 Author: HDMX-coding-agent
-Blocked-by: 0330
 
 --- log ---
 2026-07-27T11:02Z HDMX-coding-agent created
 2026-07-27T11:12Z HDMX-coding-agent note Class-level follow-up to 0330; the same defect already shipped once in libs/ (0211)
 
+2026-07-27T12:47Z HDMX-coding-agent note blocker 0330 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0330-diptest-is-undeclared-so-the-hartigan-di.erg
+++ b/tickets/closed/0330-diptest-is-undeclared-so-the-hartigan-di.erg
@@ -2,6 +2,7 @@
 Title: diptest is undeclared so the Hartigan dip test never runs
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: Option 1 implemented: diptest declared and locked, import hard-guarded, dip test runs. Result: unimodality not rejected (p=1.0); §5.3 rewrite tracked as 0345
 
 --- log ---
 2026-07-27T11:02Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 2026-07-27T14:05Z HDMX-coding-agent note Statistical stakes recorded below under "Why option 1"; the per-period delta-BIC/n confound found while explaining them is out of scope here
 2026-07-27T14:16Z HDMX-coding-agent note Dip test ran for the first time: p=1.0000 overall, 0.9943/0.9942/1.0000 per period. The falsification risk landed. Result section below; manuscript arbitration is the author's, not this ticket's
 
+2026-07-27T12:47Z HDMX-coding-agent closed — Option 1 implemented: diptest declared and locked, import hard-guarded, dip test runs. Result: unimodality not rejected (p=1.0); §5.3 rewrite tracked as 0345
 --- body ---
 ## Context
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130'",
@@ -760,6 +760,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "bibtexparser" },
     { name = "dcor" },
+    { name = "diptest" },
     { name = "ftfy" },
     { name = "langdetect" },
     { name = "litellm" },
@@ -820,6 +821,7 @@ dev = [
 requires-dist = [
     { name = "bibtexparser" },
     { name = "dcor", specifier = ">=0.6.1" },
+    { name = "diptest", specifier = ">=0.10.0" },
     { name = "ftfy", specifier = ">=6.3.1" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "litellm", specifier = ">=1.30.0,<=1.82.6" },
@@ -1240,6 +1242,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/61/7b/35cbccb7effc5d7e40f4c55e2b79399e1853041997fcda15c9ff160abba0/dictdiffer-0.9.0.tar.gz", hash = "sha256:17bacf5fbfe613ccf1b6d512bd766e6b21fb798822a133aa86098b8ac9997578", size = 31513, upload-time = "2021-07-22T13:24:29.276Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/ef/4cb333825d10317a36a1154341ba37e6e9c087bac99c1990ef07ffdb376f/dictdiffer-0.9.0-py2.py3-none-any.whl", hash = "sha256:442bfc693cfcadaf46674575d2eba1c53b42f5e404218ca2c2ff549f2df56595", size = 16754, upload-time = "2021-07-22T13:24:26.783Z" },
+]
+
+[[package]]
+name = "diptest"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-19-climate-finance-het-cpu' and extra == 'extra-19-climate-finance-het-cu130')" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/0b/92a00796fb3a7e0fd1aea26ebcacfd6282857789ea72e847662e5103b24e/diptest-0.11.0.tar.gz", hash = "sha256:cd74d61d4e2620aa4c40900b7ff0ff48b7517fd00871c9066f737ba4081b2f81", size = 88751, upload-time = "2026-04-24T15:02:30.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/72/98e16cba68767eef0d46393915ec7fe2b8e67500b1892aa90d91fefa84a7/diptest-0.11.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:9e6274617642e6eb68d9f805b67c05c67c6ad69ab51fe5ba221b97cc7c875d7e", size = 380215, upload-time = "2026-04-24T15:01:47.499Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d7/12db529042a934ccc3ffd1993a3ff22b262a867ee411800bbbfd3b3dffc3/diptest-0.11.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:93507db94b8d407f8992454979a9ac21909b326e0d8617ead9bb73e2ec1b210f", size = 418790, upload-time = "2026-04-24T15:01:48.937Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7f/8a2e0d1a0ad932e89c7b411828eebd944768ab7373b8f6885db141f74241/diptest-0.11.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553a395d9a0eb3df95f53ab5b5bc57e7aca6fa5e28ab5ac23b467ec51536c23d", size = 236321, upload-time = "2026-04-24T15:01:50.415Z" },
+    { url = "https://files.pythonhosted.org/packages/66/85/cb8e04875f59bdc8c31452dc8708f72f50a3243823a95a303dcd935c822a/diptest-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:e341ac5462fdbf8465b4b28fb718ae3cbc4cf6cafcb6041350d34b639c275be6", size = 401213, upload-time = "2026-04-24T15:01:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/66/6b/53f48c6f143ce74cf186e53f062301161e40cab1766c2a97e54eaf80ad0e/diptest-0.11.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:82a0e12a6bd4047a361748c8deaea2ccface432dbb2c59bc44d4e06ca2fc51f9", size = 381319, upload-time = "2026-04-24T15:01:53.394Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c6/d7278a5d53c5eb928dc00f3ffdb4812834732d2a01d7e6aca6a169de8683/diptest-0.11.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:021254d83aa695369c784438ec8767035acf2c51148e92fb555b11847db8a4cd", size = 420070, upload-time = "2026-04-24T15:01:54.95Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3a/b07665ad28d343fd15f61ae6b317a716655513fd3fb120239d1bf049769a/diptest-0.11.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e0720dcbb1a90d487bc7c47117039b7f12576a89d7bec99bbda1365cf072cc8", size = 236924, upload-time = "2026-04-24T15:01:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/21b6a1130ff39d8d1736e968b1476eabb7323139659dcb0e097fb30dfb34/diptest-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:399894348c60d3694c6fb37d249cbc618b2e12f2463620fd23b0f8aee442b13c", size = 401454, upload-time = "2026-04-24T15:01:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/99/1e42c734b0695aec2aef68ab1691bc1b0f602b38e72c06f086c5968ed8fd/diptest-0.11.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:7d2b8822daabbd11b0a4e4d8356e3116db8adc0a4b67b49d487fbc8809264d54", size = 382111, upload-time = "2026-04-24T15:01:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/19/81/7ee938c02e8592e63bb4affb978ec1a7038ecc84c43a16b2942e65648cef/diptest-0.11.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:e2fc655e90250ffb031e616ec78e28b6c74d90ad5cfe5e84f2b9b44c417a595f", size = 421931, upload-time = "2026-04-24T15:02:00.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ac/34d243df356728f3d1d97ea380341a65a5cbd09a52aeb40d449cddd6a450/diptest-0.11.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6748d22df28b030b34b2d47f257d45520564b63f20330ab507c888995d6b272", size = 238025, upload-time = "2026-04-24T15:02:02.362Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6b/ba30e2c6c748c54d75c6d08fde2c52a10edff987c7767be19468fea9bbf9/diptest-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:e886ff65bc938188ec65530ce377063c87ea356bf65c5e1f80e5aacb862aebb0", size = 403543, upload-time = "2026-04-24T15:02:03.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d1/75575cb04d4852354492eb869e876ed31054be6f1dfaf7b3f0c53e92d369/diptest-0.11.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:f192191bcd50d9ec715b5fb6b259a1fb136970e979b69ec0f2f47d419653a12b", size = 382114, upload-time = "2026-04-24T15:02:05.268Z" },
+    { url = "https://files.pythonhosted.org/packages/10/06/dbdbfaa2e80bb742fb12666091ed1a3bed61237842607efbb2866c64e603/diptest-0.11.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c35497a46c727618004ab0a34ceb5e17b52d83487d87de3e3a103863f0b4d49e", size = 422010, upload-time = "2026-04-24T15:02:06.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/47/14ee6416a288abeb46f40836985d6e064b9c7c90005ed3146cdf3b7f7a81/diptest-0.11.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c582ae71d4577faed5fc8487b03f9d8c00f80d6290f5455785fd1222d879b72", size = 238138, upload-time = "2026-04-24T15:02:08.666Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a0/b95dbd5ed59ec2efaa16dac075b217706fa0296d97473508c78cea66aa38/diptest-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:737a17bc806b0761684d2e2bbba7a83ec7f9d77b5bda3b2b613f59e0abba8256", size = 403545, upload-time = "2026-04-24T15:02:09.955Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/9ac5ebe1fe0a653066e71e448ee02746ffd4377df8d5bfe7dc26b00365c1/diptest-0.11.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:4c7aca12a559137395dd195e091eb4056d01f787a1861b97d20c609340d94bbe", size = 382253, upload-time = "2026-04-24T15:02:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/af/bd/acd2da0086aeab997da07b5ab5230e49a6113bb0bcf6b3097acf5c9285ef/diptest-0.11.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:ab5666183fd0051598ad1c7cca0e70d084efdc503245c9294bcf7cd4ad141b62", size = 422044, upload-time = "2026-04-24T15:02:12.414Z" },
+    { url = "https://files.pythonhosted.org/packages/08/87/4131ec4535edf36f6ef84ef379dd7cab7dcee227c10ecdc4f68826df0169/diptest-0.11.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1965173824566d873f6c7ecfcc7949b83f18880515488ecefd367bbbb7a01369", size = 238092, upload-time = "2026-04-24T15:02:14.123Z" },
+    { url = "https://files.pythonhosted.org/packages/25/46/2b4589cd82371e2ed69f351ef0384545ae46584bcf9fed4498c392844022/diptest-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:15886ee258cf7ce94fd443e29984a732230972a2ffdfb4bebea3bd2cf42bbb85", size = 414689, upload-time = "2026-04-24T15:02:15.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Ticket:** tickets/0330-diptest-is-undeclared-so-the-hartigan-di.erg

`scripts/analysis/analyze_bimodality.py` wrapped `import diptest` in a `try/except ImportError` that logged "not available" and continued. `diptest` was declared in neither `pyproject.toml` nor `uv.lock`, so the import always failed and `dip_pvalue` was empty in every row of `tab_bimodality.csv` — next to a module docstring advertising "Dip test p-values". Same class as ticket 0314 (Flag 6 without torch), hard-guarded by PR #1127.

## Decision

The author chose option 1 (declare and enforce) and rejected option 2 (drop the column) as evasive: it would leave the two-communities claim of `multilayer-detection.qmd` §5.3 resting on ΔBIC alone. The statistical reasoning is recorded in the ticket body — briefly, ΔBIC asks whether *one Gaussian* fits badly, which a skewed unimodal distribution answers "yes" to as readily as a two-humped one, and it inflates with n; Hartigan's dip tests unimodality itself, nonparametrically, on a scale that does not.

## Changes

- `diptest>=0.10.0` in `[project] dependencies` (Phase 2 runs for every figures/manuscript user; small pure wheel), `uv lock`ed to 0.11.0.
- The import raises `RuntimeError` in the 0314 idiom. **No opt-out flag**, unlike Flag 6's `--skip-llm`: torch is a 2.5 GB per-host install worth escaping, diptest is not, so a skip here could only be an accident.
- The per-period call loses its `except (ValueError, RuntimeError): pass`. The `n >= 20` guard already covers what diptest rejects, so anything still raising is a real defect that was being turned into one blank period.
- Docstring no longer promises "dip test if available".
- Three guards in `tests/test_bimodality_dip.py`. Two are source-level and run in a clean checkout with no corpus; the third needs the built table and skips without it. The swallow guard walks the AST rather than grepping, so it catches the whole class — an `except ImportError` whose body never reaches a `raise` — instead of the one phrasing that bit us.

## Invariant

Verified as the rules require: old code vs new code on the *same current corpus*, not against the committed table. Byte-identical, `tab_bimodality.csv` and `tab_axis_detection.csv` both. This change alters only what happens when `diptest` is absent.

## The dip test does not confirm §5.3

Reported, not acted on — manuscript prose is the author's arbitration.

| method | n | ΔBIC | dip p |
|---|---|---|---|
| embedding (overall) | 29,675 | 1355 | 1.0000 |
| 1990–2006 | 1,613 | 20 | 0.9943 |
| 2007–2014 | 7,399 | −60 | 0.9942 |
| 2015–2024 | 20,663 | 1119 | 1.0000 |

Dip statistic 0.00098, about six times *below* the 1/√n null scale — not a low-power near-miss. The diagnostic explains the disagreement: the axis score is skewed (0.59) and leptokurtic (excess 1.11), and the two-component mixture that wins ΔBIC = 1355 has its components 0.84σ apart, giving **one mode** in the fitted density (counted on a 20k-point grid). The winning model is unimodal; ΔBIC is measuring departure from normality.

## Two findings deliberately left out of this PR

1. §5.3 of `multilayer-detection.qmd` reads these numbers as a bimodal structure. Prose, author's call.
2. The derived table in the working checkout is stale against the corpus: a fresh run gives ΔBIC 1355 / 15990 / 1406 and `n_efficiency_pole` 874 where the committed vars quote 1,350 / 15,984 / 1,398 and 875. Separate mechanical defect, separate ticket.

Also not done, since it would change what the analysis reports a second time: the dip test still runs on the embedding axis only, so `tfidf_lexical` and `unsupervised_PC3` keep `dip_pvalue=None`.

## Gate

`make lint` 168 passed. Fast tier 1147 passed, 11 skipped. Full `make check` running; result posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)