### PR TITLE
tickets(0402,0403): roar-sweep findings from ticket 0354

### DIFF
--- a/tickets/0402-build-het-core-fabricates-a-2020-year-fo.erg
+++ b/tickets/0402-build-het-core-fabricates-a-2020-year-fo.erg
@@ -1,0 +1,114 @@
+%erg 0.1
+Title: build_het_core fabricates a 2020 year for undated works, inflating their rank
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T19:12Z HDMX-coding-agent created
+2026-07-27T19:20Z HDMX-coding-agent note Found by the ticket-0354 roar sweep for the silent-coercion class the deposit gate exposed
+
+--- body ---
+## Context
+
+Ticket 0354 found `export_deposit.py` silently turning an unparseable integer
+into an empty cell. Sweeping the same class across `scripts/` surfaced a worse
+instance: this one does not empty the value, it **invents** one.
+
+```python
+# scripts/analysis/build_het_core.py:353
+df["year_num"] = pd.to_numeric(df["year"], errors="coerce").fillna(2020)
+```
+
+A work with no year is treated as published in 2020. That value is not a
+filtering convenience — it feeds the score that selects and ranks the corpus:
+
+```python
+# build_het_core.py:399
+s2["cit_per_year"] = s2["cited_by_count_num"] / np.maximum(1, CURRENT_YEAR - s2["year_num"])
+```
+
+`cit_per_year` enters `s2["score"]` (line 416), the frame is sorted by score
+(line 422), and the top rows are written to `het_mostcited_50.csv`. So an
+undated work is scored as if six years old rather than its true age. For a
+genuinely old work the denominator falls from ~31 to ~6, inflating
+`cit_per_year` by roughly 5x and pushing it up the ranking.
+
+Measured on the current corpus: **389 of 33,344 refined works (1.2%) carry a
+blank year**, and every one of them is scored as 2020. None is unparseable —
+the defect is entirely the `fillna`, not the coercion.
+
+This reaches a published artifact. The chain is:
+
+```
+build_het_core.py -> data/derived/tables/het_mostcited_50.csv
+  -> summarize_core_venues.py -> export_core_venues_markdown.py
+  -> deliverables/_shared/tables/tab_core_venues_top10.md
+```
+
+So which venues appear in a published top-10 table depends in part on 389
+fabricated publication dates.
+
+`cited_by_count_num` (line 352) uses `.fillna(0)` in the same statement. That
+one is defensible — no citation record is close to zero citations — but it
+conflates "unknown" with "zero" and should be stated deliberately rather than
+left as a twin of the year bug.
+
+## Relevant files
+
+- `scripts/analysis/build_het_core.py:352-353` — the two `fillna` calls;
+  `:399` — where the fabricated year enters the score; `:416,422,436` — score,
+  sort, written columns.
+- `scripts/analysis/summarize_core_venues.py`,
+  `scripts/figures/export_core_venues_markdown.py` — the downstream consumers
+  that carry the effect into a published table.
+- `Makefile:386` — the `$(MOSTCITED)` rule.
+
+## Actions
+
+1. Decide the policy for an undated work and make it explicit, rather than
+   silently dating it 2020. Three candidates:
+   - **Exclude from the ranking.** A work whose age is unknown has no
+     meaningful citations-per-year; dropping it from the score is honest and
+     costs 1.2% of rows.
+   - **Rank on total citations only** for undated works, so the age-normalised
+     term is not invented.
+   - **Impute and disclose**, if the corpus genuinely needs those rows: keep an
+     imputation but record it in a column and state the count wherever the
+     table is published.
+2. Apply the same explicitness to `cited_by_count_num`'s `.fillna(0)` — either
+   justify it in a comment or handle it like the year.
+3. Regenerate `het_mostcited_50.csv` and `tab_core_venues_top10.md`, and report
+   how the published top-10 changes. If it does not change, say so — that is
+   the useful finding for the paper.
+
+## Test
+
+Red first: a test that builds a small frame with one undated work carrying a
+high citation count, runs the scoring step, and asserts the undated work is not
+ranked above a dated work with the same citation count. Today the undated work
+wins, because its denominator is smaller.
+
+Pure-pandas on a synthetic frame, so the fast tier.
+
+## Verification
+
+- [ ] The undated-work count is reported by the script's log, not silent
+- [ ] `het_mostcited_50.csv` regenerates and the diff in the published top-10
+      venues table is stated (including "no change" if that is the outcome)
+- [ ] No `fillna` on a value that feeds a score remains without a stated reason
+
+## Invariants
+
+- `tab_core_venues_top10.md` stays a valid pipe table (the ticket-0340 shape
+  guard sweeps it).
+- The Makefile contract for `$(MOSTCITED)` is unchanged — this is a scoring
+  policy fix, not a rewiring.
+
+## Exit criteria
+
+- [ ] Undated works no longer receive a fabricated publication year that feeds
+      the score
+- [ ] The policy chosen is stated in the code and, if it affects a published
+      number, in the prose that publishes it
+- [ ] Red-to-green test pins the ranking against age fabrication
+- [ ] `make check` passes

