### PR TITLE
ticket(0339): note that codebook.md is contended across open PRs

### DIFF
--- a/tickets/0339-markdown-pipe-table-emitters-interpolate.erg
+++ b/tickets/0339-markdown-pipe-table-emitters-interpolate.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T12:09Z HDMX-coding-agent created
 2026-07-27T12:15Z HDMX-coding-agent note found by the 0325 roar sweep for the same defect class. Latent, not currently firing: every row in the shipped tab_venues.md carries its five cells, because no pipe-bearing venue sits in today's top-N.
+2026-07-27T12:40Z HDMX-coding-agent note codebook.md is a contended file — several open PRs regenerate it from their own base. #1141 merged carrying a copy whose is_flagged row had no `\|` escape; a merge-tree trial predicted the escape would survive because that branch only touched the `language` row, and the merged main confirmed it (escape present, five cells, 33 rows). It survived by luck of line disjointness, not by anything protecting it. Re-grep the merged file for the escape after every sibling merge until 0340's guard exists.
 
 --- body ---
 ## Context


### PR DESCRIPTION
Ticket-ref: tickets/0339-markdown-pipe-table-emitters-interpolate.erg

One log line on ticket 0339. No code.

`codebook.md` is regenerated by several open PRs from their own bases. #1141 merged carrying a copy whose `is_flagged` row had **no** `\|` escape — its branch predated 0325. Before merging I ran `git merge-tree` against main and it predicted the escape would survive, because that branch only touched the `language` row; the merged main confirmed it (escape present, 5 cells, 33 rows, recipe whole).

It survived by line disjointness, not by anything protecting it. #1147 (stale Phase-2 tables) is in the same territory. Until 0340's standing guard exists, the only defence is re-grepping the merged file after each sibling merge — recorded on the ticket so whoever picks 0339 up sees it, rather than living in a session summary.

`erg check`: PASS (333 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)