### PR TITLE
test(0346): generalize the facade-patch guard and finish the sweep

### DIFF
--- a/tests/test_robustness_observability.py
+++ b/tests/test_robustness_observability.py
@@ -99,62 +99,37 @@ class TestUtilsHelpers:
         # Allow duplicates in fast test envs but at least one call succeeds
         assert len(ids) >= 1
 
-    def test_save_run_report_creates_file(self, tmp_path):
-        # Patch CATALOGS_DIR to tmp_path for isolation
-        import utils
+    def test_save_run_report_creates_file(self, tmp_path, monkeypatch):
         from utils import save_run_report
 
-        orig = utils.CATALOGS_DIR
-        orig_pl = pipeline_loaders.CATALOGS_DIR
-        utils.CATALOGS_DIR = str(tmp_path)
-        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
-        try:
-            data = {"elapsed_seconds": 1.5, "rows_written": 42}
-            path = save_run_report(data, "test-run-001", "my_script")
-            assert os.path.isfile(path)
-        finally:
-            utils.CATALOGS_DIR = orig
-            pipeline_loaders.CATALOGS_DIR = orig_pl
+        monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+        data = {"elapsed_seconds": 1.5, "rows_written": 42}
+        path = save_run_report(data, "test-run-001", "my_script")
+        assert os.path.isfile(path)
 
-    def test_save_run_report_json_schema(self, tmp_path):
-        import utils
+    def test_save_run_report_json_schema(self, tmp_path, monkeypatch):
         from utils import save_run_report
 
-        orig = utils.CATALOGS_DIR
-        orig_pl = pipeline_loaders.CATALOGS_DIR
-        utils.CATALOGS_DIR = str(tmp_path)
-        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
-        try:
-            data = {"counter_a": 10, "counter_b": 5, "elapsed_seconds": 2.0}
-            path = save_run_report(data, "run-xyz", "test_script")
-            with open(path) as f:
-                payload = json.load(f)
-            assert payload["script"] == "test_script"
-            assert payload["run_id"] == "run-xyz"
-            assert payload["counter_a"] == 10
-            assert payload["elapsed_seconds"] == 2.0
-        finally:
-            utils.CATALOGS_DIR = orig
-            pipeline_loaders.CATALOGS_DIR = orig_pl
+        monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+        data = {"counter_a": 10, "counter_b": 5, "elapsed_seconds": 2.0}
+        path = save_run_report(data, "run-xyz", "test_script")
+        with open(path) as f:
+            payload = json.load(f)
+        assert payload["script"] == "test_script"
+        assert payload["run_id"] == "run-xyz"
+        assert payload["counter_a"] == 10
+        assert payload["elapsed_seconds"] == 2.0
 
-    def test_save_run_report_sanitizes_run_id(self, tmp_path):
-        import utils
+    def test_save_run_report_sanitizes_run_id(self, tmp_path, monkeypatch):
         from utils import save_run_report
 
-        orig = utils.CATALOGS_DIR
-        orig_pl = pipeline_loaders.CATALOGS_DIR
-        utils.CATALOGS_DIR = str(tmp_path)
-        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
-        try:
-            path = save_run_report({}, "run id/with spaces&special!", "script")
-            assert os.path.isfile(path)
-            # filename should not contain spaces or slashes
-            basename = os.path.basename(path)
-            assert " " not in basename
-            assert "/" not in basename
-        finally:
-            utils.CATALOGS_DIR = orig
-            pipeline_loaders.CATALOGS_DIR = orig_pl
+        monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+        path = save_run_report({}, "run id/with spaces&special!", "script")
+        assert os.path.isfile(path)
+        # filename should not contain spaces or slashes
+        basename = os.path.basename(path)
+        assert " " not in basename
+        assert "/" not in basename
 
     def test_retry_get_importable(self):
         from utils import retry_get
@@ -449,36 +424,28 @@ class TestRunReport:
             reports = os.listdir(reports_dir)
             assert not any("enrich_abstracts" in r for r in reports)
 
-    def test_save_run_report_counter_consistency(self, tmp_path):
+    def test_save_run_report_counter_consistency(self, tmp_path, monkeypatch):
         """Manually verify that the report structure is consistent."""
-        import utils
         from utils import save_run_report
 
-        orig = utils.CATALOGS_DIR
-        orig_pl = pipeline_loaders.CATALOGS_DIR
-        utils.CATALOGS_DIR = str(tmp_path)
-        pipeline_loaders.CATALOGS_DIR = str(tmp_path)
-        try:
-            missing_before = 10
-            missing_after = 3
-            total_filled = missing_before - missing_after
-            data = {
-                "missing_before": missing_before,
-                "missing_after": missing_after,
-                "total_filled": total_filled,
-                "elapsed_seconds": 5.0,
-            }
-            path = save_run_report(data, "consistency-test", "enrich_abstracts")
-            with open(path) as f:
-                payload = json.load(f)
-            assert (
-                payload["missing_before"] - payload["missing_after"]
-                == payload["total_filled"]
-            )
-            assert payload["elapsed_seconds"] > 0
-        finally:
-            utils.CATALOGS_DIR = orig
-            pipeline_loaders.CATALOGS_DIR = orig_pl
+        monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+        missing_before = 10
+        missing_after = 3
+        total_filled = missing_before - missing_after
+        data = {
+            "missing_before": missing_before,
+            "missing_after": missing_after,
+            "total_filled": total_filled,
+            "elapsed_seconds": 5.0,
+        }
+        path = save_run_report(data, "consistency-test", "enrich_abstracts")
+        with open(path) as f:
+            payload = json.load(f)
+        assert (
+            payload["missing_before"] - payload["missing_after"]
+            == payload["total_filled"]
+        )
+        assert payload["elapsed_seconds"] > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_report_isolation.py
+++ b/tests/test_run_report_isolation.py
@@ -68,42 +68,68 @@ def call_time_constants():
     return found
 
 
