### PR TITLE
fix(0571): three paired structures now fail loudly when they diverge, and the band scheme has one definition

### DIFF
--- a/scripts/_band_scheme.py
+++ b/scripts/_band_scheme.py
@@ -1,0 +1,32 @@
+"""Lineage-band scheme for the citation genealogy: how many bands, and which
+colour and label belongs to each.
+
+Neutral module (the 0250/0254/0286 pattern, as `_tradition_style.py`) so the
+model (`analysis/analyze_genealogy.py`) and both renderers
+(`figures/plot_genealogy.py`, `figures/plot_genealogy_html.py`) share one
+definition without a script-to-script import. It lives at the `scripts/` root
+because that is the only directory every subpackage sees: `PYTHONPATH` carries
+the flat root, never `scripts/analysis/` or `scripts/figures/`, so
+`from analyze_genealogy import ...` would raise `ModuleNotFoundError` under the
+Makefile's own invocation.
+
+The three constants were hand-copied into all three modules, each copy carrying
+a comment saying it must match the others. Re-theming the static PNG without
+touching the HTML renderer produced two figures disagreeing on which colour
+meant which lineage — at exit 0, with no exception and no missing target
+(ticket 0571). `tests/test_band_scheme_single_source.py` now fails if a module
+re-introduces a local copy.
+
+`CDM_CLUSTER` deliberately stays in `analyze_genealogy.py`: it names a KMeans
+cluster id used to *assign* lineages, not part of the presentation scheme the
+renderers read.
+"""
+
+#: Number of lineage bands the genealogy is drawn in.
+N_COMMUNITIES = 3
+
+#: Band id → display label. Ordered as the bands are stacked.
+BAND_NAMES = {0: "CDM / Kyoto heritage", 1: "Accountability pole", 2: "Efficiency pole"}
+
+#: Band id → hex colour, shared by the static PNG and the interactive HTML.
+BAND_COLORS_RGB = {0: "#F4A261", 1: "#457B9D", 2: "#E63946"}

