### PR TITLE
fix(0470): renumber the credential ticket off the duplicate 0371 seat — main is red

### DIFF
--- a/tickets/0470-swap-agent-token-to-a-fine-grained-pat.erg
+++ b/tickets/0470-swap-agent-token-to-a-fine-grained-pat.erg
@@ -8,6 +8,7 @@ Label: needs-human
 2026-07-27T16:30Z HDMX-coding-agent created
 
 2026-07-27T17:42Z filed as the browser-only half of 0365 decision 1
+2026-07-28T07:10Z HDMX-coding-agent renumber 0371 -> 0470: collided on origin/main with 0371-included-shared-tables-are-gitignored (filed 25 min later); renumbered clear of the 0435 frontier per tickets/AGENTS.md
 --- body ---
 ## Context
 

--- a/tickets/closed/0365-hdmx-coding-agent-is-not-a-github-accoun.erg
+++ b/tickets/closed/0365-hdmx-coding-agent-is-not-a-github-accoun.erg
@@ -7,7 +7,7 @@ Closed: decided and implemented: one account, procedural gate; prompt hook delet
 --- log ---
 2026-07-27T15:45Z HDMX-coding-agent created
 
-2026-07-27T17:42Z decision recorded: one account, fine-grained PAT (0371), gate repaired as procedural
+2026-07-27T17:42Z decision recorded: one account, fine-grained PAT (0470), gate repaired as procedural
 2026-07-27T19:48Z HDMX-coding-agent closed — decided and implemented: one account, procedural gate; prompt hook deleted
 --- body ---
 ## Context
@@ -67,7 +67,7 @@ procedural reading of option 3.
 1. **One account, scope the token.** No machine account. `AGENT_GH_TOKEN`
    becomes a *fine-grained* PAT limited to this repository, replacing the
    classic account-wide one. Separation of privilege is by token scope, not by
-   account. Minting it is a browser action, so it left as child ticket 0371
+   account. Minting it is a browser action, so it left as child ticket 0470
    (`Label: needs-human`); nothing else here depends on it.
 2. **No second GitHub account.** The option-2 framing did not survive scrutiny:
    a machine account would not fix self-review, because the agent would open the
@@ -137,7 +137,7 @@ from the session that made the change — settings load at session start.
 3. ~~If option 2: add the machine token under its own name and select it via
    `KEYS=` with the rename form.~~ Not applicable — option 2 declined. One
    identity, one variable, so the rename form is unnecessary. The token swap
-   itself is ticket 0371.
+   itself is ticket 0470.
 
 ## Verification
 


### PR DESCRIPTION
`origin/main` fails `erg check`:

```
ERG CHECK FAILED (1 error):
  VIOLATION duplicate ID '0371' in: 0371-included-shared-tables-are-gitignored.erg, 0371-swap-agent-token-to-a-fine-grained-pat.erg
```

Two tickets took the `0371` seat 25 minutes apart on 2026-07-27 — the optimistic-ID trap. Nothing caught it: no CI here (0321), and a branch-local `erg check` passes by construction. It surfaced from running `erg check` against `origin/main` after the merges landed.

## Which file yields

Convention says the later filing renumbers, which would move `-included-shared-tables` (20:15). It does not here: **open PR #1234 archives that exact file** into `tickets/closed/`, so renumbering it would collide with a clean, mergeable PR for no gain. `-swap-agent-token` (19:50) is touched by no open PR and its only cross-references are three prose lines in the already-closed 0365, rewritten here.

## Why 0470 and not the next free ID

Frontier is 0435 (`0450` already claimed by a branch name). The next-free seat is the most contended number in the repo — chasing it is as collision-prone as the original allocation. On 2026-07-27 one filing collided three times doing exactly that.

## Note for whoever merges #1234

Archiving the surviving `0371` does **not** clear this error. `erg check` scans `tickets/closed/` too, so the duplicate survives the move — verified by replaying the archive against `origin/main`'s tree:

```
VIOLATION duplicate ID '0371' in: 0371-swap-agent-token-to-a-fine-grained-pat.erg, 0371-included-shared-tables-are-gitignored.erg
```

This PR is the fix; #1234 is orthogonal and they do not touch the same file.

## Gate

`erg check tickets/` PASS (384). Diff is `tickets/` only — the fast path. Collision scan for `0470` across all open PRs: clear.

**Ticket-ref:** tickets/0470-swap-agent-token-to-a-fine-grained-pat.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)