-def _module_aliases(tree):
-    """Names by which this file refers to the defining module."""
-    aliases = {DEFINING_MODULE}
+def _aliases_of(tree, module):
+    """Names by which this file refers to ``module``.
+
+    Applied to the facade as well as to the defining module: resolving one and
+    matching the other literally would leave ``import utils as u`` unflagged,
+    which is the alias blind spot the ticket-0251 guard already has.
+    """
+    aliases = {module}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for a in node.names:
-                if a.name == DEFINING_MODULE and a.asname:
+                if a.name == module and a.asname:
                     aliases.add(a.asname)
     return aliases
 
 
-def _rebinds(tree, constants):
-    """Yield ``(module_name, constant)`` for every rebinding in the file.
+def _rebinds_in(node, constants):
+    """Yield ``(module_name, constant)`` for a rebinding performed by ``node``.
 
     Three shapes, all in use in this suite: bare attribute assignment
     (``utils.CATALOGS_DIR = x``), the ``monkeypatch.setattr`` string target
     (``setattr("pipeline_loaders.CATALOGS_DIR", x)``), and the two-argument
     object form (``setattr(pl, "CATALOGS_DIR", x)``).
     """
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for tgt in node.targets:
-                if (isinstance(tgt, ast.Attribute) and tgt.attr in constants
-                        and isinstance(tgt.value, ast.Name)):
-                    yield tgt.value.id, tgt.attr
-        elif isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "setattr" \
-                or isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setattr":
-            args = node.args
-            if len(args) >= 2 and isinstance(args[0], ast.Constant) \
-                    and isinstance(args[0].value, str) and "." in args[0].value:
-                mod, _, const = args[0].value.rpartition(".")
-                if const in constants:
-                    yield mod, const
-            elif len(args) >= 3 and isinstance(args[0], ast.Name) \
-                    and isinstance(args[1], ast.Constant) and args[1].value in constants:
-                yield args[0].id, args[1].value
+    if isinstance(node, ast.Assign):
+        for tgt in node.targets:
+            if (isinstance(tgt, ast.Attribute) and tgt.attr in constants
+                    and isinstance(tgt.value, ast.Name)):
+                yield tgt.value.id, tgt.attr
+    elif isinstance(node, ast.Call) and (
+            getattr(node.func, "attr", None) == "setattr"
+            or getattr(node.func, "id", None) == "setattr"):
+        args = node.args
+        if len(args) >= 2 and isinstance(args[0], ast.Constant) \
+                and isinstance(args[0].value, str) and "." in args[0].value:
+            mod, _, const = args[0].value.rpartition(".")
+            if const in constants:
+                yield mod, const
+        elif len(args) >= 3 and isinstance(args[0], ast.Name) \
+                and isinstance(args[1], ast.Constant) and args[1].value in constants:
+            yield args[0].id, args[1].value
+
+
+def _rebinds_by_scope(tree, constants):
+    """Group rebindings by the function that performs them.
+
+    Per function, not per file. A neighbour patching the definition site says
+    nothing about this test: pairing them file-wide would exempt a genuine
+    no-op merely for sitting next to a correct one.
+    """
+    scopes = {}
+
+    def visit(node, scope):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            scope = node.name
+        for pair in _rebinds_in(node, constants):
+            scopes.setdefault(scope, []).append(pair)
+        for child in ast.iter_child_nodes(node):
+            visit(child, scope)
+
+    visit(tree, "<module>")
+    return scopes
 
 
 def _facade_patch_offenders(sources):
@@ -125,12 +151,13 @@ def _facade_patch_offenders(sources):
     constants = call_time_constants()
     for name, src in sources:
         tree = ast.parse(src)
-        aliases = _module_aliases(tree)
-        rebinds = list(_rebinds(tree, constants))
-        patched_at_source = {c for m, c in rebinds if m in aliases}
-        for const in sorted({c for m, c in rebinds if m == FACADE_MODULE}):
-            if const not in patched_at_source:
-                offenders.append(f"{name}: {const}")
+        defining = _aliases_of(tree, DEFINING_MODULE)
+        facade = _aliases_of(tree, FACADE_MODULE)
+        for scope, rebinds in sorted(_rebinds_by_scope(tree, constants).items()):
+            patched_at_source = {c for m, c in rebinds if m in defining}
+            for const in sorted({c for m, c in rebinds if m in facade}):
+                if const not in patched_at_source:
+                    offenders.append(f"{name}:{scope}: {const}")
     return offenders
 
 
@@ -233,6 +260,24 @@ def test_something(tmp_path, monkeypatch):
     compute_vars.dedup_stats({})
 """
 
+SAMPLE_CROSS_FUNCTION = """
+import pipeline_loaders
+import utils
+
+def test_correct(tmp_path, monkeypatch):
+    monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+
+def test_leaks(tmp_path):
+    utils.CATALOGS_DIR = str(tmp_path)
+"""
+
+SAMPLE_FACADE_ALIAS = """
+import utils as u
+
+def test_something(tmp_path):
+    u.CATALOGS_DIR = str(tmp_path)
+"""
+
 
 @pytest.mark.adherence
 def test_discovery_is_not_vacuous():
@@ -275,6 +320,32 @@ def test_facade_guard_leaves_the_consuming_module_idiom_alone():
     does reach it. Flagging it would push authors toward the wrong fix.
     """
     assert not _facade_patch_offenders([("sample_consumer.py", SAMPLE_CONSUMER_PATCH)])
+
+
+@pytest.mark.adherence
+def test_facade_guard_scopes_the_exemption_to_one_function():
+    """A correct neighbour must not launder the test next door.
+
+    Patching the facade *as well as* the definition site is fine, so the guard
+    needs an exemption — but keyed to the function performing both, not to the
+    file. File-level pairing would have let a real no-op through whenever any
+    sibling in the same module happened to patch ``pipeline_loaders``, which is
+    the common case in a suite that mixes fixed and unfixed tests.
+    """
+    offenders = _facade_patch_offenders([("cross.py", SAMPLE_CROSS_FUNCTION)])
+    assert offenders == ["cross.py:test_leaks: CATALOGS_DIR"], offenders
+
+
+@pytest.mark.adherence
+def test_facade_guard_resolves_an_aliased_facade_import():
+    """``import utils as u`` is the same defect wearing a different name.
+
+    The 0251 guard matches the literal string ``utils`` and documents this as
+    an accepted limitation. Repeating it here would be a poor trade for a guard
+    that already walks the AST: ``_aliases_of`` resolves the facade exactly as
+    it resolves the defining module.
+    """
+    assert _facade_patch_offenders([("alias.py", SAMPLE_FACADE_ALIAS)])
 
 
 def test_save_run_report_honours_the_patched_definition_site(tmp_path, monkeypatch):

--- a/tests/test_run_report_isolation.py
+++ b/tests/test_run_report_isolation.py
@@ -20,10 +20,10 @@ import os
 import re
 
 import pytest
+from _script_discovery import all_script_files
 from utils import BASE_DIR
 
 TESTS_DIR = os.path.join(BASE_DIR, "tests")
-SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts")
 
 #: The module that defines the path constants. ``utils`` only re-exports them.
 DEFINING_MODULE = "pipeline_loaders"
@@ -61,27 +61,27 @@ def call_time_constants():
 
     Today this finds ``CATALOGS_DIR`` (``save_run_report``, ``latest_run_report``)
     and ``POOL_DIR`` (``pool_path``, ``load_pool_ids``, ``load_pool_records``).
+
+    Enumerated through ``all_script_files()``, the one sanctioned ``scripts/``
+    walk (ticket 0260). A hand-rolled ``os.walk`` here would be the third one in
+    the suite, and 0260 exists precisely because those narrow silently under a
+    reorg — it also correctly excludes ``scripts/archive*/``, which the
+    hand-rolled version scanned.
     """
     found = set()
