### PR TITLE
ticket(0386,0387): dangling script refs in rendered prose + standing guard; renumber a duplicate 0385

### DIFF
--- a/tickets/0386-two-includes-cite-a-script-that-no-longer.erg
+++ b/tickets/0386-two-includes-cite-a-script-that-no-longer.erg
@@ -1,0 +1,90 @@
+%erg 0.1
+Title: Two rendered includes cite compute_alluvial.py, which no longer exists
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T19:05Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Found by the ticket 0364 wrap-up sweep, looking for the same defect class the
+ticket had just fixed: a document naming a source that is not there.
+
+Two shared includes carry a `**Scripts:**` provenance line naming
+`scripts/compute_alluvial.py`:
+
+- `deliverables/_shared/_includes/alluvial-diagram.md:3`
+- `deliverables/_shared/_includes/structural-breaks.md:3`
+
+That file exists nowhere in the repo. The alluvial artifacts are produced by
+`scripts/analysis/analyze_alluvial.py` plus the `scripts/figures/plot_*` set;
+`compute_alluvial.py` was a shim that has since been removed —
+`tests/test_alluvial_unit.py` still describes its `_build_argv()` flag
+forwarding in a docstring, which is how the old name survives in the tree.
+
+These includes render into deliverables, so the dangling pointer reaches
+readers. A reader checking provenance — the reason the line exists — finds
+nothing.
+
+Three things make this more than a typo:
+
+1. **The class already recurred.** Ticket 0235, "stale renamed script
+   references", is closed. This is the same defect returning in files that
+   fix did not reach.
+2. **It was already audited and not fixed.** `docs/ncc-pipeline-audit.md:286`
+   records "core-vs-full.md include references `compute_alluvial.py`". That
+   instance *was* fixed — `core-vs-full.md` no longer names it — but the two
+   above were never found, and the audit line still reads as an open finding.
+   Recording a defect in a prose audit is not a mechanism for removing it.
+3. **A green suite does not see it.** `make check` passes today. Nothing
+   resolves a `**Scripts:**` line against the filesystem.
+
+## Relevant files
+
+- `deliverables/_shared/_includes/alluvial-diagram.md:3` — dangling ref.
+- `deliverables/_shared/_includes/structural-breaks.md:3` — dangling ref.
+- `scripts/analysis/analyze_alluvial.py` — the real producer.
+- `tests/test_alluvial_unit.py:7,236,255` — docstrings naming the dead shim.
+- `docs/ncc-pipeline-audit.md:286` — the stale audit finding.
+- `deliverables/_shared/_includes/temporal-structure.md:7,12` — a *different*
+  dangling ref (`scripts/analyze_space_interactions.py`, now under
+  `scripts/archive/`) that ticket 0244 already annotated in place. It is a
+  marked exception, not a silent one; decide whether to repoint it at the
+  archive path or leave the marker, but do not treat it as the same bug.
+
+## Actions
+
+1. Repoint both `**Scripts:**` lines at the real producers. Verify against the
+   Makefile rule that actually builds each figure, not by name similarity.
+2. Update the three `tests/test_alluvial_unit.py` docstrings so the dead name
+   stops propagating; no behaviour change.
+3. Resolve `docs/ncc-pipeline-audit.md:286` — the instance it names is fixed.
+4. Decide the `temporal-structure.md` case explicitly and record the decision.
+
+## Test
+
+Ticket 0387 covers the standing guard for this class; do not write it here.
+For this ticket, the check is mechanical and one-shot: every
+`scripts/…\.py` / `tests/…\.py` path named in a file under
+`deliverables/_shared/_includes/` resolves on disk. Run it before and after —
+red on the two lines above, green after.
+
+## Verification
+
+- [ ] Both includes name a path that exists, and that path is the one the
+      Makefile rule for that figure actually invokes
+- [ ] `make check` still green
+- [ ] The audit line no longer reads as an open finding
+
+## Invariants
+
+- Prose edits only in the provenance lines — no change to any figure, table,
+  or number.
+- `make check` stays green (project has no CI; run it locally).
+
+## Exit criteria
+
+No file under `deliverables/_shared/_includes/` names a script path that does
+not exist, and every surviving exception is annotated as a deliberate one.

