### PR TITLE
ticket(0371,0375,0376): fold in the raid Imagine findings

### DIFF
--- a/tickets/0371-included-shared-tables-are-gitignored.erg
+++ b/tickets/0371-included-shared-tables-are-gitignored.erg
@@ -6,12 +6,15 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T18:20Z HDMX-coding-agent created
 2026-07-27T18:20Z HDMX-coding-agent note found by the /verify-adherence gate on PR #1191 (ticket 0370) and confirmed independently by two agents of its review panel
+2026-07-27T20:45Z HDMX-coding-agent note reimagine: premise strengthened — paths.mk's *_INCLUDES list these tables as prerequisites of two render-only .mk files that declare "no corpus data". Scope narrows: extend tests/test_deliverable_artifacts.py, do not write the sketched parser.
 2026-07-27T20:10Z HDMX-coding-agent note widened from two tables to five — the #1191 round-4 panel caught the undercount; the real set comes from git check-ignore over the 0340 discovery list, not from the diff that surfaced it
 
 --- body ---
 ## Context
 
-Five of the ten generated Markdown tables are gitignored:
+Five of the **nine** generated Markdown tables are gitignored (the
+denominator was ten when this was filed; ticket 0354 has since retired
+`codebook.md`, and the ignored five are unchanged name for name):
 
     tab_citation_coverage.md   tab_core_venues_top10.md   tab_corpus_flow.md
     tab_corpus_sources.md      tab_languages.md
@@ -28,12 +31,35 @@ panel caught the undercount; running the ignore check over the discovery list
 instead of over the diff is what produced the real number, and it is the method
 the fix should use.
 
-The other five — `codebook.md`, `tab_retrieval_protocol.md`,
-`tab_variables.md`, `tab_venues.md`, `tab_venues_fr.md` — are tracked by
-explicit negations in the same file. Nothing distinguishes the two groups: the
-`.gitignore` comment around line 57 even says `tab_corpus_sources.csv` is
-"grouped with tab_corpus_sources.md", then negates only the `.csv`. The split
-reads as accretion, not a decision.
+The other four — `tab_retrieval_protocol.md`, `tab_variables.md`,
+`tab_venues.md`, `tab_venues_fr.md` — are tracked by explicit negations in the
+same file. Nothing distinguishes the two groups: the `.gitignore` comment
+around line 57 even says `tab_corpus_sources.csv` is "grouped with
+tab_corpus_sources.md", then negates only the `.csv`. The split reads as
+accretion, not a decision.
+
+**The steelman fails on its own evidence.** The obvious defence — "tracked
+means corpus-free, ignored means corpus-derived, so this is a coherent rule" —
+is refuted by `tab_venues.md`, which is tracked *and* takes `$(REFINED)` as a
+prerequisite. No such rule is in force.
+
+**What is in force, and what these five violate.** `deliverables/data-paper/data-paper.mk`
+and `deliverables/corpus-report/corpus-report.mk` (ticket 0237) each declare in
+their own header: "Render-only: produces … from handoff artifacts on disk …
+**No uv, no corpus data, no compute rules**." Their render targets take
+`$(DATAPAPER_INCLUDES)` / `$(CORPUS_REPORT_INCLUDES)` as prerequisites, and
+`paths.mk:31-48` expands those to include `tab_corpus_sources.md`,
+`tab_corpus_flow.md`, `tab_languages.md` and `tab_citation_coverage.md`. So
+both Makefiles declare a clean-room contract they cannot honour on a fresh
+clone: four declared prerequisites are gitignored and producible only from
+corpus data, which the render-only rule says must never be needed. This is the
+defect class ticket 0348 already fixed for `-vars.yml`
+(`tests/test_handoff_artifacts_tracked.py`), never extended to tables.
+
+Ticket 0207 was closed partly on the premise that the data paper was "frozen
+externally on Zenodo"; ticket 0237 superseded that a day later, and STATE.md
+now has the data paper under active R&R (RDJ-26561). Whatever residual case
+existed for leaving these ungoverned has expired twice over.
 
 The concrete cost is a blind spot in a standing guard. Ticket 0340's
 `tests/test_markdown_table_shape.py` sweeps generated Markdown artifacts for
@@ -61,25 +87,30 @@ ten targets, the guard is blind to half its own surface.
 2. Commit the five artifacts as currently generated on a corpus machine. Verify
    first that regenerating them is a no-op — 0370's no-churn pins say it should
    be, but the check belongs here, not in the PR that added the escaper.
