### PR TITLE
ticket(0371,0375,0376): file the findings the #1191 review panel raised

### DIFF
--- a/tickets/0371-included-shared-tables-are-gitignored.erg
+++ b/tickets/0371-included-shared-tables-are-gitignored.erg
@@ -1,33 +1,47 @@
 %erg 0.1
-Title: Two tables the deliverables include are gitignored, so the 0340 guard skips them
+Title: Five generated tables are gitignored, so the 0340 guard skips half its targets
 Created: 2026-07-27
 Author: HDMX-coding-agent
 
 --- log ---
 2026-07-27T18:20Z HDMX-coding-agent created
 2026-07-27T18:20Z HDMX-coding-agent note found by the /verify-adherence gate on PR #1191 (ticket 0370) and confirmed independently by two agents of its review panel
+2026-07-27T20:10Z HDMX-coding-agent note widened from two tables to five — the #1191 round-4 panel caught the undercount; the real set comes from git check-ignore over the 0340 discovery list, not from the diff that surfaced it
 
 --- body ---
 ## Context
 
-`deliverables/_shared/tables/tab_corpus_sources.md` and `tab_languages.md` are
-gitignored. Both are `{{< include >}}`d directly by `data-paper.qmd` and
-`corpus-report.qmd`, which makes them handoff artifacts under the standing rule
-"don't gitignore handoff artifacts" — generated files a downstream workpackage
-consumes are durable state.
+Five of the ten generated Markdown tables are gitignored:
 
-Their siblings are already tracked by explicit negations in `.gitignore`:
-`tab_variables.md`, `codebook.md`, `tab_venues.md`. The `.gitignore` comment
-around line 57 even says `tab_corpus_sources.csv` is "grouped with
-tab_corpus_sources.md", then negates only the `.csv`. So the current state
-reads as an oversight rather than a decision.
+    tab_citation_coverage.md   tab_core_venues_top10.md   tab_corpus_flow.md
+    tab_corpus_sources.md      tab_languages.md
+
+(enumerated by `git check-ignore` over `tests/_mk_discovery.generated_markdown_targets()`,
+which is the authoritative target list rather than a hand roll). Each is
+`{{< include >}}`d by a deliverable, which makes them handoff artifacts under
+the standing rule "don't gitignore handoff artifacts" — generated files a
+downstream workpackage consumes are durable state.
+
+The ticket was first filed naming only `tab_corpus_sources.md` and
+`tab_languages.md`, the two the #1191 diff happened to touch. The #1191 round-4
+panel caught the undercount; running the ignore check over the discovery list
+instead of over the diff is what produced the real number, and it is the method
+the fix should use.
+
+The other five — `codebook.md`, `tab_retrieval_protocol.md`,
+`tab_variables.md`, `tab_venues.md`, `tab_venues_fr.md` — are tracked by
+explicit negations in the same file. Nothing distinguishes the two groups: the
+`.gitignore` comment around line 57 even says `tab_corpus_sources.csv` is
+"grouped with tab_corpus_sources.md", then negates only the `.csv`. The split
+reads as accretion, not a decision.
 
 The concrete cost is a blind spot in a standing guard. Ticket 0340's
 `tests/test_markdown_table_shape.py` sweeps generated Markdown artifacts for
 cell-count defects, but it can only check files that exist. On a checkout
-without corpus data these two are absent, the sweep skips them, and the
+without corpus data these five are absent, the sweep skips them, and the
 escaping fixed in 0370 ships unverified by the very guard built to verify it.
-That is how 0370 stayed live and invisible in the first place.
+That is how 0370 stayed live and invisible in the first place — and at five of
+ten targets, the guard is blind to half its own surface.
 
 ## Relevant files
 
@@ -44,7 +58,7 @@ That is how 0370 stayed live and invisible in the first place.
 1. Add `.gitignore` negations for `tab_corpus_sources.md` and
    `tab_languages.md`, and fix the stale comment that already claims the
    grouping.
-2. Commit the two artifacts as currently generated on a corpus machine. Verify
+2. Commit the five artifacts as currently generated on a corpus machine. Verify
    first that regenerating them is a no-op — 0370's no-churn pins say it should
    be, but the check belongs here, not in the PR that added the escaper.
 3. Decide the general rule rather than case by case: every `.md` under
