### PR TITLE
ticket(0359): reachability guard for generated shared artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,10 @@ NCC_FIGS        := deliverables/_shared/figures/fig_ncc_divergence.png \
 # Zoo figures (ZOO_SCHEMATICS / ZOO_RESULT_FIGS, defined in paths.mk) are
 # deliberately excluded from ALL_FIGS / make figures: plot scripts not yet wired.
 # Add them to ALL_FIGS when plot_schematic_*.py and plot_zoo_results.py have targets.
-ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
+ALL_FIGS := $(MANUSCRIPT_FIGS) $(DATAPAPER_FIGS) $(CORPUSREPORT_FIGS) $(MULTILAYER_FIGS) $(TECHREP_FIGS) $(NCC_FIGS)
 
 # ── Default target ────────────────────────────────────────
-.PHONY: all setup manuscript papers corpus-report technical-report data-paper multilayer-detection multilayer-techrep zoo figures figures-manuscript figures-datapaper figures-companion figures-techrep figures-ncc stats check check-package check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
+.PHONY: all setup manuscript papers corpus-report technical-report data-paper multilayer-detection multilayer-techrep zoo figures figures-manuscript figures-datapaper figures-corpusreport figures-companion figures-techrep figures-ncc stats check check-package check-fast lint test-durations venv-canonicalize smoke benchmark determinism-check regression regression-update audit-pdf-content check-corpus check-manuscript-data data corpus corpus-sync corpus-discover corpus-enrich corpus-extend corpus-filter corpus-align corpus-filter-all corpus-tables corpus-validate deploy-corpus clean rebuild archive-analysis archive-manuscript archive-datapaper analysis-figures analysis-tables analysis-stats manuscript-render manuscript-figures datapaper-render datapaper-figures corpus-handoff
 
 .DEFAULT_GOAL := manuscript
 
@@ -626,6 +626,7 @@ deliverables/_shared/figures/fig_ncc_alluvial.png: \
 
 figures-manuscript: corpus-handoff $(MANUSCRIPT_FIGS)
 figures-datapaper:  corpus-handoff $(DATAPAPER_FIGS)
+figures-corpusreport: corpus-handoff $(CORPUSREPORT_FIGS)
 figures-companion:  corpus-handoff $(MULTILAYER_FIGS)
 figures-techrep:    corpus-handoff $(TECHREP_FIGS)
 figures-ncc:        corpus-handoff $(NCC_FIGS)

--- a/paths.mk
+++ b/paths.mk
@@ -103,10 +103,21 @@ ZOO_INCLUDES := deliverables/_shared/_includes/techrep/overview.md \
 # Phase-2 rules that PRODUCE them live in the concern .mk (root), not here.
 MANUSCRIPT_FIGS := deliverables/_shared/figures/fig_bars_v1.png deliverables/_shared/figures/fig_composition.png deliverables/_shared/figures/fig_breaks.png
 
-DATAPAPER_FIGS  := deliverables/_shared/figures/fig_bars.png deliverables/_shared/figures/fig_dag.png \
+# fig_global_map_cocitation is built on purpose and embedded in no document: the
+# data paper carries the direct-citation map, the co-citation map backs the R1-14
+# reviewer response (ticket 0307). tests/test_global_map.py:175 pins that by
+# asserting the basename is absent from the data paper source — do not "fix" it
+# by embedding the figure. fig_sem_composition lost its consumer when ticket 0332
+# cut §4's semantic-cluster paragraph; kept pending the round-2 decision.
+# Both are recorded in tests/test_artifact_reachability.py's allowlist.
+DATAPAPER_FIGS  := deliverables/_shared/figures/fig_bars.png \
                    deliverables/_shared/figures/fig_global_map_direct.png \
                    deliverables/_shared/figures/fig_global_map_cocitation.png \
                    deliverables/_shared/figures/fig_sem_composition.png
+
+# fig_dag sat in DATAPAPER_FIGS only because no corpus-report figure list
+# existed; corpus-report.qmd:25 is its sole consumer (ticket 0359).
+CORPUSREPORT_FIGS := deliverables/_shared/figures/fig_dag.png
 
 MULTILAYER_FIGS  := deliverables/_shared/figures/fig_breakpoints.png deliverables/_shared/figures/fig_alluvial.png \
                    deliverables/_shared/figures/fig_breaks.png \

--- a/tests/test_artifact_reachability.py
+++ b/tests/test_artifact_reachability.py
@@ -57,6 +57,8 @@ import glob
 import os
 import re
 
+from _mk_discovery import all_makefiles
+
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DELIVERABLES = os.path.join(REPO_ROOT, "deliverables")
 SHARED = os.path.join(DELIVERABLES, "_shared")
@@ -79,11 +81,13 @@ def _deliverable_roots():
 
 
 def _makefiles():
-    """Every Makefile fragment that can name an artifact path."""
-    paths = [os.path.join(REPO_ROOT, "Makefile"), os.path.join(REPO_ROOT, "paths.mk")]
-    paths += sorted(glob.glob(os.path.join(REPO_ROOT, "scripts", "analysis", "*.mk")))
-    paths += sorted(glob.glob(os.path.join(DELIVERABLES, "*", "*.mk")))
-    return [p for p in paths if os.path.isfile(p)]
+    """Every Makefile fragment that can name an artifact path.
+
+    Shared discovery (ticket 0248): a `.mk` relocation updates one list, and this
+    guard cannot silently narrow its universe — which would turn a real orphan
+    into a false green.
+    """
+    return [str(p) for p in all_makefiles() if p.is_file()]
 
 
 def _read(path):
@@ -156,8 +160,113 @@ def _rel(path):
     return os.path.relpath(path, REPO_ROOT)
 
 
