### PR TITLE
tickets(0364-0366): file the 0343 wrap-up sweep findings

### DIFF
--- a/tickets/0364-hal-credentials-are-not-selected-by-keys.erg
+++ b/tickets/0364-hal-credentials-are-not-selected-by-keys.erg
@@ -1,0 +1,70 @@
+%erg 0.1
+Title: HAL credentials are not selected by KEYS= so update-publist cannot deposit
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T15:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Found by the ticket 0343 wrap-up sweep. `.claude/skills/update-publist/SKILL.md`
+step 5 says "Credentials from `.env`: `HAL_ID`, `HAL_PASSWORD`". Neither is in
+`.env`, and neither has been — 0343 removed `AGENT_GH_TOKEN`, `OPENALEX_API_KEY`
+and `S2_API_KEY`, never these. So this predates 0343 and was not caused by it;
+0343 only made the class visible.
+
+Both values *do* exist in `~/.config/keys/hal.env`. What is missing is the
+selection: the `KEYS=` line in `.env` does not name `hal`, and selection is
+default-deny, so nothing loads them. Measured from the repo root with the loader
+active — `HAL_ID: ABSENT`, `HAL_PASSWORD: ABSENT`.
+
+Consequence: the HAL SWORD deposit step of `/update-publist` cannot authenticate.
+The failure mode matches the one 0343 documented — a missing credential reads as
+an ordinary auth failure rather than as misconfiguration, so the cause is not
+obvious from the error.
+
+## Relevant files
+
+- `.env` — the `KEYS=` line needs a `hal` selection. Gitignored, machine-local,
+  and **never** a place to write the values themselves.
+- `~/.config/keys/hal.env` — already holds `HAL_ID` and `HAL_PASSWORD`, mode 0600.
+- `.claude/skills/update-publist/SKILL.md:77` — the stale "from `.env`" claim.
+- `tests/test_env_has_no_secret_literals.py` — `STALE_ENV_CLAIMS` and
+  `REQUIRED_KEYS_EXPORTS` are the two ratchets that should cover this.
+
+## Actions
+
+1. Extend the `KEYS=` line with `hal:HAL_ID,hal:HAL_PASSWORD` (selection form,
+   not bare `hal` — same least-privilege reasoning as the other four).
+2. Correct `SKILL.md:77` to name the keystore as the source.
+3. Add `HAL_ID` / `HAL_PASSWORD` to `REQUIRED_KEYS_EXPORTS` so a future removal
+   fails a test instead of a deposit.
+4. Add the SKILL.md phrasing to `STALE_ENV_CLAIMS` if it survives step 2 in a
+   form the existing patterns miss.
+
+## Test
+
+Extend `tests/test_env_has_no_secret_literals.py::test_keys_line_selects_every_consumed_credential`
+by adding both names to `REQUIRED_KEYS_EXPORTS`. It must fail before step 1 and
+pass after. Names only in any assertion message — never a value.
+
+## Verification
+
+- [ ] `HAL_ID` and `HAL_PASSWORD` resolve from the repo root and from a worktree
+- [ ] Each matches `~/.config/keys/hal.env` **by hash** — never by printing
+- [ ] `SKILL.md` no longer names `.env` as the credential source
+- [ ] The extended ratchet fails on the pre-fix `.env`
+
+## Invariants
+
+- No credential value in any committed file, test output, or PR description.
+- `~/.config/keys/` stays the single store; do not copy values into `.env`.
+- No CI (AGENTS.md, ticket 0321): run `make check` locally before the PR.
+
+## Exit criteria
+
+`/update-publist` can authenticate to HAL because `KEYS=` selects both
+credentials from the keystore, the skill documents that source correctly, and a
+test fails if either selection is dropped.