-3. Decide the general rule rather than case by case: every `.md` under
-   `deliverables/_shared/tables/` that a `.qmd` includes is tracked. Encode it
-   as the test below so the next added table cannot silently fall out.
+
+   A worktree does not see the corpus by default: its `.dvc/cache` symlink to
+   the primary checkout's cache is created by `.githooks/post-checkout` and is
+   absent on at least some worktrees, which is what makes `data/catalogs/` look
+   empty. Re-link it (`ln -sfn <primary>/.dvc/cache .dvc/cache`), then
+   `make data` (a local `dvc checkout`, no network), then `make corpus-tables`.
+   This is environmental setup, not a blocker, and not a reason to generate the
+   artifacts anywhere but a worktree.
+3. Encode the rule so the next added table cannot silently fall out: every
+   `.md` a deliverable's include closure reaches is tracked.
 
 ## Test
 
-Red first, an `adherence` test: parse every `deliverables/**/*.qmd` for
-`{{< include ../_shared/(tables/…\.md) >}}`, and assert each resolved path
-appears in `git ls-files`. It fails today on exactly these five.
+Red first, in `tests/test_deliverable_artifacts.py` — **extend it, do not
+write a new parser.** That module already has a correct include-closure
+resolver that carries the root document's directory as base through every level
+of recursion, which is exactly the hazard the architecture rule warns about and
+which produced 13 false positives when done naively. It already computes the
+reached set and has a `git ls-files` helper.
 
-```python
-@pytest.mark.adherence
-def test_included_shared_tables_are_tracked():
-    """Every table a deliverable includes is a handoff artifact."""
-```
-
-Prefer deriving the include set from the same resolver the orphan sweep uses
-if one exists by then — note the architecture rule that a nested include
-resolves against the *root document's* directory, not its own.
+The existing guard checks tracked → reachable (orphan detection). This ticket
+needs the other direction: reachable → tracked, over the `.md` members of the
+reached set. One new test function reusing both helpers. It fails today on
+exactly these five.
 
 ## Verification
 

--- a/tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
+++ b/tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T18:25Z HDMX-coding-agent created
 2026-07-27T18:25Z HDMX-coding-agent note found by the #1191 review panel while reading the escaping fix; pre-existing, not introduced by ticket 0370
+2026-07-27T20:40Z HDMX-coding-agent note reimagine: the CSV half of the premise is false — to_csv's default na_rep already emits empty fields. Fix site moves to _write_md_table, which is also what the Test section actually exercises.
 
 --- body ---
 ## Context
@@ -18,7 +19,15 @@ whose refined count is zero with five of the eight dict keys — `Source`,
 `_write_md_table` reads each cell with `row.get(c, "")`. The key *is* present
 in the Series, holding `NaN`, so the `""` default never fires: the cell becomes
 `str(float('nan'))`. The shipped table gets the literal string `nan` in four
-columns, and the `.csv` sibling gets the same.
+columns. Measured on the current tree:
+
+    | UNFCCC key documents | 50 | 0 | 0 | nan | nan | nan | nan |
+
+**Correction (reimagine, 2026-07-27).** This ticket was filed claiming the
+`.csv` sibling carries the same `nan`. It does not. `save_csv` calls
+`df.to_csv(..., index=False)`, whose default `na_rep=""` already renders NaN as
+an empty field — verified by writing and reading the file back. The defect is
+Markdown-only.
 
 Pre-existing — the code did this before ticket 0370 touched the line, and 0370
 deliberately did not widen its scope to cover it. It is latent rather than
@@ -40,14 +49,16 @@ not, in a published data paper's quality table.
 
 ## Actions
 
-1. Decide where to fix it. Filling the missing keys at the row-building site is
-   the narrower change and keeps the `.csv` correct too; coercing `NaN` to `""`
-   in `_write_md_table` fixes only the Markdown side. Prefer the row-building
-   site, and state the choice in the commit.
+1. Coerce `NaN` to `""` in `_write_md_table`, beside the existing
+   `Raw`/`Refined`/`Unique` branch. The ticket originally preferred the
+   row-building site *because* that also fixed the `.csv` — that reason is void
+   (the `.csv` was never wrong), and the row-building site is now the worse
+   choice for a second reason: the Test section below drives `_write_md_table`
+   directly, bypassing `main()`, so a fix inside `main()` would leave the
+   ticket's own test red. Fix and test must name the same site.
 2. Check the TOTAL row cannot reach the same shape.
