### PR TITLE
fix(0590): the third unattributed embedding claim, found by the roar sweep

### DIFF
--- a/deliverables/multilayer/multilayer-detection.qmd
+++ b/deliverables/multilayer/multilayer-detection.qmd
@@ -249,7 +249,7 @@ Candidate applications include AI ethics (where rapid field growth since 2018 ma
 
 *Louvain stochasticity in the graph layer.* Community detection is a stochastic procedure, and different random seeds yield different partitions. Ticket B6 showed that Louvain instability broadens zone edges on the G9 layer without shifting peak years. We fix the seed from the analysis configuration and report results from a single run; a stability study across seeds is a natural extension.
 
-*Corpus English dominance.* English accounts for {{< meta lang_english_pct >}}% of works. The multilingual embedding model places other languages in the same space, but the lexical layer is dominated by English terms, and minority-language structural changes may be underdetected. Ticket B3 quantifies the asymmetry.
+*Corpus English dominance.* English accounts for {{< meta lang_english_pct >}}% of works. The multilingual embedding model is trained to place other languages in the same space, but the lexical layer is dominated by English terms, and minority-language structural changes may be underdetected. Ticket B3 quantifies the asymmetry.
 
 *DOI resolution drift for pre-2000 works.* The citation graph depends on DOI-level reference matching, which degrades for older works where DOIs were assigned retrospectively. Ticket B10 documents the drift; the G9 layer is weaker before 2000 for this reason. We restrict the analysis window to 1998--2021 in part to limit exposure to this drift.
 


### PR DESCRIPTION
One line. `deliverables/multilayer/multilayer-detection.qmd` §7 (limitations):

> *Corpus English dominance.* … The multilingual embedding model **places** other languages in the same space, but the lexical layer is dominated by English terms…

→ "**is trained to place** other languages in the same space".

Same defect #1258 fixed twice: the indicative reports an outcome nobody measured, where the training objective is what we can vouch for. Found by the `/roar` sweep after #1258 merged, not by review.

**Why this is evidence for reverting #1258's guard, not against it.** That guard matched `semantic space`; this sentence says `same space`, so it would have sailed past. A source-text pattern match is always one spelling behind — the sweep is what closes the class, and the sweep is free.

Re-swept after the fix: **zero unattributed placings remain in any `.qmd` deliverable.** The other hits are all in `revision-rdj26561/external-review/` (the reviewers' own text, correctly untouched) and one line of `cut-plan.md` that *describes* a claim being removed.

Closes nothing — 0590 was closed by #1258.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)