### PR TITLE
fix(0346): stop tests writing run reports into the DVC corpus directory

### DIFF
--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -19,6 +19,24 @@ import pytest
 pytestmark = pytest.mark.integration
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_root(tmp_path_factory, monkeypatch):
+    """Point DATA_DIR at scratch for every test in this module.
+
+    These tests spawn pipeline scripts with ``cwd=REPO_ROOT``. A monkeypatch
+    cannot cross a process boundary, so without this the child resolves
+    CATALOGS_DIR from the repo's own ``.env`` (``data``) and its run report
+    lands in the DVC-tracked ``data/catalogs/run_reports/`` (ticket 0346).
+
+    Setting the variable in ``os.environ`` rather than at each call site is
+    deliberate: child processes inherit it, so a subprocess call added later
+    cannot forget the redirect. ``load_dotenv`` runs with ``override=False``,
+    so this wins over the checked-in ``.env``.
+    """
+    monkeypatch.setenv("CLIMATE_FINANCE_DATA", str(tmp_path_factory.mktemp("data_root")))
+
 SCRIPTS_DIR = os.path.join(REPO_ROOT, "scripts")
 HARVEST_DIR = os.path.join(SCRIPTS_DIR, "harvest")
 sys.path.insert(0, SCRIPTS_DIR)

--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 
 import pandas as pd
+import pipeline_loaders
 import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
@@ -104,20 +105,25 @@ class TestUtilsHelpers:
         from utils import save_run_report
 
         orig = utils.CATALOGS_DIR
+        orig_pl = pipeline_loaders.CATALOGS_DIR
         utils.CATALOGS_DIR = str(tmp_path)
+        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
         try:
             data = {"elapsed_seconds": 1.5, "rows_written": 42}
             path = save_run_report(data, "test-run-001", "my_script")
             assert os.path.isfile(path)
         finally:
             utils.CATALOGS_DIR = orig
+            pipeline_loaders.CATALOGS_DIR = orig_pl
 
     def test_save_run_report_json_schema(self, tmp_path):
         import utils
         from utils import save_run_report
 
         orig = utils.CATALOGS_DIR
+        orig_pl = pipeline_loaders.CATALOGS_DIR
         utils.CATALOGS_DIR = str(tmp_path)
+        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
         try:
             data = {"counter_a": 10, "counter_b": 5, "elapsed_seconds": 2.0}
             path = save_run_report(data, "run-xyz", "test_script")
@@ -129,13 +135,16 @@ class TestUtilsHelpers:
             assert payload["elapsed_seconds"] == 2.0
         finally:
             utils.CATALOGS_DIR = orig
+            pipeline_loaders.CATALOGS_DIR = orig_pl
 
     def test_save_run_report_sanitizes_run_id(self, tmp_path):
         import utils
         from utils import save_run_report
 
         orig = utils.CATALOGS_DIR
+        orig_pl = pipeline_loaders.CATALOGS_DIR
         utils.CATALOGS_DIR = str(tmp_path)
+        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
         try:
             path = save_run_report({}, "run id/with spaces&special!", "script")
             assert os.path.isfile(path)
@@ -145,6 +154,7 @@ class TestUtilsHelpers:
             assert "/" not in basename
         finally:
             utils.CATALOGS_DIR = orig
+            pipeline_loaders.CATALOGS_DIR = orig_pl
 
     def test_retry_get_importable(self):
         from utils import retry_get
@@ -445,7 +455,9 @@ class TestRunReport:
         from utils import save_run_report
 
         orig = utils.CATALOGS_DIR
+        orig_pl = pipeline_loaders.CATALOGS_DIR
         utils.CATALOGS_DIR = str(tmp_path)
+        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
         try:
             missing_before = 10
             missing_after = 3
@@ -466,6 +478,7 @@ class TestRunReport:
             assert payload["elapsed_seconds"] > 0
         finally:
             utils.CATALOGS_DIR = orig
