### PR TITLE
rules(writing): pure prose tickets carry no Test section — TDD's red step does not apply

### DIFF
--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -66,6 +66,8 @@ Prose adherence tests (`tests/test_manuscript_prose.py`) pin only **negative gua
 
 Positive editorial intent lives in `docs/editorial-brief.md` — one entry per standing decision (**Decision** / **Rationale** / **Ticket** / **Status**) — and is checked at review time by the `/review-pr-prose` brief auditor against each diff.
 
+**Pure prose tickets get no `## Test` section: TDD is not appropriate.** The red step assumes a machine-checkable positive outcome, and the polarity rule above says prose has none. Verification is review-based: the recompiled artifact and the `/review-pr-prose` panel. A prose ticket extends `tests/test_manuscript_prose.py` only when it pins a newly-observed defect class (negative or mechanical, per the polarity rule), never pro forma to satisfy the handoff template.
+
 ## Testing
 
 `make check-fast` before editing. `make clean` then `make all` (separate Bash calls) as integration test before PR.


### PR DESCRIPTION
## Summary
Adds the ticket-side corollary of the CI test polarity rule to `.claude/rules/writing.md`: pure prose tickets omit the handoff template's `## Test` section, since TDD's red step assumes a machine-checkable positive outcome and the polarity rule establishes prose has none. Verification stays review-based (recompiled artifact, `/review-pr-prose` panel); `tests/test_manuscript_prose.py` grows only when a ticket pins a newly-observed defect class.

The clause was drafted for the harness handoff template first; author redirected it here (2026-07-28) — the broader harness-level consolidation of writing rules is harness ticket 0375 (deferred).

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)