### PR TITLE
ticket(0371,0376): fold in the raid feasibility findings

### DIFF
--- a/tickets/0371-included-shared-tables-are-gitignored.erg
+++ b/tickets/0371-included-shared-tables-are-gitignored.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T18:20Z HDMX-coding-agent created
 2026-07-27T18:20Z HDMX-coding-agent note found by the /verify-adherence gate on PR #1191 (ticket 0370) and confirmed independently by two agents of its review panel
+2026-07-27T21:05Z HDMX-coding-agent note feasibility WARN: three corrections folded in — five negations not two, tab_core_venues_top10.md is include-reachable by nothing and needs an unrendered-artifacts entry, and make corpus-tables does not build it
 2026-07-27T20:45Z HDMX-coding-agent note reimagine: premise strengthened — paths.mk's *_INCLUDES list these tables as prerequisites of two render-only .mk files that declare "no corpus data". Scope narrows: extend tests/test_deliverable_artifacts.py, do not write the sketched parser.
 2026-07-27T20:10Z HDMX-coding-agent note widened from two tables to five — the #1191 round-4 panel caught the undercount; the real set comes from git check-ignore over the 0340 discovery list, not from the diff that surfaced it
 
@@ -81,12 +82,19 @@ ten targets, the guard is blind to half its own surface.
 
 ## Actions
 
-1. Add `.gitignore` negations for `tab_corpus_sources.md` and
-   `tab_languages.md`, and fix the stale comment that already claims the
-   grouping.
+1. Add `.gitignore` negations for **all five**: `tab_citation_coverage.md`,
+   `tab_core_venues_top10.md`, `tab_corpus_flow.md`, `tab_corpus_sources.md`,
+   `tab_languages.md`. (This action said "two" until the feasibility pass — a
+   leftover from before the scope widened.) Fix the stale comment that already
+   claims the `.csv`/`.md` grouping.
 2. Commit the five artifacts as currently generated on a corpus machine. Verify
    first that regenerating them is a no-op — 0370's no-churn pins say it should
    be, but the check belongs here, not in the PR that added the escaper.
+
+   `make corpus-tables` does **not** build `tab_core_venues_top10.md` — that
+   target is wired to no aggregate (it depends on `het_mostcited_50.csv`), so
+   build it explicitly:
+   `make deliverables/_shared/tables/tab_core_venues_top10.md`.
 
    A worktree does not see the corpus by default: its `.dvc/cache` symlink to
    the primary checkout's cache is created by `.githooks/post-checkout` and is
@@ -97,6 +105,17 @@ ten targets, the guard is blind to half its own surface.
    artifacts anywhere but a worktree.
 3. Encode the rule so the next added table cannot silently fall out: every
    `.md` a deliverable's include closure reaches is tracked.
+
+4. `tab_core_venues_top10.md` is the exception and needs handling, not
+   assumption. The Context above says "each is `{{< include >}}`d by a
+   deliverable" — that is true of four of the five and **false** of this one,
+   which no `.qmd` in the tree includes. Tracking it therefore trips the
+   existing orphan guard `test_shared_artifacts_are_reachable`, which fails on
+   tracked-but-unreached. Add a `config/unrendered-artifacts.txt` entry with a
+   one-line reason, exactly as `tab_retrieval_protocol.md` already has. Track it
+   anyway rather than dropping it from scope: the point of the ticket is that
+   the 0340 sweep cannot see an untracked artifact, and that applies whether or
+   not a paper floats it.
 
 ## Test
 

--- a/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
+++ b/tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg
@@ -63,9 +63,16 @@ why it is worth its own ticket rather than a sixth item on a fix-the-emitter PR.
   module docstring's rationale for the scope needs revising with it
 - `tests/_gfm_render.py` — `render_gfm`, the `-f gfm` oracle used by every
   escaping test
-- `tests/test_markdown_table.py`, `tests/test_rendered_venue_table_fidelity.py`,
-  `tests/test_corpus_table_export.py`, `tests/test_language_table.py` — the
-  callers of that oracle
+- `tests/test_corpus_flow.py`, `tests/test_corpus_table_export.py`,
+  `tests/test_language_table.py`, `tests/test_rendered_venue_table_fidelity.py`
+  — the four callers of that oracle. (This list named
+  `tests/test_markdown_table.py` until the feasibility pass; that module
+  deliberately defers render assertions and never imports `_gfm_render`, while
+  `test_corpus_flow.py` was missing.) `render_gfm` is called positionally with
+  two arguments by all four, so an optional `bibliography=` third parameter is
+  backward-compatible.
+- `deliverables/_shared/bibliography/main.bib` — a real tracked bibliography;
+  the `@key` test needs no synthesized fixture
 - `deliverables/data-paper/data-paper.qmd`,
   `deliverables/corpus-report/corpus-report.qmd` — `bibliography:` set
 


### PR DESCRIPTION
Ticket-ref: tickets/0371-included-shared-tables-are-gitignored.erg
Ticket-ref: tickets/0376-markdown-escaper-is-calibrated-to-the-wrong-reader.erg

Tickets only — closes nothing. Phase 4 of the raid on 0371/0375/0376.

Verdicts: **0376 PASS**, **0375 PASS** (unchanged), **0371 WARN**.

The one that would have bitten: 0371's Context asserts each of the five ignored
tables is `{{< include >}}`d by a deliverable. `tab_core_venues_top10.md` is
included by nothing in the tree. Tracking it would have tripped the existing
orphan guard `test_shared_artifacts_are_reachable` — the ticket would have
broken a green test on main. It still gets tracked (an untracked artifact is
invisible to the 0340 sweep regardless of whether a paper floats it), but with a
`config/unrendered-artifacts.txt` entry, as `tab_retrieval_protocol.md` has.

Also for 0371: Action 1 still said two negations, not five, and the build recipe
was incomplete — `make corpus-tables` does not build `tab_core_venues_top10.md`.

For 0376: the oracle-caller inventory was wrong in both directions — it named
`test_markdown_table.py`, which never imports `_gfm_render`, and omitted
`test_corpus_flow.py`. All four real callers pass `render_gfm` two positional
arguments, so an optional `bibliography=` is backward-compatible, and
`main.bib` is tracked, so the citation test needs no synthesized fixture.

Wave plan confirmed by the same pass: Wave 2's two tickets have zero file
intersection and can run parallel; 0376-before-0371 is required because the
readers differ on more than `@~^` (`+smart` curls quotes), so artifacts
committed before the switch could churn; and no file is edited by 2+ PRs, so the
Phase-5.0 coordination PR is correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)