+            pipeline_loaders.CATALOGS_DIR = orig_pl
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_report_isolation.py
+++ b/tests/test_run_report_isolation.py
@@ -1,0 +1,124 @@
+"""Tests must not write run reports into the real corpus directory.
+
+Ticket 0346. `data/catalogs/run_reports/` is a DVC output. Six fixture files
+were being rewritten there on every suite run — for four and a half months, and
+into four committed DVC snapshots — by two independent mechanisms:
+
+1. Patching ``utils.CATALOGS_DIR`` when ``save_run_report`` resolves
+   ``pipeline_loaders.CATALOGS_DIR`` inside its own body. The patch is a no-op
+   and the test still reports green.
+2. Spawning a script as a subprocess with ``cwd=REPO_ROOT`` and no
+   ``CLIMATE_FINANCE_DATA`` in its environment. A monkeypatch cannot cross a
+   process boundary; the child resolves the real directory.
+
+Both guards below are on the mechanism, not on the six filenames, so a new test
+written the old way fails immediately rather than quietly polluting the corpus.
+"""
+
+import ast
+import os
+import re
+
+import pytest
+from utils import BASE_DIR
+
+TESTS_DIR = os.path.join(BASE_DIR, "tests")
+
+
+def _test_sources():
+    for name in sorted(os.listdir(TESTS_DIR)):
+        if name.startswith("test_") and name.endswith(".py"):
+            path = os.path.join(TESTS_DIR, name)
+            with open(path, encoding="utf-8") as fh:
+                yield name, fh.read()
+
+
+@pytest.mark.adherence
+def test_no_test_patches_catalogs_dir_on_the_facade():
+    """Patch the module that defines the constant, not a re-export of it.
+
+    ``scripts/utils.py`` re-exports ``CATALOGS_DIR`` from ``pipeline_loaders``.
+    Rebinding the re-export leaves the definition site untouched, so anything
+    reading it at call time — ``save_run_report`` does — still sees the real
+    corpus directory.
+    """
+    offenders = []
+    for name, src in _test_sources():
+        patches_facade = re.search(r"^\s*utils\.CATALOGS_DIR\s*=", src, re.M)
+        if not patches_facade:
+            continue
+        # Patching the facade as well is fine — other code reads the re-export.
+        # What is not fine is patching *only* the facade.
+        patches_source = re.search(r"^\s*(?:pl|pipeline_loaders)\.CATALOGS_DIR\s*=", src, re.M) \
+            or 'setattr("pipeline_loaders.CATALOGS_DIR"' in src
+        if not patches_source:
+            offenders.append(name)
+    assert not offenders, (
+        "tests rebind utils.CATALOGS_DIR, which does not redirect "
+        "save_run_report: " + ", ".join(offenders) +
+        " - patch pipeline_loaders.CATALOGS_DIR instead"
+    )
+
+
+def _spawns_repo_script_without_data_env(src):
+    """Yield line numbers of subprocess calls that can reach the real corpus.
+
+    A call qualifies when it runs with ``cwd=REPO_ROOT`` and passes no ``env``.
+    Without ``env``, the child inherits the ambient environment, where
+    ``CLIMATE_FINANCE_DATA`` is normally unset — so ``pipeline_loaders`` falls
+    back to the repo's own ``.env`` (``data``), resolved against ``REPO_ROOT``.
+    """
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "attr", None) or getattr(func, "id", None)
+        if name not in {"run", "check_output", "Popen", "call"}:
+            continue
+        kwargs = {kw.arg for kw in node.keywords}
+        if "cwd" not in kwargs or "env" in kwargs:
+            continue
+        cwd_kw = next(kw for kw in node.keywords if kw.arg == "cwd")
+        if not (isinstance(cwd_kw.value, ast.Name) and cwd_kw.value.id == "REPO_ROOT"):
+            continue
+        # Only pipeline scripts can write a run report. Running ruff, make or
+        # git under cwd=REPO_ROOT is not this defect.
+        if not node.args:
+            continue
+        argsrc = ast.get_source_segment(src, node.args[0]) or ""
+        if re.search(r"\.py[\"\']|HARVEST_DIR|ANALYSIS_DIR|SCRIPTS_DIR", argsrc):
+            yield node.lineno
+
+
+@pytest.mark.adherence
+def test_no_test_spawns_a_repo_script_without_redirecting_data():
+    """A child process needs the env; a monkeypatch cannot reach it.
+
+    Two acceptable shapes: an explicit ``env=`` at each call, or one autouse
+    fixture setting ``CLIMATE_FINANCE_DATA`` for the module. The second is
+    preferred — a call site added later inherits the redirect instead of having
+    to remember it — so a module using it is exempt wholesale.
+    """
+    offenders = []
+    for name, src in _test_sources():
+        if 'setenv("CLIMATE_FINANCE_DATA"' in src:
+            continue
+        for lineno in _spawns_repo_script_without_data_env(src):
+            offenders.append(f"{name}:{lineno}")
+    assert not offenders, (
+        "tests spawn a script with cwd=REPO_ROOT and no env, so it resolves the "
+        "real data/catalogs and its run report lands in the DVC output: "
+        + ", ".join(offenders) +
+        " - pass env={**os.environ, 'CLIMATE_FINANCE_DATA': str(tmp_path)}"
+    )
+
+
+def test_save_run_report_honours_the_patched_definition_site(tmp_path, monkeypatch):
+    """The positive counterpart: patching the right module does redirect."""
+    monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+    from pipeline_io import save_run_report
+
+    path = save_run_report({"n": 1}, "isolation-probe", "probe_script")
+    assert os.path.realpath(path).startswith(os.path.realpath(str(tmp_path))), (
+        f"run report escaped the tmp dir to {path}"
+    )