--- a/tickets/0387-standing-guard-prose-must-not-name-a-scri.erg
+++ b/tickets/0387-standing-guard-prose-must-not-name-a-scri.erg
@@ -1,0 +1,94 @@
+%erg 0.1
+Title: Standing guard — tracked prose must not name a script path that does not exist
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Blocked-by: 0386
+
+--- log ---
+2026-07-27T19:06Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Companion to ticket 0386, which fixes the instances. This one stops the class
+coming back.
+
+The class has now been fixed twice and returned twice. Ticket 0235 ("stale
+renamed script references") closed. `docs/ncc-pipeline-audit.md:286` recorded
+another instance in a prose audit; that one was fixed and two siblings in
+neighbouring files were missed. The 0364 wrap-up sweep found those two. Each
+round was a point fix, and a point fix cannot cover a class that reappears
+wherever the next rename happens to land.
+
+The defect is mechanically detectable, which is what makes a standing test the
+right instrument rather than another audit. A one-off sweep of tracked prose
+for `(scripts|tests|libs)/…\.py` references that do not resolve on disk found
+99 raw hits; the signal is much smaller, and separating it is the whole design
+problem below.
+
+## The design problem: most hits are legitimate
+
+A naive "every named path must exist" test fails on day one. Three classes of
+legitimate non-existent reference:
+
+1. **Closed tickets** record paths as they were. `tickets/closed/**` is
+   history and rewriting it to satisfy a guard is the wrong direction — the
+   same reasoning that excludes `tickets/` from `STALE_ENV_CLAIMS` in
+   `tests/test_env_has_no_secret_literals.py`.
+2. **Open tickets name files they will create.** A ticket proposing
+   `scripts/compute_graph_density.py` is doing its job. This is the large
+   majority of the 99 and it is not a defect.
+3. **Documentation placeholders** — `scripts/my_script.py` in
+   `.agent/guidelines/coding-guidelines.md`, `scripts/x.py` in
+   `.claude/rules/coding.md` — are illustrative by design.
+
+So the guard's value lives almost entirely in one place: **prose that renders
+into a deliverable**, where the reference is a provenance claim a reader can
+follow. Scope it there and the false-positive rate goes to zero.
+
+## Actions
+
+1. Add an `adherence`-marked test asserting that every
+   `(scripts|tests|libs)/…\.py` path named in a file under
+   `deliverables/` resolves on disk.
+2. Discover the files, do not list them — the auto-discovery rule
+   (memory: `feedback_autodiscovery_class_guard`). A hardcoded list is how
+   the previous rounds missed siblings.
+3. Give deliberate exceptions one marker, checked for staleness, so an
+   allowlist entry cannot rot into a mute skip. `tests/test_deliverable_artifacts.py`
+   (ticket 0359) already does exactly this for includes and figures with
+   `# not-embedded:` and `config/unrendered-artifacts.txt` — follow that
+   pattern, and prefer extending that test over adding a new one if the fit
+   is clean.
+4. Decide whether to extend beyond `deliverables/` later. Do not do it in
+   this ticket: the open-ticket class above would drown the signal.
+
+## Test
+
+The guard *is* the deliverable. Its own red step: with 0386 reverted, the test
+names `deliverables/_shared/_includes/alluvial-diagram.md` and
+`structural-breaks.md` and fails. With 0386 applied, green. Assert on the
+message content too — a guard that fails without naming the offending file
+and path costs more than it saves.
+
+Second red step, for the staleness check: add an allowlist entry for a path
+that does exist, and confirm the test rejects the redundant entry.
+
+## Verification
+
+- [ ] Red before 0386's fix, green after, on the real files
+- [ ] Failure message names file, line, and the unresolved path
+- [ ] A redundant allowlist entry fails the test
+- [ ] `make lint` green; the test is `adherence`-marked, not in the fast tier
+
+## Invariants
+
+- No change to any deliverable's rendered content.
+- The guard must not fire on `tickets/**` or on documentation placeholders.
+- Auto-discovery, not a hardcoded file list.
+
+## Exit criteria
+
+A renamed or deleted script cannot leave a dangling provenance reference in
+any rendered deliverable without a test failing, and every deliberate
+exception is explicit and checked for staleness.

--- a/tickets/0388-two-guards-hand-roll-scripts-discovery-a.erg
+++ b/tickets/0388-two-guards-hand-roll-scripts-discovery-a.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T18:53Z HDMX-coding-agent created
 2026-07-27T18:58Z HDMX-coding-agent note Found by the 0346 roar sweep; the divergence is already visible in make lint output
+2026-07-27T19:12Z HDMX-coding-agent note Renumbered 0385 -> 0388: the 0384 renumber landed on a seat 0385 had already taken on main, leaving a duplicate id that failed erg check for every branch. Found by the 0364 wrap-up sweep.
 
 --- body ---
 ## Context


### PR DESCRIPTION
Ticket: none

Tickets-only diff (3 files, all `tickets/`), `erg check` PASS (370 tickets). Fast path per `.claude/rules/git.md`. Two commits, kept separate because they are unrelated:

**1. `b3e8026`-amended — renumber a duplicate 0385 that is already on main.** `erg check` currently fails on *every* branch cut from main: two merged tickets hold id 0385. The cross-PR collision gate cannot see it — it compares open PRs, not PR-vs-main, which is the blind spot `tickets/AGENTS.md` documents. The cascade is legible in the commit messages: one ticket took 0385 legitimately, the other arrived by renumbering off a 0384 collision with #1210 and landed on a seat that was taken by the time it merged. The renumbered one moves again, to 0388 — weaker claim, and nothing cross-references it. Staged so the commit carries edit + rename (1 insertion), not the rename-only diff that silently drops the change.

**2. The 0364 wrap-up sweep findings.** Looking for the same class 0364 had just fixed — a document naming a source that is not there — in rendered deliverable prose:

`deliverables/_shared/_includes/alluvial-diagram.md:3` and `structural-breaks.md:3` both name `scripts/compute_alluvial.py` in their `**Scripts:**` provenance line. It exists nowhere in the repo; the real producer is `scripts/analysis/analyze_alluvial.py`. These render into deliverables, so the dangling pointer reaches readers, and `make check` is green throughout — nothing resolves a provenance line against the filesystem.

- **0386** fixes the instances.
- **0387** is the standing guard, filed separately per the roar contract (a fix PR is the wrong place for a class test), and `Blocked-by: 0386`.

The class has recurred twice. Ticket 0235, "stale renamed script references", is closed. `docs/ncc-pipeline-audit.md:286` recorded a third instance; that one was fixed and two siblings in neighbouring files were missed — which is precisely why 0387 asks for a mechanism rather than a fourth point fix.

0387 carries the design constraint that makes it tractable: the raw sweep returns 99 hits, dominated by two *legitimate* classes — closed tickets recording history, and open tickets naming files they propose to create. Scoping the guard to `deliverables/` takes the false-positive rate to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)