### PR TITLE
ticket(0274): carry 0372 as a blocker on the R&R tracker

### DIFF
--- a/tickets/0274-rdj26561-rr-round-1-tracker.erg
+++ b/tickets/0274-rdj26561-rr-round-1-tracker.erg
@@ -2,6 +2,7 @@
 Title: RDJ-26561 data paper revise-and-resubmit round 1 — tracker
 Created: 2026-07-20
 Author: HDMX-coding-agent
+Blocked-by: 0372
 
 --- log ---
 2026-07-20T09:00Z HDMX-coding-agent created
@@ -16,6 +17,7 @@ Author: HDMX-coding-agent
 2026-07-27T08:11Z HDMX-coding-agent note two children filed 2026-07-27 from a full make check during 0317: 0320 (data paper's citation-verification claim is v1 and now wrong — says 99.0% CI [97.1,99.7], corpus v2 gives 97.0% CI [94.4,98.4]; blocks resubmission) and 0321 (main red on ruff + a tier-3 dual-role import from the 07-24 merges; no CI workflows exist in this repo so make check is a local-only gate). 0317 and 0314 closed on branch t0317-temporal-coverage.
 2026-07-27T11:00Z HDMX-coding-agent note external peer-review panel run as a pre-resubmission dress rehearsal (4 reviewers: openai/gpt-5.5 and mistralai/mistral-large-2512, grinchy + student personas). Verdicts split Reject / Major revision — harsher than the real R1 referee, by design. Nine children filed (0327, 0328, 0329, 0332, 0333, 0334, 0335, 0337, 0338) plus 0325 already open. Four findings were unanimous: corpus boundary, retrieval protocol, filter validation, multilingual overclaim. Reviews archived at deliverables/data-paper/revision-rdj26561/external-review/.
 2026-07-27T11:59Z HDMX-coding-agent bump verify-reroll — round 1: ticket ID collision with origin/main (0330, 0331 duplicated already-merged IDs; renumbered to 0337/0338), tracker log order, §4/§1 misattribution in 0335 and 0332
+2026-07-27T19:33Z HDMX-coding-agent note 0372 named as a blocker (author): the AUC = 0.818 human-validation claim is not reproducible from either shipped table. It was filed 2026-07-27 citing this tracker but never listed as a child, so it was invisible to the children roll-up. Now carried as Blocked-by and listed below; [needs-human].
 --- body ---
 ## Context
 
@@ -55,6 +57,7 @@ remarks; coverage check clean at filing time).
 - 0320 — citation-verification statistic is v1 and now wrong under corpus v2 — blocks resubmission
 - 0321 — main red on ruff + a tier-3 dual-role import from the 07-24 merges
 - 0325 — variables table drops the negation: LaTeX esc() eats the tilde, publishing an inverted filter recipe
+- 0372 — AUC = 0.818 human-validation claim not reproducible from either shipped table [needs-human] — blocker: carried as `Blocked-by`, resubmission cannot go out with an unsupported validation statistic
 
 ### From the external peer-review panel (2026-07-27)
 

--- a/tickets/0372-data-paper-s-auc-0-818-human-validation.erg
+++ b/tickets/0372-data-paper-s-auc-0-818-human-validation.erg
@@ -6,6 +6,7 @@ Label: needs-human
 
 --- log ---
 2026-07-27T18:05Z HDMX-coding-agent created surfaced by the independent Flag 5 defense round; verified directly against both artifacts
+2026-07-27T19:33Z HDMX-coding-agent note promoted to R&R blocker (author): tracker 0274 now carries Blocked-by: 0372 and lists it as a child. RDJ-26561 does not resubmit until this closes.
 
 --- body ---
 ## Context


### PR DESCRIPTION
0372 named 0274 in its body but was never listed as a child, so the tracker's roll-up did not count it among the outstanding R&R work. This adds it both ways:

- `Blocked-by: 0372` header on 0274 — machine-readable; `erg list --json` now reports the tracker blocked, and `erg ready` will not offer it while 0372 is open.
- Children-list entry with the `[needs-human]` label carried over, so the body reads complete on its own.
- Reciprocal log note on 0372.

Tickets-only diff — fast path per `.claude/rules/git.md`. No new IDs allocated, so no collision surface. `erg check tickets/` passes (382 tickets).

**Ticket-ref:** tickets/0274-rdj26561-rr-round-1-tracker.erg
**Ticket-ref:** tickets/0372-data-paper-s-auc-0-818-human-validation.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)