-    for root, _dirs, files in os.walk(SCRIPTS_DIR):
-        for fname in files:
-            if not fname.endswith(".py"):
+    for path in all_script_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            # A file this interpreter cannot parse is out of scope, and a
+            # discovery helper is the wrong place to fail the suite over it.
+            continue
+        for func in ast.walk(tree):
+            if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            path = os.path.join(root, fname)
-            with open(path, encoding="utf-8") as fh:
-                src = fh.read()
-            try:
-                tree = ast.parse(src)
-            except SyntaxError:
-                # A file this interpreter cannot parse is out of scope, and a
-                # discovery helper is the wrong place to fail the suite over it.
-                continue
-            for func in ast.walk(tree):
-                if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    continue
-                for node in ast.walk(func):
-                    if isinstance(node, ast.ImportFrom) and node.module == DEFINING_MODULE:
-                        found.update(a.name for a in node.names if a.name.isupper())
+            for node in ast.walk(func):
+                if isinstance(node, ast.ImportFrom) and node.module == DEFINING_MODULE:
+                    found.update(a.name for a in node.names if a.name.isupper())
     return found
 
 
@@ -98,6 +98,16 @@ def _aliases_of(tree, module):
             for a in node.names:
                 if a.name == module and a.asname:
                     aliases.add(a.asname)
+        # A plain rebinding (``u = utils``) is a second spelling of the same
+        # alias. One pass suffices for the shapes in this suite; chained
+        # rebindings would need the taint propagation that
+        # test_arch_compliance's loader detector already implements, and
+        # lifting that into a shared helper is the standing follow-up.
+        elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name):
+            if node.value.id in aliases:
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        aliases.add(tgt.id)
     return aliases
 
 
@@ -193,9 +203,14 @@ def _facade_patch_offenders(sources):
         tree = ast.parse(src)
         defining = _aliases_of(tree, DEFINING_MODULE)
         facade = _aliases_of(tree, FACADE_MODULE)
+        # A dotted string target names the module by import path
+        # ("scripts.utils.CATALOGS_DIR"), so match on the trailing segment too.
+        def names(mod, group):
+            return mod in group or mod.rpartition(".")[2] in group
+
         for scope, rebinds in sorted(_rebinds_by_scope(tree, constants).items()):
-            patched_at_source = {c for m, c in rebinds if m in defining}
-            for const in sorted({c for m, c in rebinds if m in facade}):
+            patched_at_source = {c for m, c in rebinds if names(m, defining)}
+            for const in sorted({c for m, c in rebinds if names(m, facade)}):
                 if const not in patched_at_source:
                     offenders.append(f"{name}:{scope}: {const}")
     return offenders
@@ -316,6 +331,20 @@ import utils as u
 
 def test_something(tmp_path):
     u.CATALOGS_DIR = str(tmp_path)
+"""
+
+SAMPLE_ASSIGNED_ALIAS = """
+import utils
+
+u = utils
+
+def test_something(tmp_path):
+    u.CATALOGS_DIR = str(tmp_path)
+"""
+
+SAMPLE_DOTTED_TARGET = """
+def test_something(tmp_path, monkeypatch):
+    monkeypatch.setattr("scripts.utils.CATALOGS_DIR", str(tmp_path))
 """
 
 SAMPLE_KEYWORD_SETATTR = """