--- a/tickets/0403-standing-guard-a-submission-document-mus.erg
+++ b/tickets/0403-standing-guard-a-submission-document-mus.erg
@@ -1,0 +1,99 @@
+%erg 0.1
+Title: Standing guard: a submission document must not name a deposit file the build does not ship
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T19:13Z HDMX-coding-agent created
+2026-07-27T19:22Z HDMX-coding-agent note Filed from the ticket-0354 roar; the class fired three times inside one merge
+
+--- body ---
+## Context
+
+Retiring one deposited file (`codebook.md`, ticket 0354) left stale references
+in **six** places. Three were caught only when the branch met `origin/main`,
+because each was a guard on main keyed to that filename:
+
+- `tests/test_markdown_table_shape.py` — pinned it as the sentinel discovery
+  must find, and as the shipped file carrying a real escaped pipe;
+- `config/unrendered-artifacts.txt` — listed it as a deliberately-unrendered
+  shared table (its earned-entry guard fired correctly);
+- `Makefile` / `.gitignore` / `build_datapaper_archive.sh` — build wiring.
+
+The other three were **prose**, and nothing caught them at all. They drifted
+silently and would have reached the editor:
+
+- `revision-rdj26561/ed04-zenodo-restructure-upload.md` — including the record
+  description the author pastes into Zenodo, and its quoted response-letter
+  bullet;
+- `revision-rdj26561/summary-of-revisions.md` — items 7 and 8;
+- `revision-rdj26561/response-letter.md` — the ED-04 reply.
+
+The asymmetry is the finding. The *build* side of the deposit is guarded:
+`tests/test_datapaper_archive_layout.py::PRODUCTS` pins the product list across
+the build script, the archive README, and `data-paper.qmd`. The *correspondence*
+side is not: the revision documents that describe the deposit to the editor are
+outside every check, so a file can leave `data/products/` while three documents
+keep promising it.
+
+`TestDepositCountsTrackTheCorpus` already establishes the precedent for exactly
+this class one layer over — it pins the deposit's hand-pasted *counts* to the
+generated vars, because "the deposit's prose is the one place the project's
+vars-driven-prose rule cannot reach". Filenames need the same treatment as
+counts.
+
+Related: 0387 (standing guard, prose must not name a script that no longer
+exists) is the same shape for scripts rather than deposit products. Consider
+whether one guard covers both.
+
+## Relevant files
+
+- `tests/test_datapaper_archive_layout.py` — owns `PRODUCTS` and the existing
+  count guard; the natural home.
+- `deliverables/data-paper/revision-rdj26561/{ed04-zenodo-restructure-upload,
+  summary-of-revisions,response-letter}.md` — the three unguarded documents.
+- `build/build_datapaper_archive.sh` — the authority on what ships.
+
+## Actions
+
+1. Extend the layout guard: for each revision document, extract every
+   `` `*.csv` ``/`` `*.json` ``/`` `*.md` ``/`` `*.npz` `` filename mentioned in
+   a deposit-products context and assert it is in `PRODUCTS` (or explicitly
+   allowlisted with a reason, following the earned-entry pattern so the
+   allowlist cannot rot).
+2. Derive the authority from the build script rather than restating it, so the
+   guard cannot drift from what is packaged.
+3. Decide the scope question this raises: `response-letter.md` and
+   `summary-of-revisions.md` are under author sign-off. The guard should fail
+   the *build*, not silently rewrite prose — it reports, the author edits.
+
+## Test
+
+Red first: with `codebook.md` re-inserted into any one of the three documents,
+the guard fails and names the document and the filename. Green: with the current
+(corrected) documents, it passes. Source inspection only — no subprocess, no
+corpus — so the adherence tier.
+
+## Verification
+
+- [ ] Re-adding a retired filename to any of the three documents fails `make lint`
+- [ ] The current tree passes
+- [ ] The product authority is read from the build script, not duplicated
+- [ ] An allowlisted exception carries a reason and is rejected when unearned
+
+## Invariants
+
+- `PRODUCTS` stays the single list; this extends its reach rather than adding a
+  second source of truth.
+- The guard reports; it never edits submission prose (prose is author-arbitrated
+  per rules/git.md).
+
+## Exit criteria
+
+- [ ] A retired deposit filename surviving in any submission document fails a
+      local gate
+- [ ] Red-to-green demonstrated on `codebook.md` specifically, the case that
+      motivated this
+- [ ] Overlap with ticket 0387 resolved — either one guard or a stated reason
+      for two
+- [ ] `make check` passes


