### PR TITLE
fix(0349): declare catalog_merge's run report and stop the glob hijack

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -152,6 +152,10 @@ stages:
       - data/catalogs/scispace_works.csv
     outs:
       - data/catalogs/unified_works.csv
+      # The dedup counters compute_vars publishes in the data paper. Declared so
+      # dvc can tell when they are stale; the timestamped siblings in
+      # run_reports/ are run history and stay undeclared (ticket 0349).
+      - data/catalogs/run_reports/catalog_merge.json
 
   # ── Phase 1b: Enrichment pipeline ──────────────────────────
   # Split into independent DVC stages so each step is cached separately.

--- a/scripts/analysis/compute_vars.py
+++ b/scripts/analysis/compute_vars.py
@@ -8,7 +8,6 @@ Usage:
     uv run python scripts/analysis/compute_vars.py
 """
 
-import glob
 import json
 import os
 import sys
@@ -16,6 +15,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from pipeline_io import latest_run_report
 from pipeline_loaders import load_refined_citations, load_refined_works
 from script_io_args import parse_io_args, validate_io
 from utils import (
@@ -357,12 +357,8 @@ def dedup_stats(v):
     error estimates from tab_dedup_error_estimates.csv (ticket 0301).
     Both are pipeline artifacts — no hand-curated numbers.
     """
-    reports = sorted(
-        glob.glob(os.path.join(CATALOGS_DIR, "run_reports", "catalog_merge__*.json"))
-    )
-    if reports:
-        with open(reports[-1]) as f:
-            rep = json.load(f)
+    rep = latest_run_report("catalog_merge", CATALOGS_DIR)
+    if rep is not None:
         v["dedup_doi_removed"] = _int(rep["doi_duplicates_removed"])
         v["dedup_titleyear_removed"] = _int(rep["title_year_duplicates_removed"])
     else:

--- a/scripts/harvest/catalog_merge.py
+++ b/scripts/harvest/catalog_merge.py
@@ -300,7 +300,9 @@ def main(run_id: str | None = None):
     # rather than in deduplicate(), which sees no source_count column.
     report = {**dedup_counters,
               "multi_source_works": int((result["source_count"] > 1).sum())}
-    report_path = save_run_report(report, run_id, "catalog_merge")
+    # stable_copy: compute_vars sources two published data-paper numbers from
+    # this report, and a DVC stage can only declare a fixed path (ticket 0349).
+    report_path = save_run_report(report, run_id, "catalog_merge", stable_copy=True)
 
     log.info("Summary:")
     log.info("  Unified works: %d", len(result))

--- a/scripts/pipeline_io.py
+++ b/scripts/pipeline_io.py
@@ -139,7 +139,57 @@ def save_csv(df: pd.DataFrame, path: str) -> None:
 # Run reports
 # ---------------------------------------------------------------------------
 
