### PR TITLE
data(0355): verify ref_match and align, then record them in DVC

### DIFF
--- a/data/catalogs/run_reports.dvc
+++ b/data/catalogs/run_reports.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 42bc3e29ab25f7aa1ffb2cd687b41472.dir
-  size: 59970
-  nfiles: 139
+- md5: a4ae94beee4d4d511adbc405cf7f0bc8.dir
+  size: 60681
+  nfiles: 141
   hash: md5
   path: run_reports

--- a/dvc.lock
+++ b/dvc.lock
@@ -263,8 +263,8 @@ stages:
       size: 93753009
     - path: data/catalogs/refined_works.csv
       hash: md5
-      md5: 1dbfa07c6c610cfccfea3b798f86fbd7
-      size: 66395965
+      md5: a2cdab95c82026b567b83947236321bd
+      size: 66400079
     - path: scripts/harvest/corpus_align.py
       hash: md5
       md5: 05f2e24e9f8f7d6099a6a7451bb64f11
@@ -275,20 +275,20 @@ stages:
       size: 14432
     - path: scripts/pipeline_loaders.py
       hash: md5
-      md5: a892abcf0b0205d7ca79575a54fced31
-      size: 15674
+      md5: 6ac145f69eb53adbd9b6fa6a750bc5c0
+      size: 18042
     - path: scripts/pipeline_progress.py
       hash: md5
       md5: 0279195c59e9de819e8b519490b26091
       size: 10311
     - path: scripts/pipeline_text.py
       hash: md5
-      md5: a3b002a94340e9b0cf56bf3773a40ded
-      size: 9971
+      md5: 5ef4cedb16c16c215b6589d53299f4a3
+      size: 11115
     - path: scripts/utils.py
       hash: md5
-      md5: 244f7b96ab8207c15a695f83da16a3a0
-      size: 6006
+      md5: 113d9b646b3bebfa6237c8922f7cd5e5
+      size: 6034
     outs:
     - path: data/catalogs/refined_citations.csv
       hash: md5
@@ -951,8 +951,8 @@ stages:
       size: 51497696
     - path: data/catalogs/refined_works.csv
       hash: md5
-      md5: 1dbfa07c6c610cfccfea3b798f86fbd7
-      size: 66395965
+      md5: a2cdab95c82026b567b83947236321bd
+      size: 66400079
     - path: scripts/corpus_merge_citations.py
       hash: md5
       md5: 66392d9fa594e9cfe82983ccfead922f
@@ -967,12 +967,12 @@ stages:
       size: 14432
     - path: scripts/pipeline_text.py
       hash: md5
-      md5: a3b002a94340e9b0cf56bf3773a40ded
-      size: 9971
+      md5: 5ef4cedb16c16c215b6589d53299f4a3
+      size: 11115
     - path: scripts/utils.py
       hash: md5
-      md5: 244f7b96ab8207c15a695f83da16a3a0
-      size: 6006
+      md5: 113d9b646b3bebfa6237c8922f7cd5e5
+      size: 6034
     outs:
     - path: data/catalogs/citations.csv
       hash: md5

