### PR TITLE
fix(0430): move the stable run report out of the DVC-tracked run_reports dir

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -157,7 +157,10 @@ stages:
       # The dedup counters compute_vars publishes in the data paper. Declared so
       # dvc can tell when they are stale; the timestamped siblings in
       # run_reports/ are run history and stay undeclared (ticket 0349).
-      - data/catalogs/run_reports/catalog_merge.json
+      # Deliberately NOT inside run_reports/ — that directory is a DVC output
+      # (run_reports.dvc), and DVC rejects an output nested in another at graph
+      # construction, which made dvc repro and dvc dag abort outright (0430).
+      - data/catalogs/catalog_merge_report.json
 
   # ── Phase 1b: Enrichment pipeline ──────────────────────────
   # Split into independent DVC stages so each step is cached separately.

--- a/scripts/harvest/catalog_merge.py
+++ b/scripts/harvest/catalog_merge.py
@@ -302,6 +302,8 @@ def main(run_id: str | None = None):
               "multi_source_works": int((result["source_count"] > 1).sum())}
     # stable_copy: compute_vars sources two published data-paper numbers from
     # this report, and a DVC stage can only declare a fixed path (ticket 0349).
+    # It lands at CATALOGS_DIR/catalog_merge_report.json, outside run_reports/,
+    # which is itself a DVC output — see stable_report_path (ticket 0430).
     report_path = save_run_report(report, run_id, "catalog_merge", stable_copy=True)
 
     log.info("Summary:")

--- a/scripts/pipeline_io.py
+++ b/scripts/pipeline_io.py
@@ -142,6 +142,22 @@ def save_csv(df: pd.DataFrame, path: str) -> None:
 RUN_ID_TIMESTAMP = re.compile(r"^\d{8}T\d{6}Z$")
 
 
