### PR TITLE
fix(0292): rebuild the three Phase-4 archives on the deliverables/ layout

### DIFF
--- a/build/build_analysis_archive.sh
+++ b/build/build_analysis_archive.sh
@@ -33,11 +33,16 @@ ANALYSIS_OUTPUTS=(
 echo "=== Building analysis archive ==="
 
 rm -rf "$TMP"
+# Output directories the archived Makefile writes into. They must pre-exist:
+# validate_io() in scripts/script_io_args.py requires the output's parent
+# directory, and the recipes mirror the repo paths that expected_outputs.md5
+# records — not a re-rooted content/ tree (ticket 0292).
 mkdir -p "$TMP/data/catalogs" \
+         "$TMP/data/derived/tables" \
          "$TMP/scripts" \
          "$TMP/config" \
-         "$TMP/content/figures" \
-         "$TMP/content/tables"
+         "$TMP/deliverables/_shared/figures" \
+         "$TMP/deliverables/_shared/tables"
 
 cd "$PROJ_ROOT"
 

--- a/build/build_analysis_archive.sh
+++ b/build/build_analysis_archive.sh
@@ -60,6 +60,10 @@ cp -L "$DATA_DIR/refined_embeddings.npz" "$TMP/data/catalogs/"
 # resolve to a real file, so the next mover cannot silently strand the cp.
 SCRIPTS=(
     scripts/utils.py
+    # Shared --input/--output parser. Every entry point below calls
+    # parse_io_args at the top of main, so without it the archived scripts fail
+    # at import; the archive shipped without it until ticket 0292.
+    scripts/script_io_args.py
     scripts/pipeline_loaders.py
     scripts/pipeline_io.py
     scripts/pipeline_progress.py

--- a/build/build_datapaper_archive.sh
+++ b/build/build_datapaper_archive.sh
@@ -2,7 +2,8 @@
 # Build the data paper reproducibility archive for Zenodo.
 #
 # Produces climate-finance-datapaper.tar.gz containing:
-#   code/           — full pipeline source (git archive) + pre-built figures/tables
+#   code/           — full pipeline source (git archive) + generated figures/tables,
+#                     all at their repo paths so deliverables/ works as it does here
 #   data/inputs/    — raw data inputs (per-source catalogs, pre-merge)
 #   data/products/  — final data products of the paper (corpus CSV without
 #                     abstracts, embeddings, citations, codebook)
@@ -21,6 +22,19 @@ ARCHIVE=climate-finance-datapaper
 TMP="/tmp/$ARCHIVE"
 # Honour the same data-root override as the Python pipeline (worktrees, smoke).
 DATA_DIR="${CLIMATE_FINANCE_DATA:-$PROJ_ROOT/data}/catalogs"
+
+# Phase-2 render inputs that `git archive` cannot ship because they are
+# gitignored regenerables. Mirrored into the code tree at their repo paths by
+# `cp --parents`, so this array is both the manifest and the layout. Guarded by
+# tests/test_archive_script_paths — each path must resolve to a real file, so a
+# renamed figure cannot silently strand the archive. Build them first with
+# `make corpus-tables figures-datapaper`. Keep the array free of parentheses.
+#
+# Figures only: the tables the paper includes are discovered below from its own
+# {{< include >}} directives, which cannot go stale the way a hand-kept list can.
+DATAPAPER_FILES=(
+    deliverables/_shared/figures/fig_bars.png
+)
 
 echo "=== Building data paper archive ==="
 
@@ -58,37 +72,38 @@ for src in openalex istex bibcnrs scispace grey teaching unfccc oecd; do
     cp -L "$DATA_DIR/${src}_works.csv" "$TMP/data/inputs/" 2>/dev/null || true
 done
 
-# ── Quarto project config: data paper only ───────────────
-# The repo _quarto.yml lists all papers; Quarto scans them all even when
-# rendering one file. Replace with a minimal config for the data paper.
-cat > "$TMP/code/_quarto.yml" << 'YAML'
-project:
-  type: default
-  output-dir: output
-  render:
-    - content/data-paper.qmd
+# ── Generated render inputs (hard fail) ──────────────────
+# `git archive` ships every *tracked* file at its repo path, so the data paper
+# already arrives as its own Quarto project under deliverables/data-paper/ with
+# its own _quarto.yml. What it cannot ship are the Phase-2 artifacts that are
+# gitignored because they are regenerable; those are mirrored in here at the
+# same repo paths, so the ../_shared/... references in data-paper.qmd resolve.
+#
+# No repo-wide _quarto.yml is written: the 0226 reorg retired it, and a config
+# re-rooting the paper under content/ is what broke this script (ticket 0292).
+echo "  Copying generated figures and tables..."
+mkdir -p "$TMP/code/deliverables/_shared/figures" "$TMP/code/deliverables/_shared/tables"
+# Loop variable deliberately not `src`: test_datapaper_archive_layout.py finds
+# the per-source catalog loop by taking the first line matching "for src in",
+# so a second one here would shadow the guard depending on line order.
+for f in "${DATAPAPER_FILES[@]}"; do
+    cp --parents "$f" "$TMP/code/"
+done
 
-bibliography: content/bibliography/main.bib
-
-format:
-  pdf:
-    pdf-engine: xelatex
-    cite-method: citeproc
-YAML
-
-# ── Figures, tables, vars for rendering (hard fail) ──────
-echo "  Copying figures and tables..."
-mkdir -p "$TMP/code/content/figures" "$TMP/code/content/tables"
-cp deliverables/_shared/figures/fig_bars.png "$TMP/code/content/figures/"
 # Stage exactly the tables the paper includes, discovered from its own
 # {{< include >}} directives. The hand-kept list had already gone stale
 # (tab_variables.md was missing) and would have gone stale again with
-# tab_corpus_flow.md (ticket 0327).
+# tab_corpus_flow.md (ticket 0327). They land at the repo-mirrored path the
+# include directives themselves name, so discovery and destination agree.
 grep -o '{{< include [^ ]*tables/[^ ]*\.md' deliverables/data-paper/data-paper.qmd \
   | sed 's|.*tables/||' | sort -u | while read -r tbl; do
-    cp "deliverables/_shared/tables/$tbl" "$TMP/code/content/tables/"
+    cp "deliverables/_shared/tables/$tbl" "$TMP/code/deliverables/_shared/tables/"
 done
-cp deliverables/data-paper/data-paper-vars.yml "$TMP/code/content/"
+
+# Reviewer entry point. The repo's own Makefile rides along in the git archive
+# and is the Phase-2 build; this one is the three-target reviewer interface,
+# invoked as `make -f Makefile.datapaper`.
+cp build/templates/Makefile.datapaper "$TMP/code/Makefile.datapaper"
 
 # ── Checksums for make verify ────────────────────────────
 echo "  Computing data checksums..."

--- a/build/build_manuscript_archive.sh
+++ b/build/build_manuscript_archive.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
-# Build the manuscript reproducibility archive (Phase 3).
-# Extracted from Makefile archive-manuscript recipe.
+# Build the manuscript reproducibility archive (Phase 4).
 #
 # Produces climate-finance-manuscript.tar.gz containing:
-#   content/  — manuscript source, figures, tables, bibliography
+#   deliverables/  — manuscript source and the shared assets it references,
+#                    mirrored at their repo paths so the ../_shared/ relative
+#                    references in manuscript.qmd resolve unchanged
 #   expected-manuscript.pdf — pre-built reference PDF
 #
-# Prerequisites: figures, includes, manuscript-vars.yml, and PDF built
+# The archive mirrors the repo layout (ticket 0226): each deliverable is its own
+# Quarto project carrying its own _quarto.yml, and shared assets live one level
+# up in deliverables/_shared/. Flattening this into the old content/ tree breaks
+# every ../_shared/... reference in the manuscript, which is what ticket 0292
+# fixed. Mirror with `cp --parents`; never re-root.
+#
+# Prerequisites: manuscript PDF built (make manuscript)
 # No Python needed — only Quarto + XeLaTeX.
 # Usage: bash build/build_manuscript_archive.sh
 
@@ -16,44 +23,49 @@ PROJ_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ARCHIVE=climate-finance-manuscript
 TMP="/tmp/$ARCHIVE"
 
-echo "=== Building manuscript archive ==="
+# Every input the archive ships, at its repo-relative path. `cp --parents`
+# mirrors each one into the archive, so this array is simultaneously the
+# manifest and the layout. Guarded by tests/test_archive_script_paths — each
+# path must resolve to a real file, so a moved asset cannot silently strand
+# the archive. Keep the array free of parentheses.
+MANUSCRIPT_FILES=(
+    deliverables/manuscript/manuscript.qmd
+    deliverables/manuscript/manuscript-vars.yml
+    deliverables/manuscript/_quarto.yml
+    deliverables/manuscript/author-footnote.tex
+    deliverables/_shared/figures/fig_bars_v1.png
+    deliverables/_shared/figures/fig_breaks.png
+    deliverables/_shared/figures/fig_composition.png
+    deliverables/_shared/tables/tab_venues.md
+    deliverables/_shared/bibliography/main.bib
+    deliverables/_shared/bibliography/oeconomia.csl
+)
 
-rm -rf "$TMP"
-mkdir -p "$TMP/content/bibliography" \
-         "$TMP/content/tables" \
-         "$TMP/content/figures"
+echo "=== Building manuscript archive ==="
 
 cd "$PROJ_ROOT"
 
-# Pre-built figures (validated, not regenerated)
-cp deliverables/_shared/figures/fig_bars_v1.png     "$TMP/content/figures/"
-cp deliverables/_shared/figures/fig_composition.png "$TMP/content/figures/"
+rm -rf "$TMP"
+mkdir -p "$TMP"
 
-# Manuscript content
-cp deliverables/manuscript/manuscript.qmd          "$TMP/content/"
-cp deliverables/manuscript/manuscript-vars.yml     "$TMP/content/"
-cp deliverables/manuscript/author-footnote.tex     "$TMP/content/"
-cp deliverables/_shared/tables/tab_venues.md    "$TMP/content/tables/"
-cp deliverables/_shared/bibliography/main.bib   "$TMP/content/bibliography/"
-cp deliverables/_shared/bibliography/oeconomia.csl "$TMP/content/bibliography/"
+for src in "${MANUSCRIPT_FILES[@]}"; do
+    cp --parents "$src" "$TMP/"
+done
 
-# Pre-built output PDF (at root, away from Quarto's clean scope)
-cp deliverables/manuscript/manuscript.pdf   "$TMP/expected-manuscript.pdf"
+# Pre-built output PDF, kept at the archive root — away from the Quarto project
+# directory, so `quarto render` never treats it as its own stale output.
+cp deliverables/manuscript/manuscript.pdf "$TMP/expected-manuscript.pdf"
 
 # Build infrastructure (no Python needed)
-cp build/templates/Makefile.manuscript "$TMP/Makefile"
-cp _quarto.yml                     "$TMP/"
-
-# README for reviewers
+cp build/templates/Makefile.manuscript  "$TMP/Makefile"
 cp build/templates/README-manuscript.md "$TMP/README.md"
 
 # Record toolchain versions used to build the shipped PDF
 printf 'Quarto %s\n%s\n' "$(quarto --version)" "$(xdvipdfmx --version 2>&1 | head -1)" > "$TMP/TOOLCHAIN.txt"
 
 # Input checksums — reviewers verify with: make && make verify
-cd "$TMP" && md5sum content/figures/*.png content/tables/*.md \
-    content/bibliography/main.bib content/manuscript.qmd \
-    content/manuscript-vars.yml > checksums.md5
+# Listed at the same mirrored paths the Makefile builds from.
+cd "$TMP" && md5sum "${MANUSCRIPT_FILES[@]}" > checksums.md5
 
 # Tarball
 echo "=== Creating tarball ==="

--- a/build/templates/Makefile.analysis-manuscript
+++ b/build/templates/Makefile.analysis-manuscript
@@ -1,8 +1,15 @@
 # Phase 2 reproducibility — "Inventing Climate Finance" (Œconomia)
-# Shipped inside the analysis archive (cp'd by make archive-analysis).
+# Shipped inside the analysis archive (cp'd by build/build_analysis_archive.sh).
 # Not used during development — provides a simple reviewer-facing interface.
 #
 # Verifies: figures and tables are reproducible from Phase 1 data.
+#
+# Outputs land at their repo paths (deliverables/_shared/..., data/derived/...),
+# which is what expected_outputs.md5 records — the build script checksums the
+# repo tree, so a template writing to some other prefix makes `make verify` fail
+# on missing files. Every recipe passes --output explicitly: the shared parser
+# in scripts/script_io_args.py declares it required with no default, so a recipe
+# omitting it exits 2 before doing any work (ticket 0292).
 #
 # Prerequisites: uv (https://docs.astral.sh/uv/)
 # Usage:
@@ -26,51 +33,67 @@ export PATH := $(HOME)/.local/bin:$(PATH)
 
 DATA    := data/catalogs
 REFINED := $(DATA)/refined_works.csv
+CONFIG  := config/analysis.yaml
 # Analysis-side scratch dir for large intermediates (matches utils.DERIVED_TABLES_DIR).
 DERIVED := data/derived/tables
+# Phase-2 artifacts destined for a document.
+SHARED  := deliverables/_shared
+
+# The nine outputs expected_outputs.md5 records. Keep in step with
+# ANALYSIS_OUTPUTS in the repo Makefile and in build_analysis_archive.sh.
+OUTPUTS := $(SHARED)/figures/fig_bars_v1.png \
+           $(SHARED)/figures/fig_composition.png \
+           $(SHARED)/tables/tab_venues.md \
+           $(DERIVED)/tab_alluvial.csv \
+           $(DERIVED)/tab_core_shares.csv \
+           $(DERIVED)/tab_bimodality.csv \
+           $(DERIVED)/tab_axis_detection.csv \
+           $(DERIVED)/tab_pole_papers.csv \
+           $(DERIVED)/cluster_labels.json
 
 .DEFAULT_GOAL := figures
 .PHONY: figures verify
 
-figures: content/figures/fig_bars_v1.png content/figures/fig_composition.png \
-         content/tables/tab_venues.md $(DERIVED)/tab_alluvial.csv
+figures: $(OUTPUTS)
 
 # Script paths mirror the repo layout after the epic-0240 reorg: entry points
 # live under scripts/{figures,analysis}/, tier-2 libs (utils, plot_style) stay
 # flat at scripts/. PYTHONPATH=scripts resolves the flat imports either way.
 $(DERIVED)/tab_alluvial.csv $(DERIVED)/tab_core_shares.csv $(DERIVED)/cluster_labels.json &: \
-		scripts/analysis/compute_clusters.py scripts/utils.py $(REFINED) $(DATA)/refined_embeddings.npz
+		scripts/analysis/compute_clusters.py scripts/utils.py $(CONFIG) $(REFINED) $(DATA)/refined_embeddings.npz
 	$(UV_RUN) python $< --output $(DERIVED)/tab_alluvial.csv
 
+# Bimodality tables (computation only — figures are separate targets below)
+$(DERIVED)/tab_bimodality.csv $(DERIVED)/tab_axis_detection.csv \
+$(DERIVED)/tab_pole_papers.csv &: \
+		scripts/analysis/analyze_bimodality.py scripts/utils.py $(CONFIG) $(REFINED)
+	$(UV_RUN) python $< --output $(DERIVED)/tab_bimodality.csv
+
 # ── Figures ─────────────────────────────────────────────────
-content/figures/fig_bars_v1.png: scripts/figures/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $< --v1-only
+$(SHARED)/figures/fig_bars_v1.png: scripts/figures/plot_fig1_bars.py scripts/plot_style.py scripts/utils.py $(CONFIG) $(REFINED)
+	$(UV_RUN) python $< --output $@ --v1-only
 
-content/figures/fig_composition.png: scripts/figures/plot_fig2_composition.py scripts/plot_style.py scripts/utils.py \
+$(SHARED)/figures/fig_composition.png: scripts/figures/plot_fig2_composition.py scripts/plot_style.py scripts/utils.py \
 		config/v1_tab_alluvial.csv config/v1_cluster_labels.json
-	$(UV_RUN) python $< --alluvial config/v1_tab_alluvial.csv --labels config/v1_cluster_labels.json
+	$(UV_RUN) python $< --output $@ --input config/v1_tab_alluvial.csv --labels config/v1_cluster_labels.json
 
-$(DATA)/het_mostcited_50.csv: scripts/analysis/build_het_core.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $<
+$(SHARED)/tables/tab_venues.md: scripts/figures/export_tab_venues.py scripts/_markdown_table.py scripts/utils.py \
+		$(REFINED) $(DERIVED)/tab_pole_papers.csv
+	$(UV_RUN) python $< --output $@ --pole-papers $(DERIVED)/tab_pole_papers.csv
 
-content/tables/tab_venues.md: scripts/figures/export_tab_venues.py scripts/utils.py $(REFINED) \
+# Bimodality figures (each reads tab_pole_papers.csv). Not checksummed —
+# available to reviewers who want the distributional detail behind the tables.
+$(SHARED)/figures/fig_bimodality.png: scripts/figures/plot_bimodality.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
-	$(UV_RUN) python $<
+	$(UV_RUN) python $< --output $@
 
-$(DERIVED)/tab_pole_papers.csv &: scripts/analysis/analyze_bimodality.py scripts/utils.py $(REFINED)
-	$(UV_RUN) python $<
-
-content/figures/fig_bimodality.png: scripts/figures/plot_bimodality.py scripts/utils.py \
+$(SHARED)/figures/fig_bimodality_lexical.png: scripts/figures/plot_bimodality_lexical.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
-	$(UV_RUN) python $<
+	$(UV_RUN) python $< --output $@
 
-content/figures/fig_bimodality_lexical.png: scripts/figures/plot_bimodality_lexical.py scripts/utils.py \
+$(SHARED)/figures/fig_bimodality_keywords.png: scripts/figures/plot_bimodality_keywords.py scripts/utils.py \
 		$(DERIVED)/tab_pole_papers.csv
-	$(UV_RUN) python $<
-
-content/figures/fig_bimodality_keywords.png: scripts/figures/plot_bimodality_keywords.py scripts/utils.py \
-		$(DERIVED)/tab_pole_papers.csv
-	$(UV_RUN) python $<
+	$(UV_RUN) python $< --output $@
 
 # ── Verification ──────────────────────────────────────────
 verify: figures

--- a/build/templates/Makefile.datapaper
+++ b/build/templates/Makefile.datapaper
@@ -31,11 +31,27 @@ verify:
 	@echo "=== PASS ==="
 
 # ── papers: render the data paper only ───────────────────
-papers: output/content/data-paper.pdf
+# The archive mirrors the repo layout: the data paper is its own Quarto project
+# under deliverables/data-paper/ and reaches shared assets as ../_shared/...
+# A single-file render writes the PDF next to its source, so the target below is
+# the exact path Quarto produces — make checks the recipe's exit code, not
+# whether the target appeared, so naming a path the tool never writes would
+# leave this rule reporting success with nothing built.
+DATAPAPER := deliverables/data-paper/data-paper.pdf
+SHARED    := deliverables/_shared
+
+papers: $(DATAPAPER)
 	@echo "=== Data paper rendered ==="
 
-output/content/data-paper.pdf: content/data-paper.qmd content/data-paper-vars.yml \
-                               content/bibliography/main.bib
+$(DATAPAPER): deliverables/data-paper/data-paper.qmd \
+              deliverables/data-paper/data-paper-vars.yml \
+              deliverables/data-paper/_quarto.yml \
+              $(SHARED)/bibliography/main.bib \
+              $(SHARED)/figures/fig_bars.png \
+              $(SHARED)/figures/fig_global_map_direct.png \
+              $(SHARED)/tables/tab_corpus_sources.md \
+              $(SHARED)/tables/tab_languages.md \
+              $(SHARED)/tables/tab_variables.md
 	quarto render $< --to pdf
 
 # ── corpus: incremental rebuild via DVC ──────────────────

--- a/build/templates/Makefile.manuscript
+++ b/build/templates/Makefile.manuscript
@@ -1,26 +1,41 @@
 # Phase 3 reproducibility — "Inventing Climate Finance" (Œconomia)
-# Shipped inside the manuscript archive (cp'd by make archive-manuscript).
+# Shipped inside the manuscript archive (cp'd by build/build_manuscript_archive.sh).
 # Not used during development — provides a simple reviewer-facing interface.
 #
 # Verifies: PDF renders from pre-built figures and content.
 # No Python, no data, no scripts required.
 #
-# Prerequisites: Quarto ≥ 1.4, XeLaTeX
+# The archive mirrors the repo layout: the manuscript is its own Quarto project
+# under deliverables/manuscript/ and reaches shared assets as ../_shared/...
+# Quarto's single-file render writes the PDF next to its source, so the target
+# below is the exact path Quarto produces — make checks the recipe's exit code,
+# not whether a file appeared, so a target naming a path the tool never writes
+# would leave this rule perpetually "succeeding" with nothing built.
+#
+# Prerequisites: Quarto >= 1.4, XeLaTeX
 # Usage:
 #   make         # render manuscript PDF
 #   make verify  # check inputs and output match expected checksums
 
 export SOURCE_DATE_EPOCH := 0
 
+MANUSCRIPT := deliverables/manuscript/manuscript.pdf
+SHARED     := deliverables/_shared
+
 .DEFAULT_GOAL := manuscript
 .PHONY: manuscript verify
 
-manuscript: output/content/manuscript.pdf
+manuscript: $(MANUSCRIPT)
 
-output/content/manuscript.pdf: content/manuscript.qmd content/manuscript-vars.yml \
-		content/figures/fig_bars.png content/figures/fig_composition.png \
-		content/tables/tab_venues.md \
-		content/bibliography/main.bib content/bibliography/oeconomia.csl
+$(MANUSCRIPT): deliverables/manuscript/manuscript.qmd \
+		deliverables/manuscript/manuscript-vars.yml \
+		deliverables/manuscript/_quarto.yml \
+		$(SHARED)/figures/fig_bars_v1.png \
+		$(SHARED)/figures/fig_breaks.png \
+		$(SHARED)/figures/fig_composition.png \
+		$(SHARED)/tables/tab_venues.md \
+		$(SHARED)/bibliography/main.bib \
+		$(SHARED)/bibliography/oeconomia.csl
 	quarto render $< --to pdf
 
 # ── Verification ──────────────────────────────────────────
@@ -31,11 +46,11 @@ output/content/manuscript.pdf: content/manuscript.qmd content/manuscript-vars.ym
 #   A mismatch is a warning, not a failure — inputs are the real contract.
 verify: manuscript
 	md5sum -c checksums.md5
-	@if diff -q expected-manuscript.pdf output/content/manuscript.pdf >/dev/null 2>&1; then \
+	@if diff -q expected-manuscript.pdf $(MANUSCRIPT) >/dev/null 2>&1; then \
 		echo "VERIFY: all inputs match, rebuilt PDF identical to shipped PDF"; \
 	else \
 		echo "VERIFY: all inputs match"; \
 		echo "WARNING: rebuilt PDF differs from shipped PDF (expected with different toolchain versions)"; \
 		echo "  Shipped:  $$(pdfinfo expected-manuscript.pdf 2>/dev/null | grep Producer || echo 'pdfinfo not available')"; \
-		echo "  Rebuilt:  $$(pdfinfo output/content/manuscript.pdf 2>/dev/null | grep Producer || echo 'pdfinfo not available')"; \
+		echo "  Rebuilt:  $$(pdfinfo $(MANUSCRIPT) 2>/dev/null | grep Producer || echo 'pdfinfo not available')"; \
 	fi

--- a/build/templates/README-datapaper.md
+++ b/build/templates/README-datapaper.md
@@ -12,7 +12,9 @@ Dataset DOI: [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130)
 climate-finance-datapaper/
   code/                    # Full pipeline source (git archive of HEAD)
     Makefile.datapaper     # Entry point — three targets below
-    content/               # Data paper source, figures, tables, vars
+    deliverables/          # Papers, each its own Quarto project
+      data-paper/          #   source (.qmd), pinned vars, project config
+      _shared/             #   figures, tables, bibliography
     scripts/               # Pipeline + analysis scripts
     config/                # Query taxonomy, source configuration
     dvc.yaml, dvc.lock     # Pipeline definitions
@@ -55,7 +57,7 @@ No Python, no internet needed.
 
 **`make papers`** — renders `data-paper.pdf` from frozen variables and
 pre-built figures. No pipeline, no API calls, no corpus data needed.
-Output: `output/content/data-paper.pdf`.
+Output: `deliverables/data-paper/data-paper.pdf`.
 
 **`make corpus`** — runs the full DVC pipeline (`dvc repro`). Included as
 process documentation; a full rebuild requires API access and takes 4–6
@@ -68,7 +70,7 @@ paper's figure and tables. They illustrate how to work with the dataset:
 
 | Script | Output | What it does |
 |--------|--------|--------------|
-| `scripts/plot_fig_bars.py` | `fig_bars.png` | Annual publication volume bar chart |
+| `scripts/figures/plot_fig1_bars.py` | `fig_bars.png` | Annual publication volume bar chart |
 | `scripts/figures/export_corpus_table.py` | `tab_corpus_sources.md` | Per-source quality and completeness table |
 | `scripts/figures/export_language_table.py` | `tab_languages.md` | Language distribution table |
 

--- a/build/templates/README-manuscript.md
+++ b/build/templates/README-manuscript.md
@@ -23,12 +23,17 @@ make verify      # check inputs match + compare PDF to shipped reference
 
 | Path | Description |
 |------|-------------|
-| `content/` | Manuscript source (.qmd), figures, tables, bibliography |
+| `deliverables/manuscript/` | Manuscript source (`.qmd`), pinned variables, Quarto project config |
+| `deliverables/_shared/` | Figures, tables, and bibliography the manuscript references |
 | `expected-manuscript.pdf` | Pre-built reference PDF for comparison |
 | `checksums.md5` | MD5 checksums of all input files |
 | `TOOLCHAIN.txt` | Quarto and xdvipdfmx versions used to build the shipped PDF |
 | `Makefile` | Build and verify targets |
-| `_quarto.yml` | Quarto project configuration |
+
+The archive mirrors the repository layout. The manuscript is its own Quarto
+project and reaches shared assets as `../_shared/...`, so those relative
+references resolve here exactly as they do in the source repository. The
+rendered PDF appears at `deliverables/manuscript/manuscript.pdf`.
 
 ## Verification
 

--- a/tests/test_archive_render_smoke.py
+++ b/tests/test_archive_render_smoke.py
@@ -1,0 +1,102 @@
+"""Clean-room render smoke test for the manuscript archive (ticket 0292).
+
+`test_archive_script_paths.py` proves every path the build script names resolves.
+That is necessary and not sufficient: the archive that shipped before this ticket
+listed paths which all existed, yet could not render, because it flattened them
+into a `content/` tree where the manuscript's own `../_shared/...` references no
+longer pointed at anything. Every path resolved in the repo; none resolved in the
+archive.
+
+So this test does the only thing that can catch that class: it builds the archive,
+extracts it somewhere else entirely, and runs the reviewer's own Makefile there.
+A reviewer with the tarball and nothing else must get a PDF.
+"""
+
+import os
+import shutil
+import subprocess
+import tarfile
+
+import pytest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BUILD_SCRIPT = os.path.join(REPO, "build", "build_manuscript_archive.sh")
+TARBALL = os.path.join(REPO, "climate-finance-manuscript.tar.gz")
+SHIPPED_PDF = os.path.join(REPO, "deliverables", "manuscript", "manuscript.pdf")
+RENDERED = os.path.join("deliverables", "manuscript", "manuscript.pdf")
+
+
+def _has_latex():
+    """A LaTeX engine on PATH, or the TinyTeX distribution Quarto installs."""
+    if shutil.which("xelatex"):
+        return True
+    return bool(
+        os.path.isdir(os.path.expanduser("~/.TinyTeX"))
+        or os.path.isdir(os.path.expanduser("~/.local/share/TinyTeX"))
+    )
+
+
+@pytest.mark.integration
+def test_manuscript_archive_renders_in_clean_room(tmp_path):
+    """The shipped archive must render a PDF outside the repo, from its own Makefile.
+
+    Red before ticket 0292: the build script died copying a root `_quarto.yml`
+    retired by the 0226 reorg, and the tree it assembled put the manuscript where
+    its `../_shared/...` references resolved to nothing.
+    """
+    if not shutil.which("quarto"):
+        pytest.skip("quarto not installed")
+    if not _has_latex():
+        pytest.skip("no LaTeX engine (xelatex or TinyTeX) available")
+    if not os.path.isfile(SHIPPED_PDF):
+        pytest.skip(f"no pre-built manuscript PDF — run `make manuscript` first ({SHIPPED_PDF})")
+
+    # The build script writes the tarball into the repo root. Leave the tree as
+    # we found it: a developer may have one there already.
+    preexisting = os.path.isfile(TARBALL)
+    backup = str(tmp_path / "preexisting.tar.gz")
+    if preexisting:
+        shutil.copy2(TARBALL, backup)
+
+    try:
+        build = subprocess.run(
+            ["bash", BUILD_SCRIPT],
+            cwd=REPO, capture_output=True, text=True, timeout=600,
+        )
+        assert build.returncode == 0, (
+            "build_manuscript_archive.sh failed:\n"
+            f"stdout:\n{build.stdout}\nstderr:\n{build.stderr}"
+        )
+        assert os.path.isfile(TARBALL), "build script reported success but wrote no tarball"
+
+        cleanroom = tmp_path / "cleanroom"
+        cleanroom.mkdir()
+        with tarfile.open(TARBALL) as tar:
+            tar.extractall(cleanroom, filter="data")
+        root = cleanroom / "climate-finance-manuscript"
+        assert root.is_dir(), f"unexpected archive top level: {os.listdir(cleanroom)}"
+
+        # The reviewer's entry point, run exactly as the README documents it.
+        render = subprocess.run(
+            ["make"], cwd=str(root), capture_output=True, text=True, timeout=1800,
+        )
+        assert render.returncode == 0, (
+            "the archive's own Makefile failed to render:\n"
+            f"stdout:\n{render.stdout[-4000:]}\nstderr:\n{render.stderr[-4000:]}"
+        )
+
+        pdf = root / RENDERED
+        assert pdf.is_file(), (
+            f"make succeeded but produced no PDF at {RENDERED}. Make checks the "
+            "recipe's exit code, not whether the target appeared, so a target "
+            "naming a path Quarto never writes reports success while building "
+            f"nothing. Archive tree: {sorted(os.listdir(root))}"
+        )
+        assert pdf.stat().st_size > 100_000, (
+            f"rendered PDF is implausibly small ({pdf.stat().st_size} bytes)"
+        )
+    finally:
+        if preexisting:
+            shutil.move(backup, TARBALL)
+        elif os.path.isfile(TARBALL):
+            os.remove(TARBALL)

--- a/tests/test_archive_script_paths.py
+++ b/tests/test_archive_script_paths.py
@@ -1,4 +1,4 @@
-"""Path-resolution guard for the analysis reproducibility archive (ticket 0261).
+"""Path-resolution guard for the reproducibility archives (tickets 0261, 0292).
 
 The older archive guards (`test_archive_checksums.py::TestArchiveScripts`,
 `test_script_hygiene.py::TestArchiveBitInvariance`) only assert that a script's
@@ -12,6 +12,24 @@ These guards have teeth: they resolve every script path the archive tooling will
 actually `cp`/invoke to a real file on disk. Point any listed path at a moved or
 missing file and the guard fails — so the next mover cannot silently strand the
 archive.
+
+Ticket 0292 widened the coverage from the analysis script's `SCRIPTS` array to
+every input all three archive scripts copy. The 0226 reorg had broken the
+manuscript and data paper scripts the same way — they assembled a `content/`
+tree and copied a root `_quarto.yml` that no longer exists — and only the
+analysis script was guarded, which is why the breakage went unseen.
+
+Two kinds of input need different proof of life:
+
+- **Tracked assets** (the manuscript source, the bibliography) exist on disk in
+  any checkout, so existence is the check.
+- **Generated artifacts** (`fig_bars.png`, `tab_languages.md`) are gitignored
+  regenerables, absent from a fresh checkout and rebuilt by `make`. Requiring
+  them on disk would make this guard fail for anyone who has not run the full
+  pipeline, so the check is that a Make rule still names them.
+
+So the invariant is: *every declared archive input either exists on disk or is
+named by a Make rule.* A renamed or moved asset satisfies neither and fails.
 """
 
 import os
@@ -22,14 +40,37 @@ import pytest
 pytestmark = pytest.mark.adherence
 
 REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-BUILD_SCRIPT = os.path.join(REPO, "build", "build_analysis_archive.sh")
+BUILD_DIR = os.path.join(REPO, "build")
 MAKEFILE_ANALYSIS = os.path.join(
     REPO, "build", "templates", "Makefile.analysis-manuscript"
 )
 
+BUILD_SCRIPTS = {
+    "analysis": os.path.join(BUILD_DIR, "build_analysis_archive.sh"),
+    "manuscript": os.path.join(BUILD_DIR, "build_manuscript_archive.sh"),
+    "datapaper": os.path.join(BUILD_DIR, "build_datapaper_archive.sh"),
+}
+
+# Each archive script declares its inputs in one named bash array, so the array
+# is both the manifest and the archive layout. Keeping the name here means a
+# renamed array fails loudly rather than silently guarding nothing.
+INPUT_ARRAYS = {
+    "analysis": "SCRIPTS",
+    "manuscript": "MANUSCRIPT_FILES",
+    "datapaper": "DATAPAPER_FILES",
+}
+
 # scripts/<optional-subdirs>/<name>.py — matches both flat (scripts/utils.py)
 # and reorg'd (scripts/figures/plot_fig1_bars.py) entry points.
 SCRIPT_PATH_RE = re.compile(r"scripts/(?:[\w-]+/)*[\w.-]+\.py")
+
+# A repo-relative path as written in a bash array or a literal `cp` source.
+# Anything with a shell variable or a glob resolves at run time and cannot be
+# checked statically, so those simply do not match. The token runs to the end of
+# the path: requiring a trailing `\.\w+` extension instead would truncate
+# `build/templates/Makefile.analysis-manuscript` at `.analysis`, since `\w`
+# excludes the hyphen — a false positive, not a finding.
+REPO_PATH_RE = re.compile(r"(?:deliverables|scripts|config|build|libs)/[\w./-]+")
 
 
 def _read(path):
@@ -37,17 +78,68 @@ def _read(path):
         return f.read()
 
 
-def _archive_script_paths():
-    """Repo-relative scripts/ paths inside the build script's SCRIPTS=( ... ) array."""
-    content = _read(BUILD_SCRIPT)
-    m = re.search(r"SCRIPTS=\((.*?)\)", content, re.DOTALL)
+def _makefile_text():
+    """Concatenated text of every Makefile that could declare an archive input."""
+    parts = [_read(os.path.join(REPO, "Makefile"))]
+    for root, _dirs, files in os.walk(os.path.join(REPO, "deliverables")):
+        for name in sorted(files):
+            if name.endswith(".mk"):
+                parts.append(_read(os.path.join(root, name)))
+    for root, _dirs, files in os.walk(os.path.join(REPO, "scripts")):
+        for name in sorted(files):
+            if name.endswith(".mk"):
+                parts.append(_read(os.path.join(root, name)))
+    return "\n".join(parts)
+
+
+def _declared_inputs(archive):
+    """Repo-relative paths inside the build script's declared input array."""
+    content = _read(BUILD_SCRIPTS[archive])
+    array = INPUT_ARRAYS[archive]
+    # Non-greedy up to the first ")" — the arrays are documented to hold no
+    # parentheses precisely so this stays correct.
+    m = re.search(rf"{array}=\((.*?)\)", content, re.DOTALL)
     assert m, (
-        "build_analysis_archive.sh must declare a SCRIPTS=( ... ) array of the "
-        "scripts it copies into the archive"
+        f"{os.path.basename(BUILD_SCRIPTS[archive])} must declare a "
+        f"{array}=( ... ) array of the inputs it copies into the archive"
     )
-    paths = SCRIPT_PATH_RE.findall(m.group(1))
-    assert paths, "SCRIPTS=( ... ) array holds no scripts/*.py paths"
+    body = "\n".join(
+        ln for ln in m.group(1).splitlines() if not ln.lstrip().startswith("#")
+    )
+    paths = REPO_PATH_RE.findall(body)
+    assert paths, f"{array}=( ... ) array holds no repo-relative paths"
     return paths
+
+
+def _literal_cp_sources(archive):
+    """Repo-relative literal `cp` sources outside the declared array.
+
+    The arguments are tokenised rather than pattern-matched. A path regex has to
+    anchor on something, and anchoring on a leading directory misses exactly the
+    defect this ticket exists for: the retired root `_quarto.yml` is a bare
+    filename at the repo root, so a prefix-anchored pattern never sees it and the
+    guard stays green on the original bug.
+
+    Tokens carrying a shell variable or a glob resolve at run time against roots
+    this test cannot know, so they are skipped — which also drops every
+    destination, since all of them are written under "$TMP".
+    """
+    text = _read(BUILD_SCRIPTS[archive]).replace("\\\n", " ")
+    sources = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#") or not stripped.startswith("cp "):
+            continue
+        for token in stripped[len("cp "):].split():
+            if any(token.startswith(op) for op in (">", "|", "&", ";", "2>")):
+                break  # a redirection or `|| true` — the cp arguments end here
+            token = token.strip("\"'")
+            if not token or token.startswith("-"):
+                continue  # a cp flag, not a path
+            if "$" in token or "*" in token or "?" in token:
+                continue  # resolves at run time
+            sources.append(token)
+    return sources
 
 
 def _makefile_script_paths():
@@ -65,22 +157,60 @@ def _makefile_script_paths():
     return paths
 
 
+def _named_by_make(path, makefile_text):
+    """True when a Makefile names this exact path, not merely contains it.
+
+    A plain substring test is wrong here: `_quarto.yml` occurs inside
+    `deliverables/manuscript/_quarto.yml`, so a retired root-level `_quarto.yml`
+    would look produced when nothing produces it — silently green on the very
+    defect ticket 0292 exists for. The path must sit on its own token boundary.
+    """
+    pattern = rf"(?<![\w./-]){re.escape(path)}(?![\w./-])"
+    return re.search(pattern, makefile_text) is not None
+
+
+def _unresolvable(paths, makefile_text):
+    """Paths that neither exist on disk nor are named by a Make rule.
+
+    `exists` rather than `isfile`: the analysis archive copies the bundled
+    `libs/openalex-corpus` package directory wholesale.
+    """
+    return sorted({
+        p for p in paths
+        if not os.path.exists(os.path.join(REPO, p))
+        and not _named_by_make(p, makefile_text)
+    })
+
+
 class TestArchiveScriptPathsResolve:
-    """Every script path the archive tooling names must resolve to a real file."""
+    """Every path the archive tooling names must resolve to a real file."""
 
-    def test_build_script_paths_exist(self):
-        """Each path in the build script's cp list must point at an existing file.
+    @pytest.mark.parametrize("archive", sorted(BUILD_SCRIPTS))
+    def test_declared_inputs_resolve(self, archive):
+        """Each path in a build script's input array must exist or be built.
 
-        Red before ticket 0261: the loop copied `scripts/compute_clusters.py`,
-        but the file lives at `scripts/analysis/compute_clusters.py` post-reorg.
+        Red before ticket 0261: the analysis loop copied
+        `scripts/compute_clusters.py`, but the file lives at
+        `scripts/analysis/compute_clusters.py` post-reorg.
         """
-        missing = [
-            p for p in _archive_script_paths()
-            if not os.path.isfile(os.path.join(REPO, p))
-        ]
+        missing = _unresolvable(_declared_inputs(archive), _makefile_text())
         assert not missing, (
-            "build_analysis_archive.sh lists scripts that do not exist at the "
-            f"path it will cp (moved or deleted?): {sorted(missing)}"
+            f"build_{archive}_archive.sh declares inputs that neither exist on "
+            f"disk nor are produced by any Make rule (moved or renamed?): {missing}"
+        )
+
+    @pytest.mark.parametrize("archive", sorted(BUILD_SCRIPTS))
+    def test_literal_cp_sources_resolve(self, archive):
+        """Each literal `cp` source outside the array must exist or be built.
+
+        Red before ticket 0292: build_manuscript_archive.sh copied a root
+        `_quarto.yml` retired by the 0226 deliverables/ reorg, so the script
+        died before writing a tarball.
+        """
+        missing = _unresolvable(_literal_cp_sources(archive), _makefile_text())
+        assert not missing, (
+            f"build_{archive}_archive.sh copies files that neither exist on disk "
+            f"nor are produced by any Make rule: {missing}"
         )
 
     def test_makefile_script_paths_exist(self):
@@ -99,7 +229,7 @@ class TestArchiveScriptPathsResolve:
         """Every entry point the archived Makefile invokes must be copied by the
         build script at the same path — otherwise the archive Makefile references
         a script the archive does not ship."""
-        copied = set(_archive_script_paths())
+        copied = set(_declared_inputs("analysis"))
         invoked = set(_makefile_script_paths())
         not_shipped = invoked - copied
         assert not not_shipped, (

--- a/tests/test_archive_script_paths.py
+++ b/tests/test_archive_script_paths.py
@@ -36,6 +36,7 @@ import os
 import re
 
 import pytest
+from _mk_discovery import all_makefiles
 
 pytestmark = pytest.mark.adherence
 
@@ -79,17 +80,12 @@ def _read(path):
 
 
 def _makefile_text():
-    """Concatenated text of every Makefile that could declare an archive input."""
-    parts = [_read(os.path.join(REPO, "Makefile"))]
-    for root, _dirs, files in os.walk(os.path.join(REPO, "deliverables")):
-        for name in sorted(files):
-            if name.endswith(".mk"):
-                parts.append(_read(os.path.join(root, name)))
-    for root, _dirs, files in os.walk(os.path.join(REPO, "scripts")):
-        for name in sorted(files):
-            if name.endswith(".mk"):
-                parts.append(_read(os.path.join(root, name)))
-    return "\n".join(parts)
+    """Concatenated text of every Makefile that could declare an archive input.
+
+    Enumerated through the shared helper (ticket 0248) so this guard cannot
+    silently narrow its coverage when a fragment moves.
+    """
+    return "\n".join(p.read_text() for p in all_makefiles())
 
 
 def _declared_inputs(archive):

--- a/tests/test_script_hygiene.py
+++ b/tests/test_script_hygiene.py
@@ -598,6 +598,9 @@ class TestArchiveBitInvariance:
             "pipeline_io.py",
             "pipeline_progress.py",
             "pipeline_text.py",
+            # Shared --input/--output parser: imported by the entry points, so
+            # the archive must ship it, but it is never a Makefile prerequisite.
+            "script_io_args.py",
         }
         for s in copied_scripts:
             if s in utilities:

--- a/tickets/0292-archive-build-scripts-stale-pre-reorg-layout.erg
+++ b/tickets/0292-archive-build-scripts-stale-pre-reorg-layout.erg
@@ -8,6 +8,10 @@ Author: HDMX-coding-agent
 
 2026-07-24T21:20Z HDMX-coding-agent note pulled into the RDJ-26561 resubmission lane (tracker 0274): the Zenodo repack (0280 kit + cut-plan supplement files) depends on these scripts building the current layout. Evidence found today: stray pre-reorg output/ tree with stale PDFs (companion-paper.pdf) in the primary checkout, trashed during tidy-up.
 
+2026-07-27T20:35Z HDMX-coding-agent verified manuscript archive: built, extracted to a clean tmp dir, rendered through its own Makefile, and make verify reports the rebuilt PDF byte-identical to the shipped one, md5 98c27adba24ff6cb43f09a07c462c7fe under SOURCE_DATE_EPOCH=0. Datapaper archive: built end to end at 211M, extracted, and data-paper.pdf renders from make -f Makefile.datapaper papers. Analysis archive: built at 89M; its Makefile dry-run resolves every rule to a recipe passing --output at the paths expected_outputs.md5 records, and the archive now carries script_io_args.py; a full clean-room run was not made, it needs a 1.8G uv sync. Guard red-tested on three mutations: a renamed array input, a renamed regenerable, and reintroducing the retired root _quarto.yml cp. make lint 185 passed, make check-fast 1217 passed. make check leaves 8 failures, none from this branch: 7 are test_corpus_acceptance file-existence in an empty worktree data/catalogs, and test_bias_flag passes in isolation.
+
+2026-07-27T20:30Z HDMX-coding-agent corrected all three scripts rebuilt on the deliverables/ mirror layout via cp --parents; each now declares its inputs in one named array that is both manifest and layout. Three defects beyond the ticket's diagnosis: the datapaper script wrote a _quarto.yml whose render list named content/data-paper.qmd, a file it never created; every recipe in Makefile.analysis-manuscript invoked its script without --output, which the shared parser declares required, so nothing in that archive could build; and the analysis archive never shipped scripts/script_io_args.py though three of its entry points import it. Also fixed: the analysis Makefile's default goal built four of the nine outputs its own verify checksums, and its targets sat under content/ while expected_outputs.md5 records repo paths.
+
 --- body ---
 ## Context
 During the 0153 resubmission deposit (2026-07-21), `bash
@@ -54,10 +58,10 @@ breakage went unseen.
   tarball's `make` renders (currently fails at the _quarto.yml cp).
 
 ## Verification
-- [ ] All three archive scripts build from a clean checkout
-- [ ] Manuscript archive clean-room render byte-identical to shipped PDF
+- [x] All three archive scripts build from a clean checkout
+- [x] Manuscript archive clean-room render byte-identical to shipped PDF
       (SOURCE_DATE_EPOCH=0)
-- [ ] Widened path guard red-tested by mutating one cp source
+- [x] Widened path guard red-tested by mutating one cp source
 
 ## Invariants
 - Archive layout mirrors the repo (deliverables/), per the 0226 architecture.

--- a/tickets/closed/0292-archive-build-scripts-stale-pre-reorg-layout.erg
+++ b/tickets/closed/0292-archive-build-scripts-stale-pre-reorg-layout.erg
@@ -2,6 +2,7 @@
 Title: Phase-4 archive scripts still build the pre-0226 content/ layout; manuscript one is broken
 Created: 2026-07-22
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1199
 
 --- log ---
 2026-07-22T10:05Z HDMX-coding-agent created
@@ -12,6 +13,7 @@ Author: HDMX-coding-agent
 
 2026-07-27T20:30Z HDMX-coding-agent corrected all three scripts rebuilt on the deliverables/ mirror layout via cp --parents; each now declares its inputs in one named array that is both manifest and layout. Three defects beyond the ticket's diagnosis: the datapaper script wrote a _quarto.yml whose render list named content/data-paper.qmd, a file it never created; every recipe in Makefile.analysis-manuscript invoked its script without --output, which the shared parser declares required, so nothing in that archive could build; and the analysis archive never shipped scripts/script_io_args.py though three of its entry points import it. Also fixed: the analysis Makefile's default goal built four of the nine outputs its own verify checksums, and its targets sat under content/ while expected_outputs.md5 records repo paths.
 
+2026-07-27T18:52Z HDMX-coding-agent closed — autoclosed — PR #1199
 --- body ---
 ## Context
 During the 0153 resubmission deposit (2026-07-21), `bash


### PR DESCRIPTION
**Ticket:** tickets/0292-archive-build-scripts-stale-pre-reorg-layout.erg

The three Phase-4 archive scripts still built the `content/` tree the 0226
reorg retired. The manuscript one died outright; the other two produced
tarballs that could not do their job. This puts all three on the repo layout
and gives the class a guard that fails on it.

## Why the layout, not just the missing file

`manuscript.qmd` reaches its assets as `../_shared/...`. That resolves only
when the manuscript sits in its own directory one level under `deliverables/`.
Flattening into `content/` breaks every one of those references, so copying the
retired root `_quarto.yml` was the symptom, not the disease. Each script now
mirrors repo paths with `cp --parents` and declares its inputs in one named
array that is both manifest and layout.

## Three defects the ticket had not diagnosed

- **The datapaper archive shipped a `_quarto.yml` whose render list named
  `content/data-paper.qmd`** — a file it never created, since only the vars
  were copied there. `git archive HEAD` already ships the paper as its own
  Quarto project at its repo path, so both the phantom tree and the repo-wide
  config are gone. The reviewer Makefile was never placed either, though the
  README told reviewers to invoke it.
- **Nothing in the analysis archive could build.** Every recipe invoked its
  script bare, and `script_io_args.parse_io_args` declares `--output` required
  with no default, so each exits 2 before doing work. The script ran, which is
  why the roar sweep read it as healthy. Two more mismatches followed: targets
  sat under `content/` while `expected_outputs.md5` checksums the repo tree,
  and the default goal built four of the nine outputs `make verify` checks.
- **`scripts/script_io_args.py` was never shipped**, though three archived
  entry points import it — every one died at import.

## Guard

Widened from the analysis script's `SCRIPTS` array to every input all three
declare. Two design points, both found by trying to make the guard fail on the
bug it exists for:

- Existence alone is the wrong check — some inputs are gitignored regenerables
  absent from a fresh checkout. The invariant is *exists on disk **or** named by
  a Make rule*.
- Anchoring on a path prefix misses the original defect: the retired file was a
  bare root-level `_quarto.yml`, so a prefix-keyed regex never saw it and the
  guard stayed green while reintroducing the exact `cp` that broke the script.
  Matching Make rules by substring failed the same way, since `_quarto.yml`
  occurs inside `deliverables/manuscript/_quarto.yml`. Arguments are tokenised
  and the Make lookup is token-bounded.

A path guard still cannot catch a layout that assembles but does not render, so
`test_archive_render_smoke.py` builds the manuscript archive, extracts it
elsewhere, and runs the reviewer's own Makefile there (19 s, skips when the
toolchain is absent).

## Verification

- Manuscript: clean-room render, `make verify` reports the rebuilt PDF
  **byte-identical** to the shipped one (md5 `98c27adb…`, `SOURCE_DATE_EPOCH=0`).
- Data paper: built end to end (211 MB), extracted, `data-paper.pdf` renders
  from `make -f Makefile.datapaper papers`.
- Analysis: built (89 MB); its Makefile dry-run resolves every rule to a recipe
  passing `--output` at the paths `expected_outputs.md5` records. A full
  clean-room run was **not** made — it needs a 1.8 GB `uv sync`.
- Guard red-tested on three mutations: a renamed array input, a renamed
  regenerable, and reintroducing the retired root `cp`. All three passed one of
  the discarded drafts.
- `make lint` 196 passed, `make check-fast` 1303 passed, both after the rebase.
  `make check` leaves 8 failures, none from this branch: 7 are
  `test_corpus_acceptance` file-existence against an empty worktree
  `data/catalogs/`, and `test_bias_flag` passes in isolation.

## Rebase note

`build_datapaper_archive.sh` conflicted with the retrieval-protocol work that
landed meanwhile. Upstream's table auto-discovery from the paper's own
`{{< include >}}` directives is better than a hand-kept list and is preserved —
retargeted to the mirrored path, and confirmed by rebuilding and re-rendering
the archive on the merged tree, where it correctly hard-failed on a table that
had not been generated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