-# Deliberate exceptions, repo-relative path -> reason. Filled by the green step.
-ALLOWED: dict[str, str] = {}
+# ── Allowlist ────────────────────────────────────────────────────────────────
+# Repo-relative artifact path -> why it is built and consumed by no document.
+#
+# Every entry states a real reason and, where one exists, the ticket that will
+# settle it. `test_allowlist_has_no_redundant_entries` deletes the exemption's
+# cover the moment an artifact becomes reachable again, so this cannot rot into
+# a permanent "ignore these" list.
+
+_FLAT_INCLUDE_REASON = (
+    "Leftover of the 0226/0240 deliverables reorg: the technical report now "
+    "composes only _includes/techrep/, so the whole flat _includes/*.md layer "
+    "fell out of every document at once. Disposition (delete / relocate to "
+    "conception/ / re-embed) is ticket 0290's, and its action 2 sends any "
+    "include not clearly superseded by the techrep/ set to the author. This "
+    "guard is 0290's action 3; it does not pre-empt its action 1."
+)
+
+_UNSETTLED_REASON = (
+    "Built by make, displayed by no prose file, disposition undecided. "
+    "Deleting a committed artifact together with its Make rules while the data "
+    "paper is mid-R&R is an author call, not a sweep's. Tracked with the "
+    "flat-include audit in ticket 0290."
+)
+
+ALLOWED: dict[str, str] = {
+    # ── The 17 flat shared includes — see _FLAT_INCLUDE_REASON, ticket 0290 ──
+    "deliverables/_shared/_includes/agentic-workflow.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/alluvial-diagram.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/bibliometric-context.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/bimodality-analysis.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/changepoint-analysis.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/citation-genealogy.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/clustering-comparison.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/cop-topic-structure.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/core-vs-full-analysis.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/core-vs-full.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/embedding-generation.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/pca-scatter.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/prior-mappings.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/structural-breaks.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/tab2_poles.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/tab_traditions.md": _FLAT_INCLUDE_REASON,
+    "deliverables/_shared/_includes/temporal-structure.md": _FLAT_INCLUDE_REASON,
+    # ── Figures: deliberate, with a stated consumer outside the render graph ──
+    "deliverables/_shared/figures/fig_global_map_cocitation.png": (
+        "Companion artifact, committed but embedded nowhere by design "
+        "(ticket 0307, R1-14): the data paper carries the direct-citation map, "
+        "the co-citation map backs the reviewer response. The intent is pinned "
+        "by tests/test_global_map.py:175, which asserts the basename is absent "
+        "from the data paper source."
+    ),
+    "deliverables/_shared/figures/fig_traditions_pre2008_citers.png": (
+        "Citer-limited variant of fig_traditions built for the RDJ4HSS R1-14 "
+        "response (ticket 0286); its consumer is "
+        "deliverables/data-paper/revision-rdj26561/r1-14-network-response.md, "
+        "a revision record rather than a rendered deliverable."
+    ),
+    "deliverables/_shared/figures/fig_ncc_alluvial.png": (
+        "NCC_FIGS is declared analysis-only at Makefile:136 — the four fig_ncc_* "
+        "figures reproduce the analysis in Nature Climate Change house format "
+        "for comparison (docs/ncc-pipeline-audit.md) and were never meant for a "
+        "deliverable."
+    ),
+    "deliverables/_shared/figures/fig_ncc_bimodality.png": (
+        "See fig_ncc_alluvial.png — analysis-only NCC_FIGS set, Makefile:136."
+    ),
+    "deliverables/_shared/figures/fig_ncc_core_comparison.png": (
+        "See fig_ncc_alluvial.png — analysis-only NCC_FIGS set, Makefile:136."
+    ),
+    "deliverables/_shared/figures/fig_ncc_divergence.png": (
+        "See fig_ncc_alluvial.png — analysis-only NCC_FIGS set, Makefile:136."
+    ),
+    "deliverables/_shared/figures/fig_sem_composition.png": (
+        "Orphaned on 2026-07-27 when ticket 0332 cut the data paper's §4 "
+        "semantic-cluster paragraph. Kept rather than deleted: the paper is "
+        "mid-R&R and §4 may be revisited in round 2, so retiring the figure "
+        "with its lit-confirmations.mk rules is reversible-only-once and "
+        "belongs to the author. The backing tab_sem_composition.csv and the "
+        "clustering behind tab_sem6_assignments.csv stay either way — §1's "
+        "literature-confirmation bullet depends on them."
+    ),
+    # ── Figures and tables with no consumer and no decision yet ───────────────
+    # These are standalone rules outside every *_FIGS render list, so `make
+    # figures` does not even build them; they run on demand from their own
+    # targets.
+    "deliverables/_shared/figures/fig_breakpoints_core.png": _UNSETTLED_REASON,
+    "deliverables/_shared/figures/fig_k_sensitivity.png": _UNSETTLED_REASON,
+    "deliverables/_shared/figures/fig_venue_concentration.png": _UNSETTLED_REASON,
+    # These two sit in TECHREP_FIGS, so `make figures` builds them, yet the
+    # technical report displays neither — their prose consumers were in the flat
+    # include layer above.
+    "deliverables/_shared/figures/fig_communities.png": _UNSETTLED_REASON,
+    "deliverables/_shared/figures/fig_traditions.png": _UNSETTLED_REASON,
+    "deliverables/_shared/tables/tab_core_venues_top10.md": _UNSETTLED_REASON,
+    # ── Markdown tables consumed by something other than a document ──────────
+    "deliverables/_shared/tables/codebook.md": (
+        "Ships in the Zenodo deposit, not in a paper: "
+        "build/build_datapaper_archive.sh:47 copies it into data/products/ of "
+        "the reproducibility archive, where README-datapaper.md documents it as "
+        "the data dictionary. Correct as-is."
+    ),
+    "deliverables/_shared/tables/tab_venues_fr_caption.md": (
+        "A build input, not a rendered fragment: manuscript.mk:62-63 "
+        "concatenates it onto tab_venues.md to produce tab_venues_fr.md, which "
+        "manuscript-Gide.qmd does include. Correct as-is."
+    ),
+}
 
 
 def test_nested_zoo_includes_are_reachable():

