### PR TITLE
fix(0327): drop the source count from the deposit title, keep it in prose

### DIFF
--- a/build/templates/README-datapaper.md
+++ b/build/templates/README-datapaper.md
@@ -1,8 +1,8 @@
 # Data paper reproducibility archive
 
-Companion to: Ha-Duong M. (2026) "A Curated Corpus of Climate Finance
-Literature, 1990–2024: Eight Sources, Multilingual Retrieval, and Grey
-Literature", Research Data Journal for the Humanities and Social Sciences.
+Companion to: Ha-Duong M. (2026) "A Curated Multi-Source Corpus of Climate
+Finance Literature, 1990–2024: Multilingual Retrieval and Grey Literature",
+Research Data Journal for the Humanities and Social Sciences.
 
 Dataset DOI: [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130)
 

--- a/deliverables/data-paper/data-paper.qmd
+++ b/deliverables/data-paper/data-paper.qmd
@@ -34,7 +34,7 @@ format:
 <!-- Format: Data Paper, max 2,500 words, diamond OA, IISG/Openjournals -->
 <!-- Structure follows Petram & Kruizinga (2024) exemplar: Introduction, Method, Data, Concluding Remarks -->
 
-- Related dataset: "A Curated Corpus of Climate Finance Literature, 1990--2024: Eight Sources, Multilingual Retrieval, and Grey Literature" with DOI [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130) in repository "Zenodo"
+- Related dataset: "A Curated Multi-Source Corpus of Climate Finance Literature, 1990--2024: Multilingual Retrieval and Grey Literature" with DOI [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130) in repository "Zenodo"
 
 ## 1. Introduction {#sec-introduction}
 
@@ -139,7 +139,7 @@ We do not hold the full texts of the corpus's academic works, so the citation gr
 
 ## 3. Data description {#sec-data}
 
-The Zenodo deposit (DOI: [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130), temporal coverage 1990--2024) is a reproducibility archive in three parts: the pipeline source code (`code/`: scripts, configuration, and DVC definitions), the raw data inputs (`data/inputs/`: the eight per-source catalogs as harvested, before merge and deduplication), and the final data products of this paper (`data/products/`: the v1.1 corpus files described below). All CSV files use UTF-8 encoding with standard comma-separated format; identifiers are opaque string keys.
+The Zenodo deposit (DOI: [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130), temporal coverage 1990--2024) is a reproducibility archive in three parts: the pipeline source code (`code/`: scripts, configuration, and DVC definitions), the raw data inputs (`data/inputs/`: the {{< meta corpus_sources >}} per-source catalogs as harvested, before merge and deduplication), and the final data products of this paper (`data/products/`: the v1.1 corpus files described below). All CSV files use UTF-8 encoding with standard comma-separated format; identifiers are opaque string keys.
 
 **climate_finance_corpus.csv** ({{< meta corpus_raw >}} rows). The complete, unfiltered corpus: one deduplicated work per row, every column described in @tbl-variables and in the deposited codebook (`codebook.md`), which adds per-column allowed values and measured missingness. The quality flags are the audit trail: users reproduce our refined subset ({{< meta corpus_total >}} works) with `df[~df['is_flagged'] | df['is_protected']]`. The `near_duplicate_group` column identifies coordinated multi-journal publications sharing near-identical content; `in_v1` marks works present in the v1.0 submission corpus. Abstracts are not included in the deposited file due to publisher redistribution restrictions; they can be retrieved programmatically via the DOI or OpenAlex identifier --- which means reuse re-fetches them from a live index that drifts, unlike the frozen fields deposited here. @fig-bars shows the temporal distribution.
 
@@ -175,6 +175,6 @@ This corpus assembles climate finance scholarship into a single, cross-lingual b
 
 The corpus data files and pipeline source code are deposited in Zenodo under CC BY 4.0 at [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130). Key software dependencies: Python $\geq$ 3.10, pandas, sentence-transformers, and DVC. Suggested citation:
 
