### PR TITLE
ticket(0570,0571): a vars file ships [MISSING] into a results paragraph; three unguarded paired structures

### DIFF
--- a/tickets/0570-a-vars-file-ships-missing-into-a-results.erg
+++ b/tickets/0570-a-vars-file-ships-missing-into-a-results.erg
@@ -1,0 +1,107 @@
+%erg 0.1
+Title: A vars file ships [MISSING] into a results paragraph, and the render oracle cannot see it
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Found by the ticket-0357 wrap-up sweep, looking for other instances of
+"a tool exits 0 while emitting a placeholder into a published artifact".
+This one is live on `origin/main`, not latent.
+
+`deliverables/multilayer/multilayer-detection-vars.yml` carries five keys set
+to the literal string `[MISSING]` as committed:
+
+```
+g9_peak_year_w3: "[MISSING]"
+l1_peak_year_w3: "[MISSING]"
+s2_peak_year_w3: "[MISSING]"
+zone_1_end:      "[MISSING]"
+zone_1_start:    "[MISSING]"
+```
+
+All five are quoted by `multilayer-detection.qmd:175,177`, in a *results*
+paragraph. The document renders today as:
+
+> S2 energy distance peaks at year [MISSING], L1 Jensen--Shannon divergence
+> peaks at year [MISSING], and G9 community divergence peaks at year
+> [MISSING].
+> The first [transition zone] runs from [MISSING] to [MISSING] and is
+> supported by all three detectors.
+
+The sentinel comes from `compute_vars.py:45` (`MISSING = "[MISSING]"`), applied
+by `v.setdefault(_k, MISSING)` at `compute_vars.py:629-637` for the Z-series
+vars, commented "require tab_summary_*.csv (not yet generated)". So the value
+is deliberate at the point of writing; what is missing is anything stopping it
+from reaching a rendered paragraph.
+
+## Why the existing guards do not catch it
+
+This is ticket 0357's class one layer deeper, and the fix 0357 shipped is
+blind to it *by construction*:
+
+- `test_render_placeholders.py` matches Quarto's own unresolved-reference
+  syntax (`?meta:`, `?@ref`, the citeproc stderr line). These keys **do**
+  resolve, so nothing fires.
+- `test_doc_vars_completeness.py` asserts a key is *declared*, never that its
+  value is meaningful.
+
+0357 closed "the key does not resolve". This is "the key resolves to a value
+that means it has no value" — a hand-rolled sentinel instead of the renderer's,
+and therefore invisible to a guard aimed at the renderer's.
+
+## Relevant files
+
+- `deliverables/multilayer/multilayer-detection-vars.yml:25,26,32,33,34` — the sentinels
+- `deliverables/multilayer/multilayer-detection.qmd:175,177` — the results paragraph quoting them
+- `scripts/analysis/compute_vars.py:45,629-637` — where `MISSING` is defined and applied
+- `tests/test_render_placeholders.py` — the guard that cannot see this
+
+## Actions
+
+1. Decide the policy question first, because it drives everything else: should
+   a vars file be *allowed* to carry a sentinel? Two coherent answers —
+   (a) never: `compute_vars` fails rather than writing one, and an
+   unavailable statistic means the prose must not claim it; or
+   (b) yes, but no document may quote a key whose value is a sentinel.
+   (b) is the smaller change and keeps the partial-build workflow the
+   `setdefault` was written for.
+2. Implement the chosen policy.
+3. Either produce the Z-series statistics (`tab_summary_*.csv`) or cut the
+   claim from the paragraph. A results sentence with the number removed is
+   not a weaker claim, it is an unsupported one.
+
+## Test
+
+Red first: a guard asserting no key quoted by a deliverable resolves to a
+value in a sentinel set (`[MISSING]`, and any sibling markers `compute_vars`
+defines). It must fail today on all five keys in
+`multilayer-detection.qmd`, naming them.
+
+Red-test it by replaying this exact defect, not a synthetic one — see
+`[[feedback_red_test_the_guard_you_wrote]]`: point it at the committed
+vars file as-is and confirm five named failures before fixing anything.
+
+## Verification
+
+- [ ] The new guard fails on `origin/main` content, listing the five keys
+- [ ] After the fix, `multilayer-detection.qmd` renders with no `[MISSING]`
+- [ ] `pdftotext` of the rendered PDF contains no `[MISSING]`
+- [ ] `make lint` and `make check` pass
+
+## Invariants
+
+- `test_render_placeholders.py`'s existing coverage (meta keys, crossrefs,
+  citations) is not weakened — this guard is additional, not a replacement.
+- The partial-build workflow keeps working: a contributor without
+  `tab_summary_*.csv` must still be able to run `make stats`.
+
+## Exit criteria
+
+No deliverable can render a sentinel value as if it were a result, and the
+multilayer paper's Z-series paragraph either carries real numbers or does not
+make the claim.

