### PR TITLE
tickets: close 0344 wontfix, deepen 0346, make 0349 huntable

### DIFF
--- a/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
+++ b/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T15:01Z HDMX-coding-agent created
 2026-07-27T15:01Z HDMX-coding-agent note Found while investigating unexpected mtimes in data/catalogs during the 0344 make pass
+2026-07-27T16:05Z HDMX-coding-agent note Read-only follow-up: TWO leak mechanisms, not one; 4.5 months old; fixtures are inside committed DVC snapshots; and a latent glob collision that would silently replace a data-paper number
 
 --- body ---
 ## Context
@@ -24,6 +25,58 @@ The names map one-to-one onto test cases in
 writes `my_script__test-run-001`, `test_save_run_report_json_schema` writes
 `test_script__run-xyz`, `test_save_run_report_sanitizes_run_id` writes the
 `run_id_with_spaces_special_` name) and `tests/test_pipeline_e2e.py`.
+
+## Read-only follow-up (2026-07-27)
+
+**Age.** `test_robustness_observability.py` was added 2026-03-12,
+`test_pipeline_e2e.py` 2026-03-16, and DVC began tracking `run_reports/` on
+2026-03-15. The leak has run for roughly four and a half months. The files are
+not stale relics: all eight were rewritten between 15:42:57 and 15:43:06 on
+2026-07-27, because concurrent sessions regenerate them on every test run.
+
+**They are committed corpus data.** Scanning the 46 `.dir` objects in the DVC
+cache, the fixtures appear in four snapshots — including
+`42bc3e29ab25f7aa1ffb2cd687b41472.dir`, the hash `run_reports.dvc` points at on
+main. Beyond the five first noticed, the snapshots also carry
+`corpus_align__smoke-test.json`, `corpus_align__test-align-001.json` and
+`enrich_citations_batch__test-preview.json`. Patching the tests stops new
+writes; it does not remove these.
+
+**Two mechanisms, not one.** The root cause below covers only the first.
+
+1. *In-process.* `test_robustness_observability.py` patches
+   `utils.CATALOGS_DIR`, while `save_run_report` re-imports from
+   `pipeline_loaders` at call time. Produces `my_script__test-run-001`,
+   `test_script__run-xyz`, `script__run_id_with_spaces_special_`,
+   `enrich_abstracts__consistency-test`, `enrich_citations_batch__test-preview`.
+2. *Subprocess.* `test_pipeline_e2e.py` (lines ~536, ~644) and
+   `test_phase1_contract.py` (~355) spawn `corpus_align.py` with
+   `cwd=REPO_ROOT`. Monkeypatching a module global in the parent cannot reach a
+   child process, so the child resolves the real `CATALOGS_DIR`. Produces
+   `corpus_align__smoke-test`, `corpus_align__e2e-smoke`,
+   `corpus_align__test-align-001`. Note `test_phase1_contract` already passes
+   `env=env` and still leaks — consistent with `pipeline_loaders` calling
+   `load_dotenv()`, which lets the checked-in `.env` override an inherited
+   environment variable. Fixing this one needs env *and* `.env` control, not a
+   monkeypatch.
+
+The repo already knows about mechanism 1. `_patched_merge_dirs` in
+`test_pipeline_e2e.py` patches `pipeline_loaders.CATALOGS_DIR` and its
+docstring explains precisely why — "without this the report would leak into the
+real DVC-tracked `data/catalogs/run_reports/`". The knowledge exists in one
+file and was never propagated to the others.
+
+**Latent hazard worth more than the pollution.** `compute_vars.dedup_stats`
+globs `catalog_merge__*.json` and takes `sorted(...)[-1]`. Run ids are UTC
+timestamps beginning with a digit, so any leaked fixture named
+`catalog_merge__test*.json` sorts *after* every real report — `t` > `2` in
+ASCII — and would silently become the source of `dedup_doi_removed` and
+`dedup_titleyear_removed` in the data paper. `test_dedup_vars.py` writes
+exactly such a file (`catalog_merge__test.json`) and is correctly isolated to
+`tmp_path` today, so this has not fired. Given that isolation demonstrably
+fails by two independent mechanisms in neighbouring files, treat the near-miss
+as the real finding: a leaked fixture would not merely litter the directory, it
+would replace a published number.
 
 ## Root cause
 

--- a/tickets/0349-a-clean-rebuild-puts-missing-into-the-dat.erg
+++ b/tickets/0349-a-clean-rebuild-puts-missing-into-the-dat.erg
@@ -103,79 +103,78 @@ worse than the author can.
 - `tickets/closed/0284-datapaper-dedup-counts-artifact.erg` — closed, artifact
   never landed
 
-## Decision required
+## Why it is not already declared
 
-The author picks; both are defensible and the choice depends on how much
-Phase-1 time is affordable before resubmission.
+A DVC `outs:` entry is a fixed path. The run report is
+`catalog_merge__<UTC timestamp>.json`, so it cannot be named as an output as
+things stand — which is very likely why it never was, rather than an oversight.
 