-> Ha-Duong, M. (2026). A Curated Corpus of Climate Finance Literature, 1990–2024: Eight Sources, Multilingual Retrieval, and Grey Literature [Data set]. Zenodo. [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130)
+> Ha-Duong, M. (2026). A Curated Multi-Source Corpus of Climate Finance Literature, 1990–2024: Multilingual Retrieval and Grey Literature [Data set]. Zenodo. [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130)
 
 ## References {.unnumbered}

--- a/deliverables/data-paper/revision-rdj26561/ed04-zenodo-restructure-upload.md
+++ b/deliverables/data-paper/revision-rdj26561/ed04-zenodo-restructure-upload.md
@@ -19,11 +19,14 @@ the latest version.
    `data/products/`; codebook.md in `data/products/`).
 2. Zenodo → record 19236130 → **New version**. Remove the old tarball, upload
    the new one.
-3. Replace the record description with the text below. Retitle the record
-   "Six Sources" → "**Eight Sources**" (ticket 0327): the v2 corpus adds the
-   curated UNFCCC and OECD DAC layers, and the paper's related-dataset entry
-   and suggested citation now carry the eight-source title. Authors, license
-   (data CC BY 4.0, code MIT), and keywords stay unchanged.
+3. Replace the record description with the text below. Retitle the record to
+   "**A Curated Multi-Source Corpus of Climate Finance Literature, 1990–2024:
+   Multilingual Retrieval and Grey Literature**", matching the paper's own
+   title. The count leaves the title entirely (author, 2026-07-27): the v2
+   corpus adds the curated UNFCCC and OECD DAC layers, and pinning a number in
+   the title only re-opens this edit at the next harvest. The source count
+   lives in the prose, where `{{< meta corpus_sources >}}` keeps it current.
+   Authors, license (data CC BY 4.0, code MIT), and keywords stay unchanged.
 4. Fill the record metadata below (ORCID, funding). It persists across
    versions, so this is a one-time pass.
 5. Set the version field (suggested: `v2.0` — new corpus harvest, eight
@@ -56,8 +59,8 @@ the **New version** button; adding it manually duplicates the chain.
 
 ## Record description (new version)
 
-Reproducibility archive for "A Curated Corpus of Climate Finance Literature,
-1990–2024: Eight Sources, Multilingual Retrieval, and Grey Literature"
+Reproducibility archive for "A Curated Multi-Source Corpus of Climate Finance
+Literature, 1990–2024: Multilingual Retrieval and Grey Literature"
 (Research Data Journal for the Humanities and Social Sciences).
 
 The archive is structured in three parts:

--- a/scripts/analysis/compute_vars.py
+++ b/scripts/analysis/compute_vars.py
@@ -349,11 +349,14 @@ def filter_stats(v):
     # Measured against action != "remove", not action == "keep" (ticket 0327).
     # The audit carries three actions: rows the filter removed ("remove"),
     # rows it kept ("keep"), and rows it kept that a later duplicate-DOI pass
-    # dropped ("deduped"). Counting only "keep" mixed two stages — 19 flagged
-    # works were protected by the filter and deduplicated afterwards, so the
-    # paper's `flagged - protected` subtraction came out 19 above the removal
-    # count it was supposed to equal. Both terms now describe the same stage;
-    # the deduplication drop is its own row in tab_corpus_flow.csv.
+    # dropped ("deduped"). Counting only "keep" mixed two stages — a few
+    # flagged works are protected by the filter and deduplicated afterwards,
+    # so the paper's `flagged - protected` subtraction came out above the
+    # removal count it was supposed to equal. Both terms now describe the same
+    # stage; the deduplication drop is its own row in tab_corpus_flow.csv.
+    #
+    # That overlap stays out of the paper on purpose: naming it costs a
+    # sentence of detail the reader does not need (author, 2026-07-27).
     flagged_protected = (flagged_mask & (audit["action"] != "remove")).sum()
     v["filter_protected"] = _int(flagged_protected)
 

--- a/tests/test_datapaper_archive_layout.py
+++ b/tests/test_datapaper_archive_layout.py
@@ -118,24 +118,42 @@ class TestDocsMatchLayout:
 
 
 class TestSourceCardinality:
-    """Ticket 0327, gap 5: the corpus grew from six sources to eight, but the
+    """Ticket 0327, gap 5: the corpus grew from six sources to eight and the
     deposit title, the related-dataset entry, the suggested citation and §3
     kept the v1.0 wording.
+
+    Writing "eight" was the wrong repair. A count in the title goes stale at
+    every harvest, which is how "six" survived into v2 in the first place, so
+    the count left the title entirely (author, 2026-07-27): both the paper and
+    the deposit are now titled "A Curated Multi-Source Corpus…". The number
+    lives in the prose, where `{{< meta corpus_sources >}}` keeps it current.
+    This guard therefore rejects *any* spelled-out cardinality, not just the
+    stale one.
 
     Scope is deliberately the data paper and the deposit metadata only. The
     Œconomia manuscript and the Gide slides say "six sources" *correctly* —
     manuscript-vars.yml is pinned to the v1.0 corpus, which had six.
     """
 
-    STALE = ("six sources", "Six Sources", "six per-source", "Six sources")
+    COUNTED = (
+        "six sources",
+        "Six Sources",
+        "six per-source",
+        "Six sources",
+        "eight sources",
+        "Eight Sources",
+        "eight per-source",
+        "Eight sources",
+    )
 
     @pytest.mark.parametrize("path", [QMD, README])
-    def test_no_stale_source_cardinality(self, path):
+    def test_source_cardinality_is_not_spelled_out(self, path):
         text = _read(path)
-        for phrase in self.STALE:
+        for phrase in self.COUNTED:
             assert phrase not in text, (
-                f"{os.path.basename(path)} still says {phrase!r} — the corpus "
-                "has eight sources since v2 (ticket 0327)"
+                f"{os.path.basename(path)} spells out a source count "
+                f"({phrase!r}). The title carries no number; the prose gets it "
+                "from {{< meta corpus_sources >}} (ticket 0327)"
             )
 
     def test_archive_ships_every_source_catalog(self):


### PR DESCRIPTION
The raid's "Six Sources" → "Eight Sources" repair was the wrong fix. A count pinned in a title goes stale at every harvest — which is precisely how "six" survived into v2 — so the count leaves the title entirely (author's call, 2026-07-27).

The deposit title now matches the paper's own, which was already neutral:

> A Curated Multi-Source Corpus of Climate Finance Literature, 1990–2024: Multilingual Retrieval and Grey Literature

Updated in the related-dataset entry, the suggested citation, the archive README template, and the Zenodo upload runbook.

The number stays where it can't rot: the deposit paragraph now reads `{{< meta corpus_sources >}} per-source catalogs` instead of a hand-typed "eight".

**The guard needed widening.** `TestSourceCardinality` rejected only the stale cardinality — it would have happily blessed "Eight Sources". It now rejects any spelled-out source count in the paper or the archive README, still scoped away from the Œconomia manuscript and Gide slides, which say "six sources" correctly against a v1.0-pinned vars file.

Also drops the specific overlap figure from the `filter_protected` comment in `compute_vars.py`. The paper deliberately does not state it, and the code doesn't need the exact number to explain why the measure changed.

Local gate: `make lint` and `make check-fast` both green (no CI in this repo).

**Author action still outstanding:** the live Zenodo record (v1.1) still reads "Six Sources" — it gets the neutral title at the pending new-version upload.

**Ticket:** none
Ticket-ref: tickets/closed/0327-datapaper-counts-do-not-reconcile.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)