### PR TITLE
ticket(0382): correct the overclaim, narrow to what survives

### DIFF
--- a/tickets/0382-worktree-env-snapshot-goes-stale-and-fai.erg
+++ b/tickets/0382-worktree-env-snapshot-goes-stale-and-fai.erg
@@ -8,6 +8,7 @@ Label: needs-human
 2026-07-27T18:55Z HDMX-coding-agent created
 2026-07-27T18:55Z HDMX-coding-agent note found by the raid 0339/0340/0341 wrap-up: a full `make check` on main went red in a long-lived worktree, and three of the eleven failures were this.
 
+2026-07-27T19:15Z HDMX-coding-agent note the body overclaims and is corrected here. 'The old secrets keep a second home on disk, per worktree, indefinitely' is wrong: git worktree remove deletes the gitignored .env with the directory (verified by probe — created a worktree, wrote a marker .env, removed it, file gone). The copy lives exactly as long as the worktree, not indefinitely. The exception is the case that actually bites: removal is REFUSED when tracked files are dirty or the tree is locked, and --force is blocked by the destructive-bash guard, so unremovable worktrees accumulate copies. Measured 2026-07-27T21:15Z: 31 non-primary worktrees, 29 holding a .env, 14 of them older than the primary's 17:51 migration. So the remedy is GC cadence (/molt), not a .worktreeinclude mechanism change. The one piece that survives independently: the guard reports a stale copy as a credential violation, giving no way to tell 'this worktree is old' from 'someone pasted a secret into .env'.
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket-ref: tickets/0382-worktree-env-snapshot-goes-stale-and-fai.erg
Ticket: none

One log line. No code.

Ticket 0382's body claims a stale worktree `.env` means "the old secrets keep a second home on disk, per worktree, **indefinitely**." The author challenged that, and the challenge is correct.

**Verified by probe:** created a worktree, wrote a marker `.env`, ran `git worktree remove` — directory and `.env` both gone. `git worktree remove` disposes of the gitignored file with the tree. The copy lives exactly as long as the worktree, not indefinitely.

**What survives**, and it is the case that actually bites: removal is *refused* when tracked files are dirty or the tree is locked, and `--force` is blocked by the destructive-bash guard. Worktrees that resist removal therefore accumulate copies. Measured just now:

| | count |
|---|---|
| non-primary worktrees | 31 |
| holding a `.env` copy | 29 |
| copies older than the primary's 17:51 keystore migration | **14** |

That reframes the remedy as GC cadence — `/molt`, already flagged as overdue — rather than a `.worktreeinclude` mechanism change, and makes this ticket largely subsumed by it.

The one piece that stands on its own regardless of GC: the guard reports a stale copy as a credential violation, so a reader cannot distinguish "this worktree is old" from "someone pasted a secret into `.env`." That conflation is worth fixing whatever the sweep cadence.

Ticket stays open and `needs-human`: whether to close it as subsumed or keep it narrowly for the guard's message is the author's call.

`erg check`: PASS (374 tickets).