--- a/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
+++ b/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
@@ -7,6 +7,8 @@ Author: HDMX-coding-agent
 2026-07-27T15:01Z HDMX-coding-agent created
 2026-07-27T15:01Z HDMX-coding-agent note Found while investigating unexpected mtimes in data/catalogs during the 0344 make pass
 2026-07-27T16:05Z HDMX-coding-agent note Read-only follow-up: TWO leak mechanisms, not one; 4.5 months old; fixtures are inside committed DVC snapshots; and a latent glob collision that would silently replace a data-paper number
+2026-07-27T16:45Z HDMX-coding-agent correction Two claims in the read-only pass were wrong: load_dotenv does NOT override an exported var, and test_phase1_contract was never a culprit. Corrected below
+2026-07-27T16:48Z HDMX-coding-agent note Leak fixed and proven by mtime. Deletion of the 8 files deliberately deferred — see the last section
 
 --- body ---
 ## Context
@@ -77,6 +79,78 @@ exactly such a file (`catalog_merge__test.json`) and is correctly isolated to
 fails by two independent mechanisms in neighbouring files, treat the near-miss
 as the real finding: a leaked fixture would not merely litter the directory, it
 would replace a published number.
+
+## Corrections to the read-only pass (2026-07-27)
+
+Two claims made above were wrong and are withdrawn.
+
+**`load_dotenv` does not override an exported variable.** `pipeline_loaders`
+calls `load_dotenv(...)` with the default `override=False`, and reads
+`CLIMATE_FINANCE_DATA` from `os.environ` afterwards. Measured directly: with
+the variable exported, `CATALOGS_DIR` resolves under the exported path; with it
+unset, it falls back to the checked-in `.env` value `data`, resolved against
+the process's cwd. So an inherited environment variable is a reliable redirect,
+and the earlier claim that `.env` beats it is false.
+
+**`test_phase1_contract` was never a culprit.** It already builds
+`_env_with_data(tmp_path)` and passes it to every spawn. Its fixture,
+`corpus_align__test-align-001.json`, is dated 2026-03-25 and has not been
+rewritten since — a relic of the code before that helper existed.
+`enrich_citations_batch__test-preview.json` (2026-03-25) is the same.
+
+Discriminating by mtime, the *active* leakers were exactly two files, six
+fixtures, all rewritten within minutes of each other on every suite run:
+
+    test_robustness_observability.py  my_script__test-run-001
+                                      test_script__run-xyz
+                                      script__run_id_with_spaces_special_
+                                      enrich_abstracts__consistency-test
+    test_pipeline_e2e.py              corpus_align__smoke-test
+                                      corpus_align__e2e-smoke
+
+## What was fixed
+
+- `test_robustness_observability.py` now patches `pipeline_loaders.CATALOGS_DIR`
+  alongside the `utils` facade, in all four save/restore blocks.
+- `test_pipeline_e2e.py` gains one autouse fixture setting
+  `CLIMATE_FINANCE_DATA` for the whole module, rather than an `env=` argument at
+  each of its twelve spawn sites. Child processes inherit it, so a subprocess
+  call added later cannot forget the redirect.
+- Two adherence guards on the mechanisms, not the filenames: no test may patch
+  `utils.CATALOGS_DIR` without also patching the defining module, and no test
+  may spawn a pipeline script with `cwd=REPO_ROOT` unless it passes `env=` or
+  sets the variable in an autouse fixture.
+
+Proven rather than assumed: with the fix in place, running both suites leaves
+the mtimes of the real fixtures untouched. An earlier check compared file
+*contents* and looked clean because the leaked writes were byte-identical —
+content equality is not evidence here, mtime is.
+
+## Why the eight files are still there
+
+Deleting them now would accomplish nothing. Several sibling sessions run their
+own worktree copies of `tests/`, still carrying the pre-fix code; four of the
+fixtures were rewritten at 16:38--16:39 by one of them *while this fix was
+being written*. The deletion becomes durable only once this lands and the other
+sessions rebase onto it.
+
+The remaining step, to run then:
+
+    rm data/catalogs/run_reports/{corpus_align__e2e-smoke,corpus_align__smoke-test,
+       corpus_align__test-align-001,enrich_abstracts__consistency-test,
+       enrich_citations_batch__test-preview,my_script__test-run-001,
+       script__run_id_with_spaces_special_,test_script__run-xyz}.json
+    dvc add data/catalogs/run_reports   # then commit the updated .dvc
+
+The eight are exactly the files whose run id is not a UTC timestamp — the same
+criterion `latest_run_report` now uses to ignore them, so nothing reads them
+even while they sit there.
+
+Not fixable by deletion: the fixtures are inside four committed DVC snapshots,
+one of which is the hash `run_reports.dvc` points at. Removing them from
+history would mean rewriting DVC state; leaving them is harmless now that no
+consumer selects a non-timestamp report. That is an author call, recorded here
+rather than taken.
 
 ## Root cause
 