-def save_run_report(data: dict[str, Any], run_id: str, script_name: str) -> str:
+RUN_ID_TIMESTAMP = re.compile(r"^\d{8}T\d{6}Z$")
+
+
+def latest_run_report(script_name: str,
+                      catalogs_dir: str | None = None) -> dict[str, Any] | None:
+    """Return the newest run report for ``script_name``, or None if there is none.
+
+    Two rules, both there to stop a stray file becoming a published number
+    (ticket 0349):
+
+    - The stable ``<script>.json`` wins when present. That is the file a DVC
+      stage can declare as an output; the timestamped siblings are run history.
+    - Otherwise only timestamped run ids are considered, ranked by timestamp.
+      The previous `sorted(glob(...))[-1]` ranked lexicographically, so
+      ``catalog_merge__test.json`` outranked every ``catalog_merge__2026…``
+      report — and fixtures with exactly that shape leak into the real corpus
+      directory (ticket 0346).
+
+    ``catalogs_dir`` is injectable on purpose. Reading the module global at call
+    time is what makes ``save_run_report`` untestable — a caller patching its
+    own ``CATALOGS_DIR`` cannot redirect it, which is the root cause behind
+    ticket 0346. Callers pass the directory they already resolved.
+    """
+    if catalogs_dir is None:
+        from pipeline_loaders import CATALOGS_DIR  # avoid circular import
+        catalogs_dir = CATALOGS_DIR
+
+    reports_dir = os.path.join(catalogs_dir, "run_reports")
+    stable = os.path.join(reports_dir, f"{script_name}.json")
+    if os.path.isfile(stable):
+        with open(stable) as f:
+            report: dict[str, Any] = json.load(f)
+        return report
+
+    prefix = f"{script_name}__"
+    dated = []
+    for name in os.listdir(reports_dir) if os.path.isdir(reports_dir) else []:
+        if not (name.startswith(prefix) and name.endswith(".json")):
+            continue
+        run_id = name[len(prefix):-len(".json")]
+        if RUN_ID_TIMESTAMP.match(run_id):
+            dated.append((run_id, os.path.join(reports_dir, name)))
+    if not dated:
+        return None
+    with open(max(dated)[1]) as f:
+        newest: dict[str, Any] = json.load(f)
+    return newest
+
+
+def save_run_report(data: dict[str, Any], run_id: str, script_name: str,
+                    stable_copy: bool = False) -> str:
     """Persist a structured run-summary dict as JSON in catalogs/run_reports/.
 
     Parameters
@@ -150,10 +200,14 @@ def save_run_report(data: dict[str, Any], run_id: str, script_name: str) -> str:
         Unique run identifier (e.g. timestamp or ``--run-id`` value).
     script_name : str
         Short script name used as filename prefix.
+    stable_copy : bool
+        Also write ``<script_name>.json``, overwritten each run. Set this when a
+        DVC stage needs a fixed path to declare as an output — a timestamped
+        filename cannot be one (ticket 0349).
 
     Returns
     -------
-    Path to the saved JSON file (str).
+    Path to the saved timestamped JSON file (str).
 
     """
     from pipeline_loaders import CATALOGS_DIR  # avoid circular import
@@ -166,6 +220,9 @@ def save_run_report(data: dict[str, Any], run_id: str, script_name: str) -> str:
     payload = {"script": script_name, "run_id": run_id, **data}
     with open(path, "w") as f:
         json.dump(payload, f, indent=2, default=str)
+    if stable_copy:
+        with open(os.path.join(reports_dir, f"{script_name}.json"), "w") as f:
+            json.dump(payload, f, indent=2, default=str)
     return path
 
 

--- a/tests/test_dedup_vars.py
+++ b/tests/test_dedup_vars.py
@@ -32,14 +32,19 @@ def artifact_dirs(tmp_path, monkeypatch):
     (catalogs / "run_reports").mkdir(parents=True)
     report = {
         "script": "catalog_merge",
-        "run_id": "test",
+        "run_id": "20260727T132143Z",
         "records_total": 43906,
         "doi_duplicates_removed": 833,
         "title_year_duplicates_removed": 154,
         "dropped_empty_title": 3,
         "records_unified": 42916,
     }
-    with open(catalogs / "run_reports" / "catalog_merge__test.json", "w") as f:
+    # Timestamped run id, matching what catalog_merge actually writes. The
+    # former "__test" name is now deliberately ignored by latest_run_report:
+    # a non-timestamp id sorts after every real report and would hijack two
+    # published numbers (ticket 0349). Keeping the old name here would have
+    # exercised a path the pipeline rejects.
+    with open(catalogs / "run_reports" / "catalog_merge__20260727T132143Z.json", "w") as f:
         json.dump(report, f)
 
     tables = tmp_path / "tables"

