### PR TITLE
ticket(0364): close and archive — harness #680 merged

### DIFF
--- a/tickets/closed/0364-hal-credentials-are-not-selected-by-keys.erg
+++ b/tickets/closed/0364-hal-credentials-are-not-selected-by-keys.erg
@@ -2,6 +2,7 @@
 Title: HAL credentials are not selected by KEYS= so update-publist cannot deposit
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: KEYS= now selects both HAL credentials, the shadowing fork is deleted, and the surviving harness SKILL.md names the keystore correctly (harness #680)
 
 --- log ---
 2026-07-27T15:45Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-07-27T18:35Z HDMX-coding-agent note Review round 1 on PR #1190 falsified the "no project consumer" premise: a project KEYS= line replaces the harness one, so the HAL names return to REQUIRED_KEYS_EXPORTS. Four sections only the deleted fork carried were ported into harness PR #680.
 2026-07-27T19:35Z HDMX-coding-agent note Corrected a false claim in this body: the harness KEYS= is a fallback, not a blanket. Override fires on the presence of a KEYS= line, not of .env, and drops every harness credential at once. Same claim corrected in harness PR #680.
 
+2026-07-27T18:53Z HDMX-coding-agent closed — KEYS= now selects both HAL credentials, the shadowing fork is deleted, and the surviving harness SKILL.md names the keystore correctly (harness #680)
 --- body ---
 ## Context
 
@@ -121,7 +123,7 @@ message — never a value.
 - [x] Dropping either from `KEYS=` fails a test — measured against a `.env`
       selecting only `openalex`: both names unset, harness selection overridden
 - [x] No tracked file names `.env` as the source of a credential
-- [ ] The harness `SKILL.md` no longer does either — harness PR #680, open
+- [x] The harness `SKILL.md` no longer does either — harness #680 merged 2026-07-27
 
 ## Invariants
 


### PR DESCRIPTION
Ticket-ref: tickets/closed/0364-hal-credentials-are-not-selected-by-keys.erg

Ticket-only diff — one `.erg` closed and archived, `erg check` PASS (366 tickets). Fast path per `.claude/rules/git.md`.

0364's last exit criterion was the one this repo could not satisfy alone. Deleting the shadowing fork made the harness `SKILL.md` the only `update-publist` document, and it still named the project `.env` as the credential source. That is why #1190 carried `Ticket-ref:` rather than `Ticket:` — so merging it could not close a ticket whose fix had an open dependency in another repo.

`ImperialDragonHarness#680` merged 2026-07-27T18:49Z with a correction better than the one I proposed: it states the override rule inline and adds a check-first probe so a wrong startup directory fails with a diagnosis rather than an auth error.

```
bash -c ': "${HAL_ID:?not selected from this cwd}"'
```

Closed by hand, per the manual chore-close recipe: `erg close`'s header edit staged **before** the `git mv`, so the commit carries an edit + rename (3 insertions) rather than a rename-only diff that would silently drop the `Closed:` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)