### PR TITLE
ticket(0374): file the grouped-target guard's variable-expansion blind spot

### DIFF
--- a/tickets/0374-grouped-target-output-guard-is-blind-to.erg
+++ b/tickets/0374-grouped-target-output-guard-is-blind-to.erg
@@ -1,0 +1,68 @@
+%erg 0.1
+Title: Grouped-target output guard is blind to variable-expanded target lists
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T18:10Z HDMX-coding-agent created
+2026-07-27T18:20Z HDMX-coding-agent note found by the raid 0327/0329 merge gate, not by the guard itself. Filed with the reproducing case already identified.
+
+--- body ---
+## Context
+
+Ticket 0327 added `test_grouped_recipes_name_their_output_explicitly` to stop a
+real defect: in a grouped Make target (`a b &:`), `$@` binds to whichever member
+make was asked to build, so a recipe using a bare `$@` can write its output to a
+sibling's path while make reports success. The tracked file is left stale and
+every downstream consumer reads it.
+
+The guard works, and it earned its keep immediately — it caught 0329's
+`tab_retrieval_protocol` rule during the raid merge, a defect neither branch
+showed alone.
+
+But `grouped_targets_using_bare_at()` detects multi-member groups by splitting
+the target-list *text* on whitespace. A group written as a single variable token
+that expands to several files is therefore invisible to it. `$(COMPUTED_STATS)
+&:` (Makefile:349) is exactly that shape, and it does pass a bare `$@`.
+
+That rule is safe today only by accident of its consumer:
+`scripts/analysis/compute_vars.py::main()` ignores `io_args.output` entirely and
+routes each of its three writes through `DOC_OUTPUT_DIR` internally (see its own
+comment, and ticket 0226). Change that script to honour `--output` — the
+direction `script-io.md` pushes every script toward — and the defect goes live
+with no test to catch it.
+
+## Relevant files
+
+- `tests/test_corpus_flow.py` — `TestOutputPathContract`, `grouped_targets_using_bare_at()`
+- `Makefile:349` — `$(COMPUTED_STATS) &:`, the invisible case
+- `scripts/analysis/compute_vars.py` — the consumer whose current behaviour masks it
+
+## Actions
+
+1. Expand Make variables in the target list before splitting, or fail closed:
+   treat any target list containing an unexpanded `$(...)` as multi-member.
+   Failing closed is cheaper and needs no Make evaluation.
+2. Fix whatever the widened guard then flags.
+
+## Test
+
+Red step: add a case to `TestOutputPathContract` asserting the guard flags a
+grouped recipe whose target list is a single variable token expanding to
+several files, and that it uses a bare `$@`. It must fail against the guard as
+written today.
+
+## Verification
+
+- [ ] The new test fails before the fix, passes after.
+- [ ] `make lint` green — the widened guard flags nothing else, or what it flags is fixed.
+
+## Invariants
+
+- No false positive on a genuine single-output rule that echoes `$@`.
+- `tests/test_corpus_flow.py::TestOutputPathContract` keeps its existing five cases.
+
+## Exit criteria
+
+The guard flags a bare `$@` in a grouped target regardless of whether the target
+list is written as literal paths or as a variable, and `make lint` is green.


### PR DESCRIPTION
Files ticket 0374, found by the raid 0327/0329 merge gate.

Ticket 0327 added `test_grouped_recipes_name_their_output_explicitly`, which immediately earned its keep: it caught 0329's `tab_retrieval_protocol` grouped target using a bare `$@` — a defect neither branch showed alone, only their union.

But the guard detects multi-member groups by splitting the target-list *text*, so a group written as one variable token that expands to several files is invisible to it. `$(COMPUTED_STATS) &:` (Makefile:349) is exactly that shape and does pass a bare `$@`. It is safe today only because `compute_vars.py` ignores `--output` entirely — the opposite of the direction `script-io.md` pushes every script.

Tickets-only diff.

**Ticket:** none
Ticket-ref: tickets/0374-grouped-target-output-guard-is-blind-to.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)