--- a/tickets/0365-hdmx-coding-agent-is-not-a-github-accoun.erg
+++ b/tickets/0365-hdmx-coding-agent-is-not-a-github-accoun.erg
@@ -1,0 +1,90 @@
+%erg 0.1
+Title: HDMX-coding-agent is not a GitHub account: decide whether to provision one
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T15:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`HDMX-coding-agent` is a git author name, not a GitHub account.
+`gh api users/HDMX-coding-agent` returns 404. `AGENT_GH_TOKEN` authenticates as
+**MinhHaDuong** with scopes `gist, read:org, repo, workflow` — the repository
+owner's own token, not a scoped machine PAT.
+
+Found while verifying ticket 0343's exit criterion that agent git operations
+still authenticate. They do: the token is byte-identical before and after that
+migration, so nothing here was caused by it. What 0343 did was make the claim
+checkable, and it turned out false in three places, now corrected:
+`.claude/rules/git.md`, `docs/data-management-plan.md`, and the
+`agentic-workflow.md` include.
+
+Two consequences remain, and both need a decision rather than an edit.
+
+**The merge gate rests on self-review.** `.claude/hooks/check-reviews.sh` counts
+reviews whose author is in `AGENT_LOGINS="HDMX-coding-agent MinhHaDuong"`. The
+first never matches anything, so the gate is satisfied by the PR author
+reviewing their own PR. The file already recorded accepting `MinhHaDuong` as a
+deliberate trade ("enables web-agent merges at the cost of permitting
+self-review"); what was not known is that the other half is inert, so the cost is
+paid unconditionally rather than as a fallback.
+
+**The data-management plan describes an access-control property the project does
+not have.** The DMP is a paper-facing deliverable; a reviewer reading "scoped
+GitHub PAT for CI/automation only" would infer a separation of privilege that
+does not exist. The prose is now accurate, but accuracy was achieved by removing
+the claim, not by making it true.
+
+## The decision
+
+Three options, in increasing cost:
+
+1. **Accept and document.** The agent is the author's hands; one identity is
+   honest. Drop the dead entry from `AGENT_LOGINS` and state plainly in the DMP
+   that agent and human share forge credentials. Cheapest, and defensible for a
+   single-author project.
+2. **Provision a real machine account** with a fine-grained PAT scoped to this
+   repository. Restores the separation the docs used to claim, makes the review
+   gate meaningful, and limits blast radius if the token leaks — which is the
+   scenario ticket 0343 exists to bound.
+3. **Keep one account, fix only the gate** — require a human review that is not
+   the PR author, independent of identity. Addresses self-review without
+   provisioning anything.
+
+MOA call: option 2 buys real privilege separation at the cost of account
+management; option 1 is honest but leaves the gate ornamental.
+
+## Relevant files
+
+- `.claude/hooks/check-reviews.sh` — `AGENT_LOGINS`, and the comment that now
+  records the dead entry
+- `docs/data-management-plan.md` § 3.2 — access management
+- `.claude/rules/git.md` — agent identity
+- `AGENTS.md` § Credentials — where a machine token would be selected via `KEYS=`
+
+## Actions
+
+1. Author decides between the three options above.
+2. Implement the chosen one, including the DMP wording.
+3. If option 2: add the machine token to `~/.config/keys/github.env` under its own
+   name and select it via `KEYS=` with the rename form, so the two identities
+   never collide under one variable.
+
+## Verification
+
+- [ ] `check-reviews.sh` contains no login that cannot match a review author
+- [ ] The DMP's § 3.2 claim is verifiable against the live configuration
+- [ ] If a machine account exists, `gh api user` under its token returns it
+
+## Invariants
+
+- No credential value in any committed file, test output, or PR description.
+- Whatever is decided, docs must describe what is true, not what is intended.
+
+## Exit criteria
+
+The project's forge identity is decided and documented, every doc describing it
+is verifiable, and the review gate either counts a review the author cannot
+supply alone or is honestly described as not doing so.

--- a/tickets/0366-main-is-red-corpus-freshness-and-bimodal.erg
+++ b/tickets/0366-main-is-red-corpus-freshness-and-bimodal.erg
@@ -1,0 +1,79 @@
+%erg 0.1
+Title: main is red: corpus freshness and bimodality dip fail on stale artifacts
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T15:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`make check` on current `main` fails three tests. None is a code defect; all
+three are stale-artifact state, and they were surfaced by the ticket 0343 gate
+run, which touched no corpus or analysis code.
+
+    tests/test_corpus_acceptance.py::TestCorpusAlign::test_refined_embeddings_freshness
+    tests/test_corpus_acceptance.py::TestCorpusAlign::test_refined_citations_freshness
+    tests/test_bimodality_dip.py::test_bimodality_dip_column_is_not_silently_empty
+
+**The two freshness failures.** A Phase-1 rebuild ran in the primary checkout on
+2026-07-27 while the gate was running: `refined_works.csv` moved from 13:21 to
+15:29 and again to 16:09, while `refined_embeddings.npz` and
+`refined_citations.csv` stayed at 13:21. The contract says the aligned artifacts
+are 1:1 with `refined_works.csv`; they are now older than it, which is exactly
+what the assertions detect. Whether the rebuild finished is worth checking before
+regenerating — a half-run pipeline is the more interesting possibility.
+
+**The dip failure.** `dip_pvalue is present but empty in every row`. The test
+arrived on main with the ticket 0330 fix (diptest was undeclared). It reads
+`data/derived/tables/tab_bimodality.csv`, dated 2026-07-24 — written before that
+fix, when `diptest` was absent and the column came out empty. The test is
+correct and the table predates it.
+
+Worth separating: 0330 made an undeclared dependency a hard error, which is why
+this is now visible. The remaining work is regeneration, not another code fix.
+
+## Relevant files
+
+- `data/catalogs/{refined_works.csv,refined_embeddings.npz,refined_citations.csv}`
+  — Phase-1 contract, DVC-managed
+- `data/derived/tables/tab_bimodality.csv`, `tab_bimodality_core.csv` — Phase-2,
+  gitignored and regenerable
+- `tests/test_corpus_acceptance.py`, `tests/test_bimodality_dip.py`
+
+## Actions
+
+1. Establish whether the 2026-07-27 Phase-1 rebuild completed or was interrupted.
+   If interrupted, finish or re-run it before anything downstream.
+2. Regenerate the aligned artifacts so `refined_embeddings.npz` and
+   `refined_citations.csv` are newer than `refined_works.csv` and still 1:1 with it.
+3. Regenerate the bimodality tables with `diptest` installed, so `dip_pvalue` is
+   populated.
+4. Confirm `dvc.lock` matches the regenerated state, and `dvc push`.
+
+## Test
+
+No new test. The three named above must pass; they are the acceptance contract
+and must not be weakened (`.claude/rules/coding.md` § Testing).
+
+## Verification
+
+- [ ] `make check` green on `main` from the primary checkout
+- [ ] `refined_embeddings.npz` / `refined_citations.csv` newer than
+      `refined_works.csv`, and row-aligned with it
+- [ ] `dip_pvalue` non-empty in `tab_bimodality.csv`
+- [ ] `dvc status` clean; regenerated corpus pushed
+
+## Invariants
+
+- Acceptance tests are the top-level contract — never weakened to go green.
+- Regenerate; do not hand-edit a derived table to satisfy an assertion.
+- Run from the primary checkout: a worktree's `data/` is empty and
+  `CLIMATE_FINANCE_DATA=data` is relative, which produces a different and
+  misleading failure set.
+
+## Exit criteria
+
+`make check` is green on `main` with the corpus reachable, and every derived
+artifact is newer than the input it derives from.


### PR DESCRIPTION
Tickets-only diff — [fast path](../blob/main/.claude/rules/git.md): `erg check` PASS (349 tickets), ID-collision scan clean against `origin/main` and all open PRs.

Filed by the ticket 0343 wrap-up sweep for the anti-pattern "a credential documented as coming from `.env`".

- **0364** — `hal.env` holds `HAL_ID`/`HAL_PASSWORD` but `KEYS=` never selects `hal`; both measure ABSENT, so `/update-publist` cannot authenticate its HAL deposit. Predates 0343 (they were never in `.env`), same class, one-line fix.
- **0365** — `HDMX-coding-agent` is not a GitHub account (404); `AGENT_GH_TOKEN` authenticates as the repo owner with full `repo`/`workflow` scopes. False prose already corrected in #1160. Two consequences need an author decision: the review gate's first accepted login matches nothing, so it rests on self-review, and the DMP claimed a privilege separation that does not exist. Filed with three options rather than a presumed fix.
- **0366** — three tests red on `main` from stale artifacts, not code: a Phase-1 rebuild moved `refined_works.csv` twice on 2026-07-27 while the aligned artifacts stayed at 13:21, and `tab_bimodality.csv` predates the 0330 diptest fix the new test assumes.

Ticket-ref: tickets/0364-hal-credentials-are-not-selected-by-keys.erg
Ticket-ref: tickets/0365-hdmx-coding-agent-is-not-a-github-accoun.erg
Ticket-ref: tickets/0366-main-is-red-corpus-freshness-and-bimodal.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)