### PR TITLE
ticket(0340): log the round-1 verify-reroll bump

### DIFF
--- a/tickets/closed/0340-standing-guard-every-generated-markdown.erg
+++ b/tickets/closed/0340-standing-guard-every-generated-markdown.erg
@@ -10,6 +10,7 @@ Closed: autoclosed — PR #1172
 
 2026-07-27T14:02Z HDMX-coding-agent note blocker 0339 closed — Blocked-by removed.
 2026-07-27T18:33Z HDMX-coding-agent closed — autoclosed — PR #1172
+2026-07-27T18:34Z HDMX-coding-agent bump verify-reroll — round 1: two defects found by execution (last-column newline hole in scan(); rule_targets() split before expand_vars). Round 2 APPROVED after red-first fixes.
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket-ref: tickets/closed/0340-standing-guard-every-generated-markdown.erg

PR #1172 took two verify rounds. Round 1 returned REROLL on two defects, both re-derived by execution:

- `scan()` in the new guard only caught a torn table cell when the truncation remainder split into ≥2 cells, so a raw newline in the **last** column fell through every check — reachable from the emitter the module itself names canonical.
- `rule_targets()` split on whitespace *before* `expand_vars`, so a `$(VAR)` holding several paths collapsed into one space-joined key. `Makefile:328` was a live instance.

Both were fixed red-first and round 2 returned APPROVED. But no bump line was written, so ticket 0340's log reads as a clean single-round pass — and the raid wrap-up tally, which counts exactly these lines, undercounts by one.

Diff is one appended log line on an already-closed ticket. `erg check`: PASS (363 tickets).

**Ticket: none** — this records history on a ticket that is already closed and archived.