### PR DESCRIPTION
Two findings from the ticket-0354 wrap-up sweep. Tickets-only diff, so the fast path applies (`erg check` PASS, 375 tickets; seats 0402/0403 verified absent from main and unclaimed by the seven open PRs).

**0402 — `build_het_core` fabricates a 2020 year for undated works.** The sweep target was the silent-coercion class 0354 fixed in `export_deposit.py`. This instance is worse than emptying a value: `pd.to_numeric(df["year"], errors="coerce").fillna(2020)` invents one, and it is not a filtering convenience — it feeds `cit_per_year`, hence `score`, hence which rows are written to `het_mostcited_50.csv` and carried into the published `tab_core_venues_top10.md`. An undated old work is scored as six years old instead of ~31, inflating its citations-per-year roughly 5× and pushing it up the ranking. 389 of 33,344 refined works (1.2%) are affected; none is unparseable, so the defect is entirely the `fillna`.

Not fixed here: choosing between exclude / rank-on-totals / impute-and-disclose is a scoring-policy call that changes a published number.

**0403 — standing guard for the class that fired three times in one merge.** Retiring `codebook.md` left stale references in six places. Three were caught only when the branch met `origin/main`, each being a guard on main keyed to that filename (the markdown-shape sentinel, the unrendered-artifacts allowlist, the build wiring). The other three were prose and nothing caught them: the ed04 upload runbook — including the record description pasted into Zenodo — plus `summary-of-revisions.md` and `response-letter.md`.

The asymmetry is the point: `PRODUCTS` guards the build side of the deposit across the build script, README, and `data-paper.qmd`, while the revision documents that describe the deposit to the editor sit outside every check. `TestDepositCountsTrackTheCorpus` already set the precedent for the deposit's hand-pasted *counts*; filenames need the same. Overlap with ticket 0387 is called out for the implementer to resolve.

Ticket-ref: tickets/0402-build-het-core-fabricates-a-2020-year-fo.erg
Ticket-ref: tickets/0403-standing-guard-a-submission-document-mus.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)