-1. **Regenerate the artifact.** `dvc repro catalog_merge` on a full-data
-   session, so the run report exists and the two counts are reproducible. Costs
-   a Phase-1 run. This is what 0284 intended.
-2. **Source the counts from something durable.** If the dedup counts can be
-   recomputed from `refined_works.csv` and the pool rather than from a run
-   report, compute them like every other variable. Costs analysis work, removes
-   the dependency on a transient report for good.
+The repo already solves this shape elsewhere. The enrichment stages write a
+`.stamp` file as their declared output precisely because their real product
+(`enrich_cache/`) has data-dependent contents, and the architecture rule says
+so: "Sentinel stamps for dynamic outputs. Use a stamp file when a script
+produces data-dependent filenames."
 
-Whichever is chosen, the fallback must stop being silent — see Actions.
+Declaring the whole `run_reports/` directory is not an option: several scripts
+write into it, and DVC forbids two stages owning one output.
 
 ## Actions
 
-1. Implement the chosen option above.
-2. Make the placeholder loud. A variable that a document renders must not
-   degrade to `[MISSING]` behind a `UserWarning`. Either fail the build for
-   placeholders in a *rendered* variable, or emit them at ERROR and list them
-   in the run's final summary. `compute_vars` already aborts on variables it
-   cannot compute at all; this fallback path deliberately bypasses that, and
-   the bypass is the defect.
-3. Audit the rest of the `setdefault(..., MISSING)` block the same way. It also
-   covers `dedup_fn_*` and `dedup_fp_*`; check which of those any document
-   renders.
+1. Have `catalog_merge` write a stable-named report alongside the timestamped
+   one — `data/catalogs/run_reports/catalog_merge.json`, overwritten each run —
+   and declare that path in the stage's `outs:`. The timestamped files stay as
+   an unversioned history, which is what they are useful for.
+2. Point `compute_vars.dedup_stats` at the stable name instead of
+   `sorted(glob(...))[-1]`. This also removes the latent collision recorded in
+   ticket 0346: the glob takes the lexicographically last match, and any leaked
+   fixture named `catalog_merge__test*.json` sorts after every timestamped
+   report, so it would silently become the source of two published numbers.
+3. Check whether any other stage has the same undeclared side-effect. Every
+   caller of `save_run_report` that runs inside a DVC stage is a candidate.
+
+Do 2 even if 1 is judged not worth it — the glob is the sharper of the two
+problems and the fix is one line.
 
 ## Test
 
-Red step:
+Red step, on the wiring rather than on the values:
 
-    def test_no_rendered_variable_is_missing():
-        """Ticket 0349. A placeholder in a rendered var must fail the build."""
-        for doc, path in VARS_FILES.items():
-            v = yaml.safe_load(open(path))
-            rendered = meta_refs_in(DOC_SOURCES[doc])
-            bad = sorted(k for k in rendered if v.get(k) == "[MISSING]")
-            assert not bad, f"{doc} renders placeholder(s): {bad}"
+    def test_catalog_merge_declares_its_run_report():
+        """Ticket 0349. A stage's artifacts must be declared, not side effects."""
+        stage = yaml.safe_load(open("dvc.yaml"))["stages"]["catalog_merge"]
+        outs = [list(o)[0] if isinstance(o, dict) else o for o in stage["outs"]]
+        assert any("run_reports" in o for o in outs), (
+            "catalog_merge writes a run report that compute_vars reads, but "
+            "declares only unified_works.csv - dvc cannot tell when the report "
+            "is stale"
+        )
 
-Fails today on the data paper for the two dedup counts.
-
-Correction to an earlier claim in this ticket: the companion Z-series
-placeholders (`zone_1_start`, `zone_1_end`, `s2_peak_year_w3`,
-`l1_peak_year_w3`, `g9_peak_year_w3`) were described as "not yet referenced by
-a document". They are — `multilayer-detection.qmd` renders all five, so that
-paper currently prints `[MISSING]` five times. A rendered-variable guard will
-therefore fail on multilayer too, which is correct but wider than this ticket.
-Either scope the guard to the data paper first and widen it once the Z-series
-lands, or fix both together. Do not narrow the guard to hide the multilayer
-case.
+Fails today. A companion test should assert `dedup_stats` reads a fixed
+filename rather than globbing, so action 2 cannot regress.
 
 ## Verification
 
-- [ ] The test above is red before the fix, green after
-- [ ] `make stats` from an empty `data/derived/` reproduces 833 and 159, or
-      whatever the corrected values are
-- [ ] A rendered data-paper PDF contains no `[MISSING]`
-- [ ] The `dedup_fn_*` / `dedup_fp_*` audit is recorded here
+- [ ] Both tests above are red before, green after
+- [ ] `dvc repro catalog_merge` on an unchanged corpus is a no-op; on a changed
+      one it rewrites `catalog_merge.json`
+- [ ] `dedup_doi_removed` and `dedup_titleyear_removed` still resolve to 833
+      and 159 on the current corpus — this ticket must not move a number
+- [ ] A file named `catalog_merge__zzz.json` dropped into `run_reports/` no
+      longer changes the vars output
 
 ## Invariants
 