--- a/tests/test_run_report_wiring.py
+++ b/tests/test_run_report_wiring.py
@@ -1,0 +1,95 @@
+"""catalog_merge's run report must be a declared artifact, not a side effect.
+
+Ticket 0349. `compute_vars.dedup_stats` sources two published data-paper
+numbers from the latest `catalog_merge` run report, but the DVC stage that
+writes it declares only `unified_works.csv`. DVC therefore cannot tell when the
+report is stale: a cache hit on `unified_works.csv` skips the stage and leaves
+the report describing an older merge than the corpus in hand.
+
+The selection was also unsafe. `sorted(glob("catalog_merge__*.json"))[-1]`
+takes the lexicographically last match; run ids are UTC timestamps starting
+with a digit, so any file named `catalog_merge__test*.json` sorts after every
+real report and would silently become the source of both numbers. Test fixtures
+with exactly that shape leak into the real corpus directory today (ticket 0346),
+so this is a near-miss rather than a hypothetical.
+"""
+
+import json
+import os
+
+import pytest
+import yaml
+from utils import BASE_DIR
+
+DVC_YAML = os.path.join(BASE_DIR, "dvc.yaml")
+STABLE_REPORT = "data/catalogs/run_reports/catalog_merge.json"
+
+
+def _stage_outs(stage_name):
+    with open(DVC_YAML, encoding="utf-8") as fh:
+        stages = yaml.safe_load(fh)["stages"]
+    outs = []
+    for entry in stages[stage_name].get("outs", []):
+        outs.append(next(iter(entry)) if isinstance(entry, dict) else entry)
+    return outs
+
+
+@pytest.mark.adherence
+def test_catalog_merge_declares_its_run_report():
+    """A stage's consumed artifacts must be declared outputs."""
+    outs = _stage_outs("catalog_merge")
+    assert STABLE_REPORT in outs, (
+        "catalog_merge writes a run report that compute_vars reads, but "
+        f"declares only {outs} - dvc cannot tell when the report is stale"
+    )
+
+
+def test_latest_report_ignores_non_timestamp_run_ids(tmp_path, monkeypatch):
+    """A stray fixture must never outrank a real timestamped report.
+
+    This is the defect the old lexicographic sort had: 't' > '2', so
+    `catalog_merge__test.json` beat every `catalog_merge__2026...json`.
+    """
+    monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+    reports = tmp_path / "run_reports"
+    reports.mkdir()
+    real = {"doi_duplicates_removed": 833, "title_year_duplicates_removed": 159}
+    (reports / "catalog_merge__20260727T132143Z.json").write_text(json.dumps(real))
+    (reports / "catalog_merge__test.json").write_text(
+        json.dumps({"doi_duplicates_removed": 1, "title_year_duplicates_removed": 2})
+    )
+
+    from pipeline_io import latest_run_report
+
+    got = latest_run_report("catalog_merge")
+    assert got is not None, "no report selected"
+    assert got["doi_duplicates_removed"] == 833, (
+        "a non-timestamp fixture outranked the real report - the published "
+        "dedup counts would come from test data"
+    )
+
+
+def test_latest_report_prefers_the_declared_stable_file(tmp_path, monkeypatch):
+    """The DVC-declared file wins when present; the archive is a fallback."""
+    monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+    reports = tmp_path / "run_reports"
+    reports.mkdir()
+    (reports / "catalog_merge__20260101T000000Z.json").write_text(
+        json.dumps({"doi_duplicates_removed": 1})
+    )
+    (reports / "catalog_merge.json").write_text(
+        json.dumps({"doi_duplicates_removed": 833})
+    )
+
+    from pipeline_io import latest_run_report
+
+    assert latest_run_report("catalog_merge")["doi_duplicates_removed"] == 833
+
+
+def test_latest_report_returns_none_when_absent(tmp_path, monkeypatch):
+    """Absence is reported, not faked — callers decide how loud to be."""
+    monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+    (tmp_path / "run_reports").mkdir()
+    from pipeline_io import latest_run_report
+
+    assert latest_run_report("catalog_merge") is None