@@ -440,6 +469,8 @@ def test_facade_guard_resolves_an_aliased_facade_import():
     it resolves the defining module.
     """
     assert _facade_patch_offenders([("alias.py", SAMPLE_FACADE_ALIAS)])
+    assert _facade_patch_offenders([("assigned.py", SAMPLE_ASSIGNED_ALIAS)])
+    assert _facade_patch_offenders([("dotted.py", SAMPLE_DOTTED_TARGET)])
 
 
 def test_save_run_report_honours_the_patched_definition_site(tmp_path, monkeypatch):

--- a/tests/test_run_report_isolation.py
+++ b/tests/test_run_report_isolation.py
@@ -32,11 +32,21 @@ FACADE_MODULE = "utils"
 
 
 def _test_sources():
-    for name in sorted(os.listdir(TESTS_DIR)):
-        if name.startswith("test_") and name.endswith(".py"):
-            path = os.path.join(TESTS_DIR, name)
+    """Every test module, including conftest and nested test directories.
+
+    ``conftest.py`` is the one file most likely to rebind a path constant for a
+    whole package, and a top-level ``listdir`` filtered on ``test_*`` missed
+    both it and any subdirectory.
+    """
+    for root, _dirs, files in os.walk(TESTS_DIR):
+        for name in sorted(files):
+            if not name.endswith(".py"):
+                continue
+            if not (name.startswith("test_") or name == "conftest.py"):
+                continue
+            path = os.path.join(root, name)
             with open(path, encoding="utf-8") as fh:
-                yield name, fh.read()
+                yield os.path.relpath(path, TESTS_DIR), fh.read()
 
 
 def call_time_constants():
@@ -57,8 +67,15 @@ def call_time_constants():
         for fname in files:
             if not fname.endswith(".py"):
                 continue
-            with open(os.path.join(root, fname), encoding="utf-8") as fh:
-                tree = ast.parse(fh.read())
+            path = os.path.join(root, fname)
+            with open(path, encoding="utf-8") as fh:
+                src = fh.read()
+            try:
+                tree = ast.parse(src)
+            except SyntaxError:
+                # A file this interpreter cannot parse is out of scope, and a
+                # discovery helper is the wrong place to fail the suite over it.
+                continue
             for func in ast.walk(tree):
                 if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     continue
@@ -97,18 +114,27 @@ def _rebinds_in(node, constants):
             if (isinstance(tgt, ast.Attribute) and tgt.attr in constants
                     and isinstance(tgt.value, ast.Name)):
                 yield tgt.value.id, tgt.attr
-    elif isinstance(node, ast.Call) and (
-            getattr(node.func, "attr", None) == "setattr"
-            or getattr(node.func, "id", None) == "setattr"):
-        args = node.args
-        if len(args) >= 2 and isinstance(args[0], ast.Constant) \
-                and isinstance(args[0].value, str) and "." in args[0].value:
-            mod, _, const = args[0].value.rpartition(".")
-            if const in constants:
-                yield mod, const
-        elif len(args) >= 3 and isinstance(args[0], ast.Name) \
-                and isinstance(args[1], ast.Constant) and args[1].value in constants:
-            yield args[0].id, args[1].value
+        return
+    if not isinstance(node, ast.Call):
+        return
+    name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+    if name not in {"setattr", "patch", "object"}:
+        return
+    # setattr accepts its arguments by keyword too, and monkeypatch names them
+    # target/name/value. Reading node.args alone made the keyword form
+    # invisible, which is a guard that can be stepped around by accident.
+    kw = {k.arg: k.value for k in node.keywords}
+    args = list(node.args)
+    first = args[0] if args else kw.get("target")
+    second = args[1] if len(args) > 1 else kw.get("name")
+    if isinstance(first, ast.Constant) and isinstance(first.value, str) \
+            and "." in first.value:
+        mod, _, const = first.value.rpartition(".")
+        if const in constants:
+            yield mod, const
+    elif isinstance(first, ast.Name) and isinstance(second, ast.Constant) \
+            and second.value in constants:
+        yield first.id, second.value
 
 
 def _rebinds_by_scope(tree, constants):
@@ -121,8 +147,12 @@ def _rebinds_by_scope(tree, constants):
     scopes = {}
 
     def visit(node, scope):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            scope = node.name
+        # Qualified by the enclosing class, not the bare name: two test classes
+        # in one module routinely define identically named methods, and keying
+        # on the name alone would merge their exemptions — the very laundering
+        # this per-scope split exists to prevent, one nesting level down.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            scope = f"{scope}.{node.name}" if scope != "<module>" else node.name
         for pair in _rebinds_in(node, constants):
             scopes.setdefault(scope, []).append(pair)
         for child in ast.iter_child_nodes(node):
@@ -140,12 +170,22 @@ def _facade_patch_offenders(sources):
     flagged: ``test_dedup_vars`` patches ``compute_vars.CATALOGS_DIR`` and does
     redirect its target, because ``dedup_stats`` passes the directory to
     ``latest_run_report`` as an argument rather than letting it re-import
-    (ticket 0349 made that parameter injectable for exactly this reason). Only
-    ``utils`` is a pure re-export with no reader of its own, so only a rebind
-    there is unambiguously a no-op.
+    (ticket 0349 made that parameter injectable for exactly this reason).
 
     Patching the facade *as well* is fine — code reading the re-export needs it.
     What is not fine is patching only the facade.
+
+    Coverage boundary, stated because the obvious reading is wrong: the facade
+    is not readerless. ``compute_vars`` (:381, :535) and ``plot_alluvial_html``
+    (:85) do function-local ``from utils import <CONST>``, so the mirror-image
+    defect exists — for a constant read at call time off ``utils``, patching
+    ``pipeline_loaders`` is the no-op instead. This guard covers one direction
+    only: constants reached through ``pipeline_loaders``, which is where ticket
+    0346's leak lived. The other direction reads rather than writes DVC data,
+    so it cannot leak the same way, and folding it in would give a guard whose
+    correct patch target flips per constant — a design call, not a widened
+    regex. The assertion below says "patch ``pipeline_loaders.<CONST>`` *too*",
+    additive on purpose, so following it stays safe either way.
     """
     offenders = []
     constants = call_time_constants()
@@ -278,6 +318,34 @@ def test_something(tmp_path):
     u.CATALOGS_DIR = str(tmp_path)
 """
 
+SAMPLE_KEYWORD_SETATTR = """
+import utils
+
+def test_something(tmp_path, monkeypatch):
+    monkeypatch.setattr(target=utils, name="CATALOGS_DIR", value=str(tmp_path))
+"""
+
+SAMPLE_MOCK_PATCH = """
+from unittest import mock
+
+def test_something(tmp_path):
+    with mock.patch("utils.CATALOGS_DIR", str(tmp_path)):
+        pass
+"""
+
+SAMPLE_SAME_NAME_TWO_CLASSES = """
+import pipeline_loaders
+import utils
+
+class TestCorrect:
+    def test_it(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pipeline_loaders, "CATALOGS_DIR", str(tmp_path))
+
+class TestLeaks:
+    def test_it(self, tmp_path):
+        utils.CATALOGS_DIR = str(tmp_path)
+"""
+
 
 @pytest.mark.adherence
 def test_discovery_is_not_vacuous():
@@ -334,6 +402,32 @@ def test_facade_guard_scopes_the_exemption_to_one_function():
     """
     offenders = _facade_patch_offenders([("cross.py", SAMPLE_CROSS_FUNCTION)])
     assert offenders == ["cross.py:test_leaks: CATALOGS_DIR"], offenders
