### PR TITLE
Ease the merge gate: check-fast + lint; full check ex post

### DIFF
--- a/.claude/hooks/check-reviews.sh
+++ b/.claude/hooks/check-reviews.sh
@@ -107,7 +107,9 @@ fi
 # opened the PR (ticket 0365, option 3b). Independence would mean requiring a
 # reviewer other than the PR author, which would stop autonomous waves from
 # merging unattended; that trade was declined deliberately.
-# The substantive merge gate is local: `make check` plus /verify; this hook only
+# The substantive merge gate is local: `make check-fast` + `make lint` plus
+# /verify (the full `make check` runs ex post on main via /lair step 9, and
+# pre-PR only for pipeline-surface diffs — AGENTS.md § Execute); this hook only
 # stops a merge that skipped the review step entirely.
 # MinhHaDuong: the single forge identity — the agent token and the web MCP
 #   token both authenticate as it, and it is also the PR author.

--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -39,7 +39,7 @@ Markers gate which `make` target runs a test. Pick the tier by **cost**, not by 
 | slow | `@pytest.mark.slow` | network, real data, a heavy numerical dependency (dcor/torch/ot/sentence_transformers), or heavy compute | `make check` |
 | adherence | `@pytest.mark.adherence` | ruff / mypy / hygiene / contracts | `make lint` |
 
-`make check-fast` = `-m "not slow and not integration and not adherence"` (the inner loop — must stay pure logic). `make lint` = `-m adherence`. `make check` runs everything. No coverage is lost by moving a test to a slower tier — `make check` still runs it before every PR.
+`make check-fast` = `-m "not slow and not integration and not adherence"` (the inner loop — must stay pure logic). `make lint` = `-m adherence`. `make check` runs everything. No coverage is lost by moving a test to a slower tier — the full `make check` still runs it: ex post on main (`/lair` step 9), and pre-PR when the diff touches the pipeline surface (AGENTS.md § Execute).
 
 Two guards keep the fast tier honest (ticket 0216, owned by `tests/test_fast_path_budget.py` + `tests/conftest.py`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,11 @@ Autonomous execution using test-driven development. The inner cycle is:
 1. **Red**: write a failing test that defines the expected behavior. Commit.
 2. **Green**: write the minimum code to make it pass. Commit.
 3. **Refactor**: clean up, then confirm tests still pass. Use `make check-fast` during development. Commit.
-4. **PR**: Pass `make check` gate, then push and open a PR.
+4. **PR**: Pass the merge gate — `make check-fast` + `make lint` (~40 s combined) — then push and open a PR. Run the full `make check` before the PR only when the diff touches the pipeline surface (`scripts/`, `libs/`, `dvc.yaml`, the Makefiles, or `tests/` files marked slow/integration); doc, prose, config, and ticket diffs skip it.
 
-Use `make check-fast` during development, `make check` before opening a PR. Makefile truth: prerequisites and targets must match each script's actual file reads and writes.
+Use `make check-fast` during development. Makefile truth: prerequisites and targets must match each script's actual file reads and writes.
 
-**There is no CI.** This repo has no `.github/workflows/`, by decision (ticket 0321, 2026-07-27). Nothing runs the suite on push or on a pull request: `make check` is a purely local gate, and a green main is only ever whatever the last session verified on its own machine. Two consequences. Run `make check` yourself before opening a PR — no forge job will do it for you. And never read a merged PR as proof that main is green: when a full `make check` surfaces failures your branch did not cause, they belong to main, and they get their own ticket.
+**There is no CI.** This repo has no `.github/workflows/`, by decision (ticket 0321, 2026-07-27). Nothing runs the suite on push or on a pull request: the gate above is purely local, and the slow/integration tier is verified **ex post**, not per PR — `/lair` step 9 runs the full `make check` on main at end of day and opens a ticket for each new failure (gate eased 2026-07-28: 18 days of session logs showed the full suite costing 4–10 min per gate run while catching nothing the fast tiers missed; every observed failure was environmental or fast/adherence-tier). Never read a merged PR as proof that main is green: when a full `make check` surfaces failures your branch did not cause, they belong to main, and they get their own ticket.
 
 ### Verify
 Gate each PR before merging via `/verify <pr-number>`. The skill runs the full loop:


### PR DESCRIPTION
**Ticket:** none

## What

The per-PR merge gate becomes `make check-fast` + `make lint` (~40 s). The full `make check` is required pre-PR only for pipeline-surface diffs (`scripts/`, `libs/`, `dvc.yaml`, Makefiles, slow/integration tests); otherwise the slow/integration tier is verified ex post by `/lair` step 9, which runs the full suite on main and tickets new failures.

Files: `AGENTS.md` (Execute contract + no-CI paragraph), `.claude/rules/coding.md` (tier-table coverage note), `.claude/hooks/check-reviews.sh` (stale comment).

## Why

Measured over 18 days of session transcripts (2026-07-10 → 07-28, ~50 merged PRs): 67 full-suite gate runs, median 232 s, p90 ~6 min, max ~10 min, ~4.5 h total — and zero gate-time catches beyond what `check-fast`+`lint` cover. Every observed test failure was either environmental (corpus-less worktree `test_corpus_acceptance` noise) or fast/adherence-tier.

## Verification

- `make lint`: 321 passed, 12 skipped
- `make check-fast`: exit 0
- No hygiene test pins the old gate wording (checked `test_agents_md.py`, `test_doc_contract_consistency.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)