### PR DESCRIPTION
**Ticket-ref:** tickets/0346-run-report-tests-patch-the-wrong-module-a.erg

Deliberately `Ticket-ref:`, not `Ticket:` — one exit criterion (deleting the eight fixture files) cannot be met yet. See the last section.

## Two mechanisms, both closed

- `test_robustness_observability.py` patched `utils.CATALOGS_DIR` while `save_run_report` resolves `pipeline_loaders.CATALOGS_DIR` inside its own body — a no-op. Now patches both, in all four save/restore blocks.
- `test_pipeline_e2e.py` spawned scripts with `cwd=REPO_ROOT` and no `env`; a monkeypatch cannot cross a process boundary. Fixed with **one autouse fixture** setting `CLIMATE_FINANCE_DATA` for the module rather than an `env=` at each of twelve spawn sites — child processes inherit it, so a call added later cannot forget the redirect.

## Two claims of mine, withdrawn

**`load_dotenv` does not beat an exported variable.** It runs with `override=False`. Measured both ways: exported → resolves under the exported path; unset → falls back to `.env`'s `data` against cwd. My ticket text said the opposite.

**`test_phase1_contract` was never a culprit.** It already builds `_env_with_data(tmp_path)`. Its fixture is dated 2026-03-25 and hasn't been rewritten since — a relic from before that helper existed. Discriminating by *mtime* rather than by name, the active leakers were exactly two files, six fixtures.

## Proven, not assumed

With the fix in place, running both suites leaves the real fixtures' mtimes **untouched**.

An earlier check of mine compared file *contents* and looked clean — because the leaked writes were byte-identical. Content equality is not evidence here; mtime is. Worth noting for whoever reviews this.

## Guards

Two adherence guards, on the mechanisms rather than the eight filenames. The second accepts either an explicit `env=` or the autouse-fixture shape, so it rewards the more robust fix instead of pinning one idiom. Both were red before the fix and named exactly the two offending files once narrowed (the first pass also flagged `test_ruff.py` and `_patched_merge_dirs`, which are innocent).

## Why the files are still there

Deleting now accomplishes nothing: sibling sessions run their own worktree copies of `tests/` still carrying pre-fix code — **four fixtures were rewritten at 16:38 by one of them while this fix was being written.** Deletion becomes durable only once this lands and those sessions rebase. The recipe is in the ticket, which stays open for it.

Not fixable by deletion either way: the fixtures sit inside four committed DVC snapshots, one being the hash `run_reports.dvc` points at. Removing them means rewriting DVC state — an author call, recorded rather than taken. Harmless now that `latest_run_report` ignores non-timestamp reports (#1170).

## Gate

`make lint` 176 passed · fast tier 1217 passed. Three pre-existing `.env` failures remain, from the sibling keystore migration against an **untracked** file this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)