--- a/tickets/0360-worktree-dvc-cache-is-private-so-make-da.erg
+++ b/tickets/0360-worktree-dvc-cache-is-private-so-make-da.erg
@@ -1,0 +1,123 @@
+%erg 0.1
+Title: A worktree's DVC cache is private and empty, so `make data` cannot work there
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T14:42Z HDMX-coding-agent created
+2026-07-27T14:50Z HDMX-coding-agent note filed while hunting 0355. My first diagnosis was wrong twice, recorded here so the correction is not lost: I read the checkout failure first as "DVC tracking is substantially incomplete", then as "the cache is missing the corpus". Both false — 29 of 33 recorded outs are in the cache, every standalone .dvc out is present, and cache and remote are in sync. The cause is narrower and fixable in one line.
+
+--- body ---
+## Context
+
+`.githooks/post-checkout` and the Makefile advertise `make data` as the way to
+populate a worktree's corpus on demand — the hook deliberately stopped copying
+data eagerly after ~1.7 GB made worktree creation time out. That path does not
+work:
+
+    $ cd .claude/worktrees/<any>
+    $ make data
+    uv run --env-file .env dvc checkout
+    ERROR: Checkout failed for following targets:
+    data/catalogs/unified_works.csv
+    data/catalogs/enriched_works.csv
+    … 12 more …
+    Is your cache up to date?
+
+## Cause
+
+A worktree resolves its DVC cache to its **own** directory:
+
+    # in the worktree
+    $ dvc cache dir
+    …/.claude/worktrees/t355-2803055/.dvc/cache    # empty
+    # in the primary checkout
+    $ dvc cache dir
+    /home/haduong/Climate_finance/.dvc/cache        # populated
+
+`.dvc/` is not tracked wholesale: a worktree gets `config` from git and
+`config.local` from `.worktreeinclude`, but the cache is gitignored, so a fresh
+worktree starts with none. And `config.local` sets only the remote URL —
+
+    ['remote "padme"']
+        url = /data/projets/dvc/oeconomia-climate-finance
+
+— never `cache.dir`. So `dvc checkout` looks in an empty private cache, finds
+nothing, and fails. `dvc pull` would succeed but copies the whole closure into
+every worktree, which is the cost the post-checkout hook exists to avoid.
+
+## What is genuinely missing from the cache (not the cause)
+
+Recorded because the first diagnosis blamed it: 4 of 33 recorded file outs are
+absent from the cache, all zero-byte stamp sentinels
+(`enrich_cache/.{dois,abstracts,language,summaries}.stamp`). Harmless, and
+unrelated to the checkout failure.
+
+## Consequence
+
+The documented on-demand path being unusable, the standing workaround becomes
+"run Phase 1 in the primary checkout" — which is what happened on ticket 0347.
+That gives up worktree isolation for corpus work and, in that instance, skipped
+the `dvc commit` / `dvc push` step entirely, leaving `dvc.lock` pointing at a
+superseded corpus until the author noticed.
+
+## Relevant files
+
+- `.dvc/config.local` — sets the remote, not `cache.dir`
+- `.worktreeinclude` — copies `.env` and `.dvc/config.local`
+- `.githooks/post-checkout` — documents `make data`; co-locates the uv env by
+  the same shared-resource reasoning, symlinked rather than copied
+- `Makefile` — the `data:` and `corpus-sync:` targets
+
+## Actions
+
+1. Point every worktree at the shared cache, by adding to the copied
+   `.dvc/config.local`:
+
+       [cache]
+           dir = /home/haduong/Climate_finance/.dvc/cache
+
+   `dvc checkout` then hardlinks or reflinks out of the shared cache —
+   near-instant, no duplication, no network. This mirrors what the hook already
+   does for the uv environment, and carries the same caveat
+   `rules/coding-python.md` records for the uv cache: it works because worktree
+   and cache share a filesystem.
+2. Prefer a computed path over the hard-coded absolute one, so the repo stays
+   clonable elsewhere: the post-checkout hook can derive it with
+   `dvc cache dir --local "$(git rev-parse --git-common-dir)/../.dvc/cache"`.
+3. Note in `.claude/rules/architecture.md` § Data location that a worktree needs
+   `make data` once, and that corpus work belongs in a worktree like any other
+   work.
+
+## Test
+
+Integration, and it must run in a real worktree — the failure is invisible from
+the primary checkout:
+
+    git worktree add <tmp> -b throwaway
+    cd <tmp> && make data
+    test -f data/catalogs/refined_works.csv
+
+Assert also that the checked-out file is a hardlink or reflink to the shared
+cache rather than a copy — compare inode with `stat -c %i`, or assert the
+worktree's own `.dvc/cache` stays empty — so a regression to per-worktree
+copying is caught by size now rather than by a timeout months later.
+
+## Verification
+
+- [ ] `dvc cache dir` in a worktree reports the shared cache
+- [ ] `make data` in a fresh worktree populates `data/catalogs/` with no network
+- [ ] The worktree's own `.dvc/cache` stays empty (no duplication)
+- [ ] Worktree creation time is unchanged
+
+## Invariants
+
+- No eager data copying at worktree creation — the timeout that motivated the
+  current hook must not come back.
+- The primary checkout's cache and the padme remote stay in sync.
+
+## Exit criteria
+
+- [ ] `make data` works in a worktree, cheaply, without network
+- [ ] Corpus work no longer needs the primary checkout, so it keeps git
+      isolation and the DVC bookkeeping that comes with a normal PR

--- a/tickets/closed/0355-ref-match-and-align-read-stale-in-dvc-af.erg
+++ b/tickets/closed/0355-ref-match-and-align-read-stale-in-dvc-af.erg
@@ -3,11 +3,17 @@ Title: ref_match and align read stale in DVC after the corpus repopulation
 Created: 2026-07-27
 Author: HDMX-coding-agent
 Label: needs-human
+Closed: verified-and-committed
 
 --- log ---
 2026-07-27T14:12Z HDMX-coding-agent created
 2026-07-27T14:15Z HDMX-coding-agent note deliberate residual of 0347, not an oversight. I could have silenced it with `dvc commit ref_match align`, which would assert those outputs correspond to the new refined_works.csv — a claim I cannot verify without running them, and running `align` rebuilds refined_embeddings.npz and refined_citations.csv, which feed the paper's citation statistics. Left stale on purpose: a truthful "may need re-running" beats a false "current".
 
