### PR TITLE
test: read MANUSCRIPT_DELIVERABLES from manuscript.mk instead of restating it

### DIFF
--- a/tests/test_build_phase_separation.py
+++ b/tests/test_build_phase_separation.py
@@ -23,7 +23,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from _mk_discovery import mk_fragments
+from _mk_discovery import makefile_constants, mk_fragments
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 MANUSCRIPT_MK = os.path.join(REPO_ROOT, "deliverables", "manuscript", "manuscript.mk")
@@ -92,18 +92,30 @@ def test_phase_purity_guard_has_teeth(tmp_path):
         disk = f.read()
     assert _has_render(disk) and _has_phase2(disk)
 
-# The manuscript's writing-facing deliverables — what manuscript.qmd actually
-# consumes via ![](../_shared/figures/...) and
-# {{< include ../_shared/tables/tab_venues.md >}}.
-MANUSCRIPT_DELIVERABLES = [
-    "deliverables/_shared/figures/fig_bars_v1.png",
-    "deliverables/_shared/figures/fig_composition.png",
-    "deliverables/_shared/figures/fig_breaks.png",
-    "deliverables/_shared/tables/tab_venues.md",
-]
+# The manuscript's writing-facing deliverables — what manuscript.qmd consumes
+# via ![](../_shared/figures/...) and {{< include ../_shared/tables/... >}}.
+#
+# Read from manuscript.mk rather than restated here. The render rule uses this
+# same variable as its prerequisites, so a copy under-covers the moment the
+# manuscript gains a deliverable: the rule would require the new file while
+# this test kept passing on the stale four and never checked it was tracked —
+# exactly the silent drift ticket 0290 found in the paths.mk include lists.
+MANUSCRIPT_DELIVERABLES = makefile_constants()["MANUSCRIPT_DELIVERABLES"].split()
 
 # Tokens that betray a Phase-1/data dependency leaking into the writing build.
 DATA_TOKENS = ["$(REFINED)", "$(DATA_DIR)", "refined_works", "data/"]
+
+
+def test_manuscript_deliverables_is_not_empty():
+    """The parametrized check below must actually have something to check.
+
+    An empty list makes `parametrize` generate zero cases, so a rename or a
+    parser regression would read as a green suite rather than as a failure.
+    """
+    assert MANUSCRIPT_DELIVERABLES, (
+        "MANUSCRIPT_DELIVERABLES resolved empty from manuscript.mk — the "
+        "variable was renamed or the .mk parser stopped reading it."
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Ticket: none

Quickfix from the 0290 roar sweep — same defect class, no ticket filed.

## The defect

`tests/test_build_phase_separation.py` hardcoded `MANUSCRIPT_DELIVERABLES` as a literal copy of the variable `deliverables/manuscript/manuscript.mk` declares. The render rule uses that same variable as its prerequisites.

A copy under-covers **silently**: add a deliverable to the manuscript and the render rule requires it, while this test keeps passing on the stale four and never checks the new file is git-tracked. The result is a clean-room writing build that breaks with a green suite — the same shape as the `paths.mk` include-list drift settled in ticket 0290.

## The fix

Read it through `_mk_discovery.makefile_constants()`, the parser the build guards already share, rather than adding a third one. It resolves the variable to the same four paths, so the checks are unchanged on today's tree.

## Verification

By mutation, not inspection — adding a deliverable to `manuscript.mk`:

```
FAILED test_deliverable_is_git_tracked[deliverables/_shared/figures/fig_planted_untracked.png]
```

A new case appears and fails because the planted file is untracked. Under the literal list it was invisible. `manuscript.mk` was restored afterwards; the diff is one test file.

Computing the parametrize source adds one failure mode a literal did not have — resolving empty would generate zero cases and read as green, the all-clear-indistinguishable-from-didn't-look trap — so `test_manuscript_deliverables_is_not_empty` covers it.

- `make lint` — 307 passed, 11 skipped
- fast tier — 1326 passed, 11 skipped
- `tests/test_build_phase_separation.py` all tiers — 22 passed
- `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)