--- a/scripts/analysis/analyze_genealogy.py
+++ b/scripts/analysis/analyze_genealogy.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from _band_scheme import BAND_NAMES, N_COMMUNITIES
 from script_io_args import parse_io_args, validate_io
 from utils import (
     BASE_DIR,
@@ -138,10 +139,10 @@ def select_backbone(works, doi_meta):
 # Step 3: Assign lineages (3 bands)
 # ============================================================
 
-# Band scheme constants
-N_COMMUNITIES = 3
-BAND_NAMES = {0: "CDM / Kyoto heritage", 1: "Accountability pole", 2: "Efficiency pole"}
-BAND_COLORS_RGB = {0: "#F4A261", 1: "#457B9D", 2: "#E63946"}
+# The band scheme itself (N_COMMUNITIES, BAND_NAMES, BAND_COLORS_RGB) lives in
+# scripts/_band_scheme.py, shared with both renderers (ticket 0571).
+# CDM_CLUSTER is not part of it: it names the KMeans cluster whose members are
+# assigned to band 0 below, a modelling input rather than a presentation choice.
 CDM_CLUSTER = 2
 
 

--- a/scripts/figures/plot_genealogy.py
+++ b/scripts/figures/plot_genealogy.py
@@ -17,6 +17,7 @@ import matplotlib.patheffects as pe
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from _band_scheme import BAND_COLORS_RGB, BAND_NAMES, N_COMMUNITIES
 from matplotlib.colors import to_rgba
 from matplotlib.path import Path
 from script_io_args import parse_io_args, validate_io
@@ -58,12 +59,6 @@ COP_EVENTS = {
     2021: "Glasgow",
     2024: "Baku",
 }
-
-# Band scheme (must match analyze_genealogy.py)
-BAND_COLORS_RGB = {0: "#F4A261", 1: "#457B9D", 2: "#E63946"}
-COMMUNITY_NAMES = {0: "CDM / Kyoto heritage", 1: "Accountability pole", 2: "Efficiency pole"}
-N_COMMUNITIES = 3
-
 
 def load_model(lineages_path):
     """Load tab_lineages.csv and build the data structures the renderer needs."""
@@ -247,7 +242,7 @@ def render_figure(backbone_dois, doi_meta, lineage, positions, edges, pdf, outpu
     for c in sorted_comms:
         band = comm_to_band[c]
         band_center = (band + 0.5) * band_height
-        name = COMMUNITY_NAMES.get(c, f"Cluster {c}")
+        name = BAND_NAMES.get(c, f"Cluster {c}")
         label_text = name.replace(" / ", "\n")
         n = sum(1 for d in backbone_dois if lineage.get(d) == c)
         label_text += f"\n(n={n})"

--- a/scripts/figures/plot_genealogy_html.py
+++ b/scripts/figures/plot_genealogy_html.py
@@ -14,6 +14,7 @@ import os
 
 import numpy as np
 import pandas as pd
+from _band_scheme import BAND_COLORS_RGB, BAND_NAMES, N_COMMUNITIES
 from matplotlib.colors import to_rgba
 from script_io_args import parse_io_args, validate_io
 from utils import (
@@ -50,11 +51,6 @@ COP_EVENTS = {
     2021: "Glasgow",
     2024: "Baku",
 }
-
-# Band scheme (must match analyze_genealogy.py)
-BAND_COLORS_RGB = {0: "#F4A261", 1: "#457B9D", 2: "#E63946"}
-COMMUNITY_NAMES = {0: "CDM / Kyoto heritage", 1: "Accountability pole", 2: "Efficiency pole"}
-N_COMMUNITIES = 3
 
 # SVG coordinate system
 SVG_W, SVG_H = 1400, 900
@@ -282,7 +278,7 @@ def _svg_legend(backbone_dois, lineage, palette, band_height, comm_to_band, sort
     for c in sorted_comms:
         band = comm_to_band[c]
         band_center_y = _to_sy((band + 0.5) * band_height)
-        name = COMMUNITY_NAMES.get(c, f"Cluster {c}")
+        name = BAND_NAMES.get(c, f"Cluster {c}")
         label_lines = name.split(" / ")
         n = sum(1 for d in backbone_dois if lineage.get(d) == c)
         label_lines.append(f"(n={n})")

--- a/tests/test_band_scheme_single_source.py
+++ b/tests/test_band_scheme_single_source.py
@@ -68,9 +68,16 @@ def test_band_scheme_module_defines_the_scheme():
 
 
 def test_no_consumer_redefines_the_band_scheme():
-    """A module that re-assigns one of the names has forked the scheme."""
+    """A module that re-assigns one of the names has forked the scheme.
+
+    Scans every module under scripts/, not just the known consumers: a fourth
+    module re-introducing a literal copy is the same defect, and a hardcoded
+    consumer list would never see it (the 0357 disk-discovery precedent).
+    """
     offenders = {}
-    for path in CONSUMERS:
+    for path in sorted(SCRIPTS.rglob("*.py")):
+        if path.name == "_band_scheme.py":
+            continue
         tree = ast.parse(path.read_text())
         redefined = _module_level_assignments(tree) & BAND_SCHEME_NAMES
         if redefined:

--- a/tests/test_band_scheme_single_source.py
+++ b/tests/test_band_scheme_single_source.py
@@ -1,0 +1,121 @@
+"""The genealogy band scheme has one definition, and every consumer reads it.
+
+`N_COMMUNITIES`, `BAND_NAMES` and `BAND_COLORS_RGB` decide which colour means
+which lineage band. They were hand-copied into three modules — the model
+(`analyze_genealogy.py`) and both renderers — each carrying a "must match"
+comment and no way to enforce it. Re-theming one renderer left
+`fig_genealogy.png` and `fig_genealogy.html` disagreeing at exit 0, with no
+exception and no missing target (ticket 0571).
+
+The fix is `scripts/_band_scheme.py`, the neutral-module pattern already used
+by `_tradition_style.py` (0250/0254/0286): the definition lives at the
+`scripts/` root, the one directory every subpackage sees on `PYTHONPATH`.
+
+This guard is a source-inspection check rather than a value comparison,
+because once the copies are gone there are no second values left to compare
+against. What can regress is a module *re-introducing* a literal, so that is
+what the test looks for.
+"""
+
+import ast
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent.parent
+SCRIPTS = BASE / "scripts"
+
+#: The names the shared module owns. A consumer may bind them by import, never
+#: by assignment.
+BAND_SCHEME_NAMES = frozenset({"N_COMMUNITIES", "BAND_NAMES", "BAND_COLORS_RGB"})
+
+#: Every module that draws or labels the lineage bands.
+CONSUMERS = (
+    SCRIPTS / "analysis" / "analyze_genealogy.py",
+    SCRIPTS / "figures" / "plot_genealogy.py",
+    SCRIPTS / "figures" / "plot_genealogy_html.py",
+)
+
+
+def _module_level_assignments(tree: ast.Module) -> set[str]:
+    """Names bound by a module-level assignment (the shape a copy takes)."""
+    bound = set()
+    for node in tree.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                bound.add(target.id)
+    return bound
+
+
+def _names_imported_from(tree: ast.Module, module: str) -> set[str]:
+    return {
+        alias.asname or alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == module
+        for alias in node.names
+    }
+
+
+def test_band_scheme_module_defines_the_scheme():
+    """`scripts/_band_scheme.py` is the single definition."""
+    tree = ast.parse((SCRIPTS / "_band_scheme.py").read_text())
+    defined = _module_level_assignments(tree)
+    missing = BAND_SCHEME_NAMES - defined
+    assert not missing, f"_band_scheme.py must define {sorted(missing)}"
+
+
+def test_no_consumer_redefines_the_band_scheme():
+    """A module that re-assigns one of the names has forked the scheme."""
+    offenders = {}
+    for path in CONSUMERS:
+        tree = ast.parse(path.read_text())
+        redefined = _module_level_assignments(tree) & BAND_SCHEME_NAMES
+        if redefined:
+            offenders[path.name] = sorted(redefined)
+    assert not offenders, (
+        "band-scheme constants must be imported from _band_scheme, not "
+        f"redefined: {offenders}"
+    )
+
+
+def test_every_consumer_imports_the_names_it_uses():
+    """Using a band-scheme name without importing it is the same fork, later.
+
+    A module that neither defines nor imports the name would raise NameError,
+    so this catches the intermediate state where one renderer is migrated and
+    another still has its own copy under a different alias.
+    """
+    for path in CONSUMERS:
+        source = path.read_text()
+        tree = ast.parse(source)
+        imported = _names_imported_from(tree, "_band_scheme")
+        used = {
+            node.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name) and node.id in BAND_SCHEME_NAMES
+        }
+        missing = used - imported
+        assert not missing, (
+            f"{path.name} uses {sorted(missing)} without importing from "
+            "_band_scheme"
+        )
+
+
+def test_no_module_keeps_the_retired_community_names_alias():
+    """`COMMUNITY_NAMES` was the renderers' local name for `BAND_NAMES`.
+
+    Two names for one mapping is how the copies survived review; the alias is
+    retired so a future reader cannot re-fork it by re-introducing a second
+    spelling.
+    """
+    offenders = [
+        path.name
+        for path in CONSUMERS
+        if "COMMUNITY_NAMES" in path.read_text()
+    ]
+    assert not offenders, (
+        f"COMMUNITY_NAMES is retired in favour of BAND_NAMES: {offenders}"
+    )

--- a/tests/test_dedup_error_estimates.py
+++ b/tests/test_dedup_error_estimates.py
@@ -155,3 +155,36 @@ def test_long_format_and_schema(refined_fixture, combined_fixture):
     assert _metric(out, "fn_exact_title_pairs") == 1
     assert _metric(out, "fp_doi_groups_near_zero_overlap") == 1
     assert _metric(out, "fp_empty_year_max_group_size") == 3
+
+
+def test_default_thresholds_and_config_block_name_the_same_keys():
+    """`DEFAULT_THRESHOLDS` and the config block must agree, key for key.
+
+    `_load_thresholds()` returns `{**DEFAULT_THRESHOLDS, **cfg}`, so neither
+    direction of divergence raises. A key renamed in the config silently falls
+    back to the hardcoded default; a key added to the config that no default
+    covers reaches production without ever being exercised by the fixtures
+    above, which run on `DEFAULT_THRESHOLDS`. Both are wrong at exit 0, so the
+    assertion is equality, not a subset relation in either direction (ticket
+    0571).
+    """
+    import yaml
+
+    config_path = os.path.join(
+        os.path.dirname(__file__), "..", "config", "analysis.yaml"
+    )
+    with open(config_path) as fh:
+        cfg = yaml.safe_load(fh)
+
+    assert "dedup_error_estimates" in cfg, (
+        "config/analysis.yaml lost its dedup_error_estimates block; "
+        "_load_thresholds() would silently fall back to DEFAULT_THRESHOLDS"
+    )
+    config_keys = set(cfg["dedup_error_estimates"])
+    default_keys = set(DEFAULT_THRESHOLDS)
+
+    assert config_keys == default_keys, (
+        "DEFAULT_THRESHOLDS and the dedup_error_estimates block must name the "
+        f"same thresholds. Only in config: {sorted(config_keys - default_keys)}; "
+        f"only in DEFAULT_THRESHOLDS: {sorted(default_keys - config_keys)}"
+    )

--- a/tests/test_dedup_error_estimates.py
+++ b/tests/test_dedup_error_estimates.py
@@ -21,6 +21,7 @@ from compute_dedup_error_estimates import (
     compute_false_negatives,
     compute_false_positives,
 )
+from pipeline_loaders import load_analysis_config
 
 
 def _metric(df, name):
@@ -168,13 +169,7 @@ def test_default_thresholds_and_config_block_name_the_same_keys():
     assertion is equality, not a subset relation in either direction (ticket
     0571).
     """
-    import yaml
-
-    config_path = os.path.join(
-        os.path.dirname(__file__), "..", "config", "analysis.yaml"
-    )
-    with open(config_path) as fh:
-        cfg = yaml.safe_load(fh)
+    cfg = load_analysis_config()
 
     assert "dedup_error_estimates" in cfg, (
         "config/analysis.yaml lost its dedup_error_estimates block; "

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -19,16 +19,40 @@ ZOO_RENDER_MK = (
     Path(__file__).resolve().parent.parent / "deliverables" / "zoo" / "zoo.mk"
 )
 
-_CROSSYEAR_RE = re.compile(
-    r"^CROSSYEAR_METHODS\s*:=\s*(.*?)(?=\n\S|\n\n|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
+SCHEMATIC_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts" / "figures"
+
+
+def _make_list_re(name: str) -> re.Pattern:
+    return re.compile(
+        rf"^{name}\s*:=\s*(.*?)(?=\n\S|\n\n|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+
+
+_CROSSYEAR_RE = _make_list_re("CROSSYEAR_METHODS")
+_SCHEMATIC_STEMS_RE = _make_list_re("ZOO_SCHEMATIC_STEMS")
+
+
+def _parse_make_list(mk: str, pattern: re.Pattern, name: str) -> list[str]:
+    m = pattern.search(mk)
+    assert m, f"{name} not found in zoo-figures.mk"
+    return [t for t in m.group(1).split() if t != "\\"]
 
 
 def _parse_crossyear_methods(mk: str) -> list[str]:
-    m = _CROSSYEAR_RE.search(mk)
-    assert m, "CROSSYEAR_METHODS not found in zoo-figures.mk"
-    return [t for t in m.group(1).split() if t != "\\"]
+    return _parse_make_list(mk, _CROSSYEAR_RE, "CROSSYEAR_METHODS")
+
+
+def _parse_schematic_stems(mk: str) -> list[str]:
+    return _parse_make_list(mk, _SCHEMATIC_STEMS_RE, "ZOO_SCHEMATIC_STEMS")
+
+
+def _schematic_script_stems() -> set[str]:
+    """Stems of the plot_schematic_*.py scripts actually on disk."""
+    return {
+        p.stem[len("plot_schematic_"):]
+        for p in SCHEMATIC_SCRIPTS_DIR.glob("plot_schematic_*.py")
+    }
 
 
 @pytest.fixture(scope="class")
@@ -78,6 +102,26 @@ class TestZooMkStructure:
             "G7_disruption",
         ):
             assert expected in methods, f"{expected} missing from CROSSYEAR_METHODS"
+
+    def test_schematic_stems_match_the_scripts_on_disk(self, zoo_mk_text):
+        """`ZOO_SCHEMATIC_STEMS` and `plot_schematic_*.py` must name the same set.
+
+        The pattern rule builds `schematic_$(stem).png` from
+        `plot_schematic_$(stem).py`, so a stem with no script fails loudly at
+        build time — but the other direction is silent: a script the list omits
+        is simply never built, and `make zoo-figures` ships the deliverable one
+        panel short at exit 0. The comment at the head of zoo-figures.mk says
+        the two "match exactly" and nothing enforced it (ticket 0571), so the
+        assertion is set equality rather than a subset check.
+        """
+        declared = set(_parse_schematic_stems(zoo_mk_text))
+        on_disk = _schematic_script_stems()
+        assert declared == on_disk, (
+            "ZOO_SCHEMATIC_STEMS must match scripts/figures/plot_schematic_*.py. "
+            f"Declared with no script: {sorted(declared - on_disk)}; "
+            f"script with no stem (panel would never build): "
+            f"{sorted(on_disk - declared)}"
+        )
 
     def test_zoo_pdf_target_in_render_mk(self):
         """The zoo PDF render rule lives in deliverables/zoo/zoo.mk (ticket 0237).

--- a/tests/test_zoo_mk.py
+++ b/tests/test_zoo_mk.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 
 import pytest
+from _mk_discovery import makefile_constants
 
 ZOO_MK = (
     Path(__file__).resolve().parent.parent / "scripts" / "analysis" / "zoo-figures.mk"
@@ -22,29 +23,11 @@ ZOO_RENDER_MK = (
 SCHEMATIC_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts" / "figures"
 
 
-def _make_list_re(name: str) -> re.Pattern:
-    return re.compile(
-        rf"^{name}\s*:=\s*(.*?)(?=\n\S|\n\n|\Z)",
-        re.MULTILINE | re.DOTALL,
-    )
-
-
-_CROSSYEAR_RE = _make_list_re("CROSSYEAR_METHODS")
-_SCHEMATIC_STEMS_RE = _make_list_re("ZOO_SCHEMATIC_STEMS")
-
-
-def _parse_make_list(mk: str, pattern: re.Pattern, name: str) -> list[str]:
-    m = pattern.search(mk)
-    assert m, f"{name} not found in zoo-figures.mk"
-    return [t for t in m.group(1).split() if t != "\\"]
-
-
-def _parse_crossyear_methods(mk: str) -> list[str]:
-    return _parse_make_list(mk, _CROSSYEAR_RE, "CROSSYEAR_METHODS")
-
-
-def _parse_schematic_stems(mk: str) -> list[str]:
-    return _parse_make_list(mk, _SCHEMATIC_STEMS_RE, "ZOO_SCHEMATIC_STEMS")
+def _mk_list(name: str) -> list[str]:
+    """`name`'s tokens from zoo-figures.mk, via the shared `.mk` parser (0248)."""
+    constants = makefile_constants(files=[ZOO_MK])
+    assert name in constants, f"{name} not found in zoo-figures.mk"
+    return constants[name].split()
 
 
 def _schematic_script_stems() -> set[str]:
@@ -86,15 +69,15 @@ class TestZooMkStructure:
             "crossyear-tables must be declared .PHONY"
         )
 
-    def test_crossyear_methods_has_18_methods(self, zoo_mk_text):
-        methods = _parse_crossyear_methods(zoo_mk_text)
+    def test_crossyear_methods_has_18_methods(self):
+        methods = _mk_list("CROSSYEAR_METHODS")
         assert len(methods) == 18, (
             f"Expected 18 CROSSYEAR_METHODS, got {len(methods)}: {methods}"
         )
 
-    def test_cumulative_methods_included(self, zoo_mk_text):
+    def test_cumulative_methods_included(self):
         """L3, G3, G4, G7 use cumulative/single windows — must still have recipes."""
-        methods = _parse_crossyear_methods(zoo_mk_text)
+        methods = _mk_list("CROSSYEAR_METHODS")
         for expected in (
             "L3",
             "G3_coupling_age",
@@ -103,7 +86,7 @@ class TestZooMkStructure:
         ):
             assert expected in methods, f"{expected} missing from CROSSYEAR_METHODS"
 
-    def test_schematic_stems_match_the_scripts_on_disk(self, zoo_mk_text):
+    def test_schematic_stems_match_the_scripts_on_disk(self):
         """`ZOO_SCHEMATIC_STEMS` and `plot_schematic_*.py` must name the same set.
 
         The pattern rule builds `schematic_$(stem).png` from
@@ -114,7 +97,7 @@ class TestZooMkStructure:
         the two "match exactly" and nothing enforced it (ticket 0571), so the
         assertion is set equality rather than a subset check.
         """
-        declared = set(_parse_schematic_stems(zoo_mk_text))
+        declared = set(_mk_list("ZOO_SCHEMATIC_STEMS"))
         on_disk = _schematic_script_stems()
         assert declared == on_disk, (
             "ZOO_SCHEMATIC_STEMS must match scripts/figures/plot_schematic_*.py. "

--- a/tickets/0571-three-paired-structures-must-agree-and-no.erg
+++ b/tickets/0571-three-paired-structures-must-agree-and-no.erg
@@ -5,6 +5,8 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-28T00:00Z HDMX-coding-agent created
+2026-07-28T09:06Z claude note raid 570/571 Imagine+Plan — path corrected (schematics are in scripts/figures/, not scripts/analysis/); instance-1 import does not resolve under PYTHONPATH, shared module scripts/_band_scheme.py instead; Action 3 considered and deferred; exit criteria untouched
+2026-07-28T09:12Z claude note feasibility PASS — all six pair files verified; surfaces disjoint from 0570; no cross-cutting registry in this wave
 
 --- body ---
 ## Context
@@ -44,8 +46,10 @@ opens the config to compare.
 
 **3. `ZOO_SCHEMATIC_STEMS` vs the scripts on disk.**
 `scripts/analysis/zoo-figures.mk:21-26` ("stems match the plot_schematic_*.py
-script suffixes exactly") vs the 17 `scripts/analysis/plot_schematic_*.py`
-files. Adding a script without adding its stem does not error — `make
+script suffixes exactly") vs the 17 `scripts/figures/plot_schematic_*.py`
+files (path corrected at Plan phase — the original filing said
+`scripts/analysis/`; a guard globbing there finds zero scripts and passes
+vacuously). Adding a script without adding its stem does not error — `make
 zoo-figures` simply never builds that panel and the deliverable ships without
 it. `tests/test_zoo_mk.py` checks the pattern rule and `CROSSYEAR_METHODS`, but
 never globs the schematic scripts.
@@ -54,19 +58,42 @@ never globs the schematic scripts.
 
 - `scripts/analysis/analyze_genealogy.py:141-144`, `scripts/figures/plot_genealogy.py:62-64`, `scripts/figures/plot_genealogy_html.py:54-56`
 - `scripts/analysis/compute_dedup_error_estimates.py:59-64`, `config/analysis.yaml:231-235`
-- `scripts/analysis/zoo-figures.mk:21-26`, `scripts/analysis/plot_schematic_*.py`
+- `scripts/analysis/zoo-figures.mk:21-26`, `scripts/figures/plot_schematic_*.py`
 - `tests/test_doc_vars_completeness.py` — the reference implementation from 0357
 
 ## Actions
 
-1. For **1**, prefer deletion to assertion: derive the two figure modules'
-   constants from `analyze_genealogy` by import rather than testing three
-   copies agree. A parity test is the fallback when a shared definition is not
-   reachable; here it is.
-2. For **2** and **3**, add the parity assertions — the config block and the
-   Makefile list are genuinely separate artifacts and cannot be collapsed.
-3. Consider whether `_load_thresholds()` should warn when the config block is
-   absent instead of falling back silently.
+Plan-phase finding: the filing's preferred fix for **1** (import from
+`analyze_genealogy`) does NOT resolve — `PYTHONPATH` carries only the flat
+`scripts/` root (`pyproject.toml:81`, `Makefile:72`), never `scripts/analysis/`
+or `scripts/figures/`, so `from analyze_genealogy import ...` raises
+`ModuleNotFoundError` under the exact Make invocation (`Makefile:512`). The
+shared definition must live at `scripts/` root, the one directory every
+subpackage sees — the established convention for private shared helpers
+(`_companion_plot_utils.py`, `_divergence_io.py`).
+
+1. Create `scripts/_band_scheme.py` holding `N_COMMUNITIES`, `BAND_NAMES`,
+   `BAND_COLORS_RGB` (values verbatim from `analyze_genealogy.py:141-144`).
+   All three modules import from it; rename `COMMUNITY_NAMES` → `BAND_NAMES`
+   at the call sites (`plot_genealogy.py:250`, `plot_genealogy_html.py:285`).
+   Add a source-inspection hygiene test asserting the two plot files import
+   from `_band_scheme` rather than defining literals.
+2. Parity test for **2**: key-set equality between `DEFAULT_THRESHOLDS` and
+   the `dedup_error_estimates` block of `config/analysis.yaml`, both
+   directions. The `{**DEFAULT_THRESHOLDS, **cfg}` merge order
+   (compute_dedup_error_estimates.py:327-331) stays untouched.
+3. Parity test for **3**: parse `ZOO_SCHEMATIC_STEMS` from `zoo-figures.mk`
+   (copy the `_parse_crossyear_methods` regex pattern already in
+   `tests/test_zoo_mk.py`) vs `glob("scripts/figures/plot_schematic_*.py")`
+   stems — set equality, both directions.
+4. Byte-compare `fig_genealogy.png` before/after the instance-1 refactor
+   (`save_figure()` already strips metadata, so identical values ⇒ identical
+   bytes; the compare is the proof, not the green suite).
+
+Considered and DEFERRED (not required by exit criteria): a runtime warning in
+`_load_thresholds()` when the config block is absent — the bidirectional
+parity test fails earlier and unconditionally, where a log line fires only on
+an actual invocation and is easy to miss.
 
 ## Test
 

--- a/tickets/0571-three-paired-structures-must-agree-and-no.erg
+++ b/tickets/0571-three-paired-structures-must-agree-and-no.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-07-28T00:00Z HDMX-coding-agent created
 2026-07-28T09:06Z claude note raid 570/571 Imagine+Plan — path corrected (schematics are in scripts/figures/, not scripts/analysis/); instance-1 import does not resolve under PYTHONPATH, shared module scripts/_band_scheme.py instead; Action 3 considered and deferred; exit criteria untouched
 2026-07-28T09:12Z claude note feasibility PASS — all six pair files verified; surfaces disjoint from 0570; no cross-cutting registry in this wave
+2026-07-28T15:10Z claude note byte-compare PASS — tab_lineages.csv, fig_genealogy.png and fig_genealogy.html all byte-identical old-vs-new on the same inputs under PYTHONHASHSEED=0. Unpinned, two runs of main's own code differ: load_edges() returns list(set(...)), so edge draw order follows the string-hash seed. Pre-existing, out of scope here, worth its own ticket.
 
 --- body ---
 ## Context
@@ -107,9 +108,9 @@ For **3** the red step is mechanical: add a throwaway
 
 ## Verification
 
-- [ ] Each guard fails when its pair is made to diverge, both directions
-- [ ] `make lint` and `make check` pass with all three in place
-- [ ] Instance 1 has one definition, not three, or a test explaining why not
+- [x] Each guard fails when its pair is made to diverge, both directions
+- [x] `make lint` and `make check` pass with all three in place
+- [x] Instance 1 has one definition, not three, or a test explaining why not
 
 ## Invariants
 

--- a/tickets/0593-in-place-mutation-evades-the-band-scheme.erg
+++ b/tickets/0593-in-place-mutation-evades-the-band-scheme.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: in-place mutation evades the band-scheme single-source AST guard
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T13:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Scope-overflow finding from the /gaze verify of PR #1269 (ticket 0571). The
+band scheme now has one definition (`scripts/_band_scheme.py`) and an AST
+guard asserting no module re-defines the constants. The guard catches
+re-definition but not re-binding at runtime: an in-place mutation such as
+`BAND_COLORS_RGB[0] = "#000000"` in a consumer module silently forks the
+scheme for every later reader in the same process, and no test fails.
+
+The gaze panel classified this non-blocking for 0571 (whose scope was the
+three hand-copied literals), but it is the same defect class one step
+removed: divergence with no failing test.
+
+## Relevant files
+
+- `scripts/_band_scheme.py` — the single source
+- `tests/test_band_scheme_single_source.py` — the AST guard this extends
+
+## Actions
+
+1. Make the shared constants immutable: `MappingProxyType` for the dicts
+   (or freeze at import); attempted mutation then raises at the mutation
+   site instead of corrupting downstream readers.
+2. Extend the AST guard only if immutability cannot cover a route (e.g.
+   `copy()`-then-mutate-then-rebind is fine and should stay legal).
+
+## Test
+
+Red first: a test that mutates `BAND_COLORS_RGB[0]` and asserts the
+mutation raises. Fails today (dict accepts it), green with the proxy.
+
+## Verification
+
+- [ ] In-place mutation of any band-scheme constant raises
+- [ ] `make lint` and `make check` pass
+
+## Exit criteria
+
+The band scheme cannot be forked at runtime without an exception at the
+forking line.

--- a/tickets/closed/0571-three-paired-structures-must-agree-and-no.erg
+++ b/tickets/closed/0571-three-paired-structures-must-agree-and-no.erg
@@ -2,6 +2,7 @@
 Title: Three paired structures must agree and nothing asserts they do
 Created: 2026-07-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1269
 
 --- log ---
 2026-07-28T00:00Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-07-28T09:12Z claude note feasibility PASS — all six pair files verified; surfaces disjoint from 0570; no cross-cutting registry in this wave
 2026-07-28T15:10Z claude note byte-compare PASS — tab_lineages.csv, fig_genealogy.png and fig_genealogy.html all byte-identical old-vs-new on the same inputs under PYTHONHASHSEED=0. Unpinned, two runs of main's own code differ: load_edges() returns list(set(...)), so edge draw order follows the string-hash seed. Pre-existing, out of scope here, worth its own ticket.
 
+2026-07-28T13:46Z HDMX-coding-agent closed — autoclosed — PR #1269
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0571-three-paired-structures-must-agree-and-no.erg

Three pairs of structures had to agree and nothing asserted they did. Each
divergence was silent — no exception, no missing target, wrong or absent output
at exit 0 — and each carried a "must match" comment, which is evidence someone
foresaw the drift and had no way to enforce it.

## What landed

**1. Band scheme — one definition instead of three.** `N_COMMUNITIES`,
`BAND_NAMES` and `BAND_COLORS_RGB` move to `scripts/_band_scheme.py`; the model
(`analyze_genealogy.py`) and both renderers import from it. The `scripts/` root
rather than an import from `analyze_genealogy`, because `PYTHONPATH` carries
only the flat root (`pyproject.toml:81`, `Makefile:72`) — a script-to-script
import raises `ModuleNotFoundError` under the Makefile's own invocation. Same
neutral-module pattern as `_tradition_style.py`. `COMMUNITY_NAMES`, the
renderers' local spelling of `BAND_NAMES`, is retired. `CDM_CLUSTER` stays in
`analyze_genealogy.py`: it names the KMeans cluster assigned to band 0, a
modelling input rather than presentation.

**2. `DEFAULT_THRESHOLDS` vs `config/analysis.yaml`.** Key-set equality with the
`dedup_error_estimates` block, both directions, plus an explicit check that the
block exists at all — `_load_thresholds()` returns `{**DEFAULT_THRESHOLDS,
**cfg}`, so a renamed block falls back to the hardcoded defaults silently. The
merge order is untouched; config still wins.

**3. `ZOO_SCHEMATIC_STEMS` vs the scripts on disk.** Set equality against
`glob("scripts/figures/plot_schematic_*.py")` — 17 stems, 17 scripts. The
build-time failure covers only one direction: a stem with no script errors
loudly, a script with no stem is simply never built and `make zoo-figures` ships
the deliverable one panel short. `tests/test_zoo_mk.py`'s make-list parser was
generalized to take the variable name, so `CROSSYEAR_METHODS` and
`ZOO_SCHEMATIC_STEMS` share one regex instead of two copies.

## Byte-compare verdict: IDENTICAL

The load-bearing proof for the refactor, `origin/main` code vs this branch on
the same inputs:

| artifact | old sha256 | new sha256 | `cmp` |
|---|---|---|---|
| `tab_lineages.csv` | `9874ad87…` | `9874ad87…` | identical |
| `fig_genealogy.png` (1 946 533 B) | `aec70687…` | `aec70687…` | identical |
| `fig_genealogy.html` | `c4838dd7…` | `c4838dd7…` | identical |

Method: `make data` + the producing targets built `semantic_clusters.csv` and
`tab_pole_papers.csv`; then each side ran `analyze_genealogy.py` (model) and
both renderers on one common `tab_lineages.csv`, with the old side obtained by
`git checkout origin/main -- <the three scripts>`.

**The compare needs `PYTHONHASHSEED` pinned, and that is a finding of its own.**
`load_edges()` returns `list(set(...))`, so the edge draw order follows the
string-hash seed: two runs of `origin/main`'s *own* code, unpinned, produce
different bytes (`fig_genealogy.html` sha `afb28167…` vs `80657ff5…`, first
difference at byte 3375 — an edge `<line>` element). Pinned at
`PYTHONHASHSEED=0`, old and new agree byte for byte. This non-determinism is
pre-existing, untouched by this branch, and out of scope here; it deserves its
own ticket, since Phase 2 is documented as deterministic and `save_figure()`
strips metadata precisely to make PNGs byte-reproducible.

## Evidence per exit criterion

**"Each guard fails when its pair is made to diverge, both directions"** — each
guard re-red-tested in this worktree, not taken on the interrupted run's word:

| guard | divergence injected | failure |
|---|---|---|
| zoo | extra `plot_schematic_XXTEST.py` | `script with no stem (panel would never build): ['XXTEST']` |
| zoo | extra stem `XXGHOST` in the `.mk` | `Declared with no script: ['XXGHOST']` |
| thresholds | `year_gap_max` → `year_gap_maximum` in the config | `Only in config: ['year_gap_maximum']; only in DEFAULT_THRESHOLDS: ['year_gap_max']` |
| thresholds | `collision_jaccard_threshold` dropped from `DEFAULT_THRESHOLDS` | `Only in config: ['collision_jaccard_threshold']` |
| thresholds | whole block renamed | `config/analysis.yaml lost its dedup_error_estimates block` |
| band scheme | `N_COMMUNITIES = 4` re-added to `plot_genealogy_html.py` | `must be imported from _band_scheme, not redefined: {'plot_genealogy_html.py': ['N_COMMUNITIES']}` |
| band scheme | import deleted from `plot_genealogy.py` | `uses ['BAND_COLORS_RGB', 'BAND_NAMES', 'N_COMMUNITIES'] without importing` |
| band scheme | `BAND_COLORS_RGB` renamed in the shared module | `_band_scheme.py must define ['BAND_COLORS_RGB']` |

**"`make lint` and `make check` pass"** — `make lint`: 324 passed, 10 skipped.
`make check`: 2257 passed, 39 skipped, exit 0.

One environmental note. A first `make check` failed
`test_corpus_acceptance.py::TestFileExistence::test_reranker_cache_exists`:
`data/catalogs/llm_relevance_cache.csv` is neither git- nor DVC-tracked, so a
fresh worktree does not have it and `make data` cannot fetch it. Pointing the
worktree at the primary checkout's copy turns the test green with nothing else
changed. Not caused by this branch, and not fixed here.

**"Instance 1 has one definition, not three"** — `scripts/_band_scheme.py` is
the only module-level assignment of the three names; a repo-wide grep finds no
other definition and no surviving `COMMUNITY_NAMES`.
`tests/test_band_scheme_single_source.py` inspects the AST rather than grepping,
so a name inside a string or comment cannot forge a pass.

## Provenance

The first three commits were salvaged from a raid interrupted by a session
limit and are unchanged in content; the WIP commit was reworded. The salvaged
branch `t571-band-scheme-and-parity-guards` is superseded by this one — the
reword rewrote its tip and force-push is denied here, so the work moved to a
fresh branch rather than being pushed over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Scope overflow: tickets/0593-in-place-mutation-evades-the-band-scheme.erg (filed on this branch; stays open)