### PR TITLE
fix(0356): derive the deposited table's language count from config

### DIFF
--- a/deliverables/_shared/tables/tab_corpus_sources.csv
+++ b/deliverables/_shared/tables/tab_corpus_sources.csv
@@ -1,5 +1,5 @@
 Source,Query,Raw,Refined,Unique,%non-EN,%Journal,%DOI,%Refs,%Abstract
-OpenAlex,"4-tier keyword taxonomy, 9 languages (default.search on title+abstract+fulltext)",41138,31544,30815,6%,86%,76%,61%,88%
+OpenAlex,"4-tier keyword taxonomy, 8 languages (default.search on title+abstract+fulltext)",41138,31544,30815,6%,86%,76%,61%,88%
 ISTEX,"""climate finance"" OR ""finance climat*"" on French institutional archive",748,635,443,2%,100%,100%,96%,97%
 bibCNRS,"FR, ZH, JA, DE queries via Gale/Wanfang/NewsBank (CNRS legacy portal)",233,219,200,8%,85%,10%,1%,5%
 SciSpace,AI-curated systematic review (RIS + CSV exports),663,618,238,1%,77%,83%,66%,90%

--- a/scripts/figures/export_corpus_table.py
+++ b/scripts/figures/export_corpus_table.py
@@ -12,6 +12,7 @@ and abstract availability.
 import os
 
 import pandas as pd
+import yaml
 from _markdown_table import markdown_text_cell
 from pipeline_loaders import load_refined_works
 from script_io_args import parse_io_args, validate_io
@@ -21,11 +22,30 @@ log = get_logger("export_corpus_table")
 
 CORE_THRESHOLD = 50
 
+
+def _openalex_language_count() -> int:
+    """Target languages the Tier-1 taxonomy declares (ticket 0356).
+
+    Same source of truth as the paper's language sentence
+    (`tests/test_retrieval_protocol.py::target_languages`): distinct non-null
+    `term_languages` tags. A hand-typed "9 languages" shipped in the deposit
+    against a config declaring eight; deriving the count is what keeps table,
+    paper, and config on one number. The ISTEX and bibCNRS descriptions below
+    stay literal — they describe manual pulls with no config source to derive
+    from.
+    """
+    path = os.path.join(BASE_DIR, "config", "openalex_queries.yaml")
+    with open(path, encoding="utf-8") as fh:
+        tags = yaml.safe_load(fh)["term_languages"]
+    return len({lang for lang in tags.values() if lang})
+
+
 # Source metadata: label and query description from catalog_*.py scripts
 SOURCE_META = {
     "openalex": {
         "label": "OpenAlex",
-        "query": "4-tier keyword taxonomy, 9 languages (default.search on title+abstract+fulltext)",
+        "query": f"4-tier keyword taxonomy, {_openalex_language_count()} languages"
+                 " (default.search on title+abstract+fulltext)",
     },
     "istex": {
         "label": "ISTEX",

--- a/tests/test_retrieval_protocol.py
+++ b/tests/test_retrieval_protocol.py
@@ -107,6 +107,30 @@ def test_language_neutral_terms_are_tagged_null():
     assert untagged, "at least the institution-name terms must be tagged null"
 
 
+def test_source_table_language_count_matches_config():
+    """The OpenAlex row of the deposited source table states config's count.
+
+    Red before ticket 0356: `SOURCE_META["openalex"]["query"]` hand-typed
+    "9 languages" against a config declaring eight, so the Zenodo deposit
+    contradicted the paper it accompanies on the number the paper puts in
+    its own title claim ("Multilingual Retrieval"). The count must come
+    from `term_languages`, the same source of truth the paper's language
+    sentence is checked against.
+    """
+    from export_corpus_table import SOURCE_META
+
+    query = SOURCE_META["openalex"]["query"]
+    m = re.search(r"(\d+)\s+languages", query)
+    assert m, (
+        f"the OpenAlex query description no longer states a language count: "
+        f"{query!r}"
+    )
+    assert int(m.group(1)) == len(target_languages()), (
+        f"the deposited source table says {m.group(1)} languages, config "
+        f"declares {len(target_languages())} ({target_languages()})"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Prose ↔ config — the paper names the languages config declares
 # --------------------------------------------------------------------------- #

--- a/tickets/0356-corpus-source-table-hand-types-nine-langu.erg
+++ b/tickets/0356-corpus-source-table-hand-types-nine-langu.erg
@@ -6,6 +6,8 @@ Author: HDMX-coding-agent
 --- log ---
 2026-07-27T16:35Z HDMX-coding-agent created split out of 0329, whose review found the defect and whose log wrongly deferred it to 0327 (0327 does not track it)
 
+2026-07-28T09:30Z HDMX-coding-agent note action 3 sweep decided: the ISTEX query string and the bibCNRS language list stay literal — both describe manual pulls (French institutional archive export; Gale/Wanfang/NewsBank portal queries) with no config file to derive from, so there is no source of truth to drift against. Only the OpenAlex count had one (term_languages), and only it is derived. Recorded in the _openalex_language_count docstring too.
+
 --- body ---
 ## Context
 

--- a/tickets/closed/0356-corpus-source-table-hand-types-nine-langu.erg
+++ b/tickets/closed/0356-corpus-source-table-hand-types-nine-langu.erg
@@ -2,12 +2,14 @@
 Title: The corpus-source table hand-types "9 languages" against a config that declares eight
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1247
 
 --- log ---
 2026-07-27T16:35Z HDMX-coding-agent created split out of 0329, whose review found the defect and whose log wrongly deferred it to 0327 (0327 does not track it)
 
 2026-07-28T09:30Z HDMX-coding-agent note action 3 sweep decided: the ISTEX query string and the bibCNRS language list stay literal — both describe manual pulls (French institutional archive export; Gale/Wanfang/NewsBank portal queries) with no config file to derive from, so there is no source of truth to drift against. Only the OpenAlex count had one (term_languages), and only it is derived. Recorded in the _openalex_language_count docstring too.
 
+2026-07-28T13:04Z HDMX-coding-agent closed — autoclosed — PR #1247
 --- body ---
 ## Context
 


### PR DESCRIPTION
The Zenodo deposit's source table hand-typed **"9 languages"** for the OpenAlex row while `config/openalex_queries.yaml` declares eight and the paper says eight in §2.1 and §2.3 — the deposit contradicted the paper it accompanies on the number in the paper's own title claim ("Multilingual Retrieval").

**Ticket:** tickets/0356-corpus-source-table-hand-types-nine-langu.erg

## Fix

`_openalex_language_count()` derives the count from `term_languages` — distinct non-null tags, the same semantics as `test_retrieval_protocol.py::target_languages`, which already gates the paper's language sentence. Table, paper, and config now hold one number from one source of truth; adding a language to the taxonomy moves all three.

## TDD trail

- Red (commit 1): guard extracts the count from `SOURCE_META["openalex"]["query"]` by regex and compares to `len(target_languages())` — failed at 9 vs 8.
- Green (commit 2): derived count; regenerated table.

## Regeneration evidence

The tracked `tab_corpus_sources.csv` diff is **exactly one cell** (`9 languages` → `8 languages`); every corpus count is byte-identical, proving the worktree corpus matches the committed table and no count churn rides along. The `.md` sibling regenerates with the same row and no stray `nan` (checked), but is untracked — its gitignoring is open ticket 0371-included-shared-tables.

## Ticket action 3 — sweep of other hand-typed retrieval facts

Decided and logged in the ticket: the ISTEX query string and the bibCNRS language list **stay literal**. Both describe manual pulls (French institutional archive export; Gale/Wanfang/NewsBank portal queries) with no config file to derive from — no source of truth, nothing to drift against. Only the OpenAlex count had one.

## Relation to #1245

Both PRs touch `export_corpus_table.py` in disjoint regions (module top vs `_write_md_table`); merge order is indifferent.

## Gates

`test_retrieval_protocol.py` + `test_corpus_table_export.py`: 54 passed, 2 skipped. `make check-fast` 1325 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)