### PR TITLE
ticket(0374,0358): cross-link two instances of one Makefile-parser bug shape

### DIFF
--- a/tickets/0358-migrate-the-hand-rolled-makefile-parsers.erg
+++ b/tickets/0358-migrate-the-hand-rolled-makefile-parsers.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-07-27T14:40Z HDMX-coding-agent note filed by the 0340 adherence self-gate, round 2. Both of its residual nits close with this one change.
 2026-07-27T15:05Z HDMX-coding-agent note corrected: the 0340 review panel found test_arch_compliance.py has no Makefile parser at all — its _ASSIGN is a Python-source regex for architecture rule 9. Two copies, not three.
 
+2026-07-27T18:38Z HDMX-coding-agent note now motivated by two confirmed instances of the same bug shape in two separate hand-rolled parsers: tests/_mk_discovery.py::rule_targets() (fixed in PR #1172) and tests/test_corpus_flow.py::grouped_targets_using_bare_at() (ticket 0374, open). Both split a Make target list on whitespace before expanding variables, so a $(VAR) holding several paths reads as one target. Each was found by a merge gate, neither by the guard itself.
 --- body ---
 ## Context
 

--- a/tickets/0374-grouped-target-output-guard-is-blind-to.erg
+++ b/tickets/0374-grouped-target-output-guard-is-blind-to.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-07-27T18:10Z HDMX-coding-agent created
 2026-07-27T18:20Z HDMX-coding-agent note found by the raid 0327/0329 merge gate, not by the guard itself. Filed with the reproducing case already identified.
 
+2026-07-27T18:38Z HDMX-coding-agent note second confirmed instance of this class, found independently by PR #1172's round-1 verify gate: tests/_mk_discovery.py::rule_targets() split the target list on whitespace before expand_vars, collapsing a multi-path $(VAR) into one space-joined key. Fixed there by expanding first (Make's own order). This ticket's grouped_targets_using_bare_at() at tests/test_corpus_flow.py:190 does the same split with no expansion and does NOT route through rule_targets(), so that fix does not reach it. Two hand-rolled parsers, one bug shape — ticket 0358 (migrate to a single Makefile parser) is the structural fix for both.
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket-ref: tickets/0374-grouped-target-output-guard-is-blind-to.erg
Ticket-ref: tickets/0358-migrate-the-hand-rolled-makefile-parsers.erg
Ticket: none

Two log lines, no code.

PR #1172's round-1 verify gate found `tests/_mk_discovery.py::rule_targets()` splitting a Make target list on whitespace *before* `expand_vars`, so a `$(VAR)` holding several paths collapsed into a single space-joined key and every artifact behind it was skipped silently. Fixed there by expanding first, which is Make's own order.

Ticket 0374 — filed independently by another session's merge gate 20 minutes before #1172 merged — is the same bug shape in `tests/test_corpus_flow.py::grouped_targets_using_bare_at()`, with the same `$(COMPUTED_STATS)` live instance. That function splits raw target text at line 190 and does **not** route through `rule_targets()`, so the #1172 fix does not reach it. Without this note, the next reader can reasonably conclude the merge already closed 0374. It did not.

The second-order point goes on 0358: two hand-rolled Makefile parsers have now produced the same defect, and both were caught by a merge gate rather than by the guard itself. That is the concrete argument for migrating to one parser that 0358 was filed without.

`erg check`: PASS (363 tickets).