+
+
+@pytest.mark.adherence
+def test_facade_guard_distinguishes_same_named_methods_in_two_classes():
+    """Qualify the scope by class, or the per-function split leaks one level down.
+
+    Two classes each defining ``test_it`` is ordinary pytest style. Keyed on the
+    bare function name they would share one exemption bucket, and the correct
+    one would launder the leaking one — the file-level laundering this guard
+    already rejects, merely nested.
+    """
+    offenders = _facade_patch_offenders([("two.py", SAMPLE_SAME_NAME_TWO_CLASSES)])
+    assert offenders == ["two.py:TestLeaks.test_it: CATALOGS_DIR"], offenders
+
+
+@pytest.mark.adherence
+def test_facade_guard_sees_past_the_call_shape():
+    """The rebinding shapes differ; the defect does not.
+
+    ``setattr`` takes its arguments by keyword too, and ``unittest.mock`` offers
+    a third spelling. A guard that reads positional ``setattr`` args alone is
+    steppable by accident — nobody writes ``target=`` to evade a check, they
+    write it because the call is long.
+    """
+    assert _facade_patch_offenders([("kw.py", SAMPLE_KEYWORD_SETATTR)])
+    assert _facade_patch_offenders([("mockp.py", SAMPLE_MOCK_PATCH)])
 
 
 @pytest.mark.adherence

--- a/tests/test_run_report_isolation.py
+++ b/tests/test_run_report_isolation.py
@@ -23,6 +23,12 @@ import pytest
 from utils import BASE_DIR
 
 TESTS_DIR = os.path.join(BASE_DIR, "tests")
+SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts")
+
+#: The module that defines the path constants. ``utils`` only re-exports them.
+DEFINING_MODULE = "pipeline_loaders"
+#: The pure re-export facade. Rebinding a constant here redirects nothing.
+FACADE_MODULE = "utils"
 
 
 def _test_sources():
@@ -33,30 +39,116 @@ def _test_sources():
                 yield name, fh.read()
 
 
-@pytest.mark.adherence
-def test_no_test_patches_catalogs_dir_on_the_facade():
-    """Patch the module that defines the constant, not a re-export of it.
+def call_time_constants():
+    """Return the constants a ``scripts/`` function re-imports at call time.
 
-    ``scripts/utils.py`` re-exports ``CATALOGS_DIR`` from ``pipeline_loaders``.
-    Rebinding the re-export leaves the definition site untouched, so anything
-    reading it at call time — ``save_run_report`` does — still sees the real
-    corpus directory.
+    A function-local ``from pipeline_loaders import X`` re-reads the definition
+    site on every call, so rebinding X anywhere else — the ``utils`` facade, the
+    calling module's own namespace — does not redirect it. That is the ticket
+    0346 mechanism, and it is a property of the source, not of a name we
+    happened to notice: discovering the set by AST keeps the guard correct when
+    a new constant joins.
+
+    Today this finds ``CATALOGS_DIR`` (``save_run_report``, ``latest_run_report``)
+    and ``POOL_DIR`` (``pool_path``, ``load_pool_ids``, ``load_pool_records``).
+    """
+    found = set()
+    for root, _dirs, files in os.walk(SCRIPTS_DIR):
+        for fname in files:
+            if not fname.endswith(".py"):
+                continue
+            with open(os.path.join(root, fname), encoding="utf-8") as fh:
+                tree = ast.parse(fh.read())
+            for func in ast.walk(tree):
+                if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for node in ast.walk(func):
+                    if isinstance(node, ast.ImportFrom) and node.module == DEFINING_MODULE:
+                        found.update(a.name for a in node.names if a.name.isupper())
+    return found
+
+
+def _module_aliases(tree):
+    """Names by which this file refers to the defining module."""
+    aliases = {DEFINING_MODULE}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name == DEFINING_MODULE and a.asname:
+                    aliases.add(a.asname)
+    return aliases
+
+
+def _rebinds(tree, constants):
+    """Yield ``(module_name, constant)`` for every rebinding in the file.
+
+    Three shapes, all in use in this suite: bare attribute assignment
+    (``utils.CATALOGS_DIR = x``), the ``monkeypatch.setattr`` string target
+    (``setattr("pipeline_loaders.CATALOGS_DIR", x)``), and the two-argument
+    object form (``setattr(pl, "CATALOGS_DIR", x)``).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if (isinstance(tgt, ast.Attribute) and tgt.attr in constants
+                        and isinstance(tgt.value, ast.Name)):
+                    yield tgt.value.id, tgt.attr
+        elif isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "setattr" \
+                or isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setattr":
+            args = node.args
+            if len(args) >= 2 and isinstance(args[0], ast.Constant) \
+                    and isinstance(args[0].value, str) and "." in args[0].value:
+                mod, _, const = args[0].value.rpartition(".")
+                if const in constants:
+                    yield mod, const
+            elif len(args) >= 3 and isinstance(args[0], ast.Name) \
+                    and isinstance(args[1], ast.Constant) and args[1].value in constants:
+                yield args[0].id, args[1].value
+
+
+def _facade_patch_offenders(sources):
+    """Return ``"file: CONST"`` for each constant rebound on the facade alone.
+
+    Scoped to the ``utils`` facade on purpose. Rebinding the constant on the
+    *consuming* module is the correct idiom (ticket 0249) and must not be
+    flagged: ``test_dedup_vars`` patches ``compute_vars.CATALOGS_DIR`` and does
+    redirect its target, because ``dedup_stats`` passes the directory to
+    ``latest_run_report`` as an argument rather than letting it re-import
+    (ticket 0349 made that parameter injectable for exactly this reason). Only
+    ``utils`` is a pure re-export with no reader of its own, so only a rebind
+    there is unambiguously a no-op.
+
+    Patching the facade *as well* is fine — code reading the re-export needs it.
+    What is not fine is patching only the facade.
     """
     offenders = []
