### PR TITLE
fix: main is red — products_named_in lost its return statement in d7d9789f

### DIFF
--- a/tests/test_datapaper_archive_layout.py
+++ b/tests/test_datapaper_archive_layout.py
@@ -109,6 +109,7 @@ def products_named_in(text):
                     last_stem = re.sub(_PRODUCT_EXT + r"$", "", matches[-1])
                 elif last_stem and re.fullmatch(_PRODUCT_EXT, token):
                     found.add(last_stem + token)
+    return found
 
 
 class TestRenderRuleTracksTheIncludeClosure:
@@ -396,3 +397,17 @@ class TestSubmissionProseNamesOnlyShippedProducts:
         named = products_named_in(doc)
         assert "climate_finance_corpus.csv" in named, "the real products must parse"
         assert sorted(named - shipped_products()) == ["codebook.md"]
+
+    def test_a_split_extension_shorthand_is_expanded(self):
+        """Red-proof for the `` `stem.csv`/`.md` `` shorthand (ed04 writes
+        `tab_retrieval_protocol.csv`/`.md`): the bare-extension token expands
+        against the preceding stem, and the function returns the set — the
+        2026-07-27 patch that added this branch dropped the return statement,
+        which blinded the whole guard (three docs reported as naming nothing)
+        and broke its own self-test with a TypeError."""
+        doc = (
+            "The `data/products/` folder ships\n"
+            "`tab_retrieval_protocol.csv`/`.md` for the appendix.\n"
+        )
+        named = products_named_in(doc)
+        assert named == {"tab_retrieval_protocol.csv", "tab_retrieval_protocol.md"}

--- a/tickets/0403-standing-guard-a-submission-document-mus.erg
+++ b/tickets/0403-standing-guard-a-submission-document-mus.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-07-27T19:22Z HDMX-coding-agent note Filed from the ticket-0354 roar; the class fired three times inside one merge
 2026-07-27T22:10Z HDMX-coding-agent note Guard landed; kept separate from 0387 because this authority is a closed set and needs no signal separation
 2026-07-28T07:20Z HDMX-coding-agent note origin/main is red on this guard: 4 failures in test_datapaper_archive_layout, reproducible on a branch with zero commits. Three are test_document_names_only_shipped_products on response-letter.md, summary-of-revisions.md and ed04-zenodo-restructure-upload.md ("names no deposit product at all"); the fourth is test_a_retired_product_is_caught failing with TypeError: argument of type 'NoneType' is not iterable, which is the guard's own self-test and points at d7d9789f "Potential fix for pull request finding" rather than at the prose. Found incidentally by a make lint run from ticket 0470; not diagnosed further
+2026-07-28T09:05Z HDMX-coding-agent note Diagnosed and repaired: d7d9789f restructured the token loop of products_named_in to expand ed04's split-extension shorthand and dropped `return found`, so the function returned None — all four failures were that one guard bug (the three docs read as naming nothing via `assert None`; the self-test hit TypeError on `in None`). The prose was never at fault. Fix restores the return and adds test_a_split_extension_shorthand_is_expanded as red-proof for the previously untested shorthand branch. Guard stands; ticket stays open
 
 --- body ---
 ## Context


### PR DESCRIPTION
**Ticket-ref:** tickets/0403-standing-guard-a-submission-document-mus.erg

## What was actually broken

`origin/main` was red on four failures in `tests/test_datapaper_archive_layout.py`, all in the ticket-0403 guard (`TestSubmissionProseNamesOnlyShippedProducts`). All four were **one bug in the guard, not defects in the prose**.

Commit d7d9789f ("Potential fix for pull request finding", an auto-suggested patch) restructured the token loop of `products_named_in` to expand ed04's split-extension shorthand — `` `tab_retrieval_protocol.csv`/`.md` `` — and dropped the `return found` line in the rewrite. The function returned `None`, which showed two faces:

- the three parametrized document checks (`response-letter.md`, `summary-of-revisions.md`, `ed04-zenodo-restructure-upload.md`) failed `assert named` and reported "names no deposit product at all";
- the guard's own self-test `test_a_retired_product_is_caught` died on `TypeError: argument of type 'NoneType' is not iterable` — the tell that the detection path could not run at all.

The three submission documents were verified against the fixed guard: their deposit enumerations parse and name only shipped products. No prose was touched.

## Why the fix is this shape

- **Restore `return found`** — one line; the d7d9789f branch logic itself is correct (it exists to catch ed04's `` `.md` `` shorthand, which would otherwise let `tab_retrieval_protocol.md` escape the subset check).
- **Add `test_a_split_extension_shorthand_is_expanded`** — the shorthand branch had no red-proof, so a wholesale revert of d7d9789f would have gone green while silently losing that detection. The new test pins both the expansion and the returned set.
- **Red-proof replayed mechanically**: with `return found` mutated away, 5 tests fail — the new one with a plain assertion (`assert None == {...}`), not just the self-test's TypeError. With the fix, the full file passes (23 tests).

`CLIMATE_FINANCE_DATA=/home/haduong/Climate_finance/data make lint`: **318 passed, 12 skipped** — clean.

Also appends a diagnosis line to ticket 0403's log (referenced, not closed — it is the standing-guard ticket, not this repair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)