### PR TITLE
cut(0332): drop the semantic-cluster view and the coverage mechanism from section 4

### DIFF
--- a/deliverables/data-paper/data-paper.qmd
+++ b/deliverables/data-paper/data-paper.qmd
@@ -147,21 +147,17 @@ The dataset is released under CC BY 4.0. The five automated or semi-automated so
 
 ## 4. Descriptive statistics {#sec-descriptive}
 
-Three views summarise the corpus: its growth in time, the structure of its citations, and the structure of its vocabulary.
+Two views summarise the corpus: its growth in time and the structure of its citations.
 
 ![Annual publication volume in the corpus (light bars) and the subset with the phrase "climate finance" in title or abstract (dark segments). The phrase is nearly absent before 2009, then spreads through the literature. Background bands mark the three periods (before 2007, crystallisation, established field); labels flag the Rio Convention (1992), the Bali Action Plan (2007), and the Paris Agreement (2015). The search window is 1990--2024; the earliest works date from 1992.](../_shared/figures/fig_bars.png){#fig-bars width=100%}
 
-Citation coverage --- the share of corpus works that appear as a citing source in the citation network --- rises across the three periods: {{< meta cite_cov_pre2007_pct >}}% for works published before 2007, {{< meta cite_cov_cryst_pct >}}% for 2007--2014, and {{< meta cite_cov_post2015_pct >}}% for post-2015 works. The gradient tracks DOI carriage rather than indexing quality: {{< meta cite_doi_pre2007_pct >}}% of pre-2007 works carry a DOI against {{< meta cite_doi_post2015_pct >}}% post-2015, and among works that do carry one the early period is the better covered ({{< meta cite_cov_pre2007_of_doi_pct >}}% against {{< meta cite_cov_post2015_of_doi_pct >}}%). A work without a DOI cannot be matched as a citing source at all, so the undercount falls on precisely the early and grey-literature works whose connectivity a temporal analysis would most want to measure.
+Citation coverage --- the share of corpus works that appear as a citing source in the citation network --- rises across the three periods: {{< meta cite_cov_pre2007_pct >}}% for works published before 2007, {{< meta cite_cov_cryst_pct >}}% for 2007--2014, and {{< meta cite_cov_post2015_pct >}}% for post-2015 works. Works without a DOI cannot be matched as citing sources, so the undercount concentrates in early and grey-literature works.
 
 Who cites whom gives the first structure. @fig-global-map maps the citation network at full-corpus scale: Louvain community detection on the intra-corpus citation graph yields {{< meta gm_communities >}} major communities covering {{< meta gm_coverage_pct >}}% of the {{< meta gm_n_connected >}} connected works, and the communities correspond to recognisable research programmes, from carbon markets to green bonds.
 
 ![Communities in the corpus citation network. Each work is a node; an edge links a work to each corpus work it cites (DOI-matched). Louvain detection (fixed seed, modularity {{< meta gm_modularity >}}) groups them into communities; the map draws the {{< meta gm_communities >}} communities holding at least 2% of connected works, which together cover {{< meta gm_coverage_pct >}}% of the {{< meta gm_n_connected >}} works with at least one link. Circle area is proportional to community size, edge width to the number of citations between communities; each community is labelled by its top TF-IDF terms. The force-directed layout is indicative --- distances carry no measurement.](../_shared/figures/fig_global_map_direct.png){#fig-global-map width=100%}
 
-What the works say gives the second structure. The companion study [Ha-Duong, under review] partitions the field into six semantic clusters; k-means with k = 6 on the present corpus and its 1024-dimensional embeddings (against 384 in v1.0) recovers five of the six themes, with a land-use cluster emerging in place of the \$100bn/fund-flows theme, and the partition is stable across estimation variants (adjusted Rand index $\geq$ {{< meta lit_sem6_ari >}} over {{< meta lit_sem6_n >}} works).
-
-![Thematic composition shifts across the three periods: Kyoto-era clusters contract while green bonds and Paris-era vocabularies expand. Six k-means clusters (k = 6, fixed seed) of the multilingual embeddings; each panel gives the cluster's share of works published Before (1990--2006), during Crystallisation (2007--2014), and during Disputes (2015--2024), with its top TF-IDF terms as subtitle. Works whose abstract field holds repository boilerplate (Section 2.4) are excluded from the clustering input.](../_shared/figures/fig_sem_composition.png){#fig-sem-composition width=90%}
-
-The two structures do not correspond one for one: communities that share a vocabulary do not necessarily cite each other. The corpus supports studying that gap --- the per-work assignment table crossing semantic cluster with citation community ships in the deposit.
+The deposit also ships a per-work table crossing citation community with semantic cluster, for studying where the two diverge: works that share a vocabulary do not necessarily cite each other.
 
 ## 5. Concluding Remarks {#sec-concluding}
 

--- a/scripts/analysis/compute_vars.py
+++ b/scripts/analysis/compute_vars.py
@@ -55,12 +55,13 @@ DOC_VARS = {
         #   embedding-generation
         "cite_coverage_core_pct",
         "cite_cov_cryst_pct",
-        "cite_cov_post2015_of_doi_pct",
         "cite_cov_post2015_pct",
-        "cite_cov_pre2007_of_doi_pct",
         "cite_cov_pre2007_pct",
-        "cite_doi_post2015_pct",
-        "cite_doi_pre2007_pct",
+        # The four DOI-carriage vars (cite_doi_{pre2007,post2015}_pct and
+        # cite_cov_{pre2007,post2015}_of_doi_pct) left with 0332's cut of the
+        # gradient-mechanism sentences; the three period coverages above stay.
+        # compute_citation_coverage.py still emits all seven — re-add here if
+        # the mechanism argument returns.
         "cite_refined_coverage_pct",
         "cite_refined_rows",
         "cite_total_rows",
@@ -105,12 +106,12 @@ DOC_VARS = {
         "lang_detected_pct",
         "lang_english_pct",
         "lang_non_english_n",
-        # The adaptation-share and chi-square/p details left the paper with
-        # PR #1120's cut pass; only the two finance-journal shares survive in
-        # the literature-confirmation bullet (§1). Re-add here if the bullet
-        # ever regains its test statistics.
-        "lit_sem6_ari",
-        "lit_sem6_n",
+        # Two earlier cuts orphaned lit_* vars, both still emitted upstream:
+        # the adaptation-share and chi-square/p details went with PR #1120,
+        # leaving only the two finance-journal shares in the
+        # literature-confirmation bullet (§1); lit_sem6_ari and lit_sem6_n went
+        # with 0332's §4 cut, since the semantic-cluster paragraph they served
+        # needed an under-review companion paper to interpret.
         "lit_finshare_post_pct",
         "lit_finshare_pre_pct",
         "lit_growth_f",

--- a/tickets/0332-datapaper-section-4-scope-and-length.erg
+++ b/tickets/0332-datapaper-section-4-scope-and-length.erg
@@ -7,6 +7,8 @@ Label: needs-human
 --- log ---
 2026-07-27T11:00Z HDMX-coding-agent created
 2026-07-27T11:00Z HDMX-coding-agent note child of 0274. Raised by 3 of 4 external panel reviewers. Marked needs-human: cutting §4 is an author call, and it deletes work landed earlier today (0317's periodised coverage paragraph, 0320's verification numbers).
+2026-07-27T15:10Z HDMX-coding-agent note AUTHOR DECISION: cut, in two pieces. (1) The semantic-cluster paragraph and its composition figure, whole — a finding rather than a dataset property, and it needed an under-review companion paper to interpret. (2) The DOI-carriage mechanism sentences from the coverage paragraph, keeping the three period percentages and a one-line limitation. The author revised my first proposal here: I had marked the whole second half for removal, and the closing clause is a limitation disclosure 0333 wants MORE of, so it survives compressed. -227 words.
+2026-07-27T15:10Z HDMX-coding-agent note the cut orphaned six vars that test_doc_vars_completeness caught (four cite_*_of_doi/cite_doi_*, two lit_sem6_*); dropped from DOC_VARS with a comment. compute_citation_coverage.py and the sem6 pipeline still emit them — other deliverables consume them, and this is prose scope only.
 2026-07-27T12:05Z HDMX-coding-agent note Action 2 corrected: the field-history statistics (Chow break, 17% growth, cross-pole z) are in §1's replication bullets (data-paper.qmd:57-59), not §4, so the §4 cut does not free them. Split into 2(i) §4 and 2(ii) §1, and the budget rationale no longer credits the §4 cut with §1's words. Added the 0327 sequencing note — §4 removal precedes 0327's table, per the remove-whole-before-condensing rule.
 
 --- body ---


### PR DESCRIPTION
Author-approved cut of §4, the panel's 3-of-4 finding that the section reads as a research article rather than dataset validation. Two whole removals, per remove-before-condensing.

## What went

**The semantic-cluster paragraph and its composition figure, entirely** (~230 w). A finding, not a dataset property — and reading it required an under-review companion paper, which a data paper must not demand. The figure also carried the "Kyoto mechanisms & CDM grows to 20% post-2015" label the panel flagged as probably wrong; that question now belongs to whichever deliverable keeps the figure.

**The DOI-carriage mechanism sentences from the coverage paragraph** (~55 w). The three period percentages stay: they describe how complete the citation network is. The mechanism explained what the gradient *means*, which is analysis.

## What the author changed in my proposal

I had marked the whole second half of the coverage paragraph for removal. The author kept the closing clause, compressed:

> Works without a DOI cannot be matched as citing sources, so the undercount concentrates in early and grey-literature works.

That is a limitation disclosure, and 0333 asks for **more** of those. Saved 55 words instead of 90 and kept the candour. The right call.

## Forced follow-ons

- §4's opener promised "three views", now delivers two.
- Its closing sentence referred to "the two structures" when only one survives — rewritten to point at the deposited cross-table directly, keeping the reuse pointer.

## Orphaned vars

`test_doc_vars_completeness` caught six (`cite_doi_{pre2007,post2015}_pct`, `cite_cov_{pre2007,post2015}_of_doi_pct`, `lit_sem6_ari`, `lit_sem6_n`) — the guard working as designed. Dropped from `DOC_VARS` with a comment naming the cut. **Both producers still emit them**: other deliverables consume the sem6 tables, and `compute_citation_coverage.py`'s seven-column output is 0317's contract.

## Result

**−227 words** (3,940 → 3,713 source). §4 now holds the growth figure, the coverage numbers, the network map, and the deposit pointer.

## Verification

- fast tier: 1154 passed, 11 skipped
- `erg check` PASS (335 tickets)
- Word budget still not machine-verified — `qa_word_count.py` needs a Phase-3 render.

## Not addressed here

The panel's field-history objection (Chow test, 17% growth, periodisation) targets **§1**, not §4 — untouched by this cut, tracked in 0335.

**Ticket-ref:** tickets/0332-datapaper-section-4-scope-and-length.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)