--- a/tickets/0571-three-paired-structures-must-agree-and-no.erg
+++ b/tickets/0571-three-paired-structures-must-agree-and-no.erg
@@ -1,0 +1,98 @@
+%erg 0.1
+Title: Three paired structures must agree and nothing asserts they do
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Found by the ticket-0357 wrap-up sweep. 0357 split one registry into
+`DOC_VARS` and `DOC_VARS_FILE` and added
+`test_the_two_registry_halves_name_the_same_documents` to assert their key
+sets match. The sweep looked for the same shape elsewhere: two structures that
+must agree, kept in step by a comment rather than a check.
+
+Three instances, all currently in agreement — so this closes a gap rather than
+fixing a break. What makes each worth a test is that divergence is **silent**:
+no exception, no missing target, just wrong or absent output at exit 0. A
+comment saying "must match" is evidence someone already foresaw the drift and
+had no way to enforce it.
+
+## The three
+
+**1. Band-scheme constants, triplicated.**
+`N_COMMUNITIES`, `BAND_NAMES`/`COMMUNITY_NAMES`, `BAND_COLORS_RGB` are hand-copied in
+`scripts/analysis/analyze_genealogy.py:141-144` (source of truth),
+`scripts/figures/plot_genealogy.py:62-64` ("must match analyze_genealogy.py"),
+and `scripts/figures/plot_genealogy_html.py:54-56` (same comment).
+Each module reads only its own copy. Re-theming the static PNG without touching
+the other two yields `fig_genealogy.png` and `fig_genealogy.html` — both real
+Make targets (`Makefile:512,516`) — that disagree on which colour means which
+lineage band. No test references any of the three names.
+
+**2. `DEFAULT_THRESHOLDS` vs `config/analysis.yaml`.**
+`scripts/analysis/compute_dedup_error_estimates.py:59-64` ("keep the two in
+sync") vs `config/analysis.yaml:231-235`. `_load_thresholds()` does
+`{**DEFAULT_THRESHOLDS, **cfg}` where `cfg` is
+`load_analysis_config().get("dedup_error_estimates", {})` — so a renamed or
+deleted *block* falls back to the hardcoded defaults with no warning.
+`tests/test_dedup_error_estimates.py` exercises `DEFAULT_THRESHOLDS` but never
+opens the config to compare.
+
+**3. `ZOO_SCHEMATIC_STEMS` vs the scripts on disk.**
+`scripts/analysis/zoo-figures.mk:21-26` ("stems match the plot_schematic_*.py
+script suffixes exactly") vs the 17 `scripts/analysis/plot_schematic_*.py`
+files. Adding a script without adding its stem does not error — `make
+zoo-figures` simply never builds that panel and the deliverable ships without
+it. `tests/test_zoo_mk.py` checks the pattern rule and `CROSSYEAR_METHODS`, but
+never globs the schematic scripts.
+
+## Relevant files
+
+- `scripts/analysis/analyze_genealogy.py:141-144`, `scripts/figures/plot_genealogy.py:62-64`, `scripts/figures/plot_genealogy_html.py:54-56`
+- `scripts/analysis/compute_dedup_error_estimates.py:59-64`, `config/analysis.yaml:231-235`
+- `scripts/analysis/zoo-figures.mk:21-26`, `scripts/analysis/plot_schematic_*.py`
+- `tests/test_doc_vars_completeness.py` — the reference implementation from 0357
+
+## Actions
+
+1. For **1**, prefer deletion to assertion: derive the two figure modules'
+   constants from `analyze_genealogy` by import rather than testing three
+   copies agree. A parity test is the fallback when a shared definition is not
+   reachable; here it is.
+2. For **2** and **3**, add the parity assertions — the config block and the
+   Makefile list are genuinely separate artifacts and cannot be collapsed.
+3. Consider whether `_load_thresholds()` should warn when the config block is
+   absent instead of falling back silently.
+
+## Test
+
+Red first, one per instance, each red-tested in **both** directions — dropping
+an entry from each side in turn. A one-directional check passes a guard that
+only asserts one subset relation, which is the trap
+`[[feedback_split_contract_needs_parity]]` records.
+
+For **3** the red step is mechanical: add a throwaway
+`plot_schematic_XXTEST.py`, confirm the guard fails, remove it.
+
+## Verification
+
+- [ ] Each guard fails when its pair is made to diverge, both directions
+- [ ] `make lint` and `make check` pass with all three in place
+- [ ] Instance 1 has one definition, not three, or a test explaining why not
+
+## Invariants
+
+- No figure output changes: this is a refactor plus guards, and
+  `fig_genealogy.png` must be byte-identical before and after (see the
+  refactor-validation rule — byte-compare the artifact, not just green tests).
+- The `{**DEFAULT_THRESHOLDS, **cfg}` override order stays as it is; config
+  still wins over the defaults.
+
+## Exit criteria
+
+No pair in this ticket can diverge without a test failing, and the band scheme
+has one definition rather than three.


### PR DESCRIPTION
Tickets-only filing PR (fast path per `.claude/rules/git.md`). Both found by the ticket-0357 wrap-up sweep for other instances of the two anti-pattern classes 0357 fixed.

## 0570 — live on main, and it is in a results paragraph

`deliverables/multilayer/multilayer-detection-vars.yml` commits five keys as the literal string `[MISSING]`, and `multilayer-detection.qmd:175,177` quotes all five. The paper renders today as:

> S2 energy distance peaks at year **[MISSING]**, L1 Jensen–Shannon divergence peaks at year **[MISSING]**, and G9 community divergence peaks at year **[MISSING]**.
> The first [transition zone] runs from **[MISSING]** to **[MISSING]** and is supported by all three detectors.

This is 0357's class one layer deeper, and **0357's own fix is blind to it by construction**: `test_render_placeholders.py` matches Quarto's unresolved-reference syntax (`?meta:`, `?@ref`), and these keys *do* resolve — to a hand-rolled sentinel from `compute_vars.py:45`. `test_doc_vars_completeness.py` asserts a key is declared, never that its value means anything.

0357 closed "the key does not resolve". This is "the key resolves to a value that means it has no value."

The ticket puts the policy question first, because it drives the fix: may a vars file carry a sentinel at all, or only — the smaller change — may no document quote one?

## 0571 — three paired structures, no parity check

All three agree today, so this closes a gap rather than fixing a break. Each divergence is **silent**: no exception, no missing target, wrong or absent output at exit 0. In each case a `# must match …` comment already shows someone foresaw the drift and had no way to enforce it.

| Pair | Silent failure |
|---|---|
| band scheme in `analyze_genealogy.py` + two figure modules | PNG and HTML disagree on which colour means which band |
| `DEFAULT_THRESHOLDS` vs `config/analysis.yaml:231-235` | renamed config block falls back to hardcoded defaults, no warning |
| `ZOO_SCHEMATIC_STEMS` vs `plot_schematic_*.py` on disk | a new panel is simply never built |

The ticket prefers deletion to assertion for the first — import the constants rather than test three copies agree — and assertions for the other two, which are genuinely separate artifacts.

## Deliberately not filed

Two sweep findings were already ticketed by sibling sessions while 0357 was in flight, so filing them again would duplicate:

- the `or ""` NaN idiom → **0550**
- the clean-clone data gate, including the `llm_relevance_cache.csv` assertion that makes `make check` un-greenable in any worktree → **0450**

**Ticket-ref:** tickets/0570-a-vars-file-ships-missing-into-a-results.erg
**Ticket-ref:** tickets/0571-three-paired-structures-must-agree-and-no.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
