### PR TITLE
ticket(0344): make pass results — premise corrected, two R&R findings filed

### DIFF
--- a/tickets/0344-phase2-derived-tables-are-stale-against-t.erg
+++ b/tickets/0344-phase2-derived-tables-are-stale-against-t.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T14:30Z HDMX-coding-agent created
 2026-07-27T14:30Z HDMX-coding-agent note Found while checking ticket 0330's byte-compare invariant, not by a sweep
+2026-07-27T15:10Z HDMX-coding-agent correction Premise error: the vars files are gitignored, not committed. Action 1's "commit the vars diff" is void. Corrected below
+2026-07-27T15:12Z HDMX-coding-agent note make stats run, exit 0. Full diff below. It surfaced two R&R-relevant findings that outrank the drift this ticket was filed for
 
 --- body ---
 ## Context
@@ -52,6 +54,63 @@ whoever renders the manuscript reads committed vars rather than rebuilding.
 
 The general shape: a corpus regeneration is a Phase-1 event, and nothing
 obliges the Phase-2 artifacts committed to git to be rebuilt in the same PR.
+
+## Correction and result of the make pass (2026-07-27)
+
+**The premise above is partly wrong.** All three `*-vars.yml` files are
+gitignored, not committed. There is therefore no "committed layer quoting stale
+numbers" in git, and action 1's instruction to commit the vars diff is void —
+nothing is committable. The staleness is purely local build state in the
+author's checkout: derived tables built 2026-07-24 against a corpus that has
+since moved. Anyone who runs `make` gets the fresh numbers.
+
+The earlier claim that "the committed vars reproduce byte-clean from the
+current tables" was not evidence either: a gitignored file always shows a clean
+`git status`, whatever its content.
+
+`make stats` was run against the current corpus (exit 0). Diffing every
+variable, author's checkout vs fresh rebuild:
+
+    technical-report-vars.yml   0 changed, 0 added
+    data-paper-vars.yml         3 changed, 3 added
+    multilayer-detection-vars.yml  8 changed, 9 added
+
+    data-paper:
+      dedup_doi_removed        833   -> [MISSING]      REGRESSION
+      dedup_titleyear_removed  159   -> [MISSING]      REGRESSION
+      lang_english_pct         89.9  -> 93.8
+      + lang_detected_n 1,331 / lang_detected_pct 4.0 / lang_non_english_n 2,061
+
+    multilayer:
+      bim_dbic_embedding    1,350 -> 1,355
+      bim_dbic_tfidf       15,984 -> 15,990
+      bim_dbic_pre2007         19 -> 20
+      bim_dbic_2007_2014      −59 -> −60
+      bim_dbic_post2015     1,118 -> 1,119
+      bim_n_efficiency        875 -> 874
+      pca_emb_pc2_cosine   -0.695 -> -0.696
+      lang_english_pct       89.9 -> 93.8
+      + the nine dip/shape/period-n variables added by ticket 0345
+
+The bimodality drift this ticket was filed for is real but small, and it
+changes no qualitative claim — §5.3's rewritten wording does not depend on the
+exact delta_bic values. Two findings from the same pass matter more, and both
+touch the data paper under R&R:
+
+1. **A clean rebuild puts `[MISSING]` into the data paper.**
+   `dedup_doi_removed` and `dedup_titleyear_removed` are rendered by
+   `data-paper.qmd`. They currently show 833 and 159 only because the author's
+   vars file predates the loss; `compute_vars` now falls back to `[MISSING]`
+   because the `catalog_merge` run report is absent. Ticket 0284 was closed by
+   PR #1082 without that artifact ever landing. Filed as its own ticket.
+
+2. **`lang_english_pct` moves 89.9 → 93.8 in a paper under R&R.** The 0297
+   language backfill (PR #1129) is in the corpus — the three new `lang_*`
+   variables prove it. STATE.md recorded this as an open author call: "do it
+   before the letter or after resubmission, not between." The corpus has
+   already moved; only the stale derived layer is hiding it. This is the
+   author's decision, not an agent's, and it is the reason this pass stopped at
+   reporting rather than refreshing the author's checkout.
 
 ## Relevant files
 

--- a/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
+++ b/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
@@ -1,0 +1,119 @@
+%erg 0.1
+Title: Run-report tests patch the wrong module and write into the real corpus directory
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T15:01Z HDMX-coding-agent created
+2026-07-27T15:01Z HDMX-coding-agent note Found while investigating unexpected mtimes in data/catalogs during the 0344 make pass
+
+--- body ---
+## Context
+
+`data/catalogs/run_reports/` in the author's checkout contains five files that
+are test fixtures, not corpus artifacts:
+
+    enrich_abstracts__consistency-test.json
+    script__run_id_with_spaces_special_.json
+    test_script__run-xyz.json
+    my_script__test-run-001.json
+    corpus_align__e2e-smoke.json
+
+The names map one-to-one onto test cases in
+`tests/test_robustness_observability.py` (`test_save_run_report_creates_file`
+writes `my_script__test-run-001`, `test_save_run_report_json_schema` writes
+`test_script__run-xyz`, `test_save_run_report_sanitizes_run_id` writes the
+`run_id_with_spaces_special_` name) and `tests/test_pipeline_e2e.py`.
+
+## Root cause
+
+The tests do attempt isolation. They patch the constant:
+
+    import utils
+    utils.CATALOGS_DIR = str(tmp_path)
+
+But `save_run_report` resolves the directory from the *definition site*, inside
+its own body:
+
+    def save_run_report(data, run_id, script_name):
+        from pipeline_loaders import CATALOGS_DIR  # avoid circular import
+        reports_dir = os.path.join(CATALOGS_DIR, "run_reports")
+
+`utils.CATALOGS_DIR` is a re-export binding in a different module. Rebinding it
+does not touch `pipeline_loaders.CATALOGS_DIR`, and the function-local import
+re-reads the definition site on every call. The patch is a no-op, so every one
+of these tests writes to the real, DVC-tracked corpus directory while reporting
+green.
+
+This is the re-export facade trap the project's own coding rules describe for
+`scripts/utils.py`, landing in a test rather than in production code.
+
+## Why it matters
+
+`data/catalogs/run_reports/` is a DVC output (`run_reports.dvc`). Test fixtures
+accumulating there are candidates for being committed as corpus data, and they
+pollute the run-report series that Phase-1 QA reads. The blast radius is small
+today — five small JSON files, no numeric artifact derives from them — but the
+directory is corpus state and the tests are writing to it on every run.
+
+There is also a silent-success problem independent of the files: a test that
+believes it is isolated and is not will keep passing if the isolation breaks
+further.
+
+## Relevant files
+
+- `tests/test_robustness_observability.py` — three tests patching `utils.CATALOGS_DIR`
+- `tests/test_pipeline_e2e.py` — the e2e-smoke and consistency-test writers
+- `scripts/pipeline_io.py::save_run_report` — the function-local import
+- `data/catalogs/run_reports/` — the polluted directory (DVC output)
+
+## Actions
+
+1. Patch the definition site: `monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))`.
+   Use `monkeypatch` rather than bare assignment so the change is undone on
+   teardown — the current tests mutate a module global and restore it by hand,
+   which leaks if an assertion fails midway.
+2. Delete the five fixture files from `data/catalogs/run_reports/` and confirm
+   DVC does not carry them in a committed revision.
+3. Sweep for the same trap elsewhere: any test that patches a constant on
+   `utils` rather than on the module that defines it.
+
+## Test
+
+Red step — assert the isolation actually holds, rather than assuming it:
+
+    def test_save_run_report_honours_patched_catalogs_dir(tmp_path, monkeypatch):
+        """Ticket 0346. The patch must reach the definition site."""
+        monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+        path = save_run_report({"n": 1}, "isolation-probe", "probe_script")
+        assert Path(path).is_relative_to(tmp_path), (
+            f"run report escaped the tmp dir to {path}"
+        )
+
+Fails today: the returned path points into the real `data/catalogs/`. This
+guards the defect class, not just the filename — any future resolution change
+that escapes `tmp_path` trips it.
+
+## Verification
+
+- [ ] The probe test above is red before the fix, green after
+- [ ] A full `make check` leaves `data/catalogs/run_reports/` unchanged
+      (capture a directory listing before and after and compare)
+- [ ] The five existing fixture files are gone
+
+## Invariants
+
+- No production behaviour changes. `save_run_report`'s real-run path must still
+  resolve to `CATALOGS_DIR/run_reports`.
+- The function-local import stays; it exists to break a circular import.
+
+## Exit criteria
+
+- [ ] Tests patch the defining module and use `monkeypatch`
+- [ ] A test suite run provably writes nothing into `data/catalogs/`
+- [ ] The sweep for the same trap on other `utils` constants is done and its
+      result recorded here
+
+## See also
+
+- 0344 — the Phase-2 rebuild during which these files were noticed

--- a/tickets/0347-a-clean-rebuild-puts-missing-into-the-dat.erg
+++ b/tickets/0347-a-clean-rebuild-puts-missing-into-the-dat.erg
@@ -1,0 +1,125 @@
+%erg 0.1
+Title: A clean rebuild puts [MISSING] into the data paper's dedup counts
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-27T15:15Z HDMX-coding-agent created
+2026-07-27T15:15Z HDMX-coding-agent note Found by the 0344 make pass; ticket 0284 was closed by PR #1082 without its artifact landing
+
+--- body ---
+## Context
+
+`data-paper.qmd` renders `dedup_doi_removed` and `dedup_titleyear_removed`.
+They show 833 and 159 in the author's checkout. A clean `make stats` against
+the current corpus produces `[MISSING]` for both.
+
+The vars are not computed from a table. `compute_vars.py` reads them from the
+`catalog_merge` run report, and when that report is absent it falls back:
+
+    for _k in ("dedup_doi_removed", "dedup_titleyear_removed", ...):
+        v.setdefault(_k, MISSING)
+
+with the comment that the report "awaits a dvc-capable full-data session
+(ticket 0284)". The run emits `UserWarning: Missing: catalog_merge run report
+(dvc repro catalog_merge)` and continues to exit 0.
+
+Ticket 0284 was closed by PR #1082. The artifact it was supposed to produce was
+never generated, so the two numbers currently in the author's vars file are
+survivors of an older build rather than something the pipeline can reproduce.
+
+## Why this is urgent rather than tidy
+
+RDJ-26561 is in Revise-and-Resubmit, due ~2026-10-20. The failure mode is
+silent in the direction that matters: `make stats` exits 0, the warning is one
+line in a long log, and the placeholder only becomes visible in the rendered
+PDF. A rebuild on a fresh machine — a clean-room reproducibility check, a
+co-author's checkout, the Zenodo archive build — would render the deposited
+data paper with `[MISSING]` where two deduplication counts belong.
+
+The reproducibility archive is the sharpest case: the whole point of that
+artifact is that a stranger can rebuild the paper. Today a stranger rebuilds it
+worse than the author can.
+
+## Relevant files
+
+- `scripts/analysis/compute_vars.py` — the `setdefault(..., MISSING)` fallback
+  block and the `catalog_merge` reader above it
+- `deliverables/data-paper/data-paper.qmd` — renders both variables
+- `dvc.yaml` — the `catalog_merge` stage that would emit the run report
+- `tickets/closed/0284-datapaper-dedup-counts-artifact.erg` — closed, artifact
+  never landed
+
+## Decision required
+
+The author picks; both are defensible and the choice depends on how much
+Phase-1 time is affordable before resubmission.
+
+1. **Regenerate the artifact.** `dvc repro catalog_merge` on a full-data
+   session, so the run report exists and the two counts are reproducible. Costs
+   a Phase-1 run. This is what 0284 intended.
+2. **Source the counts from something durable.** If the dedup counts can be
+   recomputed from `refined_works.csv` and the pool rather than from a run
+   report, compute them like every other variable. Costs analysis work, removes
+   the dependency on a transient report for good.
+
+Whichever is chosen, the fallback must stop being silent — see Actions.
+
+## Actions
+
+1. Implement the chosen option above.
+2. Make the placeholder loud. A variable that a document renders must not
+   degrade to `[MISSING]` behind a `UserWarning`. Either fail the build for
+   placeholders in a *rendered* variable, or emit them at ERROR and list them
+   in the run's final summary. `compute_vars` already aborts on variables it
+   cannot compute at all; this fallback path deliberately bypasses that, and
+   the bypass is the defect.
+3. Audit the rest of the `setdefault(..., MISSING)` block the same way. It also
+   covers `dedup_fn_*` and `dedup_fp_*`; check which of those any document
+   renders.
+
+## Test
+
+Red step:
+
+    def test_no_rendered_variable_is_missing():
+        """Ticket 0347. A placeholder in a rendered var must fail the build."""
+        for doc, path in VARS_FILES.items():
+            v = yaml.safe_load(open(path))
+            rendered = meta_refs_in(DOC_SOURCES[doc])
+            bad = sorted(k for k in rendered if v.get(k) == "[MISSING]")
+            assert not bad, f"{doc} renders placeholder(s): {bad}"
+
+Fails today on the data paper for the two dedup counts. Written against
+*rendered* variables rather than all variables, so the genuinely pending
+companion Z-series placeholders (`zone_1_start`, `s2_peak_year_w3`) do not
+force unrelated work — they are in the vars file but not yet referenced by a
+document.
+
+## Verification
+
+- [ ] The test above is red before the fix, green after
+- [ ] `make stats` from an empty `data/derived/` reproduces 833 and 159, or
+      whatever the corrected values are
+- [ ] A rendered data-paper PDF contains no `[MISSING]`
+- [ ] The `dedup_fn_*` / `dedup_fp_*` audit is recorded here
+
+## Invariants
+
+- No number in the data paper changes silently. If regenerating the artifact
+  yields values other than 833 and 159, that is a finding for the author and a
+  correction to the manuscript, not a quiet substitution.
+- The Z-series placeholders stay out of scope; they are a known separate gap.
+
+## Exit criteria
+
+- [ ] The two dedup counts are reproducible from a clean checkout
+- [ ] A rendered variable can no longer degrade to a placeholder without
+      failing the build
+- [ ] The audit of the remaining fallback keys is done and recorded
+
+## See also
+
+- 0344 — the make pass that surfaced this
+- 0284 (closed, PR #1082) — closed without producing the artifact it was about

--- a/tickets/0348-vars-yml-are-handoff-artifacts-but-gitign.erg
+++ b/tickets/0348-vars-yml-are-handoff-artifacts-but-gitign.erg
@@ -1,0 +1,138 @@
+%erg 0.1
+Title: vars.yml are handoff artifacts but gitignored, which defeats the clean-room writing build
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-27T15:25Z HDMX-coding-agent created
+2026-07-27T15:25Z minh question Asked whether *-vars.yml are phase deliverables; they are, and the repo contradicts itself
+
+--- body ---
+## Context
+
+`deliverables/_shared/technical-report-vars.yml`,
+`deliverables/data-paper/data-paper-vars.yml` and
+`deliverables/multilayer/multilayer-detection-vars.yml` are gitignored.
+`deliverables/manuscript/manuscript-vars.yml` is whitelisted back in because it
+is pinned to v1.0 values.
+
+Three independent sources say the ignored three are Phase-2 handoff artifacts
+that should be tracked:
+
+1. `.claude/rules/architecture.md`, artifact-homes table: Phase 2 produces
+   "writing deliverables" at `deliverables/_shared/{figures,tables,_includes}/`
+   **and `deliverables/<x>/*-vars.yml`**.
+2. The harness git rule: "Don't gitignore handoff artifacts. Generated files
+   that a downstream workpackage consumes are durable state — commit them."
+3. Every sibling class in that same list *is* committed — 9 figures, 18 tables,
+   50 includes. The vars files are the only exception.
+
+Six writing-side Makefiles list them as prerequisites of a render target
+(`corpus-report.mk`, `data-paper.mk`, `multilayer.mk` twice,
+`technical-report.mk`, `zoo.mk`).
+
+## The contradiction
+
+`multilayer.mk` states the design intent in its own header:
+
+    Render-only: ... rendered from handoff artifacts on disk (includes,
+    bibliography, vars) produced by a prior `make analysis` (Phase 2).
+    No uv, no corpus data, no compute rules.
+    Toolchain: Quarto + a LaTeX engine only.
+
+That is the clean-room property the harness rule calls for: the writing
+workpackage builds from artifacts alone. But a fresh clone does not have the
+vars files, so the render cannot run without first executing Phase 2 — which
+needs uv *and* the DVC corpus. The writing build is clean-room by design and
+not clean-room in fact, and the gitignore is the only reason.
+
+## Why it matters beyond tidiness
+
+Confirmed consequences, all observed on 2026-07-27:
+
+- A fresh worktree cannot render any of the three documents.
+- Ticket 0344 was filed against a wrong premise — that the vars were committed
+  and quoting stale numbers — because the architecture doc says they are
+  handoff artifacts. The correction cost a round trip.
+- **Detection.** Ticket 0347 found that a clean rebuild silently turns
+  `dedup_doi_removed` from 833 into `[MISSING]` in a data paper under R&R. If
+  the vars were tracked, that regression would arrive as a one-line diff in a
+  PR instead of materialising at build time behind a `UserWarning`. Tracking
+  these files converts a silent numeric regression into a reviewable one.
+
+The last point is the strongest argument and the reason to treat this as more
+than a consistency clean-up.
+
+## Decision required
+
+The author picks. This changes a standing policy, so it is not an agent call.
+
+1. **Track them** (recommended). Remove the three gitignore lines, commit the
+   current generated files, and let every Phase-2 rerun surface its numeric
+   diff in review. Restores the clean-room render, aligns the repo with its own
+   architecture doc, and gives 0347's failure class a detector for free.
+   Cost: every `make stats` dirties the tree, and vars diffs add noise to
+   unrelated PRs. That noise is the signal — but it is real noise, and on a
+   busy day it means a rebase conflict in a generated file.
+2. **Keep them ignored and fix the docs.** Strike `*-vars.yml` from the
+   architecture doc's Phase-2 artifact list, and drop or qualify the clean-room
+   claim in the writing-side Makefile headers, since it would then be false.
+   Cost: no clean-room render, and 0347's class stays undetectable by diff.
+
+Option 2 is worth stating plainly because it is defensible — churn in generated
+files is a genuine cost — but it means giving up a property the architecture
+currently advertises.
+
+## Relevant files
+
+- `.gitignore` lines 88--93 — the three ignores and the manuscript whitelist
+- `.claude/rules/architecture.md` — the artifact-homes table listing vars under
+  Phase 2
+- `deliverables/*/*.mk` — six render targets taking vars as prerequisites
+- `deliverables/multilayer/multilayer.mk` — the clean-room claim in its header
+
+## Test
+
+Red step under option 1 — assert the property the Makefile header claims:
+
+    @pytest.mark.integration
+    def test_writing_build_needs_no_phase2_artifacts_from_git():
+        """Ticket 0348. Every render prerequisite must be tracked."""
+        for mk in glob("deliverables/*/*.mk"):
+            for prereq in render_prerequisites(mk):
+                assert is_tracked(prereq), (
+                    f"{mk} renders from {prereq}, which git does not carry - "
+                    "a fresh clone cannot build this document"
+                )
+
+Fails today on all six render targets. Guards the class rather than the three
+filenames: any future handoff artifact that gets gitignored trips it.
+
+## Verification
+
+- [ ] The test above is red before, green after
+- [ ] A render succeeds from a clean clone with no `uv` and no `dvc pull`
+      (the real check — run it, do not infer it)
+- [ ] Under option 2 instead: no doc or Makefile header still claims a
+      clean-room writing build
+
+## Invariants
+
+- `manuscript-vars.yml` stays pinned to v1.0 and is not swept into any
+  regeneration.
+- No variable's *value* changes under this ticket. It moves files across the
+  git boundary; it does not recompute anything.
+
+## Exit criteria
+
+- [ ] The choice between option 1 and option 2 is recorded in this log
+- [ ] The chosen option is implemented
+- [ ] The repo no longer contradicts itself: either the vars are tracked as the
+      architecture doc says, or the doc and the Makefile headers stop saying it
+
+## See also
+
+- 0344 — filed against the wrong premise because of this
+- 0347 — the silent `[MISSING]` regression that tracking would have exposed
+- 0226 — introduced the per-deliverable vars layout the gitignore comment cites


### PR DESCRIPTION
**Ticket:** none — records findings, closes nothing.
**Ticket-ref:** tickets/0344-phase2-derived-tables-are-stale-against-t.erg
**Ticket-ref:** tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
**Ticket-ref:** tickets/0347-a-clean-rebuild-puts-missing-into-the-dat.erg

Ticket records only, no code. `make stats` ran against the current corpus, exit 0.

## 0344's premise was partly wrong

All three `*-vars.yml` are **gitignored**, not committed. So there is no committed layer quoting stale numbers, and action 1's "commit the vars diff" is void — nothing is committable. My earlier claim that the committed vars reproduced byte-clean was also not evidence: a gitignored file always shows a clean `git status`.

## The drift, every variable

| file | changed | added |
|---|---|---|
| `technical-report-vars.yml` | 0 | 0 |
| `data-paper-vars.yml` | 3 | 3 |
| `multilayer-detection-vars.yml` | 8 | 9 |

Bimodality drift is real but small — `bim_dbic_embedding` 1,350 → 1,355, `bim_n_efficiency` 875 → 874, `pca_emb_pc2_cosine` -0.695 → -0.696. No qualitative claim moves; §5.3's rewritten wording does not depend on the values.

## Two findings that outrank it, both on the data paper under R&R

**0347 — a clean rebuild renders `[MISSING]` in the data paper.** `dedup_doi_removed` (833) and `dedup_titleyear_removed` (159) are rendered by `data-paper.qmd`. `compute_vars` falls back to a placeholder because the `catalog_merge` run report is absent; **ticket 0284 was closed by PR #1082 without that artifact ever landing**. The build exits 0, the warning is one line in a long log, and the placeholder surfaces only in the PDF. A clean-room or Zenodo archive rebuild would deposit the paper with two counts missing — a stranger currently rebuilds it *worse* than the author can.

**0346 — tests write into the DVC-tracked corpus directory.** `save_run_report` does `from pipeline_loaders import CATALOGS_DIR` inside its own body; the tests patch `utils.CATALOGS_DIR`, a re-export binding in a different module. The isolation is a no-op, and five fixtures now sit in `data/catalogs/run_reports/`. The project's own `utils`-facade trap, landed in a test that reports green.

## Recorded, deliberately not acted on

`lang_english_pct` moves **89.9 → 93.8**. The 0297 backfill (PR #1129) is already in the corpus — the three new `lang_*` variables prove it. STATE.md logged this as an open author call: *"do it before the letter or after resubmission, not between."* The corpus has already moved; only the stale derived layer hides it. That is the author's decision, and the reason this pass stopped at reporting rather than refreshing the author's checkout.

`erg check` passes (337 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)