-3. Confirm the `.csv` sibling carries an empty field, not the string `nan` —
-   the invariant in 0370 was that escaping is a Markdown concern; this one is
-   not, and touches both outputs.
+3. Confirm the `.csv` sibling still carries an empty field. This is a
+   regression check, not a fix: it already passes.
 
 ## Test
 
@@ -65,6 +76,7 @@ dropped a computed field before.
 
 - [ ] A zero-refined source renders four empty cells, not `nan`
 - [ ] The `.csv` row carries empty fields for the same four columns
+      (already true before the change — pinned so it stays true)
 - [ ] Sources with a non-zero refined count are byte-unchanged
 - [ ] `make lint` and `make check-fast` hold
 

--- a/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
+++ b/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T19:05Z HDMX-coding-agent created
 2026-07-27T19:05Z HDMX-coding-agent note raised by the #1191 red-team agent, re-triaged from blocker to its own ticket, and reproduced independently before filing
+2026-07-27T20:50Z HDMX-coding-agent note reimagine: reader established off a real quarto render (strace + intercepted defaults), not off the docs. Character set settled at @ ~ ^ by measurement — see the resolved tension in Actions 3.
 
 --- body ---
 ## Context
@@ -41,9 +42,13 @@ folded into 0370:
 
 ## Scope — this predates 0370 and is wider than it
 
-The gap lives in the shared helper, so it reaches every caller: the deposit
-codebook (0325), both venue tables and the core-venues table (0339), and the
-corpus-sources and language tables (0370). The venue emitters are the most
+The gap lives in the shared helper, so it reaches every caller: both venue
+tables and the core-venues table (0339), the corpus-sources, language and
+corpus-flow tables (0370), and the retrieval-protocol table. (This ticket was
+filed naming the deposit codebook of 0325 as a carrier; ticket 0354 has since
+retired that emitter, and `markdown_cell` — the function it used — now has no
+live caller at all. That is inert to this ticket, which only touches
+`_GFM_LITERAL`, but it deserves its own ticket.) The venue emitters are the most
 plausible carrier by a wide margin — they interpolate *journal names straight
 out of the bibliographic corpus*, where an `@` is far likelier than in a
 hand-edited source label. Those emitters are already merged.
@@ -66,17 +71,50 @@ why it is worth its own ticket rather than a sixth item on a fix-the-emitter PR.
 
 ## Actions
 
-1. Establish which reader Quarto invokes for these documents, and with which
-   extensions. Do not assume plain `markdown`; read it off a real Quarto run
-   rather than off the docs, and record the answer in the module docstring.
+1. **Settled — record it, do not re-derive.** Established from two real
+   `quarto render` runs by intercepting the `--defaults` YAML Quarto hands its
+   bundled pandoc, cross-checked with `strace -f -e trace=execve`: `from:` is
+   not a reader name but a custom Lua reader,
+   `/opt/quarto/share/filters/qmd-reader.lua`, whose source sets
+   `Extensions = pandoc.format.extensions 'markdown'` and reads with
+   `{format = "markdown", extensions = …}`. No `reader-extensions:` key appears
+   in the captured defaults, so the extension set is pandoc's own default for
+   `markdown` — the full extended reader. When `bibliography:` is set (all ten
+   deliverables), Quarto appends the `citeproc` filter automatically.
+
+   `pandoc --list-extensions` confirms the gap: `markdown` carries
+   `+citations +subscript +superscript`; `gfm` has none of them.
+
+   Record this in the module docstring so the next reader does not re-derive it.
 2. Switch the oracle to that reader. This is the load-bearing step — do it
    first, so the character-set change lands against a test that can fail.