@@ -55,7 +69,7 @@ That is how 0370 stayed live and invisible in the first place.
 
 Red first, an `adherence` test: parse every `deliverables/**/*.qmd` for
 `{{< include ../_shared/(tables/…\.md) >}}`, and assert each resolved path
-appears in `git ls-files`. It fails today on exactly these two.
+appears in `git ls-files`. It fails today on exactly these five.
 
 ```python
 @pytest.mark.adherence
@@ -70,8 +84,9 @@ resolves against the *root document's* directory, not its own.
 ## Verification
 
 - [ ] The new adherence test fails before the `.gitignore` change and passes after
-- [ ] `git ls-files deliverables/_shared/tables` lists both `.md` files
-- [ ] Regenerating both on a corpus machine leaves the working tree clean
+- [ ] `git ls-files deliverables/_shared/tables` lists all ten generated `.md`
+      files, checked via `generated_markdown_targets()` rather than by hand
+- [ ] Regenerating them on a corpus machine leaves the working tree clean
 - [ ] `tests/test_markdown_table_shape.py` no longer skips them on a
       corpus-free checkout
 

--- a/tickets/0371-included-shared-tables-are-gitignored.erg
+++ b/tickets/0371-included-shared-tables-are-gitignored.erg
@@ -1,0 +1,88 @@
+%erg 0.1
+Title: Two tables the deliverables include are gitignored, so the 0340 guard skips them
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T18:20Z HDMX-coding-agent created
+2026-07-27T18:20Z HDMX-coding-agent note found by the /verify-adherence gate on PR #1191 (ticket 0370) and confirmed independently by two agents of its review panel
+
+--- body ---
+## Context
+
+`deliverables/_shared/tables/tab_corpus_sources.md` and `tab_languages.md` are
+gitignored. Both are `{{< include >}}`d directly by `data-paper.qmd` and
+`corpus-report.qmd`, which makes them handoff artifacts under the standing rule
+"don't gitignore handoff artifacts" — generated files a downstream workpackage
+consumes are durable state.
+
+Their siblings are already tracked by explicit negations in `.gitignore`:
+`tab_variables.md`, `codebook.md`, `tab_venues.md`. The `.gitignore` comment
+around line 57 even says `tab_corpus_sources.csv` is "grouped with
+tab_corpus_sources.md", then negates only the `.csv`. So the current state
+reads as an oversight rather than a decision.
+
+The concrete cost is a blind spot in a standing guard. Ticket 0340's
+`tests/test_markdown_table_shape.py` sweeps generated Markdown artifacts for
+cell-count defects, but it can only check files that exist. On a checkout
+without corpus data these two are absent, the sweep skips them, and the
+escaping fixed in 0370 ships unverified by the very guard built to verify it.
+That is how 0370 stayed live and invisible in the first place.
+
+## Relevant files
+
+- `.gitignore:47` — the ignore rule; lines 57-61 hold the negations for the
+  tracked siblings and the misleading comment
+- `deliverables/data-paper/data-paper.qmd`,
+  `deliverables/corpus-report/corpus-report.qmd` — the two includers
+- `tests/test_markdown_table_shape.py` — the 0340 sweep that skips them
+- `tests/_mk_discovery.py` — `generated_markdown_targets()`, the authoritative
+  list of generated Markdown artifacts
+
+## Actions
+
+1. Add `.gitignore` negations for `tab_corpus_sources.md` and
+   `tab_languages.md`, and fix the stale comment that already claims the
+   grouping.
+2. Commit the two artifacts as currently generated on a corpus machine. Verify
+   first that regenerating them is a no-op — 0370's no-churn pins say it should
+   be, but the check belongs here, not in the PR that added the escaper.
+3. Decide the general rule rather than case by case: every `.md` under
+   `deliverables/_shared/tables/` that a `.qmd` includes is tracked. Encode it
+   as the test below so the next added table cannot silently fall out.
+
+## Test
+
+Red first, an `adherence` test: parse every `deliverables/**/*.qmd` for
+`{{< include ../_shared/(tables/…\.md) >}}`, and assert each resolved path
+appears in `git ls-files`. It fails today on exactly these two.
+
+```python
+@pytest.mark.adherence
+def test_included_shared_tables_are_tracked():
+    """Every table a deliverable includes is a handoff artifact."""
+```
+
+Prefer deriving the include set from the same resolver the orphan sweep uses
+if one exists by then — note the architecture rule that a nested include
+resolves against the *root document's* directory, not its own.
+
+## Verification
+
+- [ ] The new adherence test fails before the `.gitignore` change and passes after
+- [ ] `git ls-files deliverables/_shared/tables` lists both `.md` files
+- [ ] Regenerating both on a corpus machine leaves the working tree clean
+- [ ] `tests/test_markdown_table_shape.py` no longer skips them on a
+      corpus-free checkout
+
+## Invariants
+
+- No change to the generated content — this ticket tracks files, it does not
+  regenerate or reformat them.
+- The `.csv` siblings keep their current tracking status; escaping and
+  inclusion are Markdown concerns.
+
+## Exit criteria
+
+- [ ] Both files are tracked and the 0340 sweep covers them on a clean checkout
+- [ ] An adherence test pins the rule for every future shared table

--- a/tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
+++ b/tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
@@ -1,0 +1,80 @@
+%erg 0.1
+Title: export_corpus_table ships a literal "nan" when a source refines to zero works
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T18:25Z HDMX-coding-agent created
+2026-07-27T18:25Z HDMX-coding-agent note found by the #1191 review panel while reading the escaping fix; pre-existing, not introduced by ticket 0370
+
+--- body ---
+## Context
+
+`scripts/figures/export_corpus_table.py:167-172` builds the row for a source
+whose refined count is zero with five of the eight dict keys — `Source`,
+`Query`, `Raw`, `Refined`, `Unique` — and skips the four percentage columns.
+`pd.DataFrame(rows)` then fills those columns with `NaN` for that row.
+
+`_write_md_table` reads each cell with `row.get(c, "")`. The key *is* present
+in the Series, holding `NaN`, so the `""` default never fires: the cell becomes
+`str(float('nan'))`. The shipped table gets the literal string `nan` in four
+columns, and the `.csv` sibling gets the same.
+
+Pre-existing — the code did this before ticket 0370 touched the line, and 0370
+deliberately did not widen its scope to cover it. It is latent rather than
+live: it needs a source present in `unified_works.csv` whose every record is
+dropped by the six-flag quality filter. The `unfccc` and `oecd` key-document
+layers are the plausible candidates, since `sources_present` admits a source as
+soon as its `from_*` column exists in either frame.
+
+An empty cell is the right output. A dash would also be defensible; `nan` is
+not, in a published data paper's quality table.
+
+## Relevant files
+
+- `scripts/figures/export_corpus_table.py:167-172` — the five-key row
+- `scripts/figures/export_corpus_table.py:104-113` — `_write_md_table`, where
+  `row.get(c, "")` fails to catch it
+- `tests/test_corpus_table_export.py` — where the regression test belongs;
+  ticket 0370's `_summary_row` helper and `_render` oracle are already there
+
+## Actions
+
+1. Decide where to fix it. Filling the missing keys at the row-building site is
+   the narrower change and keeps the `.csv` correct too; coercing `NaN` to `""`
+   in `_write_md_table` fixes only the Markdown side. Prefer the row-building
+   site, and state the choice in the commit.
+2. Check the TOTAL row cannot reach the same shape.
+3. Confirm the `.csv` sibling carries an empty field, not the string `nan` —
+   the invariant in 0370 was that escaping is a Markdown concern; this one is
+   not, and touches both outputs.
+
+## Test
+
+Red first, in `tests/test_corpus_table_export.py`: build a summary from a rows
+list where one source dict carries only the five keys, run it through
+`_write_md_table`, and assert on the rendered row (via `tests/_gfm_render.py`,
+the oracle 0325 established) that the four percentage cells are empty. Assert
+on the render, not on the emitted source.
+
+Cover the `.csv` path in the same ticket: drive the write and read the file
+back rather than asserting on the in-memory frame — a `columns=` allowlist has
+dropped a computed field before.
+
+## Verification
+
+- [ ] A zero-refined source renders four empty cells, not `nan`
+- [ ] The `.csv` row carries empty fields for the same four columns
+- [ ] Sources with a non-zero refined count are byte-unchanged
+- [ ] `make lint` and `make check-fast` hold
+
+## Invariants
+
+- No change to the shipped table on today's corpus — no source refines to zero
+  in the current build, so this must be a no-op there.
+- The escaping added in 0370 stays: whatever replaces `NaN` still routes
+  through `markdown_text_cell`.
+
+## Exit criteria
+
+- [ ] No `nan` can reach `tab_corpus_sources.md` or `tab_corpus_sources.csv`

--- a/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
+++ b/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
@@ -1,0 +1,108 @@
+%erg 0.1
+Title: The Markdown cell escaper is calibrated to GFM, but the manuscript renders through pandoc-markdown
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T19:05Z HDMX-coding-agent created
+2026-07-27T19:05Z HDMX-coding-agent note raised by the #1191 red-team agent, re-triaged from blocker to its own ticket, and reproduced independently before filing
+
+--- body ---
+## Context
+
+`scripts/_markdown_table.py` escapes three characters — `\`, `|`, `` ` `` — and
+the render oracle that validates it, `tests/_gfm_render.py`, runs
+`pandoc -f gfm`. Both are calibrated to GitHub-Flavored Markdown.
+
+Quarto does not read GFM. It renders through pandoc's `markdown` reader, where
+several more characters are live syntax. Reproduced on this machine:
+
+    | A | B |
+    |---|---|
+    | Grey lit @smith2020 set | x |
+    | Tilde ~sub~ and ^sup^   | y |
+
+Under `-f gfm` all three render literally. Under `-f markdown`, `@smith2020`
+becomes `<span class="citation">` and the tildes and carets become `<sub>` and
+`<sup>`. `deliverables/data-paper/data-paper.qmd:11` and
+`deliverables/corpus-report/corpus-report.qmd:7` both set `bibliography:`, so
+citeproc runs: a cell value carrying an `@` that collides with a real
+bibliography key renders a wrong citation, silently, in a published table.
+
+Two consequences, and the second is the reason this is filed rather than
+folded into 0370:
+
+1. The escaper's character set is too narrow for the reader that actually
+   renders the tables.
+2. **The oracle cannot see it.** Every test written for 0325, 0339 and 0370
+   asserts through `-f gfm`, so all of them would stay green while the rendered
+   manuscript carried the defect. That is the same failure the render-oracle
+   discipline was introduced to prevent, one reader-flag deeper.
+
+## Scope — this predates 0370 and is wider than it
+
+The gap lives in the shared helper, so it reaches every caller: the deposit
+codebook (0325), both venue tables and the core-venues table (0339), and the
+corpus-sources and language tables (0370). The venue emitters are the most
+plausible carrier by a wide margin — they interpolate *journal names straight
+out of the bibliographic corpus*, where an `@` is far likelier than in a
+hand-edited source label. Those emitters are already merged.
+
+So this is not a regression from 0370 and 0370 does not worsen it. One fix in
+the helper plus one fix in the oracle covers six emitters at once, which is
+why it is worth its own ticket rather than a sixth item on a fix-the-emitter PR.
+
+## Relevant files
+
+- `scripts/_markdown_table.py` — `_GFM_LITERAL`, the three-character map; the
+  module docstring's rationale for the scope needs revising with it
+- `tests/_gfm_render.py` — `render_gfm`, the `-f gfm` oracle used by every
+  escaping test
+- `tests/test_markdown_table.py`, `tests/test_rendered_venue_table_fidelity.py`,
+  `tests/test_corpus_table_export.py`, `tests/test_language_table.py` — the
+  callers of that oracle
+- `deliverables/data-paper/data-paper.qmd`,
+  `deliverables/corpus-report/corpus-report.qmd` — `bibliography:` set
+
+## Actions
+
+1. Establish which reader Quarto invokes for these documents, and with which
+   extensions. Do not assume plain `markdown`; read it off a real Quarto run
+   rather than off the docs, and record the answer in the module docstring.
+2. Switch the oracle to that reader. This is the load-bearing step — do it
+   first, so the character-set change lands against a test that can fail.
+3. Widen `_GFM_LITERAL` to whatever the reader makes live in a table cell
+   (`@`, `~`, `^` at minimum), keeping the existing rule that constructs
+   needing a matched pair are left alone so shipped tables do not churn.
+4. Re-check the no-churn pins in all six emitters. If widening the set rewrites
+   a currently-shipped value, that is a finding, not a nuisance — report it
+   before suppressing it.
+
+## Test
+
+Red first, in `tests/test_markdown_table.py`: feed `markdown_text_cell` a value
+containing `@smith2020`, render through the **Quarto reader** with a
+bibliography in scope, and assert the cell text is the literal string — no
+`<span class="citation">`. It must fail today, and it will only fail once
+action 2 has landed, which is the point of that ordering.
+
+Add the same shape for `~` and `^`.
+
+## Verification
+
+- [ ] The new test fails under the current three-character map and passes after
+- [ ] Every existing escaping test still passes against the new oracle
+- [ ] Regenerating all six tables on a corpus machine is a no-op, or each
+      changed value is explained
+- [ ] `make lint` and `make check-fast` hold
+
+## Invariants
+
+- The two-function split (`markdown_cell` vs `markdown_text_cell`) is unchanged
+  — this widens a character set, it does not merge the contracts.
+- `markdown_text_cell` still never raises.
+
+## Exit criteria
+
+- [ ] The escaper's character set matches the reader that renders the tables
+- [ ] No escaping test asserts through a reader the build does not use


