### PR TITLE
doc(ed04): record the Zenodo metadata checklist — ORCID, CNRS funding

### DIFF
--- a/deliverables/data-paper/revision-rdj26561/ed04-zenodo-restructure-upload.md
+++ b/deliverables/data-paper/revision-rdj26561/ed04-zenodo-restructure-upload.md
@@ -21,11 +21,35 @@ the latest version.
    the new one.
 3. Replace the record description with the text below; keep title, authors,
    license (data CC BY 4.0, code MIT), and keywords unchanged.
-4. Set the version field (suggested: `v1.1.1` — same data, restructured
+4. Fill the record metadata below (ORCID, funding). It persists across
+   versions, so this is a one-time pass.
+5. Set the version field (suggested: `v1.1.1` — same data, restructured
    packaging + codebook) and publish.
-5. Check that the paper's cited DOI still resolves; the paper cites
+6. Check that the paper's cited DOI still resolves; the paper cites
    10.5281/zenodo.19236130 — if the journal prefers, switch the citation to
    the concept DOI or the new version DOI at proof stage.
+
+## Record metadata (author, one pass)
+
+Typed into the Zenodo form by hand: the upload is a web click-path, so no
+repo-side metadata file is read. These three items are the whole list.
+
+- **ORCID** on the author entry: `0000-0001-9988-2100`. Already carried by the
+  paper front matter (`deliverables/data-paper/data-paper.qmd:5`); the Zenodo
+  record is the only other place it belongs.
+- **Funding**: CNRS. Zenodo's funder picker resolves either identifier —
+  ROR `https://ror.org/02feahw73`, Crossref Funder ID
+  `10.13039/501100004794` (verified against both registries 2026-07-27; the ROR
+  record carries the same fundref ID). Recurring institutional support with no
+  grant number: leave the award field empty rather than inventing one.
+- **Related identifier** — `IsSupplementTo` the journal article, added **at
+  proof stage**: RDJ4HSS has not assigned the article DOI yet, so the field
+  cannot be filled on this version. This is the relation that makes the
+  paper↔data link machine-traversable, which is what a data journal indexes on.
+
+Do **not** hand-add the version relation. Zenodo sets `IsVersionOf` /
+`HasVersion` between the concept DOI and each version DOI itself when you use
+the **New version** button; adding it manually duplicates the chain.
 
 ## Record description (new version)
 


### PR DESCRIPTION
Closes the envelope half of the deposit-metadata question as a **checklist**, per the author's decision: manual web upload, one resubmission, so no repo-side `CITATION.cff` or `.zenodo.json` — neither would ever be read, and shipping one would be metadata nothing consumes.

Adds a `## Record metadata (author, one pass)` section to the ED-04 upload runbook with exactly three items:

| Item | Value |
|:--|:--|
| ORCID | `0000-0001-9988-2100` (already at `data-paper.qmd:5`) |
| Funding | CNRS — ROR `02feahw73`, Crossref Funder ID `10.13039/501100004794` |
| `IsSupplementTo` | the article DOI, **at proof stage** — RDJ4HSS has not assigned it yet |

**Identifiers verified, not recalled.** Queried both registries; the ROR record's own `fundref` external ID matches the Crossref funder DOI, so the two cross-confirm. A wrong funder ID in a runbook is worse than an absent one.

**Two deliberate omissions, both documented in the file:**

- The **award field stays empty** — recurring institutional support has no grant number, and inventing one is worse than omitting it.
- The **version relation is not hand-added**. Zenodo's *New version* button builds the `IsVersionOf`/`HasVersion` chain between concept and version DOIs itself; a manual entry duplicates it.

Steps 4–5 renumbered to 5–6 to seat the new metadata step.

`make lint`: 170 passed, 6 skipped.

Not self-merged — this is data-paper revision material, so the arbitration is yours.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)