### PR TITLE
fix(0375): a zero-refined source ships empty cells, not literal nan

### DIFF
--- a/scripts/figures/export_corpus_table.py
+++ b/scripts/figures/export_corpus_table.py
@@ -147,6 +147,14 @@ def _write_md_table(summary: pd.DataFrame, path: str, caption: str) -> None:
             v = row.get(c, "")
             if c in ("Raw", "Refined", "Unique"):
                 v = f"{int(v):,}" if pd.notna(v) else ""
+            elif pd.isna(v):
+                # A zero-refined source reaches here as float NaN: main()
+                # builds its row without the percentage keys and the
+                # DataFrame fills them, so the .get default above never
+                # fires. An empty cell, not str(nan), in the deposit
+                # (ticket 0375). The .csv sibling was never wrong —
+                # to_csv's default na_rep already writes empty fields.
+                v = ""
             cell = markdown_text_cell(v)
             vals.append(f"**{cell}**" if is_total else cell)
         lines.append("| " + " | ".join(vals) + " |")

--- a/tests/test_corpus_table_export.py
+++ b/tests/test_corpus_table_export.py
@@ -301,3 +301,63 @@ def test_shipped_labels_are_untouched_by_the_escaper(tmp_path):
         assert f"| {meta['label']} |" in emitted, (
             f"label {meta['label']!r} was rewritten by the escaper"
         )
+
+
+# --- Ticket 0375: a zero-refined source must not ship a literal "nan" ---
+
+# main() builds the row for a source whose refined count is zero with five of
+# the eight keys; pd.DataFrame(rows) fills the four percentage columns with
+# float NaN for that row. The key IS present in the Series, so _write_md_table's
+# `row.get(c, "")` default never fires and the cell became str(float('nan')).
+ZERO_REFINED_ROW = {
+    "Source": "UNFCCC key documents", "Raw": 50, "Refined": 0, "Unique": 0,
+}
+
+
+@pytest.mark.integration
+def test_zero_refined_source_renders_empty_cells_not_nan(tmp_path):
+    """The four percentage cells of a zero-refined source render empty.
+
+    Red before ticket 0375: the shipped table carried
+    `| UNFCCC key documents | 50 | 0 | 0 | nan | nan | nan | nan |`.
+    Asserted on the rendered page, not the emitted source (0325's oracle) —
+    and against float NaN arriving through the DataFrame fill, the exact
+    shape main() produces, not a hand-written None.
+    """
+    require_pandoc()
+    summary = pd.DataFrame(
+        [_summary_row("OpenAlex"), ZERO_REFINED_ROW], columns=_MD_COLUMNS
+    )
+
+    row = row_with(_render(summary, tmp_path), "UNFCCC")
+
+    assert cell_texts(row) == [
+        "UNFCCC key documents", "50", "0", "0", "", "", "", "",
+    ], f"a zero-refined source leaked NaN into the rendered row:\n{row}"
+
+
+def test_zero_refined_source_keeps_empty_csv_fields(tmp_path):
+    """The .csv sibling carries empty fields for the same four columns.
+
+    This is a regression pin, not a fix: `to_csv`'s default `na_rep` already
+    renders NaN as an empty field. Pinned by reading the written file back —
+    a `columns=` allowlist has silently dropped a computed field before
+    (tickets 0288/0347), so the in-memory frame proves nothing.
+    """
+    from export_corpus_table import save_csv
+
+    summary = pd.DataFrame(
+        [_summary_row("OpenAlex"), ZERO_REFINED_ROW], columns=_MD_COLUMNS
+    )
+    csv_path = tmp_path / "tab_corpus_sources.csv"
+    save_csv(summary, str(csv_path))
+
+    text = csv_path.read_text(encoding="utf-8")
+    unfccc = [ln for ln in text.splitlines() if ln.startswith("UNFCCC")]
+    assert unfccc, f"the zero-refined row vanished from the csv:\n{text}"
+    assert "nan" not in unfccc[0], (
+        f"the csv row carries a literal nan: {unfccc[0]!r}"
+    )
+    assert unfccc[0].endswith(",,,,"), (
+        f"expected four trailing empty fields, got: {unfccc[0]!r}"
+    )


### PR DESCRIPTION
Closes the latent deposit defect the #1191 review panel found: the day a source present in `unified_works.csv` refines to zero works, the Markdown quality table shipped to Zenodo carries `| UNFCCC key documents | 50 | 0 | 0 | nan | nan | nan | nan |`.

**Ticket:** tickets/0375-corpus-table-ships-literal-nan-for-empty-sources.erg

## Mechanism

`main()` builds a zero-refined row with five of the eight keys; `pd.DataFrame(rows)` fills the four percentage columns with float NaN. The key *is* present in the Series, so `_write_md_table`'s `row.get(c, "")` default never fires and the cell became `str(float('nan'))`.

## Fix

Coerce NaN to `""` in `_write_md_table`, beside the existing `Raw`/`Refined`/`Unique` branch — the site the ticket's reimagine note selected (the `.csv` half of the original premise was false, and the ticket's own test drives `_write_md_table` directly, so a fix inside `main()` would have left it red).

## TDD trail

- Red (`ff` commit 1): rendered through the 0325 pandoc oracle, the row shows four `nan` cells — the exact shipped shape, with NaN arriving through the DataFrame fill as `main()` produces it, not a hand-written `None`.
- Green (commit 2): four empty cells.
- Same commit pins the `.csv` sibling **by reading the written file back** (`to_csv`'s default `na_rep` was never wrong): row ends `,,,,`, no literal `nan`. In-memory assertions have missed a dropped computed field before (0288/0347).

## Ticket action 2 — the TOTAL row

Checked, recorded in the commit: TOTAL is built with every key as a pre-formatted string, so float NaN cannot reach it via the fill; the only path is an empty corpus turning `mean()` into the *string* `"nan%"` — a different shape at a different site, unreachable once `load_refined_works` has produced rows.

## Invariants held

- Full rows never enter the new branch (their values are non-null strings) → regenerating today's table is byte-identical; the render-level pins on pipe-bearing and shipped-label rows hold unchanged.
- 0370's escaping stays: the coerced value still routes through `markdown_text_cell`.

## Gates

`tests/test_corpus_table_export.py` 16 passed, 2 skipped (pandoc-gated pins run green locally); `make check-fast` 1325 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)