### PR DESCRIPTION
Ticket-ref: tickets/0371-included-shared-tables-are-gitignored.erg
Ticket-ref: tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
Ticket-ref: tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg

Files only — closes nothing. Both findings came out of the #1191 review panel
(ticket 0370, Markdown-table escaping) and are deliberately not folded into
that PR: one changes what git tracks, the other changes what an emitter writes.

**0371 — two included tables are gitignored.**
`tab_corpus_sources.md` and `tab_languages.md` are ignored while
`tab_variables.md`, `codebook.md` and `tab_venues.md` are force-tracked by
explicit negations in the same file — and the `.gitignore` comment already
claims the `.csv` is "grouped with tab_corpus_sources.md" before negating only
the `.csv`. Both are `{{< include >}}`d by `data-paper.qmd` and
`corpus-report.qmd`, so the handoff-artifact rule applies. The real cost: the
0340 shape sweep can only check files that exist, so on a corpus-free checkout
it skips exactly the two artifacts #1191 fixes. Carries a red-first adherence
test that derives the include set from the `.qmd` sources.

**0375 — a literal `nan` can reach the published quality table.**
`export_corpus_table.py:167` builds a zero-refined source's row with five of
eight keys; `pd.DataFrame` fills the rest with NaN; `row.get(c, "")` never
fires because the key is present, so four cells render `nan`. Pre-existing and
currently latent — it needs a source in `unified_works.csv` whose every record
the six-flag filter drops, with the `unfccc`/`oecd` key-document layers the
plausible trigger. Affects the `.csv` sibling too.

**0376 — the escaper is calibrated to a reader the build does not use.**
Raised by the #1191 red team, re-triaged to its own ticket, and reproduced
before filing. `_markdown_table.py` escapes `\`, `|` and `` ` ``, and
`tests/_gfm_render.py` validates it through `pandoc -f gfm`. Quarto renders
these tables through pandoc's `markdown` reader, where `@`, `~` and `^` are
live syntax: the same cell that renders literally under `-f gfm` yields
`<span class="citation">` under `-f markdown`, and both consuming `.qmd` files
set `bibliography:`, so citeproc runs. The sharper half is that **the oracle
cannot see it** — every escaping test since 0325 asserts through `-f gfm` and
would stay green while the rendered manuscript carried the defect. The ticket
therefore orders the work oracle-first, character-set-second. Predates #1191
and is wider than it: the gap is in the shared helper, and the venue emitters
merged under 0339 interpolate corpus journal names — a far likelier `@` carrier
than a hand-edited source label.

Seat check: 0371, 0375 and 0376 are absent from `origin/main` and from every open
PR's added ticket paths (scanned 2026-07-27; 0372 is on main, 0373/0374 are on
#1195/#1194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)