+2026-07-27T14:42Z HDMX-coding-agent note VERIFIED then committed — action 1, not the cheaper action 2. Both stages re-run with outputs redirected to scratch (both accept explicit --out paths), so no shared artifact was overwritten during verification. All three DVC outs came out identical to what is on disk: citations.csv byte-identical, refined_citations.csv byte-identical, refined_embeddings.npz vectors array identical by shape/dtype/sha256 (the .npz container is a zip, so content was compared, not bytes). The ref_matches.csv intermediate was byte-identical too. align took 42s and kept 1,087,209 citation rows, matching the frozen figure. dvc commit -f ref_match align then recorded the new dep hashes; dvc status now reports both up to date, and dvc push had nothing to send because the outputs never changed.
+2026-07-27T14:42Z HDMX-coding-agent note honest limit on the ref_match evidence: its fuzzy matcher hit the cache on all 148,127 refs (0 new), so that run never consulted the corpus index and cannot by itself prove the corpus change is inert for this stage. What carries the argument for ref_match is inspection — _build_corpus_index reads only doi, title and year via explicit row.get calls, and 0347's byte-compare showed all three identical across every one of the 33,344 rows — plus the fact that citations.csv, the stage's actual DVC out, came out byte-identical through the full merge_citations path. align needs no such caveat: its documented matching key is doi then source_id with row-order alignment, all verified unchanged.
+2026-07-27T14:42Z HDMX-coding-agent note SIDE FINDING, bigger than this ticket: 'make data' cannot populate a worktree — dvc checkout fails with missing files for data/syllabi, openalex_citations.csv, istex_works.csv, refined_embeddings.npz and grey_works.csv, so neither the local cache nor the padme remote holds much of the corpus. The DVC tracking is substantially incomplete: padme's working tree is the only copy of several artifacts, and a clean-room reproduction of the deposit would fail. That is why verification here had to run against the primary checkout's data rather than an isolated worktree. Filed separately — it is a backup and reproducibility gap, not a 0355 blocker.
+2026-07-27T14:45Z HDMX-coding-agent note also committed data/catalogs/run_reports so the primary checkout's dvc checkout is no longer blocked: my catalog_merge and corpus_align runs had left two unsaved reports there, and DVC refuses to proceed past unsaved files without --force. 3 files pushed. The catalog_merge report is the one ticket 0349 is waiting on.
+2026-07-27T14:45Z HDMX-coding-agent closed — verified-and-committed
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/closed/0355-ref-match-and-align-read-stale-in-dvc-af.erg
**Ticket-ref:** tickets/0360-worktree-dvc-cache-is-private-so-make-da.erg
**Ticket-ref:** tickets/0349-a-clean-rebuild-puts-missing-into-the-dat.erg

0347 left `ref_match` and `align` reading stale in DVC — their recorded dep on `refined_works.csv` still named the pre-repopulation file. 0355 offered a cheap path (commit the dep hashes, assume the outputs match) and an honest one (re-run, byte-compare, then commit). This takes the honest one.

## Verification

Both stages accept explicit output paths, so the probe wrote to scratch and overwrote nothing:

| output | result |
|---|---|
| `citations.csv` | byte-identical |
| `refined_citations.csv` | byte-identical |
| `refined_embeddings.npz` | identical vectors: shape, dtype, sha256 |
| `ref_matches.csv` (intermediate) | byte-identical |

`align` ran in 42 s and kept 1,087,209 citation rows — the frozen figure. The `.npz` was compared by *content*, not bytes, because it is a zip whose container carries a timestamp. Only then `dvc commit -f ref_match align`; `dvc status ref_match align` now reports up to date, and `dvc push` had nothing to send — itself confirmation that no output moved.

**One limit, stated rather than glossed:** `ref_match`'s matcher hit its cache on all 148,127 refs (0 new), so that run never consulted the corpus index and proves nothing about corpus sensitivity on its own. What carries `ref_match` is inspection — `_build_corpus_index` reads only `doi`, `title`, `year` through explicit `row.get` calls, and 0347's byte-compare showed all three identical across every one of the 33,344 rows — plus `citations.csv`, its actual DVC out, matching through the full `merge_citations` path. `align` needs no caveat: its documented key is `doi` then `source_id` with row-order alignment.

## Also here

`run_reports.dvc` moves because my `catalog_merge` and `corpus_align` runs left two unsaved reports there, which blocks `dvc checkout` in the primary checkout until saved (3 files pushed). One of them is the `catalog_merge` report **0349** is waiting on.

## New ticket 0360 — and a correction

While diagnosing why verification could not run in a worktree, I filed 0360: **a worktree's DVC cache is private and empty**, so the documented `make data` path cannot work. `.worktreeinclude` copies `.dvc/config.local`, but that file sets only the remote URL, never `cache.dir` — so `dvc checkout` searches an empty cache. One-line fix, with a computed-path variant so the repo stays clonable.

My first two diagnoses of that failure were wrong and the ticket records both: I called it "DVC tracking is substantially incomplete", then "the cache is missing the corpus". Neither is true — 29 of 33 recorded outs are cached, every standalone `.dvc` out is present, and cache and remote are in sync. The only genuinely absent blobs are 4 zero-byte stamp sentinels.

This is the root cause of the 0347 detour: with `make data` unusable, the standing workaround becomes "run Phase 1 in the primary checkout", which gives up worktree isolation and, there, skipped the DVC bookkeeping entirely.

## Gate

`make lint` 177 passed · `make check-fast` exit 0 · `erg check` PASS (346 tickets). No CI here. Branch is current with `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)