+def stable_report_path(script_name: str, catalogs_dir: str) -> str:
+    """Fixed path a DVC stage can declare as an output for ``script_name``.
+
+    One definition because the writer and the reader must not drift: if
+    ``save_run_report`` and ``latest_run_report`` disagree about where the
+    stable copy lives, the reader silently falls back to the timestamped
+    siblings and the published number changes with no error anywhere.
+
+    Deliberately in ``CATALOGS_DIR`` rather than ``CATALOGS_DIR/run_reports/``.
+    The latter is a DVC output in its own right, and DVC rejects an output
+    nested inside another at graph-construction time — which is what made
+    ``dvc repro`` refuse to run (ticket 0430).
+    """
+    return os.path.join(catalogs_dir, f"{script_name}_report.json")
+
+
 def latest_run_report(script_name: str,
                       catalogs_dir: str | None = None) -> dict[str, Any] | None:
     """Return the newest run report for ``script_name``, or None if there is none.
@@ -149,8 +165,11 @@ def latest_run_report(script_name: str,
     Two rules, both there to stop a stray file becoming a published number
     (ticket 0349):
 
-    - The stable ``<script>.json`` wins when present. That is the file a DVC
-      stage can declare as an output; the timestamped siblings are run history.
+    - The stable ``<script>_report.json`` wins when present. That is the file a
+      DVC stage can declare as an output; the timestamped siblings are run
+      history. It sits in ``catalogs_dir`` itself, not in ``run_reports/``,
+      because that directory is already a DVC output and nesting one inside
+      another makes ``dvc repro`` refuse to build the graph (ticket 0430).
     - Otherwise only timestamped run ids are considered, ranked by timestamp.
       The previous `sorted(glob(...))[-1]` ranked lexicographically, so
       ``catalog_merge__test.json`` outranked every ``catalog_merge__2026…``
@@ -167,7 +186,7 @@ def latest_run_report(script_name: str,
         catalogs_dir = CATALOGS_DIR
 
     reports_dir = os.path.join(catalogs_dir, "run_reports")
-    stable = os.path.join(reports_dir, f"{script_name}.json")
+    stable = stable_report_path(script_name, catalogs_dir)
     if os.path.isfile(stable):
         with open(stable) as f:
             report: dict[str, Any] = json.load(f)
@@ -201,9 +220,16 @@ def save_run_report(data: dict[str, Any], run_id: str, script_name: str,
     script_name : str
         Short script name used as filename prefix.
     stable_copy : bool
-        Also write ``<script_name>.json``, overwritten each run. Set this when a
-        DVC stage needs a fixed path to declare as an output — a timestamped
-        filename cannot be one (ticket 0349).
+        Also write ``CATALOGS_DIR/<script_name>_report.json``, overwritten each
+        run. Set this when a DVC stage needs a fixed path to declare as an
+        output — a timestamped filename cannot be one (ticket 0349).
+
+        It lands beside the other catalog artifacts, *not* inside
+        ``run_reports/``, and that placement is load-bearing. ``run_reports/``
+        is itself a DVC output (``run_reports.dvc`` tracks the directory), and
+        DVC forbids one output nesting inside another: declaring a file in
+        there makes ``dvc repro`` and ``dvc dag`` abort at graph construction,
+        so the pipeline stops being reproducible at all (ticket 0430).
 
     Returns
     -------
@@ -221,7 +247,7 @@ def save_run_report(data: dict[str, Any], run_id: str, script_name: str,
     with open(path, "w") as f:
         json.dump(payload, f, indent=2, default=str)
     if stable_copy:
-        with open(os.path.join(reports_dir, f"{script_name}.json"), "w") as f:
+        with open(stable_report_path(script_name, CATALOGS_DIR), "w") as f:
             json.dump(payload, f, indent=2, default=str)
     return path
 

--- a/tests/test_dvc_output_overlap.py
+++ b/tests/test_dvc_output_overlap.py
@@ -1,0 +1,132 @@
+"""DVC outputs must not nest inside one another (ticket 0430).
+
+DVC forbids overlapping outputs: if two objects own a path, neither can
+authoritatively restore or invalidate it. It enforces this at *graph
+construction*, so an overlap does not degrade the pipeline — it refuses it.
+``dvc repro`` and ``dvc dag`` both abort before running a single stage.
+
+The failure that motivated this guard hid for weeks because every cheap check
+sidesteps the graph. ``dvc status <path>.dvc``, ``dvc commit``, ``dvc push``
+and even a bare ``dvc status`` all succeed while ``dvc repro`` is dead.
+
+This guard reads the declarations rather than invoking DVC, so it runs in the
+fast tier and needs neither the corpus nor a DVC remote.
+"""
+
+import os
+
+import pytest
+import yaml
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DVC_YAML = os.path.join(BASE_DIR, "dvc.yaml")
+
+
+def _out_path(entry):
+    """Extract the path from an out entry.
+
+    Two shapes, and confusing them makes the guard pass vacuously. In
+    ``dvc.yaml`` an out is a bare string or a single-key mapping of
+    ``path -> options``. In a ``.dvc`` file it is a mapping carrying the hash
+    fields *first* (``md5``, ``size``, ``nfiles``, ``hash``, ``path``), so
+    taking the first key yields the checksum rather than the path.
+    """
+    if not isinstance(entry, dict):
+        return entry
+    if "path" in entry:
+        return entry["path"]
+    return next(iter(entry))
+
+
+def declared_outputs():
+    """Every DVC-tracked path: ``dvc.yaml`` stage outs plus every ``*.dvc`` file.
+
+    Returns ``(path, owner)`` pairs, repo-relative and normalised, where owner
+    names the declaring stage or ``.dvc`` file — the guard's message is only
+    useful if it can say which two objects collide.
+    """
+    found = []
+
+    with open(DVC_YAML, encoding="utf-8") as fh:
+        pipeline = yaml.safe_load(fh) or {}
+    for stage, spec in (pipeline.get("stages") or {}).items():
+        for kind in ("outs", "metrics", "plots"):
+            for entry in (spec.get(kind) or []):
+                found.append((os.path.normpath(_out_path(entry)), stage))
+
+    for root, dirs, files in os.walk(BASE_DIR):
+        dirs[:] = [d for d in dirs if d not in {".git", ".venv", ".dvc", "node_modules"}]
+        for name in files:
+            if not name.endswith(".dvc"):
+                continue
+            dvc_file = os.path.join(root, name)
+            with open(dvc_file, encoding="utf-8") as fh:
+                spec = yaml.safe_load(fh) or {}
+            # A .dvc file's `path` is relative to the file's own directory.
+            for entry in (spec.get("outs") or []):
+                path = _out_path(entry)
+                abs_path = os.path.normpath(os.path.join(root, path))
+                rel_owner = os.path.relpath(dvc_file, BASE_DIR)
+                found.append((os.path.relpath(abs_path, BASE_DIR), rel_owner))
+
+    return found
+
+
+def _nested_output_pairs():
+    """Return ``"a (owner) contains b (owner)"`` for each nesting violation."""
+    outs = declared_outputs()
+    violations = []
+    for parent, powner in outs:
+        for child, cowner in outs:
+            if parent == child and powner == cowner:
+                continue
+            if child == parent:
+                continue
+            if child.startswith(parent + os.sep):
+                violations.append(f"{parent} ({powner}) contains {child} ({cowner})")
+    return sorted(set(violations))
+
+
+@pytest.mark.adherence
+def test_no_dvc_output_nested_inside_another():
+    """Overlapping outs make dvc repro refuse to build the graph at all.
+
+    Not a style rule: DVC rejects the *declaration*, so the pipeline is
+    unreproducible from the moment the overlap lands, whether or not the file
+    exists yet. Ticket 0430 — `run_reports/` was tracked as a directory while
+    `dvc.yaml` separately declared `run_reports/catalog_merge.json`.
+    """
+    overlaps = _nested_output_pairs()
+    assert not overlaps, (
+        "DVC forbids overlapping outputs; dvc repro and dvc dag abort at graph "
+        "construction while every per-target command still reports healthy:\n  "
+        + "\n  ".join(overlaps)
+        + "\nDeclare the inner path outside the tracked directory, or let one "
+        "object own it."
+    )
+
+
+@pytest.mark.adherence
+def test_discovery_sees_both_declaration_sources():
+    """A guard driven by discovery passes vacuously if discovery finds nothing.
+
+    Both sources must be live: `dvc.yaml` stage outs and standalone `.dvc`
+    files. The 0430 overlap spanned exactly those two, so a guard reading only
+    one of them would have been blind to it.
+    """
+    outs = declared_outputs()
+    owners = {owner for _, owner in outs}
+    assert any(o.endswith(".dvc") for o in owners), "no .dvc file outputs discovered"
+    assert any(not o.endswith(".dvc") for o in owners), "no dvc.yaml stage outputs discovered"
+
+    # Paths, not just owners. The first draft read a .dvc entry's leading `md5`
+    # key as its path, so every .dvc output was a 32-char hex string: discovery
+    # looked populated, no path could ever nest, and the guard passed on a tree
+    # that DVC itself rejects.
+    paths = [p for p, _ in outs]
+    assert all("/" in p or p.endswith((".csv", ".json", ".npz")) for p in paths), (
+        f"outputs do not look like paths, discovery is misreading entries: {paths[:5]}"
+    )
+    assert any(p.startswith("data" + os.sep) for p in paths), (
+        f"no output under data/, discovery is misreading entries: {paths[:5]}"
+    )

--- a/tests/test_run_report_wiring.py
+++ b/tests/test_run_report_wiring.py
@@ -22,7 +22,10 @@ import yaml
 from utils import BASE_DIR
 
 DVC_YAML = os.path.join(BASE_DIR, "dvc.yaml")
-STABLE_REPORT = "data/catalogs/run_reports/catalog_merge.json"
+# Outside run_reports/ on purpose: that directory is itself a DVC output, and
+# DVC rejects an output nested inside another at graph-construction time — the
+# original placement made `dvc repro` and `dvc dag` abort outright (ticket 0430).
+STABLE_REPORT = "data/catalogs/catalog_merge_report.json"
 
 
 def _stage_outs(stage_name):
@@ -70,20 +73,64 @@ def test_latest_report_ignores_non_timestamp_run_ids(tmp_path, monkeypatch):
 
 
 def test_latest_report_prefers_the_declared_stable_file(tmp_path, monkeypatch):
-    """The DVC-declared file wins when present; the archive is a fallback."""
+    """The DVC-declared file wins when present; the archive is a fallback.
+
+    The stable file sits beside the catalogs, not in `run_reports/` — see the
+    module constant. Writing it to the old location must NOT satisfy this test,
+    which is why the path comes from `stable_report_path` rather than a literal.
+    """
     monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
     reports = tmp_path / "run_reports"
     reports.mkdir()
     (reports / "catalog_merge__20260101T000000Z.json").write_text(
         json.dumps({"doi_duplicates_removed": 1})
     )
-    (reports / "catalog_merge.json").write_text(
-        json.dumps({"doi_duplicates_removed": 833})
-    )
 
-    from pipeline_io import latest_run_report
+    from pipeline_io import latest_run_report, stable_report_path
+
+    with open(stable_report_path("catalog_merge", str(tmp_path)), "w") as fh:
+        json.dump({"doi_duplicates_removed": 833}, fh)
 
     assert latest_run_report("catalog_merge")["doi_duplicates_removed"] == 833
+
+
+def test_stable_report_is_not_inside_the_tracked_run_reports_dir(tmp_path):
+    """The placement is the fix; pin it so a later tidy-up cannot undo it.
+
+    Moving this file back under `run_reports/` would look like housekeeping and
+    would silently make the whole pipeline unreproducible again (ticket 0430).
+    """
+    from pipeline_io import stable_report_path
+
+    path = stable_report_path("catalog_merge", str(tmp_path))
+    assert os.path.dirname(path) == str(tmp_path), (
+        f"stable report must sit in CATALOGS_DIR, not a subdirectory: {path}"
+    )
+    assert "run_reports" not in path, (
+        f"stable report is inside the DVC-tracked run_reports/ directory: {path}"
+    )
+
+
+def test_save_run_report_writes_the_stable_copy_where_dvc_expects_it(tmp_path, monkeypatch):
+    """End-to-end: the writer and the declaration must agree.
+
+    Asserting on the written artifact rather than on the returned path — the
+    return value is the timestamped report, so a stable copy written to the
+    wrong place would leave every other assertion here green.
+    """
+    monkeypatch.setattr("pipeline_loaders.CATALOGS_DIR", str(tmp_path))
+
+    from pipeline_io import save_run_report
+
+    save_run_report({"doi_duplicates_removed": 833}, "20260727T132143Z",
+                    "catalog_merge", stable_copy=True)
+
+    declared = os.path.join(str(tmp_path), os.path.basename(STABLE_REPORT))
+    assert os.path.isfile(declared), (
+        f"dvc.yaml declares {STABLE_REPORT}; nothing was written to {declared}"
+    )
+    with open(declared) as fh:
+        assert json.load(fh)["doi_duplicates_removed"] == 833
 
 
 def test_latest_report_returns_none_when_absent(tmp_path, monkeypatch):

--- a/tickets/0430-dvc-output-overlap-makes-the-pipeline-unr.erg
+++ b/tickets/0430-dvc-output-overlap-makes-the-pipeline-unr.erg
@@ -1,0 +1,145 @@
+%erg 0.1
+Title: DVC output overlap makes the whole pipeline unreproducible
+Created: 2026-07-27
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-27T20:10Z HDMX-coding-agent created
+2026-07-27T20:10Z HDMX-coding-agent note Found while working around a stale dvc add recipe in 0346; the workaround hid how broad the failure is
+
+--- body ---
+## Context
+
+`dvc repro` does not run. Neither does `dvc dag`. Both fail before executing
+anything:
+
+    ERROR: The output paths:
+    'data/catalogs/run_reports'('data/catalogs/run_reports.dvc')
+    'data/catalogs/run_reports/catalog_merge.json'('catalog_merge')
+    overlap and are thus in the same tracked directory.
+    To keep reproducibility, outputs should be in separate tracked directories
+    or tracked individually.
+
+Two DVC objects claim the same path. `data/catalogs/run_reports.dvc` tracks the
+whole directory as one output (133 files). `dvc.yaml` line 160 declares
+`data/catalogs/run_reports/catalog_merge.json` as an output of the
+`catalog_merge` stage. DVC forbids overlapping outputs — if two objects own a
+path, neither can authoritatively restore or invalidate it — and it refuses at
+graph-construction time, before any stage runs.
+
+The corpus rebuild is the thing this blocks. Phase 1 is "slow, API-dependent,
+run rarely", so the breakage is invisible until someone actually needs it.
+
+## Why nobody has noticed
+
+The failure is in the declaration, not in the data, and every cheap check
+sidesteps the graph:
+
+- `catalog_merge.json` does not exist on disk. Only timestamped siblings do
+  (`catalog_merge__20260724T112050Z.json`, `…__20260727T132143Z.json`).
+- `dvc.lock` for `catalog_merge` still records only
+  `data/catalogs/unified_works.csv`. The stage has not run since 0349 added the
+  declaration, so the lock never picked it up.
+- Per-target commands do not build the full graph and all succeed:
+  `dvc status <path>.dvc`, `dvc commit`, `dvc push`, and even a bare
+  `dvc status`, which happily prints per-stage output.
+
+So the repo reports healthy on every command except the one that matters.
+
+## How it got here
+
+Ticket 0349 wanted DVC to know when the data paper's dedup counters go stale,
+and a timestamped filename cannot be declared as a stage output. So
+`save_run_report` gained a `stable_copy` flag writing `<script>.json` beside
+the timestamped report, and `catalog_merge` calls it with `stable_copy=True`.
+The reasoning is sound and the comment in `dvc.yaml` shows the intent was
+deliberately narrow — "the timestamped siblings in `run_reports/` are run
+history and stay undeclared".
+
+The miss: `run_reports/` was already a DVC output in its own right, so *any*
+file declared inside it collides with the parent. The stable path needed to be
+outside that directory, not inside it.
+
+## Chosen fix
+
+Move the stable copy out of `run_reports/` and declare it there. It keeps
+0349's staleness signal, dissolves the overlap, and needs no change to how run
+history works.
+
+`data/catalogs/` is not tracked wholesale — it holds individually declared
+stage outputs (`unified_works.csv`, …) and per-file `.dvc` records — so a file
+directly in `CATALOGS_DIR` is a clean home and matches the existing pattern.
+
+Two alternatives were considered and rejected:
+
+- *Let the stage own `run_reports/` and drop `run_reports.dvc`.* Wrong: the
+  directory holds run history from many scripts (`enrich_*`, `corpus_align`,
+  `qa_*`), so no single stage can own it.
+- *Revert the declaration.* Gives up the staleness signal 0349 deliberately
+  built, and returns the published dedup counters to being sourced from a
+  timestamped file.
+
+## Relevant files
+
+- `dvc.yaml:160` — the overlapping declaration
+- `data/catalogs/run_reports.dvc` — the directory output it collides with
+- `scripts/pipeline_io.py::save_run_report` — writes the stable copy inside `run_reports/`
+- `scripts/pipeline_io.py::latest_run_report` — prefers the stable copy
+- `scripts/harvest/catalog_merge.py:305` — the one `stable_copy=True` caller
+- `tests/test_phase_layout.py` — the existing guard over Make/DVC path layout
+
+## Actions
+
+1. `save_run_report(stable_copy=True)` writes `<script_name>_report.json` to
+   `CATALOGS_DIR`, not to `CATALOGS_DIR/run_reports/`.
+2. `latest_run_report` reads the stable copy from the new location, keeping its
+   precedence over timestamped siblings.
+3. `dvc.yaml` declares `data/catalogs/catalog_merge_report.json`.
+4. Add a standing guard: no DVC output may be nested inside another. This is
+   the defect class, and it is mechanically checkable from `dvc.yaml` plus the
+   `.dvc` files without invoking DVC.
+
+## Test
+
+Red step — the class guard, which fails on the tree as it stands:
+
+    @pytest.mark.adherence
+    def test_no_dvc_output_nested_inside_another():
+        """Ticket 0430. Overlapping outs make dvc repro refuse to build the graph."""
+        overlaps = _nested_output_pairs()
+        assert not overlaps, (
+            "DVC forbids overlapping outputs; dvc repro and dvc dag fail at "
+            "graph construction: " + ", ".join(overlaps)
+        )
+
+Fails today naming
+`data/catalogs/run_reports` / `data/catalogs/run_reports/catalog_merge.json`.
+It reads the declarations rather than shelling out to DVC, so it stays in the
+fast tier and works without the corpus present.
+
+## Verification
+
+- [ ] The guard is red before the fix, green after
+- [ ] `dvc dag` and `dvc repro --dry` load the graph instead of erroring
+- [ ] `latest_run_report("catalog_merge")` still prefers the stable copy
+- [ ] `make lint` and `make check-fast` pass
+
+## Invariants
+
+- 0349's staleness signal survives: a stable, DVC-declarable path still carries
+  the published dedup counters.
+- Run history in `run_reports/` keeps its timestamped-only shape, and
+  `run_reports.dvc` keeps tracking the directory.
+- The `RUN_ID_TIMESTAMP` filter from 0346 stays — a non-timestamp file must
+  never become a published number.
+
+## Exit criteria
+
+- [ ] `dvc repro --dry` builds the graph
+- [ ] A standing guard fails on any nested DVC output
+- [ ] The stable counter file is declared and lives outside `run_reports/`
+
+## See also
+
+- 0349 — added the stable copy and the declaration
+- 0346 — the run-report isolation work that surfaced this

--- a/tickets/closed/0430-dvc-output-overlap-makes-the-pipeline-unr.erg
+++ b/tickets/closed/0430-dvc-output-overlap-makes-the-pipeline-unr.erg
@@ -2,11 +2,13 @@
 Title: DVC output overlap makes the whole pipeline unreproducible
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1228
 
 --- log ---
 2026-07-27T20:10Z HDMX-coding-agent created
 2026-07-27T20:10Z HDMX-coding-agent note Found while working around a stale dvc add recipe in 0346; the workaround hid how broad the failure is
 
+2026-07-27T19:32Z HDMX-coding-agent closed — autoclosed — PR #1228
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0430-dvc-output-overlap-makes-the-pipeline-unr.erg

## `dvc repro` does not run — and hasn't for weeks

```
$ dvc repro --dry          # whole pipeline, no target
ERROR: The output paths:
'data/catalogs/run_reports'('data/catalogs/run_reports.dvc')
'data/catalogs/run_reports/catalog_merge.json'('catalog_merge')
overlap and are thus in the same tracked directory.
```

`run_reports.dvc` tracks the directory as one output; `dvc.yaml:160` separately declared a file inside it. DVC forbids overlapping outputs — with two owners, neither can authoritatively restore or invalidate the path — and enforces it at **graph construction**. So the corpus rebuild was not slow or degraded; it was refused. `dvc dag` fails identically.

## Why it stayed invisible

The failure is in the declaration, not the data, and every cheap check sidesteps the graph:

- `catalog_merge.json` never existed on disk — only timestamped siblings
- `dvc.lock` for `catalog_merge` still records only `unified_works.csv`; the stage hasn't run since 0349 added the line
- `dvc status <path>.dvc`, `dvc commit`, `dvc push` and even bare `dvc status` all succeed and report healthy

I hit this as a "stale recipe" while finishing 0346, worked around it with `dvc commit`, and called it cosmetic. It wasn't.

## The fix

0349's reasoning was right: `compute_vars` publishes two data-paper numbers from that report, a timestamped filename can't be a declared output, so a stable copy was added. The miss was putting that stable path *inside* a directory that was already an output.

It now lands at `CATALOGS_DIR/<script>_report.json` — beside the other catalog artifacts, which are individually declared and not tracked wholesale. Staleness signal kept, overlap dissolved.

Both alternatives are worse, and one is wrong on the facts:
- *Let the stage own `run_reports/`* — no. It holds history from `enrich_*`, `corpus_align`, `qa_*`; no single stage can own it.
- *Revert the declaration* — gives up the staleness signal and returns the published counters to a timestamped source.

`stable_report_path()` is one definition shared by writer and reader. Had they drifted, the reader would silently fall back to timestamped siblings and the published number would change with no error anywhere.

## The guard, and its own near-miss

Class-level, not instance-level: **no DVC output may nest inside another**, checked by reading `dvc.yaml` plus every `.dvc` file rather than shelling out to DVC — so it stays fast-tier and needs neither the corpus nor a remote.

Its first draft **passed on a tree DVC rejects.** A `.dvc` entry lists hash fields before `path`, so `next(iter(entry))` read the md5 as the path; every output was a 32-char hex string, nothing could nest, green. The discovery test now asserts the extracted values *look like paths*, not merely that both sources were read. (Same lesson as this session's `gh pr list --json files`: a check whose all-clear is indistinguishable from its could-not-look is not a check.)

## Verification — against DVC, not just the guard

- `dvc dag catalog_merge` now **renders the DAG** instead of erroring
- `dvc repro --dry` gets **past graph construction**, failing only on `data/exports` being absent in this worktree (no DVC data pulled) — unrelated
- `make lint` 305 passed · `make check-fast` 1324 passed · `ruff` clean · `erg check` PASS (381 tickets)
- Guard confirmed red before the fix, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)