-    for name, src in _test_sources():
-        patches_facade = re.search(r"^\s*utils\.CATALOGS_DIR\s*=", src, re.M)
-        if not patches_facade:
-            continue
-        # Patching the facade as well is fine — other code reads the re-export.
-        # What is not fine is patching *only* the facade.
-        patches_source = re.search(r"^\s*(?:pl|pipeline_loaders)\.CATALOGS_DIR\s*=", src, re.M) \
-            or 'setattr("pipeline_loaders.CATALOGS_DIR"' in src
-        if not patches_source:
-            offenders.append(name)
+    constants = call_time_constants()
+    for name, src in sources:
+        tree = ast.parse(src)
+        aliases = _module_aliases(tree)
+        rebinds = list(_rebinds(tree, constants))
+        patched_at_source = {c for m, c in rebinds if m in aliases}
+        for const in sorted({c for m, c in rebinds if m == FACADE_MODULE}):
+            if const not in patched_at_source:
+                offenders.append(f"{name}: {const}")
+    return offenders
+
+
+@pytest.mark.adherence
+def test_no_test_patches_a_call_time_constant_off_the_definition_site():
+    """Patch the module that defines the constant, not a re-export of it.
+
+    ``scripts/utils.py`` re-exports these constants from ``pipeline_loaders``.
+    Rebinding the re-export leaves the definition site untouched, so anything
+    reading it at call time — ``save_run_report`` does — still sees the real
+    corpus directory, and the test reports green while writing there.
+    """
+    offenders = _facade_patch_offenders(_test_sources())
     assert not offenders, (
-        "tests rebind utils.CATALOGS_DIR, which does not redirect "
-        "save_run_report: " + ", ".join(offenders) +
-        " - patch pipeline_loaders.CATALOGS_DIR instead"
+        "tests rebind a constant that its consumer re-imports from "
+        f"{DEFINING_MODULE} at call time, so the patch does not redirect it: "
+        + ", ".join(offenders)
+        + f" - patch {DEFINING_MODULE}.<CONST> too"
     )
 
 
@@ -111,6 +203,78 @@ def test_no_test_spawns_a_repo_script_without_redirecting_data():
         + ", ".join(offenders) +
         " - pass env={**os.environ, 'CLIMATE_FINANCE_DATA': str(tmp_path)}"
     )
+
+
+SAMPLE_POOL_OFFENDER = """
+import utils
+
+def test_something(tmp_path):
+    utils.POOL_DIR = str(tmp_path)
+    from utils import pool_path
+    pool_path("openalex", "probe")
+"""
+
+SAMPLE_POOL_CLEAN = """
+import pipeline_loaders
+import utils
+
+def test_something(tmp_path, monkeypatch):
+    monkeypatch.setattr("pipeline_loaders.POOL_DIR", str(tmp_path))
+    from utils import pool_path
+    pool_path("openalex", "probe")
+"""
+
+
+SAMPLE_CONSUMER_PATCH = """
+import compute_vars
+
+def test_something(tmp_path, monkeypatch):
+    monkeypatch.setattr(compute_vars, "CATALOGS_DIR", str(tmp_path))
+    compute_vars.dedup_stats({})
+"""
+
+
+@pytest.mark.adherence
+def test_discovery_is_not_vacuous():
+    """A guard driven by discovery passes trivially if discovery finds nothing.
+
+    ``CATALOGS_DIR`` is pinned because the ticket-0346 invariant keeps the
+    function-local import that puts it here — it breaks a circular import. If
+    that ever changes, this fails and the guard gets re-derived deliberately
+    rather than quietly protecting nothing.
+    """
+    constants = call_time_constants()
+    assert "CATALOGS_DIR" in constants, (
+        "pipeline_io no longer re-imports CATALOGS_DIR at call time; "
+        "re-derive this guard instead of letting it pass vacuously"
+    )
+
+
+@pytest.mark.adherence
+def test_facade_guard_detects_a_constant_it_was_never_told_about():
+    """The guard must cover the mechanism, not the one constant that bit us.
+
+    ``POOL_DIR`` has exactly the shape ``CATALOGS_DIR`` had: ``pipeline_io``
+    re-imports it from ``pipeline_loaders`` inside ``pool_path`` and friends, so
+    rebinding it on the ``utils`` facade is a no-op — and ``pool_path`` calls
+    ``os.makedirs``, so the leak would create directories inside the DVC-tracked
+    ``data/pool/``. No test exercises the pool helpers today, which is precisely
+    why a name-based guard would not notice when one does.
+    """
+    assert _facade_patch_offenders([("sample_offender.py", SAMPLE_POOL_OFFENDER)])
+    assert not _facade_patch_offenders([("sample_clean.py", SAMPLE_POOL_CLEAN)])
+
+
+@pytest.mark.adherence
+def test_facade_guard_leaves_the_consuming_module_idiom_alone():
+    """Patching the consumer is the recommended idiom, not the defect.
+
+    The first draft of this guard flagged ``test_dedup_vars`` for patching
+    ``compute_vars.CATALOGS_DIR``. That is a false positive: ``dedup_stats``
+    hands the directory to ``latest_run_report`` as an argument, so the patch
+    does reach it. Flagging it would push authors toward the wrong fix.
+    """
+    assert not _facade_patch_offenders([("sample_consumer.py", SAMPLE_CONSUMER_PATCH)])
 
 
 def test_save_run_report_honours_the_patched_definition_site(tmp_path, monkeypatch):

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -906,12 +906,20 @@ class TestNoWrongNamespacePatch:
     - an aliased import (``import utils as u`` then patching ``u``) is not
       caught; no test file aliases utils today (checked 2026-07-11, ticket
       0251) and new code has no reason to start.
