### PR TITLE
ticket(0366): close — corpus artifacts regenerated, main is green

### DIFF
--- a/tickets/closed/0366-main-is-red-corpus-freshness-and-bimodal.erg
+++ b/tickets/closed/0366-main-is-red-corpus-freshness-and-bimodal.erg
@@ -2,10 +2,12 @@
 Title: main is red: corpus freshness and bimodality dip fail on stale artifacts
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: regenerated: rebuild had completed; bimodality tables rebuilt with diptest
 
 --- log ---
 2026-07-27T15:45Z HDMX-coding-agent created
 
+2026-07-27T16:01Z HDMX-coding-agent closed — regenerated: rebuild had completed; bimodality tables rebuilt with diptest
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes ticket 0366. The diff is one ticket file; no code and no data changed.

`Ticket-ref: tickets/closed/0366-main-is-red-corpus-freshness-and-bimodal.erg`
— the close commit is already on this branch, so this is deliberately not a
`**Ticket:**` close claim.

## What the three red tests actually were

Two different problems wearing the same "stale artifact" label.

**The two freshness failures had already resolved.** The ticket asked whether
the 2026-07-27 Phase-1 rebuild completed or was interrupted — worth checking
before regenerating anything, as it said. It completed.
`refined_embeddings.npz` and `refined_citations.csv` now carry a 16:41 mtime
against `refined_works.csv` at 16:09, which is the direction the assertions
check. `TestCorpusAlign` passes whole, including
`test_refined_embeddings_row_count`, so the 1:1 contract holds on rows as well
as on mtime. Nothing was regenerated for these.

**The dip failure needed a regeneration.** `tab_bimodality.csv` dated from
2026-07-24, written while `diptest` was undeclared, so `dip_pvalue` came out
empty in every row. `diptest 0.11.0` is installed; rebuilding both bimodality
tables populates it:

| method | n | dip_pvalue |
|---|---|---|
| embedding | 29675 | 1.0000 |
| embedding_1990–2006 | 1613 | 0.9943 |
| embedding_2007–2014 | 7399 | 0.9942 |
| embedding_2015–2024 | 20663 | 1.0000 |

NaN on the `tfidf_lexical` and unsupervised rows is by design — the dip test
only runs on the embedding axis. The values agree with the established finding
that the axis is unimodal. Both tables are gitignored, so no data rides this PR.

Regenerated rather than adjusted the test, per the ticket's invariant.

## Gate

`make check` on `main` from the primary checkout: **1915 passed, 22 skipped, 0
failed** (6:00). Run from the primary checkout as the ticket's invariants
require — a worktree's `data/` is empty and `CLIMATE_FINANCE_DATA=data` is
relative, which produces a different and misleading failure set.

`erg check tickets/`: PASS (351 tickets).

## The one verification item not met

Verification item 4 asked for a clean `dvc status`. It is not clean, and I did
not clear it, because the drift is neither caused by nor related to this ticket.

All 20 stages are dirty and every one is *dep-hash* drift: `dvc.lock` (last
written by 0355, commit 9f9ef18d) records the script hashes current when the
outputs were produced, and six tickets merged into `main` this afternoon —
0323, 0343, 0346, 0349, 0355, 0363 — edited `utils.py`, `pipeline_io.py`,
`pipeline_loaders.py`, `pipeline_text.py`, and `catalog_merge.py` afterwards.

The data itself is fine. `dvc status` reports no changed outputs for any stage,
and `dvc status --cloud` says the cache and remote `padme` are in sync, so
there is nothing to push. What is stale is the certification, not the corpus.

Clearing it means a full `dvc repro` — network, hours, and the Flag-6 rescore —
which rebuilds the corpus underneath the manuscript and should not happen
without the author's call. `dvc commit` is the wrong shortcut: 0323 changed the
language normaliser, so recording current outputs against new script hashes
would certify a corpus the new code did not produce.

One stage also has a genuinely missing output: `catalog_merge` declares
`data/catalogs/run_reports/catalog_merge.json`, which 0349 added along with the
`stable_copy=True` call at `scripts/harvest/catalog_merge.py:305`. The last
`catalog_merge` run was 13:21, before 0349 landed at 16:16, so only timestamped
reports exist. One run of the stage writes it.

Filed as its own ticket in a separate PR.