-3. Widen `_GFM_LITERAL` to whatever the reader makes live in a table cell
-   (`@`, `~`, `^` at minimum), keeping the existing rule that constructs
-   needing a matched pair are left alone so shipped tables do not churn.
-4. Re-check the no-churn pins in all six emitters. If widening the set rewrites
-   a currently-shipped value, that is a finding, not a nuisance — report it
-   before suppressing it.
+3. Widen `_GFM_LITERAL` to `@`, `~`, `^`.
+
+   **A tension in this ticket's original wording, resolved by measurement.**
+   "At minimum `@`, `~`, `^`" and "keep the matched-pair exemption" conflict:
+   `@` fires on a single occurrence, but `~`/`^` need a pair, which would put
+   them under the exemption alongside `*`/`_`. Measured:
+
+   - `@` is live alone, and an *unmatched* key is worse than a matched one — it
+     renders visible broken-citation garbage rather than failing quietly.
+   - `` ` `` pairs **across cells**: `` c`1 | MID3 | d`2 `` swallows the middle
+     cell into a code span. That, not single-character liveness, is why the
+     backtick is already escaped unconditionally.
+   - `~`/`^` do **not** pair across cells, but do fire within one:
+     `CO~2~ emissions` renders `CO<sub>2</sub> emissions` — an entirely
+     plausible string in this corpus.
+
+   So the exemption's real basis is not "needs a pair". It is that the emitters
+   themselves add `**…**` after escaping, so escaping `*` would destroy markup
+   they intend. No emitter ever adds a tilde or caret. `~`/`^` are therefore
+   escaped and `*`/`_` stay exempt, and the docstring's rationale should say
+   this rather than "changes the rendering on their own", which is the criterion
+   that created the ambiguity.
+4. Re-check the no-churn pins in all six emitters. Measured so far: the four
+   git-tracked shipped tables contain **zero** occurrences of `@`, `~` or `^`,
+   so they cannot churn. The four corpus-derived tables could not be checked
+   without `data/catalogs/` populated — that check is still owed, and if
+   widening rewrites a shipped value it is a finding to report, not suppress.
 
 ## Test
 


### PR DESCRIPTION
Ticket-ref: tickets/0371-included-shared-tables-are-gitignored.erg
Ticket-ref: tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg
Ticket-ref: tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg

Tickets only — closes nothing. Phase 2 of a raid on these three. Landing the
corrections before execution so the coding agents read accurate tickets.

Each pass corrected something in the ticket it read, which is the phase working
rather than failing.

**0375 — the CSV half of the premise is false.** `save_csv` → `to_csv`, whose
default `na_rep=""` already emits an empty field; verified by write-and-read-back.
The defect is Markdown-only (`| UNFCCC key documents | 50 | 0 | 0 | nan | nan | nan | nan |`),
one Verification item is already green, and Action 1's reason for preferring the
row-building site is void. That site also contradicted the ticket's own Test
section, which drives `_write_md_table` directly and would have stayed red after
a `main()`-side fix — the two halves named different sites. Now they agree.

**0371 — premise strengthened, scope narrowed.** I asked for a steelman of the
opposite case; it fails on evidence, since `tab_venues.md` is tracked *and* needs
`$(REFINED)`, so "tracked = corpus-free" is not a rule in force. What is in force
is stronger than the ticket claimed: `data-paper.mk` and `corpus-report.mk` both
declare "**No uv, no corpus data, no compute rules**" in their headers, while
`paths.mk:31-48` expands their prerequisites to four of the ignored tables — a
clean-room contract neither can honour on a fresh clone. Same defect class 0348
fixed for `-vars.yml`. Denominator corrected 10 → 9 (0354 retired `codebook.md`);
the ignored five are unchanged. The sketched regex parser is dropped in favour of
extending `tests/test_deliverable_artifacts.py`, whose resolver already carries
the root document's directory through recursion — the exact hazard that produced
13 false positives when hand-rolled.

**0376 — reader settled empirically, and a contradiction in my own ticket text
resolved by measurement.** The reader was read off two real `quarto render` runs
by intercepting the `--defaults` YAML and cross-checking with `strace`: a custom
Lua reader setting `Extensions = pandoc.format.extensions 'markdown'`, with
`citeproc` appended whenever `bibliography:` is set (all ten deliverables).

The ticket said both "widen to `@`, `~`, `^` at minimum" and "keep the
matched-pair exemption" — which conflict, since `~`/`^` need a pair. Measured:

- `` ` `` pairs **across cells** — `` c`1 | MID3 | d`2 `` swallows the middle
  cell into a code span. That is the real reason it is escaped unconditionally.
- `~`/`^` do not pair across cells but fire within one: `CO~2~ emissions` →
  `CO<sub>2</sub> emissions`, entirely plausible in this corpus.
- So the exemption's basis is not "needs a pair" — it is that emitters add
  `**…**` themselves after escaping, so escaping `*` would destroy intended
  markup. No emitter adds a tilde or caret.

Verdict: escape `@`, `~`, `^`; `*`/`_` stay exempt; the docstring rationale gets
corrected too. Churn measured zero on the four tracked tables; the four
corpus-derived ones still need checking on a machine with `data/catalogs/`.

Also noted for a future ticket, not acted on: `markdown_cell` has had no live
caller since 0354 retired `export_codebook.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)