-    - direct attribute assignment (``utils.CONST = x``) is not flagged. The
-      two legitimate patterns found by the 0249 sweep use it and stay
-      allowed: a test patching utils' own namespace before calling a
-      function that lives in utils itself (test_robustness_observability.py
-      save_run_report tests), and dual-namespace patching of utils AND the
-      consuming module together (test_pipeline_e2e.py _patched_merge_dirs).
+    - direct attribute assignment (``utils.CONST = x``) is not flagged here.
+      One of the two patterns the 0249 sweep called legitimate turned out not
+      to be: the save_run_report tests in test_robustness_observability.py
+      were said to patch "utils' own namespace before calling a function that
+      lives in utils itself", but save_run_report lives in pipeline_io and
+      re-imports CATALOGS_DIR from pipeline_loaders inside its body, so the
+      assignment redirected nothing and the tests wrote into the DVC-tracked
+      corpus for four and a half months while reporting green (ticket 0346).
+      Bare assignment is now covered by
+      test_run_report_isolation.py::test_no_test_patches_a_call_time_constant_off_the_definition_site,
+      which resolves the defining module from the AST instead of trusting a
+      claim about where a function lives. What remains allowed here is
+      dual-namespace patching of utils AND the consuming module together
+      (test_pipeline_e2e.py _patched_merge_dirs).
     """
 
     FORBIDDEN = [

--- a/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
+++ b/tickets/0346-run-report-tests-patch-the-wrong-module-a.erg
@@ -9,6 +9,8 @@ Author: HDMX-coding-agent
 2026-07-27T16:05Z HDMX-coding-agent note Read-only follow-up: TWO leak mechanisms, not one; 4.5 months old; fixtures are inside committed DVC snapshots; and a latent glob collision that would silently replace a data-paper number
 2026-07-27T16:45Z HDMX-coding-agent correction Two claims in the read-only pass were wrong: load_dotenv does NOT override an exported var, and test_phase1_contract was never a culprit. Corrected below
 2026-07-27T16:48Z HDMX-coding-agent note Leak fixed and proven by mtime. Deletion of the 8 files deliberately deferred — see the last section
+2026-07-27T18:30Z HDMX-coding-agent note Sweep done and recorded: POOL_DIR is the same latent defect, the 0251 guard exempts bare assignment on a rationale this ticket falsifies, and the consuming-module patch is not the defect. Guard now AST-driven, not name-keyed
+2026-07-27T18:35Z HDMX-coding-agent note Exit criteria 1-3 discharged. Full suite (1846 passed, 7 known corpus-absent failures) left all 224 data/catalogs mtimes untouched. Fixture deletion remains the one open post-merge step
 
 --- body ---
 ## Context
@@ -111,15 +113,24 @@ fixtures, all rewritten within minutes of each other on every suite run:
 ## What was fixed
 
 - `test_robustness_observability.py` now patches `pipeline_loaders.CATALOGS_DIR`
-  alongside the `utils` facade, in all four save/restore blocks.
+  in all four blocks, via `monkeypatch` rather than hand-rolled save/restore, so
+  the rebinding is undone on teardown even when an assertion fails midway. The
+  facade patch is gone rather than kept alongside: `save_run_report` resolves
+  the definition site at call time and never reads `utils`, so patching it was
+  dead weight — and `monkeypatch.setattr(utils, ...)` is what the 0251 guard
+  forbids. Dropping it satisfies both. The module no longer imports `utils`.
 - `test_pipeline_e2e.py` gains one autouse fixture setting
   `CLIMATE_FINANCE_DATA` for the whole module, rather than an `env=` argument at
   each of its twelve spawn sites. Child processes inherit it, so a subprocess
   call added later cannot forget the redirect.
 - Two adherence guards on the mechanisms, not the filenames: no test may patch
-  `utils.CATALOGS_DIR` without also patching the defining module, and no test
-  may spawn a pipeline script with `cwd=REPO_ROOT` unless it passes `env=` or
-  sets the variable in an autouse fixture.
+  a call-time constant on the `utils` facade without also patching the defining
+  module, and no test may spawn a pipeline script with `cwd=REPO_ROOT` unless it
+  passes `env=` or sets the variable in an autouse fixture. The first guard is
+  driven by AST discovery rather than a list of names, so it covers `POOL_DIR`
+  and anything added later; three meta-tests pin that discovery is non-vacuous,
+  that it catches a constant it was never told about, and that it leaves the
+  consuming-module idiom alone.
 
 Proven rather than assumed: with the fix in place, running both suites leaves
 the mtimes of the real fixtures untouched. An earlier check compared file
@@ -146,11 +157,65 @@ The eight are exactly the files whose run id is not a UTC timestamp — the same
 criterion `latest_run_report` now uses to ignore them, so nothing reads them
 even while they sit there.
 
+Still deferred as of this branch, and deliberately so. The reasoning above has
+not expired: sibling worktrees still carry pre-fix `tests/`, and `rm` plus
+`dvc add` against the author's real corpus directory is a destructive action on
+data this branch cannot make durable — a sibling suite run would recreate the
+files before the deletion was committed. It is also the author's checkout, not
+this worktree's. Run it after this merges and the other sessions rebase; the
+recipe above is exact and the files are inert until then.
+
 Not fixable by deletion: the fixtures are inside four committed DVC snapshots,
 one of which is the hash `run_reports.dvc` points at. Removing them from
 history would mean rewriting DVC state; leaving them is harmless now that no
 consumer selects a non-timestamp report. That is an author call, recorded here
 rather than taken.
+
+## Sweep result (exit criterion 3)
+
+The sweep was run as code, not as a one-off grep: `call_time_constants()` in
+`tests/test_run_report_isolation.py` walks the `scripts/` AST for every
+function-local `from pipeline_loaders import <CONST>` and derives the guarded
+set from the source. Four findings.
+
+**`POOL_DIR` is the same defect, one call site short of firing.**
+`pipeline_io.pool_path`, `load_pool_ids` and `load_pool_records` re-import
+`POOL_DIR` from `pipeline_loaders` inside their own bodies — the exact shape
+`save_run_report` had. `pool_path` then calls `os.makedirs`, so a test
+patching the `utils` facade would create directories inside DVC-tracked
+`data/pool/`. No test exercises the pool helpers today, which is precisely why
+a guard keyed on the name `CATALOGS_DIR` would not have noticed the first one
+that does. Discovery covers it now, pinned by
+`test_facade_guard_detects_a_constant_it_was_never_told_about`.
+
+**The 0251 guard has a blind spot, and its rationale for keeping it was
+false.** `TestNoWrongNamespacePatch` matches `setattr(utils, ...)` and the
+`"utils.CONST"` string form, but deliberately exempts bare attribute
+assignment — and named this ticket's own tests as one of the two legitimate
+patterns relying on it: "a test patching utils' own namespace before calling a
+function that lives in utils itself (test_robustness_observability.py
+save_run_report tests)". `save_run_report` does not live in `utils`; it lives
+in `pipeline_io` and re-imports from `pipeline_loaders`. The exemption's
+justification was wrong, and it is what let `utils.CATALOGS_DIR = str(tmp_path)`
+run unflagged for four and a half months. The docstring is corrected in this
+branch, and the new guard covers bare assignment, which 0251 does not.
+
+**Patching the *consuming* module is not this defect.** The first draft of the
+generalised guard flagged `test_dedup_vars.py` for
+`monkeypatch.setattr(compute_vars, "CATALOGS_DIR", ...)`. False positive:
+`dedup_stats` passes the directory to `latest_run_report` as an argument — 0349
+made that parameter injectable — so the patch does reach it. That is the idiom
+0249 recommends. The guard is scoped to the `utils` facade alone, the only
+module here that is a pure re-export with no reader of its own, and the
+narrowing is pinned by
+`test_facade_guard_leaves_the_consuming_module_idiom_alone` so the over-fire
+cannot come back.
+
+**One residual, left alone.** `_patched_merge_dirs` in `test_pipeline_e2e.py`
+patches `utils.BASE_DIR` alongside `cm` and `pipeline_loaders`. `BASE_DIR` is
+not re-imported at call time by anything, so that particular line is probably
+dead weight rather than a leak — out of scope here, and harmless because the
+same fixture patches the definition site too.
 
 ## Root cause
 
@@ -223,10 +288,14 @@ that escapes `tmp_path` trips it.
 
 ## Verification
 
-- [ ] The probe test above is red before the fix, green after
-- [ ] A full `make check` leaves `data/catalogs/run_reports/` unchanged
-      (capture a directory listing before and after and compare)
-- [ ] The five existing fixture files are gone
+- [x] The probe test above is red before the fix, green after
+- [x] A full `make check` leaves `data/catalogs/run_reports/` unchanged —
+      a 1,931-test run (`pytest tests/`, 10m34s) against a `%T@`-plus-path
+      listing of all 224 files under `data/catalogs/`, taken in both the
+      author's checkout and this worktree: byte-identical before and after,
+      no mtime moved. The seven failures are `test_corpus_acceptance`
+      file-existence checks, the known absent-DVC-data gap in a worktree.
+- [ ] The eight existing fixture files are gone — still deferred, see below
 
 ## Invariants
 
@@ -236,9 +305,9 @@ that escapes `tmp_path` trips it.
 
 ## Exit criteria
 
-- [ ] Tests patch the defining module and use `monkeypatch`
-- [ ] A test suite run provably writes nothing into `data/catalogs/`
-- [ ] The sweep for the same trap on other `utils` constants is done and its
+- [x] Tests patch the defining module and use `monkeypatch`
+- [x] A test suite run provably writes nothing into `data/catalogs/`
+- [x] The sweep for the same trap on other `utils` constants is done and its
       result recorded here
 
 ## See also


### PR DESCRIPTION
**Ticket-ref:** tickets/0346-run-report-tests-patch-the-wrong-module-a.erg

Deliberately `Ticket-ref:`, not `Ticket:`. All three exit criteria are discharged, but Action 2 — deleting the eight leaked fixture files and re-running `dvc add` — is still open and can only be done once this lands and sibling worktrees rebase. Closing 0346 on merge would leave that recipe as prose in a closed ticket with nothing tracking it. The ticket stays open until the deletion runs.

PR #1174 stopped the two leaks. This closes the residue: the second half of exit criterion 1 (`monkeypatch`, not hand-rolled save/restore) and exit criterion 3 (the sweep, recorded in the ticket).

## The guard was keyed on the constant that bit us

`CATALOGS_DIR` was a name in the guard, not a mechanism. It is now derived from the source: an AST walk over `scripts/` collects every constant a function re-imports from `pipeline_loaders` inside its own body — that function-local import re-reads the definition site on every call, which is exactly why rebinding the `utils` re-export redirects nothing.

That set is `{CATALOGS_DIR, POOL_DIR}` today. **`POOL_DIR` is the same defect one call site short of firing**: `pool_path()` re-imports it and then calls `os.makedirs`, so a test patching the facade would create directories inside DVC-tracked `data/pool/`. No test exercises the pool helpers yet — which is precisely why a name-keyed guard would miss the first one that does.

## Scoped to the facade, not to any module

The first draft flagged `test_dedup_vars` for patching `compute_vars.CATALOGS_DIR`. False positive: `dedup_stats` passes the directory to `latest_run_report` as an argument (0349 made it injectable), so the patch does reach it, and it is the idiom 0249 recommends. Flagging it would push authors toward the wrong fix, so the narrowing is pinned by its own test rather than left as a comment.

## The 0251 guard's exemption rested on a false claim

`TestNoWrongNamespacePatch` exempts bare attribute assignment, and named *these very tests* as legitimate: "a test patching utils' own namespace before calling a function that lives in utils itself". `save_run_report` lives in `pipeline_io`. That wrong justification is what let the leak run unflagged for four and a half months; its docstring now says so and points at the guard that does cover bare assignment.

## Second commit: the guard failing on its own terms

The pre-PR adherence pass found two blind spots, both closed here rather than deferred:

- Rebind analysis was **per file**, so a facade-only patch was exempted whenever any sibling function patched the definition site — one correct neighbour would launder every no-op beside it. Now grouped per enclosing function. `_patched_merge_dirs` does both in one fixture and stays exempt; verified, not assumed.
- The facade name was matched **literally** while the defining module was alias-resolved, so `import utils as u` slipped through — the exact limitation this ticket faults 0251 for accepting.

## Verification

Exit criterion 2 was discharged by **mtime, not content** — the leaked writes were byte-identical, so a content diff looked clean. A full suite run (1846 passed) left all 224 mtimes under `data/catalogs/` untouched in both the author's checkout and this worktree. The 7 failures are `test_corpus_acceptance` file-existence checks, the known absent-DVC-data gap in a worktree, unrelated to this change.

- `make lint` — 185 passed, 6 skipped
- `make check-fast` — 1217 passed, 11 skipped
- `erg check tickets/` — PASS (351 tickets)
- `/verify-adherence` — PASS, `mechanical_failures: []`

## One step deliberately left open

Deleting the eight leaked fixture files stays deferred, as the ticket recorded: sibling worktrees still run pre-fix `tests/` and would recreate them before the deletion could be committed. The recipe is in the ticket; run it once this merges and the other sessions rebase. The files are inert meanwhile — `latest_run_report` ignores every non-timestamp run id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