--- a/tests/test_artifact_reachability.py
+++ b/tests/test_artifact_reachability.py
@@ -43,11 +43,21 @@ a guard whose verdict depends on whether `make` has run is worthless.
 
 - Includes: every `_includes/**/*.md` on disk. All are committed handoff
   artifacts; no build step writes one.
-- Figures / markdown tables: every such path named literally in a Makefile or
-  `.mk`. Most are gitignored and regenerable, so the filesystem is not a stable
-  universe; the build graph is. Dynamic outputs whose filenames are computed at
-  run time (`fig_lexical_tfidf_{year}.png`, tracked by `.lexical_tfidf.stamp`)
-  are outside any static universe and outside this guard.
+- Figures / markdown tables: the build graph, not the filesystem — most are
+  gitignored and regenerable. The build graph is read two ways, and the union is
+  the universe, because neither way alone is complete:
+    * a text scan of every Makefile, which catches paths written literally as
+      rule targets;
+    * `make` itself, expanding every variable the Makefiles assign, which
+      catches lists composed by a make function. Eight figures reach the disk
+      only that way — `BIAS_FIGS` via `$(foreach)` in `zoo-figures.mk` and
+      `SENS_FIG_PCA`/`SENS_FIG_JL` in `divergence.mk` — and a text scan cannot
+      see them: even the directory is a variable (`$(ZOO_FIGS)/…`). Letting
+      make do the expansion also means the universe cannot narrow when a list
+      is refactored from literals into a function.
+  Dynamic outputs whose filenames are computed at run time inside a *script*
+  (`fig_lexical_tfidf_{year}.png`, tracked by `.lexical_tfidf.stamp`) are in
+  neither reading and remain outside this guard.
 - CSV and JSON artifacts are excluded: scripts read them, documents do not.
 
 Adherence tier: a build-graph contract, like every other `_mk_discovery` consumer
@@ -60,6 +70,9 @@ guards, and this one is invisible there unless marked.
 import glob
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 
 import pytest
 from _mk_discovery import all_makefiles
@@ -155,11 +168,68 @@ def _displayed_basenames():
     return names
 
 