--- a/tickets/closed/0349-a-clean-rebuild-puts-missing-into-the-dat.erg
+++ b/tickets/closed/0349-a-clean-rebuild-puts-missing-into-the-dat.erg
@@ -2,6 +2,7 @@
 Title: catalog_merge's run report is an undeclared side-effect output
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: catalog_merge.json declared in the stage outs; latest_run_report replaces the lexicographic glob and ignores non-timestamp run ids
 
 --- log ---
 2026-07-27T15:15Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 2026-07-27T15:52Z HDMX-coding-agent correction The [MISSING] was my artifact, not a defect. Ticket rescoped and downgraded; see the correction section. needs-human removed
 
 2026-07-27T13:36Z HDMX-coding-agent note observation from 0347's corpus rerun, not a fix of this ticket. catalog_merge ran on 2026-07-27 and wrote data/catalogs/run_reports/catalog_merge__20260727T132143Z.json carrying doi_duplicates_removed=833 and title_year_duplicates_removed=159 — the two values already in the author's vars file, so those numbers reproduce from the pipeline and are not stale survivors. Note also that reports from the 07-24 build were already on disk in the main checkout (catalog_merge__20260724T132552Z.json, same two keys). That makes the 'artifact was never generated' premise worth re-checking before acting: a clean 'make stats' run inside a git worktree sees an empty data/ (only .dvc pointers, no run_reports) unless the DVC data is pulled, which would produce the same [MISSING] fallback with the artifact present all along. I have not isolated which of the two it is — reporting the observation, not the cause. Cheap discriminator: re-run the make pass in the main checkout where data/ is populated.
+2026-07-27T14:16Z HDMX-coding-agent closed — catalog_merge.json declared in the stage outs; latest_run_report replaces the lexicographic glob and ignores non-timestamp run ids
 --- body ---
 ## Correction (2026-07-27): the premise was wrong
 


### PR DESCRIPTION
**Ticket:** tickets/0349-a-clean-rebuild-puts-missing-into-the-dat.erg

## The wiring

`compute_vars.dedup_stats` sources two published data-paper numbers from the latest `catalog_merge` run report, but the DVC stage declared only `unified_works.csv`. A cache hit there skips the stage and leaves the report describing an older merge than the corpus in hand.

DVC `outs:` are fixed paths and the report is timestamped — which is *why* it was never declared, not an oversight. `catalog_merge` now also writes a stable `catalog_merge.json` (the repo's existing sentinel-stamp answer for data-dependent filenames, per the architecture rule), and `dvc.yaml` declares it. The timestamped siblings stay as run history.

## The sharper half: the glob hijack

`dedup_stats` did `sorted(glob("catalog_merge__*.json"))[-1]`. Run ids are UTC timestamps starting with a digit, so **any `catalog_merge__test*.json` sorted last** and would silently become the source of `dedup_doi_removed` and `dedup_titleyear_removed`.

`latest_run_report` prefers the declared stable file, else ranks only timestamp-shaped run ids. Fixtures with exactly that unsafe shape leak into the real corpus directory today (ticket 0346), so this was a near-miss rather than a hypothetical.

## Two things worth reviewing

**`catalogs_dir` is injectable, and that's the design, not a convenience.** My first version read `pipeline_loaders.CATALOGS_DIR` at call time and broke two dedup tests that patch `compute_vars.CATALOGS_DIR` — I had reproduced the exact 0346 defect *inside the fix for it*. Callers now pass the directory they already resolved.

**`test_dedup_vars`' fixture moves from `catalog_merge__test.json` to a timestamped name.** Not a weakening: the old name is precisely what the new selector rejects, so leaving it would pin a path the pipeline refuses. The test failing on it is the guard demonstrating itself.

## Gate

`make lint` 171 passed · fast tier 1174 passed · 4 new tests in `test_run_report_wiring.py`, all red before the fix.

**Invariant held:** the dedup counts still resolve to 833 and 159 on the current corpus. This ticket must not move a number, and does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)