### PR TITLE
ticket(0381): note what 0292 already covers

### DIFF
--- a/tickets/0381-archive-guard-checks-the-declaration-no.erg
+++ b/tickets/0381-archive-guard-checks-the-declaration-no.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T19:20Z HDMX-coding-agent created found while executing 0352, which fixed the parser that reads the declaration. Deliberately not folded into that PR: it is a different concern and 0352's exit criteria do not reach it.
 
+2026-07-27T19:01Z note partly overtaken by ticket 0292, which landed on main after this was filed. origin/main:tests/test_archive_script_paths.py now carries _literal_cp_sources(), which tokenises cp arguments and collects literal repo-relative sources outside the declared array — that is Action 2, done. Action 1 is NOT covered: _literal_cp_sources skips any token containing a dollar sign, so a slice like CORE_SCRIPTS=("${SCRIPTS[@]:0:6}") is passed over exactly as "${SCRIPTS[@]}" is. The subset case, which is the one that silently ships fewer files than were validated, remains open. Action 3 (the docstring overclaim) also remains. Re-scope before executing.
 --- body ---
 ## Context
 


### PR DESCRIPTION
Raid 328/352/359 integration pass. Ticket-only diff — fast path.

0292 landed on main after 0381 was filed and rewrote the same guard, adding `_literal_cp_sources()`. That closes 0381's **Action 2**: a `cp` of a literal path outside the declared array is now caught.

**Action 1 survives, and it is the one that matters.** `_literal_cp_sources()` skips any token containing a dollar sign:

```python
if "$" in token or "*" in token or "?" in token:
    continue  # resolves at run time
```

So a slice like `CORE_SCRIPTS=("${SCRIPTS[@]:0:6}")` is passed over exactly as `"${SCRIPTS[@]}"` is. Shipping a *subset* of the validated array stays silent — which was 0352's failure mode one level down, and the reason 0381 exists. Action 3 (the docstring overclaim) also stands.

Recorded now rather than left for the executor to rediscover: the ticket would otherwise read as wholly open and buy a redundant implementation of a check already on main.

**Ticket-ref:** tickets/0381-archive-guard-checks-the-declaration-no.erg
**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)