+# A Make variable assignment: `NAME :=`, `NAME =`, `NAME ?=`, `NAME +=`.
+_VAR_ASSIGN_RE = re.compile(r"^[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]*[:?+]?=", re.M)
+
+# Ask make to expand every assigned variable and keep only the artifact paths.
+# make does the filtering, so nothing shell-hostile ever reaches printf.
+_PROBE = (
+    "__erg_artifacts:\n"
+    "\t@printf '%s\\n' $(sort $(filter"
+    " deliverables/_shared/figures/%.png"
+    " deliverables/_shared/tables/%.md"
+    ",{refs}))\n"
+)
+
+
+def _assigned_variable_names():
+    names = set()
+    for mk in _makefiles():
+        names |= set(_VAR_ASSIGN_RE.findall(_read(mk)))
+    return sorted(names)
+
+
+def _make_expanded_artifacts():
+    """Artifact paths make computes from the variables the Makefiles assign.
+
+    Enumerating the names lexically and letting *make* expand them keeps this
+    honest about `$(foreach)`-composed lists, which no text scan can resolve —
+    the directory itself is often a variable. `.VARIABLES` would be the obvious
+    shortcut; it silently drops fragment-defined variables here, so the explicit
+    name list is deliberate.
+    """
+    make = shutil.which("make")
+    if make is None:
+        pytest.skip("make not on PATH — cannot expand the build graph's variables")
+    refs = " ".join(f"$({name})" for name in _assigned_variable_names())
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = os.path.join(tmp, "probe.mk")
+        with open(probe, "w", encoding="utf-8") as f:
+            f.write(_PROBE.format(refs=refs))
+        result = subprocess.run(
+            [make, "-s", "-f", "Makefile", "-f", probe, "__erg_artifacts"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    assert result.returncode == 0, (
+        "make could not expand the build graph — the guard's universe would "
+        f"silently narrow:\n{result.stderr}"
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
 def _declared(pattern):
-    """Artifact paths (repo-relative) named literally in the build graph."""
+    """Artifact paths (repo-relative) the build graph produces.
+
+    Union of the two readings described in the module docstring: paths written
+    literally anywhere in a Makefile, and paths make computes from a variable.
+    """
     found = set()
     for mk in _makefiles():
         found |= {m.group(0) for m in pattern.finditer(_read(mk))}
+    found |= {p for p in _make_expanded_artifacts() if pattern.fullmatch(p)}
     return found
 
 
@@ -187,8 +257,18 @@ _FLAT_INCLUDE_REASON = (
 _UNSETTLED_REASON = (
     "Built by make, displayed by no prose file, disposition undecided. "
     "Deleting a committed artifact together with its Make rules while the data "
-    "paper is mid-R&R is an author call, not a sweep's. Tracked with the "
-    "flat-include audit in ticket 0290."
+    "paper is mid-R&R is an author call, not a sweep's. No ticket covers these "
+    "yet — 0290 audits the flat includes only — so this entry is the record "
+    "until one is filed."
+)
+
+_ZOO_DIAGNOSTIC_REASON = (
+    "Method-zoo robustness diagnostic, reachable only through its own on-demand "
+    "phony target (bias-figures / sensitivity-figures / convergence). Outside "
+    "ALL_FIGS, so `make figures` never builds it, and displayed by no prose "
+    "file. Whether the zoo paper should show its own robustness panels is an "
+    "open editorial question, not a build defect; untracked, like the entries "
+    "above."
 )
 
 ALLOWED: dict[str, str] = {
@@ -261,6 +341,17 @@ ALLOWED: dict[str, str] = {
     "deliverables/_shared/figures/fig_communities.png": _UNSETTLED_REASON,
     "deliverables/_shared/figures/fig_traditions.png": _UNSETTLED_REASON,
     "deliverables/_shared/tables/tab_core_venues_top10.md": _UNSETTLED_REASON,
+    # Method-zoo diagnostics, visible only because make expands the variables
+    # that compose them ($(foreach) in zoo-figures.mk and divergence.mk).
+    "deliverables/_shared/figures/fig_zoo_bias_S1_MMD.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_zoo_bias_S2_energy.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_zoo_bias_L1.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_zoo_bias_C2ST_embedding.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_sensitivity_pca_S1_MMD.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_sensitivity_pca_S2_energy.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_sensitivity_jl_S1_MMD.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_sensitivity_jl_S2_energy.png": _ZOO_DIAGNOSTIC_REASON,
+    "deliverables/_shared/figures/fig_convergence.png": _ZOO_DIAGNOSTIC_REASON,
     # ── Markdown tables consumed by something other than a document ──────────
     "deliverables/_shared/tables/codebook.md": (
         "Ships in the Zenodo deposit, not in a paper: "
@@ -294,6 +385,28 @@ def test_nested_zoo_includes_are_reachable():
         "nested zoo includes reported unreachable — the resolver is resolving "
         "include paths against the including file's directory instead of the "
         "root document's:\n" + "\n".join(missing)
+    )
+
+
+def test_variable_composed_figures_are_in_the_universe():
+    """The universe includes figures no text scan can see.
+
+    `BIAS_FIGS` is `$(foreach m,$(BIAS_METHODS),$(ZOO_FIGS)/fig_zoo_bias_$(m).png)`
+    — both the directory and the stem come from variables, so its four figures
+    appear nowhere in the Makefiles as literal text. They escaped the guard
+    entirely until make was asked to do the expansion. This pin fails if the
+    universe ever narrows back to a text scan, which would turn real orphans
+    into a silent pass.
+    """
+    universe = _declared(_MK_FIGURE_RE)
+    composed = [
+        f"deliverables/_shared/figures/fig_zoo_bias_{m}.png"
+        for m in ("S1_MMD", "S2_energy", "L1", "C2ST_embedding")
+    ]
+    missing = [p for p in composed if p not in universe]
+    assert not missing, (
+        "variable-composed figures absent from the guard's universe — the build "
+        "graph is being read by text scan alone:\n" + "\n".join(missing)
     )
 
 

--- a/tests/test_artifact_reachability.py
+++ b/tests/test_artifact_reachability.py
@@ -1,0 +1,255 @@
+"""Reachability guard for generated artifacts under `deliverables/_shared/` (ticket 0359).
+
+`make` builds includes, tables and figures into `deliverables/_shared/`. Nothing
+checked that a document still consumes them, so a prose cut silently left the
+build graph producing artifacts for nobody: 0332's §4 cut orphaned
+`fig_sem_composition.png`, and the 0226/0240 deliverables reorg orphaned the
+whole flat `_includes/*.md` layer. This guard makes the next such orphaning fail
+a test instead of accumulating.
+
+## Two edge types, two checks
+
+An artifact reaches a reader over two different edges, and each check owns one:
+
+1. **Includes** — strict transitive reachability. A shared `_includes/**/*.md`
+   must be reachable from one of the deliverable `.qmd` roots by following
+   `{{< include >}}` directives.
+2. **Figures and markdown tables** — displayed by *some* prose file in the
+   corpus (a root `.qmd` or a shared include). Whether that prose file is itself
+   reachable is check 1's business.
+
+The split avoids reporting one root cause twice: 13 further figures are
+displayed only from the 17 unreachable includes. Reporting them here as well
+would triple the noise for a single finding, and would hide the real property —
+that when ticket 0290 settles those includes, those 13 figures newly fail check
+2 and force their own follow-up.
+
+## The trap this resolver must not fall into
+
+Quarto resolves a `{{< include >}}` path against the **top rendering document's**
+directory, not against the file that contains the directive (see
+`.claude/rules/architecture.md`). So the walk carries the *root's* directory as
+base through every level of recursion. Joining each include against its own
+directory is the natural implementation and it is wrong: a 2026-07-27 sweep
+written that way returned 13 confident false positives, all of
+`_includes/zoo/*.md`, which `_includes/techrep-zoo.md` reaches as
+`../_shared/_includes/zoo/…` from the zoo deliverable's folder.
+`test_nested_zoo_includes_are_reachable` pins that so the trap cannot return.
+
+## Artifact universes, and why each is chosen that way
+
+Each universe must be identical on a fresh checkout and on a fully built tree —
+a guard whose verdict depends on whether `make` has run is worthless.
+
+- Includes: every `_includes/**/*.md` on disk. All are committed handoff
+  artifacts; no build step writes one.
+- Figures / markdown tables: every such path named literally in a Makefile or
+  `.mk`. Most are gitignored and regenerable, so the filesystem is not a stable
+  universe; the build graph is. Dynamic outputs whose filenames are computed at
+  run time (`fig_lexical_tfidf_{year}.png`, tracked by `.lexical_tfidf.stamp`)
+  are outside any static universe and outside this guard.
+- CSV and JSON artifacts are excluded: scripts read them, documents do not.
+
+Fast tier: pure-Python lexical scan, no subprocess, no heavy import.
+"""
+
+import glob
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DELIVERABLES = os.path.join(REPO_ROOT, "deliverables")
+SHARED = os.path.join(DELIVERABLES, "_shared")
+
+# `{{< include path >}}` — Quarto's include shortcode.
+_INCLUDE_RE = re.compile(r"\{\{<\s*include\s+([^\s>]+)\s*>\}\}")
+# `![caption](path)` — markdown image.
+_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)\s]+)")
+# `\includegraphics[opts]{path}` — raw LaTeX, used by the slide decks.
+_GRAPHICS_RE = re.compile(r"\\includegraphics(?:\[[^\]]*\])?\{([^}]+)\}")
+
+# Artifact paths as they appear in the build graph.
+_MK_FIGURE_RE = re.compile(r"deliverables/_shared/figures/[\w.-]+\.png")
+_MK_TABLE_RE = re.compile(r"deliverables/_shared/tables/[\w.-]+\.md")
+
+
+def _deliverable_roots():
+    """The top rendering documents: one `.qmd` per deliverable folder."""
+    return sorted(glob.glob(os.path.join(DELIVERABLES, "*", "*.qmd")))
+
+
+def _makefiles():
+    """Every Makefile fragment that can name an artifact path."""
+    paths = [os.path.join(REPO_ROOT, "Makefile"), os.path.join(REPO_ROOT, "paths.mk")]
+    paths += sorted(glob.glob(os.path.join(REPO_ROOT, "scripts", "analysis", "*.mk")))
+    paths += sorted(glob.glob(os.path.join(DELIVERABLES, "*", "*.mk")))
+    return [p for p in paths if os.path.isfile(p)]
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _includes_in(text):
+    return [m.group(1) for m in _INCLUDE_RE.finditer(text)]
+
+
+def _assets_in(text):
+    return [m.group(1) for m in _IMAGE_RE.finditer(text)] + [
+        m.group(1) for m in _GRAPHICS_RE.finditer(text)
+    ]
+
+
+def _reachable_includes():
+    """Absolute paths of shared includes reachable from some deliverable root.
+
+    The base directory stays the ROOT document's directory at every depth — see
+    the module docstring. Changing that to the including file's directory is the
+    known defect this guard exists to avoid.
+    """
+    reached = set()
+    for root in _deliverable_roots():
+        base = os.path.dirname(root)
+        queue = [root]
+        seen = {os.path.normpath(root)}
+        while queue:
+            current = queue.pop()
+            if not os.path.isfile(current):
+                continue
+            for rel in _includes_in(_read(current)):
+                target = os.path.normpath(os.path.join(base, rel))
+                reached.add(target)
+                if target not in seen:
+                    seen.add(target)
+                    queue.append(target)
+    return reached
+
+
+def _all_shared_includes():
+    return sorted(glob.glob(os.path.join(SHARED, "_includes", "**", "*.md"), recursive=True))
+
+
+def _displayed_basenames():
+    """Basenames of every asset any prose file in the corpus references.
+
+    The corpus is the deliverable roots plus every shared include — reachable or
+    not. Check 1 owns whether the referencing include is itself reachable.
+    """
+    names = set()
+    for path in _deliverable_roots() + _all_shared_includes():
+        text = _read(path)
+        for rel in _assets_in(text) + _includes_in(text):
+            names.add(os.path.basename(rel))
+    return names
+
+
+def _declared(pattern):
+    """Artifact paths (repo-relative) named literally in the build graph."""
+    found = set()
+    for mk in _makefiles():
+        found |= {m.group(0) for m in pattern.finditer(_read(mk))}
+    return found
+
+
+def _rel(path):
+    return os.path.relpath(path, REPO_ROOT)
+
+
+# Deliberate exceptions, repo-relative path -> reason. Filled by the green step.
+ALLOWED: dict[str, str] = {}
+
+
+def test_nested_zoo_includes_are_reachable():
+    """Nested includes resolve against the ROOT document's directory.
+
+    `_includes/zoo/*.md` are reached only through `_includes/techrep-zoo.md`,
+    which names them `../_shared/_includes/zoo/…` — a path that resolves from
+    the zoo deliverable's folder, not from `_includes/`. A resolver that joins
+    each include against its own directory reports all 18 as orphans. This test
+    is the regression pin for that defect; it must fail loudly if the base ever
+    stops being the root's directory.
+    """
+    reached = _reachable_includes()
+    zoo = sorted(glob.glob(os.path.join(SHARED, "_includes", "zoo", "*.md")))
+    assert zoo, "no zoo includes found — the fixture this test pins has moved"
+    missing = [_rel(p) for p in zoo if p not in reached]
+    assert not missing, (
+        "nested zoo includes reported unreachable — the resolver is resolving "
+        "include paths against the including file's directory instead of the "
+        "root document's:\n" + "\n".join(missing)
+    )
+
+
+def test_shared_includes_are_reachable():
+    """Every shared include is reachable from a deliverable, or allowlisted."""
+    reached = _reachable_includes()
+    orphans = [
+        _rel(p)
+        for p in _all_shared_includes()
+        if p not in reached and _rel(p) not in ALLOWED
+    ]
+    assert not orphans, (
+        f"{len(orphans)} shared include(s) reachable from no deliverable .qmd. "
+        "Re-embed, delete, or add to ALLOWED with the reason:\n" + "\n".join(orphans)
+    )
+
+
+def test_declared_figures_are_displayed():
+    """Every figure the build graph declares is displayed by some prose file."""
+    orphans = sorted(
+        p
+        for p in _declared(_MK_FIGURE_RE)
+        if os.path.basename(p) not in _displayed_basenames() and p not in ALLOWED
+    )
+    assert not orphans, (
+        f"{len(orphans)} figure(s) built by make and displayed by no prose file. "
+        "Embed, drop the rule, or add to ALLOWED with the reason:\n" + "\n".join(orphans)
+    )
+
+
+def test_declared_markdown_tables_are_included():
+    """Every markdown table the build graph declares is included somewhere."""
+    orphans = sorted(
+        p
+        for p in _declared(_MK_TABLE_RE)
+        if os.path.basename(p) not in _displayed_basenames() and p not in ALLOWED
+    )
+    assert not orphans, (
+        f"{len(orphans)} markdown table(s) built by make and included by no prose "
+        "file. Include, drop the rule, or add to ALLOWED with the reason:\n"
+        + "\n".join(orphans)
+    )
+
+
+def test_allowlist_has_no_redundant_entries():
+    """An allowlist entry that is no longer orphaned must be removed.
+
+    Without this the allowlist rots into a permanent exemption list: an artifact
+    re-embedded by a later ticket would keep its exemption and the guard would
+    stop covering it.
+    """
+    reached = _reachable_includes()
+    displayed = _displayed_basenames()
+    declared = _declared(_MK_FIGURE_RE) | _declared(_MK_TABLE_RE)
+    on_disk = {_rel(p) for p in _all_shared_includes()}
+
+    redundant, unknown = [], []
+    for entry in ALLOWED:
+        if entry in on_disk:
+            if os.path.join(REPO_ROOT, entry) in reached:
+                redundant.append(f"{entry} — now reachable from a deliverable")
+        elif entry in declared:
+            if os.path.basename(entry) in displayed:
+                redundant.append(f"{entry} — now displayed by a prose file")
+        else:
+            unknown.append(entry)
+
+    assert not redundant, (
+        "allowlist entries that are no longer orphaned — delete them:\n"
+        + "\n".join(redundant)
+    )
+    assert not unknown, (
+        "allowlist entries naming no shared include and no build-graph artifact "
+        "(typo, or the artifact was deleted) — delete them:\n" + "\n".join(unknown)
+    )

--- a/tests/test_artifact_reachability.py
+++ b/tests/test_artifact_reachability.py
@@ -50,14 +50,21 @@ a guard whose verdict depends on whether `make` has run is worthless.
   are outside any static universe and outside this guard.
 - CSV and JSON artifacts are excluded: scripts read them, documents do not.
 
-Fast tier: pure-Python lexical scan, no subprocess, no heavy import.
+Adherence tier: a build-graph contract, like every other `_mk_discovery` consumer
+(`test_build_phase_separation`, `test_mk_discovery_unified`,
+`test_handoff_artifacts_tracked`). Cost is fast-tier — a pure-Python lexical scan,
+no subprocess, no heavy import — but `make lint` is the gate built to run rule
+guards, and this one is invisible there unless marked.
 """
 
 import glob
 import os
 import re
 
+import pytest
 from _mk_discovery import all_makefiles
+
+pytestmark = pytest.mark.adherence
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DELIVERABLES = os.path.join(REPO_ROOT, "deliverables")

--- a/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
+++ b/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
@@ -8,9 +8,10 @@ Author: HDMX-coding-agent
 2026-07-27T16:45Z HDMX-coding-agent note found while verifying 0328's cluster labels. One of the three orphans was created today by 0332's §4 cut; the other two predate it.
 
 2026-07-27T17:40Z HDMX-coding-agent note widened after a roar reachability sweep: this is not three figures in one variable, it is 17 includes, 2 tables and 5 figures across the whole build graph. Retitled. The sweep also found the trap the guard must avoid — see Test.
-2026-07-27T18:04Z note scope: 0290 owns disposition of the 17 flat includes (its action 2 is author-gated), so this ticket satisfies the explained arm — they are allowlisted with a grouped reason pointing at 0290. This guard is also 0290's action 3.
-2026-07-27T18:04Z note action 1 decided conservatively: fig_sem_composition kept, not deleted. Data paper is mid-R&R and 0332's cut §4 may return in round 2; retiring a committed figure with its lit-confirmations.mk rules mid-revision is an author call. Overrule cheaply by deleting the allowlist entry, SEM_COMPO_FIG/SEM_COMPO_TAB and tab_sem_composition.csv together.
-2026-07-27T18:04Z note sweep re-run with the root-relative resolver found 32 orphans, not 22: 17 includes (as filed), 3 markdown tables (codebook, tab_venues_fr_caption, plus tab_core_venues_top10 which the filing missed), 12 declared figures. The filing's fig_lexical_tfidf_2007/2013 are outside any static universe — dynamic filenames behind .lexical_tfidf.stamp — and outside this guard.
+
+2026-07-27T18:04Z HDMX-coding-agent note scope: 0290 owns disposition of the 17 flat includes (its action 2 is author-gated), so this ticket satisfies the explained arm — they are allowlisted with a grouped reason pointing at 0290. This guard is also 0290's action 3.
+2026-07-27T18:04Z HDMX-coding-agent note action 1 decided conservatively: fig_sem_composition kept, not deleted. Data paper is mid-R&R and 0332's cut §4 may return in round 2; retiring a committed figure with its lit-confirmations.mk rules mid-revision is an author call. Overrule cheaply by deleting the allowlist entry, SEM_COMPO_FIG/SEM_COMPO_TAB and tab_sem_composition.csv together.
+2026-07-27T18:04Z HDMX-coding-agent note sweep re-run with the root-relative resolver found 32 orphans, not 22: 17 includes (as filed), 3 markdown tables (codebook, tab_venues_fr_caption, plus tab_core_venues_top10 which the filing missed), 12 declared figures. The filing's fig_lexical_tfidf_2007/2013 are outside any static universe — dynamic filenames behind .lexical_tfidf.stamp — and outside this guard.
 --- body ---
 ## Context
 

--- a/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
+++ b/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
@@ -12,6 +12,7 @@ Author: HDMX-coding-agent
 2026-07-27T18:04Z HDMX-coding-agent note scope: 0290 owns disposition of the 17 flat includes (its action 2 is author-gated), so this ticket satisfies the explained arm — they are allowlisted with a grouped reason pointing at 0290. This guard is also 0290's action 3.
 2026-07-27T18:04Z HDMX-coding-agent note action 1 decided conservatively: fig_sem_composition kept, not deleted. Data paper is mid-R&R and 0332's cut §4 may return in round 2; retiring a committed figure with its lit-confirmations.mk rules mid-revision is an author call. Overrule cheaply by deleting the allowlist entry, SEM_COMPO_FIG/SEM_COMPO_TAB and tab_sem_composition.csv together.
 2026-07-27T18:04Z HDMX-coding-agent note sweep re-run with the root-relative resolver found 32 orphans, not 22: 17 includes (as filed), 3 markdown tables (codebook, tab_venues_fr_caption, plus tab_core_venues_top10 which the filing missed), 12 declared figures. The filing's fig_lexical_tfidf_2007/2013 are outside any static universe — dynamic filenames behind .lexical_tfidf.stamp — and outside this guard.
+2026-07-27T18:34Z HDMX-coding-agent note review round 1 found the universe was a text scan only, blind to figure lists make composes with $(foreach): BIAS_FIGS (zoo-figures.mk) and SENS_FIG_PCA/JL (divergence.mk), 9 real orphans escaping. Fixed by letting make expand every assigned variable rather than hand-mirroring the lists as literals; test_variable_composed_figures_are_in_the_universe pins it.
 --- body ---
 ## Context
 

--- a/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
+++ b/tickets/0359-datapaper-figs-lists-three-figures-the-p.erg
@@ -8,6 +8,9 @@ Author: HDMX-coding-agent
 2026-07-27T16:45Z HDMX-coding-agent note found while verifying 0328's cluster labels. One of the three orphans was created today by 0332's §4 cut; the other two predate it.
 
 2026-07-27T17:40Z HDMX-coding-agent note widened after a roar reachability sweep: this is not three figures in one variable, it is 17 includes, 2 tables and 5 figures across the whole build graph. Retitled. The sweep also found the trap the guard must avoid — see Test.
+2026-07-27T18:04Z note scope: 0290 owns disposition of the 17 flat includes (its action 2 is author-gated), so this ticket satisfies the explained arm — they are allowlisted with a grouped reason pointing at 0290. This guard is also 0290's action 3.
+2026-07-27T18:04Z note action 1 decided conservatively: fig_sem_composition kept, not deleted. Data paper is mid-R&R and 0332's cut §4 may return in round 2; retiring a committed figure with its lit-confirmations.mk rules mid-revision is an author call. Overrule cheaply by deleting the allowlist entry, SEM_COMPO_FIG/SEM_COMPO_TAB and tab_sem_composition.csv together.
+2026-07-27T18:04Z note sweep re-run with the root-relative resolver found 32 orphans, not 22: 17 includes (as filed), 3 markdown tables (codebook, tab_venues_fr_caption, plus tab_core_venues_top10 which the filing missed), 12 declared figures. The filing's fig_lexical_tfidf_2007/2013 are outside any static universe — dynamic filenames behind .lexical_tfidf.stamp — and outside this guard.
 --- body ---
 ## Context
 
@@ -111,11 +114,15 @@ Nothing is broken; `make` is doing work and the maintenance burden is real.
 
 ## Verification
 
-- [ ] Every entry in every `*_FIGS` variable is either rendered by that
-      deliverable or on the commented allowlist
-- [ ] `make figures` builds the same set as before, or the difference is
-      deliberate and stated
-- [ ] `ALL_FIGS` unchanged by the `fig_dag` move
+- [x] Every entry in every `*_FIGS` variable is either rendered by that
+      deliverable or on the commented allowlist —
+      `tests/test_artifact_reachability.py::test_declared_figures_are_displayed`
+- [x] `make figures` builds the same set as before, or the difference is
+      deliberate and stated — `make figures` expands `ALL_FIGS`, byte-identical
+      below, so the built set is unchanged
+- [x] `ALL_FIGS` unchanged by the `fig_dag` move — 35 paths before and after,
+      compared with `make --eval='__p:; @printf "%s\n" $(ALL_FIGS)' __p | sort`
+      run on the pre-change and post-change trees; `diff` empty
 
 ## Invariants
 
@@ -125,8 +132,18 @@ Nothing is broken; `make` is doing work and the maintenance burden is real.
 
 ## Exit criteria
 
-- [ ] Every generated artifact is reachable from a deliverable, or on the
-      commented allowlist with its reason
-- [ ] The 17 flat includes are deleted, revived, or explained
-- [ ] `paths.mk` answers "which artifacts does this deliverable need?" correctly
-- [ ] A guard fails when the next prose cut orphans an artifact
+- [x] Every generated artifact is reachable from a deliverable, or on the
+      commented allowlist with its reason — `tests/test_artifact_reachability.py`,
+      three checks over includes / declared figures / declared markdown tables,
+      plus `test_allowlist_has_no_redundant_entries` so an exemption dies the
+      moment its artifact is consumed again
+- [x] The 17 flat includes are deleted, revived, or explained — *explained*:
+      allowlisted under `_FLAT_INCLUDE_REASON` (0226/0240 reorg leftover),
+      disposition left to ticket 0290, whose action 2 is author-gated
+- [x] `paths.mk` answers "which artifacts does this deliverable need?" correctly
+      — `fig_dag` moved to the new `CORPUSREPORT_FIGS`; the cocitation map's and
+      `fig_sem_composition`'s built-not-rendered status commented above
+      `DATAPAPER_FIGS`
+- [x] A guard fails when the next prose cut orphans an artifact — demonstrated
+      red-then-green: the guard's first commit fails on 32 orphans with no
+      allowlist, the second passes with the allowlist filled


### PR DESCRIPTION
## What

A guard that fails when the build graph produces an artifact no document consumes, plus the two `paths.mk` fixes the ticket asked for.

`tests/test_artifact_reachability.py` (adherence tier) checks three artifact classes under `deliverables/_shared/`:

| check | universe | rule |
|---|---|---|
| includes | every `_includes/**/*.md` on disk | transitively reachable from one of the 11 deliverable `.qmd` roots |
| figures | every `figures/*.png` named in the build graph | displayed by some prose file |
| markdown tables | every `tables/*.md` named in the build graph | included by some prose file |

Plus `test_allowlist_has_no_redundant_entries`, so an exemption dies the moment its artifact is consumed again — without it the allowlist rots into a permanent ignore-list.

Red-then-green: the first commit fails with an empty allowlist; at HEAD, emptying `ALLOWED` yields exactly 41 orphans — equal to the allowlist keys, no gaps and no redundant entries.

## Two design calls worth reviewing

**Two edge types, two checks — not one strict transitive walk.** Includes get strict reachability from a root. Figures and tables get "displayed by *some* prose file", reachable or not. A single strict walk would report 25 orphaned figures instead of 12, because 13 are displayed only from the 17 orphaned includes — one root cause, reported three times. It would also hide the useful property this split gives: when ticket 0290 settles those includes, those 13 figures newly fail on their own and force their follow-up.

**Universes are chosen so the verdict never depends on whether `make` has run.** Includes come from disk (all committed handoff artifacts); figures and tables from the build graph (most are gitignored and regenerable). CSV and JSON are excluded — scripts read them, documents do not. Dynamic outputs (`fig_lexical_tfidf_{year}.png`, behind `.lexical_tfidf.stamp`) are in no static universe and out of scope; that is stated in the docstring.

## The trap

Quarto resolves `{{< include >}}` against the **top rendering document's** directory, not the including file's. The resolver carries the root's directory as base through every level of recursion. `test_nested_zoo_includes_are_reachable` pins it: the 18 `_includes/zoo/*.md` are reached only via `techrep-zoo.md` as `../_shared/_includes/zoo/…` from the zoo deliverable's folder, and the natural wrong implementation reports all 18 as orphans. That defect is what produced this ticket's 13 false positives. `/verify-adherence` mutation-tested it — swapping in the wrong-base resolver fails the test.

## Scope: what this PR deliberately does NOT do

**The 17 flat includes are explained, not settled.** Ticket 0290 owns their disposition and its action 2 sends any include not clearly superseded by the `techrep/` set to the author. Deleting or reviving them here would pre-empt an author call. They are allowlisted under one grouped reason naming 0290. Conversely 0290's action 3 asked for exactly this guard, so that arm is now supplied.

**`fig_sem_composition` is kept, not deleted.** It lost its consumer to 0332's §4 cut today, but the data paper is mid-R&R and §4 may return in round 2. Retiring a committed figure together with its `lit-confirmations.mk` rules mid-revision is the author's call. The reasoning is in the ticket log so it can be overruled cheaply: delete the allowlist entry, `SEM_COMPO_FIG`/`SEM_COMPO_TAB`, and `tab_sem_composition.csv` together. `tab_sem6_assignments.csv` and §1's literature-confirmation bullet are untouched either way.

## paths.mk

`fig_dag` moves from `DATAPAPER_FIGS` to a new `CORPUSREPORT_FIGS` — `corpus-report.qmd:25` is its only consumer, and it sat in the data paper's list only because no corpus-report list existed. `ALL_FIGS` absorbs the new variable and is **byte-identical**: 35 paths, `make --eval` on the pre- and post-change trees, empty `diff`. So `make figures` builds exactly the same set. `figures-corpusreport` added for symmetry with the other five per-deliverable targets.

The co-citation map's built-not-embedded status is now commented above `DATAPAPER_FIGS`, pointing at `tests/test_global_map.py:175` — a reader no longer has to grep to learn it is intentional.

## Sweep correction

The re-run found **41** orphans, not the 22 the filing estimated: 17 includes (as filed), 3 markdown tables (the filing missed `tab_core_venues_top10.md`), and 21 declared figures. Recorded in the ticket log.

## Verification

- `make lint` — 187 passed, 6 skipped (was 180; +7 from this guard).
- `make check` — 1848 passed, 7 failed. All 7 are `test_corpus_acceptance.py` file-existence checks: `.env` sets `CLIMATE_FINANCE_DATA=data` relative, so it resolves to this worktree's own `data/`, which holds only `.dvc` pointers. Pre-existing worktree condition, unrelated to this diff. The three ticket-0366 failures expected on main are gone — 0366 merged at c852824c.
- `erg check tickets/` — PASS (352 tickets).
- `/verify-adherence` — PASS, two nits, both fixed in the last commit (adherence marker; author field in the log entries).

**Ticket:** tickets/0359-datapaper-figs-lists-three-figures-the-p.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review rounds 1 and 2 — what changed

**Round 1 blocker: the universe was blind to composed variables.** The build graph was read by text scan alone, so figure lists make builds with `$(foreach)` were invisible — `BIAS_FIGS` in `zoo-figures.mk`, `SENS_FIG_PCA`/`SENS_FIG_JL` in `divergence.mk`. Nine real orphans escaped while the suite passed. A text scan cannot reach them even in principle: `$(ZOO_FIGS)/fig_zoo_bias_$(m).png` has neither the directory nor the stem as literal text. Rather than hand-mirror the lists as literals (the repo's existing habit for `ZOO_RESULT_FIGS`), the guard now enumerates assigned variable names lexically and lets **make** expand them — so the universe also cannot narrow when someone refactors a literal list into a function, which is the failure this PR had just suffered from the other side. `test_variable_composed_figures_are_in_the_universe` pins it.

**Round 2, two silent-pass gaps, both fixed rather than deferred** — each is the exact failure mode the guard exists to prevent:

- *Render fragments went unexpanded.* The probe ran `make -f Makefile`, which `-include`s the eight Phase-2 concern fragments but never the six per-deliverable render `.mk` (`make papers` invokes those with their own `$(MAKE) -f`). Every variable they assign expanded to nothing. The probe now runs once per entry point; the universe goes 80 → 86 paths.
- *Commented-out prose counted as a consumer.* `<!-- ![x](fig.png) -->` read as displayed. 0332 orphaned `fig_sem_composition` by deleting its paragraph — had it commented the paragraph out instead, this ticket would never have been filed. HTML comments are stripped before any prose scan, pinned by `test_commented_out_prose_is_not_a_consumer`.

Also dual-marked `integration` alongside `adherence` (four checks spawn `make`), matching `test_handoff_artifacts_tracked` and `test_phase_layout`.

`tests/_mk_discovery` supplies every makefile list — `test_no_handrolled_mk_enumeration` caught this file twice, and was right both times.

## ⚠️ Collision with PR #1195 — needs a human decision before either merges

PR #1195 (ticket 0290, `t290-orphaned-includes`) is open and overlaps this work substantially. It deletes 14 of the 17 flat includes, relocates 3, rewrites `paths.mk`'s include sets, adds a competing guard `tests/test_include_graph.py`, and files ticket 0373 on figure-set drift.

The branches merge **without textual conflict**, so `git` will not warn anyone. I built the combined tree and ran the suite against it: **3 of 7 checks go red** — 17 allowlist entries name files #1195 deletes, 13 figures lose their last prose consumer, 1 table follows. The failure is loud and self-describing (`test_allowlist_has_no_redundant_entries` names each stale entry), so nothing lands silently broken, but whoever merges second owns the reconciliation.

Two guards covering the include half is duplication worth resolving deliberately rather than by merge order.

**Ticket-ref:** tickets/0290-orphaned-shared-includes-audit.erg