-- No number in the data paper changes silently. If regenerating the artifact
-  yields values other than 833 and 159, that is a finding for the author and a
-  correction to the manuscript, not a quiet substitution.
-- The Z-series placeholders stay out of scope; they are a known separate gap.
+- No published number changes. The counts are correct today; this is about how
+  the artifact carrying them is declared.
+- The timestamped reports keep being written. They are the run history and
+  other tooling may read them.
 
 ## Exit criteria
 
-- [ ] The two dedup counts are reproducible from a clean checkout
-- [ ] A rendered variable can no longer degrade to a placeholder without
-      failing the build
-- [ ] The audit of the remaining fallback keys is done and recorded
+- [ ] `catalog_merge`'s run report is a declared output of its DVC stage, or a
+      recorded decision that a stamp is not worth it
+- [ ] `compute_vars` reads a fixed filename, not the last glob match
+- [ ] The audit of other `save_run_report` callers inside DVC stages is recorded
 
 ## See also
 

--- a/tickets/closed/0344-phase2-derived-tables-are-stale-against-t.erg
+++ b/tickets/closed/0344-phase2-derived-tables-are-stale-against-t.erg
@@ -2,6 +2,7 @@
 Title: Phase-2 derived tables are stale against the corpus, and the manuscript quotes the stale numbers
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: wontfix — 0348 (vars now tracked) makes drift visible as a diff, and remake-before-shipping covers the rest; a fingerprint guard would need new pipeline surface to detect a condition a make pass already resolves
 
 --- log ---
 2026-07-27T14:30Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-07-27T15:10Z HDMX-coding-agent correction Premise error: the vars files are gitignored, not committed. Action 1's "commit the vars diff" is void. Corrected below
 2026-07-27T15:12Z HDMX-coding-agent note make stats run, exit 0. Full diff below. It surfaced two R&R-relevant findings that outrank the drift this ticket was filed for
 
+2026-07-27T14:03Z HDMX-coding-agent closed — wontfix — 0348 (vars now tracked) makes drift visible as a diff, and remake-before-shipping covers the rest; a fingerprint guard would need new pipeline surface to detect a condition a make pass already resolves
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0344-phase2-derived-tables-are-stale-against-t.erg
**Ticket-ref:** tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
**Ticket-ref:** tickets/0349-a-clean-rebuild-puts-missing-into-the-dat.erg

Ticket records only, no code.

## 0344 — closed wontfix

Three of its four legs are already gone. 0348 put the vars in git, so drift now shows as a diff; remake-before-shipping covers the release risk directly. The fingerprint guard would add new pipeline surface and a new false-alarm mode (fingerprint stale, corpus fine) to detect a condition a `make` pass resolves anyway — and it could not distinguish staleness from work in progress, so it would fire all session.

## 0346 — read-only follow-up

- **Age:** culprit tests added **2026-03-12** and **03-16**; DVC began tracking `run_reports/` **03-15**. ~4.5 months. Not relics — all eight fixtures were rewritten 15:42:57–15:43:06 today by concurrent sessions.
- **Committed corpus data:** the fixtures sit in **four** DVC `.dir` snapshots, including `42bc3e29…`, the hash `run_reports.dvc` points at on main. Patching the tests stops new writes; it does not remove these.
- **Two mechanisms, not one.** (1) the `utils` vs `pipeline_loaders` patch target; (2) **subprocess** tests that a monkeypatch cannot reach at all — and `test_phase1_contract` already passes `env=` and still leaks, consistent with `load_dotenv()` letting the checked-in `.env` win.
- The repo already knew about (1): `_patched_merge_dirs` documents it exactly. It was never propagated.

**The near-miss is worth more than the pollution.** `dedup_stats` globs `catalog_merge__*.json` and takes `sorted(...)[-1]`. Timestamped run ids start with a digit, so a leaked fixture named `catalog_merge__test*.json` sorts *last* and would silently become the source of `dedup_doi_removed` and `dedup_titleyear_removed`. `test_dedup_vars` writes exactly that filename and is correctly isolated today — but isolation demonstrably fails two other ways in neighbouring files.

## 0349 — rewritten to be huntable

Its Actions still described the withdrawn `[MISSING]` premise. The new scope has a real constraint I had not accounted for: **DVC `outs:` are fixed paths and the report is timestamped**, which is very likely why it was never declared rather than an oversight. The repo already solves this shape with sentinel stamps for the enrichment caches, so the fix is a stable-named `catalog_merge.json` declared in `outs:`, plus pointing `compute_vars` at the fixed name instead of the glob — which also kills 0346's near-miss.

`erg check` PASS (341 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)