### PR TITLE
ticket(0364): the harness KEYS= is a fallback, not a blanket

### DIFF
--- a/tickets/0364-hal-credentials-are-not-selected-by-keys.erg
+++ b/tickets/0364-hal-credentials-are-not-selected-by-keys.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-07-27T15:45Z HDMX-coding-agent created
 2026-07-27T17:44Z HDMX-coding-agent note Scope changed by the author mid-execution: update-publist is a harness skill, and the project copy was a stale fork shadowing it. The fork is deleted rather than repaired; the doc fix moves to the harness repo. See "Scope change" below.
 2026-07-27T18:35Z HDMX-coding-agent note Review round 1 on PR #1190 falsified the "no project consumer" premise: a project KEYS= line replaces the harness one, so the HAL names return to REQUIRED_KEYS_EXPORTS. Four sections only the deleted fork carried were ported into harness PR #680.
+2026-07-27T19:35Z HDMX-coding-agent note Corrected a false claim in this body: the harness KEYS= is a fallback, not a blanket. Override fires on the presence of a KEYS= line, not of .env, and drops every harness credential at once. Same claim corrected in harness PR #680.
 
 --- body ---
 ## Context
@@ -59,8 +60,27 @@ silent failure this ticket exists to close. The list's meaning widens to
 "credentials that must resolve for work started in this repo".
 
 Two things landed outside this PR: `~/.claude/.env` gained the same `hal`
-selection (machine-local, no value written) so the skill authenticates from any
-cwd, and the harness repo gets its own PR for the stale line in its `SKILL.md`.
+selection (machine-local, no value written), and the harness repo gets its own
+PR for the stale line in its `SKILL.md`.
+
+The harness selection is a fallback, not a blanket — an earlier draft of this
+paragraph said it lets "the skill authenticate from any cwd", which contradicts
+the override finding six paragraphs above and is false. Measured across three
+startup directories:
+
+| startup directory | harness `KEYS=` survives? |
+|---|---|
+| no `.env` at all | yes |
+| `.env` present, no `KEYS=` line | yes |
+| `.env` with a `KEYS=` line not naming `hal` | no |
+
+So the override fires on the presence of a **`KEYS=` line**, not of `.env`: a
+project whose `.env` holds only plain settings keeps the whole harness
+selection, and adding a single `KEYS=` line to that file drops *every* harness
+credential at once, not only the one under discussion. That cliff is what
+harness ticket 0360 tracks. For this repo it means the `hal` entry in the local
+`.env` is what makes a deposit launched from here work; `~/.claude/.env` covers
+launches from elsewhere.
 
 ## Relevant files
 
@@ -96,7 +116,8 @@ message — never a value.
 
 - [x] `HAL_ID` and `HAL_PASSWORD` resolve from the repo root and from a worktree
 - [x] Each matches `~/.config/keys/hal.env` **by hash** — never by printing
-- [x] They also resolve from a cwd outside the project (harness-level selection)
+- [x] They also resolve from a cwd outside the project that declares no `KEYS=`
+      of its own (harness-level selection; a cwd that declares one does not)
 - [x] Dropping either from `KEYS=` fails a test — measured against a `.env`
       selecting only `openalex`: both names unset, harness selection overridden
 - [x] No tracked file names `.env` as the source of a credential


### PR DESCRIPTION
Ticket-ref: tickets/0364-hal-credentials-are-not-selected-by-keys.erg

Ticket-only diff — one existing `.erg` edited, no new id, `erg check` PASS (366 tickets). Fast path per `.claude/rules/git.md`.

0364's body claimed `~/.claude/.env`'s selection lets `/update-publist` "authenticate from any cwd". That contradicts the same ticket six paragraphs earlier, where the override finding is stated correctly. A ticket arguing against itself is the defect shape 0364 exists to remove from a document, so it does not get to keep one.

Caught by the harness-side agent reviewing #680, which carried the same claim — merged together the two PRs would have landed a statement and its refutation.

Measuring it to write the correction produced a sharper fact than either side had:

| startup directory | harness `KEYS=` survives? |
|---|---|
| no `.env` at all | yes |
| `.env` present, no `KEYS=` line | yes |
| `.env` with a `KEYS=` line not naming `hal` | **no** — and `OPENAI_API_KEY` goes too |

The override fires on the presence of a `KEYS=` **line**, not of `.env`. So a project whose `.env` holds only plain settings keeps the entire harness selection, and adding a single `KEYS=` line to that file drops every harness credential at once — a cliff, invisible until some unrelated tool fails to authenticate. Harness ticket 0360 ([#681](https://github.com/MinhHaDuong/ImperialDragonHarness/pull/681)) tracks the fix; this PR records the measurement where the next reader of 0364 will meet it, and sharpens one verification checkbox that was true only by accident of where I ran the probe.

Same correction applied to #680's body; its file text is the harness agent's to fix, and the exact replacement wording is posted as a comment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)