### PR TITLE
fix(0591): stop the genealogy chain and three sibling scripts from writing hash-seed order into artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -858,10 +858,15 @@ audit-pdf-content:
 smoke:
 	$(PYTHON) -m pytest tests/test_smoke_pipeline.py -v --tb=short
 
-# Determinism check: run figure scripts twice on smoke data, diff outputs.
+# Determinism check: run figure scripts twice, diff outputs.
 # Catches unseeded randomness, leaking timestamps, floating-point non-determinism.
+# Two modules, and the second is the stricter one: test_determinism.py runs both
+# halves under a pinned PYTHONHASHSEED=0, so it cannot see a producer that walks
+# a set into its output, while test_hash_seed_determinism.py varies the seed
+# between the two runs and can (ticket 0591).
 determinism-check:
-	$(PYTHON) -m pytest tests/test_determinism.py -v --tb=short
+	$(PYTHON) -m pytest tests/test_determinism.py \
+		tests/test_hash_seed_determinism.py -v --tb=short
 
 # Regression hashes: compare Phase 2 output hashes against golden baseline.
 # Runs as pytest (one test per script, module-scoped fixture = scripts run once).

--- a/scripts/analysis/analyze_genealogy.py
+++ b/scripts/analysis/analyze_genealogy.py
@@ -115,21 +115,27 @@ def load_data():
 # ============================================================
 
 def select_backbone(works, doi_meta):
-    """Select highly-cited papers with abstracts and valid years."""
+    """Select highly-cited papers with abstracts and valid years.
+
+    Returns a DOI list in ascending DOI order. The order is part of the
+    contract, not an accident: downstream steps enumerate this collection to
+    assign layout jitter and to lay out CSV rows, so a `set` here would put the
+    interpreter's hash seed into `tab_lineages.csv` and, through it, into both
+    genealogy figures (ticket 0591).
+    """
     cite_threshold = _cfg["clustering"]["cite_threshold"]
     year_max = _cfg["periodization"]["year_max"]
     log.info("Selecting backbone (cited_by_count >= %d)...", cite_threshold)
 
     has_abs = works["abstract"].notna() & (works["abstract"].str.len() > 50)
     high_cited = works[has_abs & (works["cited_by_count"] >= cite_threshold)]
-    backbone_dois = set(high_cited["doi_norm"])
 
     # Filter to papers with valid year
-    backbone_dois = {
-        d for d in backbone_dois
+    backbone_dois = sorted({
+        d for d in set(high_cited["doi_norm"])
         if d in doi_meta and doi_meta[d]["year"] is not None
         and 1985 <= (doi_meta[d]["year"] or 0) <= year_max
-    }
+    })
 
     log.info("Backbone papers (with valid year): %d", len(backbone_dois))
     return backbone_dois
@@ -178,8 +184,8 @@ def assign_lineages(backbone_dois, doi_meta, doi_to_cluster):
         else:
             lineage[d] = doi_to_cluster.get(d, 0)
 
-    # Keep only papers with assigned lineages
-    backbone_dois = {d for d in backbone_dois if d in lineage}
+    # Keep only papers with assigned lineages, preserving the sorted order
+    backbone_dois = [d for d in backbone_dois if d in lineage]
     band_counts = {
         b: sum(1 for d in backbone_dois if lineage[d] == b)
         for b in range(N_COMMUNITIES)
@@ -196,16 +202,22 @@ def assign_lineages(backbone_dois, doi_meta, doi_to_cluster):
 # ============================================================
 
 def build_citation_dag(backbone_dois, cit):
-    """Build directed edges between backbone papers (cited → citing)."""
+    """Build directed edges between backbone papers (cited → citing).
+
+    Returns the edges sorted, so the list does not carry set iteration order.
+    ``backbone_dois`` arrives as an ordered list; the membership test runs once
+    per citation row, so it needs the set.
+    """
     log.info("Building citation DAG...")
+    backbone = set(backbone_dois)
     edges = set()
     for _, row in cit.iterrows():
         s = row["source_doi"]
         r = row["ref_doi"]
-        if s in backbone_dois and r in backbone_dois:
+        if s in backbone and r in backbone:
             edges.add((r, s))  # cited → citing
 
-    edges = list(edges)
+    edges = sorted(edges)
     log.info("Internal citation edges: %d", len(edges))
     return edges
 
@@ -292,8 +304,11 @@ def save_lineage_table(backbone_dois, lineage, positions, doi_meta, output_path)
             "y": round(y, 6),
         })
 
+    # kind="stable": the default quicksort would reorder the many ties in
+    # cited_by_count arbitrarily. A stable sort keeps them in the DOI order
+    # `rows` was built in, so the row order is a function of the data alone.
     lineage_df = pd.DataFrame(rows).sort_values(
-        ["lineage", "cited_by_count"], ascending=[True, False]
+        ["lineage", "cited_by_count"], ascending=[True, False], kind="stable"
     )
     lineage_df.to_csv(output_path, index=False)
     log.info("Saved lineage table -> %s (%d papers)", output_path, len(lineage_df))

--- a/scripts/figures/export_tab_venues.py
+++ b/scripts/figures/export_tab_venues.py
@@ -60,7 +60,11 @@ def main():
     acc_counts = acc["journal"].value_counts()
 
     rows = []
-    for j in set(eff_counts.index) | set(acc_counts.index):
+    # sorted(): the union is a set of journal-name strings, and `rows` order
+    # survives all the way to which venues `nlargest` keeps among ties below,
+    # so an unordered walk here put the hash seed into tab_venues.md — a
+    # git-tracked table the Œconomia manuscript includes (ticket 0591).
+    for j in sorted(set(eff_counts.index) | set(acc_counts.index)):
         ne = eff_counts.get(j, 0)
         na = acc_counts.get(j, 0)
         total = ne + na
@@ -73,7 +77,13 @@ def main():
             "total": total, "log_odds": lor,
         })
 
-    df = pd.DataFrame(rows).sort_values("log_odds", ascending=False)
+    # kind="stable" here and at the final sort below: log_odds ties are common
+    # (any two journals with the same efficiency/accountability counts share
+    # one), and the pandas default is quicksort, whose tie order is a numpy
+    # implementation detail. Stable sorting pins ties to the journal-name order
+    # `rows` was built in.
+    df = pd.DataFrame(rows).sort_values("log_odds", ascending=False,
+                                        kind="stable")
 
     # Assign lean labels
     def lean(lor):
@@ -107,7 +117,7 @@ def main():
 
     selected = pd.concat([eff_sel, shared_sel, acc_sel, key_rows])
     selected = selected.drop_duplicates(subset="journal")
-    selected = selected.sort_values("log_odds", ascending=False)
+    selected = selected.sort_values("log_odds", ascending=False, kind="stable")
 
     # Build markdown table
     lines = []

--- a/scripts/figures/plot_fig_traditions.py
+++ b/scripts/figures/plot_fig_traditions.py
@@ -146,7 +146,11 @@ def _draw_labels(ax, G, pos, trad_to_comm, comm_to_nodes, ref_counts,
     # Keep readable labels only; dedupe identical label texts
     # (e.g. two distinct references both rendered "Axel Michaelowa 2003"),
     # keeping the most-cited node.
-    candidates = sorted(label_nodes, key=lambda d: -ref_counts.get(d, 0))
+    # DOI is the tiebreaker, not decoration: `label_nodes` is a set, citation
+    # counts tie constantly, and the dedupe below keeps whichever tied node
+    # comes first — so without it, which node carries a shared label text
+    # followed the hash seed (ticket 0591).
+    candidates = sorted(label_nodes, key=lambda d: (-ref_counts.get(d, 0), d))
     labels, seen_texts = {}, set()
     for n in candidates:
         text = G.nodes[n]["label"]

--- a/scripts/figures/plot_fig_traditions_pre2008_citers.py
+++ b/scripts/figures/plot_fig_traditions_pre2008_citers.py
@@ -95,7 +95,10 @@ def _draw_labels(ax, res, pos, barrett_nodes):
     for c in res["trad_to_comm"].values():
         label_nodes.update(sorted(
             res["comm_to_nodes"][c], key=lambda d: -ref_counts.get(d, 0))[:4])
-    candidates = sorted(label_nodes, key=lambda d: -ref_counts.get(d, 0))
+    # DOI tiebreaker — same defect as plot_fig_traditions._draw_labels:
+    # `label_nodes` is a set and tied citation counts let the hash seed decide
+    # which node keeps a shared label text (ticket 0591).
+    candidates = sorted(label_nodes, key=lambda d: (-ref_counts.get(d, 0), d))
     labels, seen = {}, set()
     for n in candidates:
         t = G.nodes[n]["label"]

--- a/scripts/figures/plot_genealogy.py
+++ b/scripts/figures/plot_genealogy.py
@@ -61,17 +61,24 @@ COP_EVENTS = {
 }
 
 def load_model(lineages_path):
-    """Load tab_lineages.csv and build the data structures the renderer needs."""
+    """Load tab_lineages.csv and build the data structures the renderer needs.
+
+    ``backbone_dois`` is a list in CSV row order, not a set: the renderer
+    enumerates it to draw nodes and to break ties when ranking by citation
+    count, so a set would put the interpreter's hash seed into the figure
+    (ticket 0591). Callers that need membership tests build their own set.
+    """
     df = pd.read_csv(lineages_path)
 
     doi_meta = {}
     lineage = {}
     positions = {}
-    backbone_dois = set()
+    backbone_dois = []
 
     for _, row in df.iterrows():
         d = row["doi"]
-        backbone_dois.add(d)
+        if d not in lineage:
+            backbone_dois.append(d)
         lineage[d] = int(row["lineage"])
         positions[d] = (float(row["x"]), float(row["y"]))
         doi_meta[d] = {
@@ -85,18 +92,24 @@ def load_model(lineages_path):
 
 
 def load_edges(backbone_dois):
-    """Load citation edges between backbone papers."""
+    """Load citation edges between backbone papers, in ascending edge order.
+
+    Sorted rather than ``list(set(...))``: edges are drawn in list order and
+    overlapping semi-transparent strokes composite differently depending on it,
+    so an unordered dedup made the PNG and HTML hash-seed dependent (0591).
+    """
     cit = load_refined_citations()
     cit["source_doi"] = cit["source_doi"].apply(normalize_doi)
     cit["ref_doi"] = cit["ref_doi"].apply(normalize_doi)
 
+    backbone = set(backbone_dois)
     edges = set()
     for _, row in cit.iterrows():
         s = row["source_doi"]
         r = row["ref_doi"]
-        if s in backbone_dois and r in backbone_dois:
+        if s in backbone and r in backbone:
             edges.add((r, s))  # cited → citing
-    return list(edges)
+    return sorted(edges)
 
 
 def _infer_bands(backbone_dois, lineage, positions):

--- a/scripts/figures/plot_genealogy_html.py
+++ b/scripts/figures/plot_genealogy_html.py
@@ -68,17 +68,24 @@ def _to_sy(ynorm):
 
 
 def load_model(lineages_path):
-    """Load tab_lineages.csv and build the data structures the renderer needs."""
+    """Load tab_lineages.csv and build the data structures the renderer needs.
+
+    ``backbone_dois`` is a list in CSV row order, not a set: the renderer
+    enumerates it to emit ``<circle>`` elements and to break ties when ranking
+    by citation count, so a set would put the interpreter's hash seed into the
+    SVG (ticket 0591). Callers that need membership tests build their own set.
+    """
     df = pd.read_csv(lineages_path)
 
     doi_meta = {}
     lineage = {}
     positions = {}
-    backbone_dois = set()
+    backbone_dois = []
 
     for _, row in df.iterrows():
         d = row["doi"]
-        backbone_dois.add(d)
+        if d not in lineage:
+            backbone_dois.append(d)
         lineage[d] = int(row["lineage"])
         positions[d] = (float(row["x"]), float(row["y"]))
         doi_meta[d] = {
@@ -92,18 +99,24 @@ def load_model(lineages_path):
 
 
 def load_edges(backbone_dois):
-    """Load citation edges between backbone papers."""
+    """Load citation edges between backbone papers, in ascending edge order.
+
+    Sorted rather than ``list(set(...))``: edges are emitted as ``<line>``
+    elements in list order, so an unordered dedup made the HTML hash-seed
+    dependent — the first byte to differ across two runs (0591).
+    """
     cit = load_refined_citations()
     cit["source_doi"] = cit["source_doi"].apply(normalize_doi)
     cit["ref_doi"] = cit["ref_doi"].apply(normalize_doi)
 
+    backbone = set(backbone_dois)
     edges = set()
     for _, row in cit.iterrows():
         s = row["source_doi"]
         r = row["ref_doi"]
-        if s in backbone_dois and r in backbone_dois:
+        if s in backbone and r in backbone:
             edges.add((r, s))
-    return list(edges)
+    return sorted(edges)
 
 
 def _infer_bands(backbone_dois, lineage, positions):

--- a/tests/test_genealogy_determinism.py
+++ b/tests/test_genealogy_determinism.py
@@ -1,0 +1,208 @@
+"""Genealogy artifacts are byte-reproducible without pinning PYTHONHASHSEED (0591).
+
+The genealogy chain builds its citation edge list and its backbone paper list as
+Python ``set`` objects, then iterates them to draw. Set iteration order over
+strings follows the interpreter's hash seed, so two runs of the same code on the
+same inputs produced different bytes unless ``PYTHONHASHSEED`` happened to be
+pinned — which the Makefile does globally, hiding the defect from every
+``make``-driven run and surfacing it only in a refactor byte-compare
+(ticket 0571, PR #1269).
+
+These tests deliberately run each producer under *two different* hash seeds.
+Pinning the seed to a single value, as ``tests/test_determinism.py`` does, would
+make them pass against the defect.
+"""
+
+import filecmp
+import os
+import subprocess
+import sys
+
+import pytest
+
+from _source_roots import source_root_env
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "scripts")
+)
+
+# Two arbitrary, different seeds. Any pair works; fixed values keep failures
+# reproducible.
+SEED_A = "1"
+SEED_B = "12345"
+
+N_PAPERS = 60
+
+
+def _dois():
+    return [f"10.1000/paper{i:03d}" for i in range(N_PAPERS)]
+
+
+def _citation_rows():
+    """Deterministic edge list dense enough that set order is observable.
+
+    Every paper cites a handful of lower-numbered ones, which keeps the graph a
+    DAG in publication order and produces both within-lineage and cross-lineage
+    edges under the lineage assignment below.
+    """
+    dois = _dois()
+    rows = []
+    for i, source in enumerate(dois):
+        for step in (1, 3, 7, 11):
+            j = i - step
+            if j >= 0:
+                rows.append((source, dois[j], 1990 + j % 30))
+    return rows
+
+
+def _write_csv(path, header, rows):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(",".join(header) + "\n")
+        for row in rows:
+            fh.write(",".join(str(c) for c in row) + "\n")
+
+
+def _write_citations(data_dir):
+    _write_csv(
+        os.path.join(data_dir, "catalogs", "refined_citations.csv"),
+        ["source_doi", "ref_doi", "ref_year", "ref_title", "ref_first_author"],
+        [(s, r, y, f"Ref title {r}", f"Author{r[-3:]}") for s, r, y in _citation_rows()],
+    )
+
+
+def _write_lineages(path):
+    """A tab_lineages.csv covering all three bands with position jitter."""
+    rows = []
+    for i, doi in enumerate(_dois()):
+        lineage = i % 3
+        year = 1990 + (i % 30)
+        x = (year - 1990) / 29
+        y = (lineage + 0.5) / 3 + 0.02 * ((i % 5) - 2)
+        rows.append(
+            (
+                doi,
+                lineage,
+                f"Band{lineage}",
+                False,
+                f"Author{i:03d}",
+                year,
+                # Deliberate ties in cited_by_count: a tie-break that falls
+                # through to set order is exactly the defect under test.
+                100 + (i % 4) * 50,
+                f"Title {i:03d}",
+                round(x, 6),
+                round(y, 6),
+            )
+        )
+    _write_csv(
+        path,
+        ["doi", "lineage", "lineage_name", "peripheral", "first_author",
+         "year", "cited_by_count", "title", "x", "y"],
+        rows,
+    )
+
+
+def _write_model_inputs(data_dir):
+    """refined_works + semantic_clusters + tab_pole_papers for analyze_genealogy."""
+    abstract = "Synthetic abstract padded well past the fifty character floor."
+    _write_csv(
+        os.path.join(data_dir, "catalogs", "refined_works.csv"),
+        ["doi", "title", "year", "cited_by_count", "abstract", "first_author"],
+        [
+            (doi, f"Title {i:03d}", 1990 + (i % 30), 100 + (i % 4) * 50,
+             abstract, f"Author{i:03d}")
+            for i, doi in enumerate(_dois())
+        ],
+    )
+    derived = os.path.join(data_dir, "derived", "tables")
+    _write_csv(
+        os.path.join(derived, "semantic_clusters.csv"),
+        ["doi", "semantic_cluster"],
+        [(doi, i % 4) for i, doi in enumerate(_dois())],
+    )
+    _write_csv(
+        os.path.join(derived, "tab_pole_papers.csv"),
+        ["doi", "axis_score"],
+        [(doi, round(-1.0 + 2.0 * (i % 7) / 6, 4)) for i, doi in enumerate(_dois())],
+    )
+
+
+def _run(script, args, data_dir, seed):
+    env = source_root_env(
+        {
+            **os.environ,
+            "CLIMATE_FINANCE_DATA": data_dir,
+            "PYTHONHASHSEED": seed,
+            "SOURCE_DATE_EPOCH": "0",
+            "MPLBACKEND": "Agg",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS_DIR, script), *args],
+        capture_output=True, text=True, env=env, timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"{script} failed under PYTHONHASHSEED={seed}:\n{result.stderr}"
+    )
+
+
+def _run_under_both_seeds(script, out_name, extra_args, tmp_path, data_dir):
+    """Run ``script`` once per seed into its own dir; return the two outputs."""
+    produced = []
+    for seed in (SEED_A, SEED_B):
+        out_dir = tmp_path / f"seed{seed}"
+        out_dir.mkdir()
+        out_path = out_dir / out_name
+        _run(script, ["--output", str(out_path), *extra_args], data_dir, seed)
+        assert out_path.exists(), f"{script} wrote no {out_name}"
+        produced.append(out_path)
+    return produced
+
+
+@pytest.mark.integration
+class TestGenealogyHashSeedIndependence:
+    """Same code, same inputs, different hash seed → identical bytes."""
+
+    @pytest.fixture
+    def fixture_root(self, tmp_path):
+        data_dir = tmp_path / "data"
+        _write_citations(str(data_dir))
+        _write_model_inputs(str(data_dir))
+        lineages = tmp_path / "tab_lineages.csv"
+        _write_lineages(str(lineages))
+        return str(data_dir), str(lineages)
+
+    def test_html_renderer(self, tmp_path, fixture_root):
+        data_dir, lineages = fixture_root
+        p1, p2 = _run_under_both_seeds(
+            "figures/plot_genealogy_html.py", "fig_genealogy.html",
+            ["--lineages", lineages], tmp_path, data_dir,
+        )
+        assert filecmp.cmp(str(p1), str(p2), shallow=False), (
+            "fig_genealogy.html differs between hash seeds — a set is being "
+            "iterated into the output"
+        )
+
+    def test_png_renderer(self, tmp_path, fixture_root):
+        data_dir, lineages = fixture_root
+        p1, p2 = _run_under_both_seeds(
+            "figures/plot_genealogy.py", "fig_genealogy.png",
+            ["--lineages", lineages], tmp_path, data_dir,
+        )
+        assert filecmp.cmp(str(p1), str(p2), shallow=False), (
+            "fig_genealogy.png differs between hash seeds — a set is being "
+            "iterated into the output"
+        )
+
+    def test_lineage_model(self, tmp_path, fixture_root):
+        """The upstream model table is the renderers' input — pin it too."""
+        data_dir, _ = fixture_root
+        p1, p2 = _run_under_both_seeds(
+            "analysis/analyze_genealogy.py", "tab_lineages.csv",
+            [], tmp_path, data_dir,
+        )
+        assert filecmp.cmp(str(p1), str(p2), shallow=False), (
+            "tab_lineages.csv differs between hash seeds — layout jitter or row "
+            "order is following set iteration order"
+        )

--- a/tests/test_genealogy_determinism.py
+++ b/tests/test_genealogy_determinism.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 
 import pytest
-
 from _source_roots import source_root_env
 
 SCRIPTS_DIR = os.path.abspath(

--- a/tests/test_hash_seed_determinism.py
+++ b/tests/test_hash_seed_determinism.py
@@ -1,16 +1,22 @@
-"""Genealogy artifacts are byte-reproducible without pinning PYTHONHASHSEED (0591).
+"""Phase-2 artifacts are byte-reproducible without pinning PYTHONHASHSEED (0591).
 
-The genealogy chain builds its citation edge list and its backbone paper list as
-Python ``set`` objects, then iterates them to draw. Set iteration order over
-strings follows the interpreter's hash seed, so two runs of the same code on the
-same inputs produced different bytes unless ``PYTHONHASHSEED`` happened to be
-pinned — which the Makefile does globally, hiding the defect from every
-``make``-driven run and surfacing it only in a refactor byte-compare
-(ticket 0571, PR #1269).
+Set iteration order over strings follows the interpreter's hash seed. Where a
+producer walks a set into its output — the genealogy chain's citation edges and
+backbone paper list, the venue table's journal-name union — two runs of the same
+code on the same inputs produced different bytes unless ``PYTHONHASHSEED``
+happened to be pinned. The Makefile pins it globally (``export PYTHONHASHSEED
+:= 0``), which is why every ``make``-driven run looked deterministic and the
+defect surfaced only in ticket 0571's refactor byte-compare, where it read as a
+spurious regression.
 
 These tests deliberately run each producer under *two different* hash seeds.
 Pinning the seed to a single value, as ``tests/test_determinism.py`` does, would
 make them pass against the defect.
+
+Not every sweep hit earns a test here. The two `plot_fig_traditions*` renderers
+carry the same defect but need a Louvain partition over a real citation graph to
+reach the tied labels, which no synthetic fixture reproduces cheaply; they are
+fixed by inspection and left uncovered.
 """
 
 import filecmp
@@ -204,4 +210,56 @@ class TestGenealogyHashSeedIndependence:
         assert filecmp.cmp(str(p1), str(p2), shallow=False), (
             "tab_lineages.csv differs between hash seeds — layout jitter or row "
             "order is following set iteration order"
+        )
+
+
+@pytest.mark.integration
+class TestVenueTableHashSeedIndependence:
+    """The venue table walks a set union of journal names (0591 sweep).
+
+    Covered here rather than in its own module because it is the same defect
+    class on the same harness. It earns a test where the two traditions figures
+    do not: `tab_venues.md` is git-tracked and included by the Œconomia
+    manuscript, so a hash-seed flip changes which journals a published table
+    names.
+    """
+
+    @pytest.fixture
+    def venue_inputs(self, tmp_path):
+        """Journals engineered so several tie on both total and log-odds.
+
+        Ties are the whole point: `nlargest(5, "total")` keeps the first row
+        among equals, so a tied group is what exposes an unordered walk.
+        """
+        works_rows = []
+        poles_rows = []
+        doi_n = 0
+        # 12 journals in 4 tie-groups of 3, each group sharing one
+        # (efficiency, accountability) count pair — hence one log_odds and one
+        # total across the group.
+        for group, (n_eff, n_acc) in enumerate([(9, 3), (3, 9), (6, 6), (8, 4)]):
+            for member in range(3):
+                journal = f"Journal of Group{group} Variant{member}"
+                for pole, count in (("efficiency", n_eff), ("accountability", n_acc)):
+                    for _ in range(count):
+                        doi = f"10.2000/venue{doi_n:04d}"
+                        doi_n += 1
+                        works_rows.append((doi, journal, 100, f"Title {doi_n}"))
+                        poles_rows.append((doi, 0.5 if pole == "efficiency" else -0.5, pole))
+        works = tmp_path / "refined_works.csv"
+        poles = tmp_path / "tab_pole_papers.csv"
+        _write_csv(str(works), ["doi", "journal", "cited_by_count", "title"], works_rows)
+        _write_csv(str(poles), ["doi", "axis_score", "pole_assignment"], poles_rows)
+        return str(works), str(poles)
+
+    def test_venue_table(self, tmp_path, venue_inputs):
+        works, poles = venue_inputs
+        p1, p2 = _run_under_both_seeds(
+            "figures/export_tab_venues.py", "tab_venues.md",
+            ["--refined-works", works, "--pole-papers", poles],
+            tmp_path, str(tmp_path),
+        )
+        assert filecmp.cmp(str(p1), str(p2), shallow=False), (
+            "tab_venues.md differs between hash seeds — the journal set union "
+            "is being walked unordered into the table"
         )

--- a/tickets/closed/0591-fig-genealogy-render-order-is-hash-seed.erg
+++ b/tickets/closed/0591-fig-genealogy-render-order-is-hash-seed.erg
@@ -2,10 +2,12 @@
 Title: fig_genealogy render order is hash-seed nondeterministic
 Created: 2026-07-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1272
 
 --- log ---
 2026-07-28T13:17Z HDMX-coding-agent created
 
+2026-07-28T14:50Z HDMX-coding-agent closed — autoclosed — PR #1272
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0591-fig-genealogy-render-order-is-hash-seed.erg

## What was wrong

`load_edges()` in both genealogy renderers returned `list(set(...))`, so edge
draw order followed the interpreter's string-hash seed. Two runs of the same
code on the same inputs produced different bytes. The Makefile pins
`PYTHONHASHSEED := 0` globally, which is why every `make`-driven build looked
deterministic and the defect only surfaced in ticket 0571's refactor
byte-compare (PR #1269), where it read as a spurious regression.

Reading the chain turned up two sinks the ticket had not named:

- **`backbone_dois` was a set in both `load_model()`s.** It is enumerated to
  draw nodes, and passed to `sorted(..., key=cited_by_count)` — whose many ties
  fall through to set order, because Python's sort is stable.
- **`analyze_genealogy.py`, upstream of both, had the same defect in the model
  itself.** `compute_layout()` enumerates `backbone_dois` to assign the
  per-(band, year) jitter index, so the `y` coordinate written to
  `tab_lineages.csv` was hash-seed dependent. Fixing only the renderers would
  have left them reproducible from a non-reproducible input.

## The sweep (ticket action 2)

Two independent passes — a search agent over all of `scripts/figures` and
`scripts/analysis`, and the adherence pass's semantic reviewer — converged on
the same three files. All three are fixed here; none was a `list(set(...))`.
All three are the variant that reads as already-sorted: `sorted(<a set>,
key=...)` is *stable*, so tied keys fall through to hash order.

| File | Reaches | Fix |
|---|---|---|
| `export_tab_venues.py` | `tab_venues.md` — **git-tracked, included by the Œconomia manuscript** | `sorted()` on the journal-name union; `kind="stable"` on both `sort_values` |
| `plot_fig_traditions.py` | `fig_traditions.png` | DOI tiebreaker on the label-node sort |
| `plot_fig_traditions_pre2008_citers.py` | `fig_traditions_pre2008_citers.png` — **git-tracked, cited to RDJ26561 reviewers** | same |

`export_tab_venues.py` is the one that matters: `nlargest(5, "total")` keeps
the first row among equals, so *which journals a published table names*
depended on the hash seed. That is a live science-lane defect, not a latent
one.

Ruled out and worth recording so a later sweep does not re-flag them: sets used
only for membership or `len()`, `sorted(set(...))` with no key, and sets feeding
order-independent reductions (`np.median`, `sum`, modularity). One further
match, `compute_interpretation.py`, is the **same defect, dormant** — its
`vocab` set feeds a `sort_values(...).head(top_n)` where tied terms compete for
the cut — but no Make target drives it, so it reaches no deliverable today.
Left alone rather than widening the diff; recorded here so the next sweep
recognises it instead of rediscovering it.

## Tests

`tests/test_hash_seed_determinism.py` runs each producer twice under **two
different** hash seeds and byte-compares. Running under a single pinned seed —
as `tests/test_determinism.py` and the Makefile both do — would pass against
the defect, so the two-seed design is the whole instrument.

Four cases: `fig_genealogy.html`, `fig_genealogy.png`, `tab_lineages.csv`,
`tab_venues.md`. All four red before, green after. The genealogy three were
verified red against `origin/main`'s scripts in a scratch tree; the venue guard
was verified by reverting `export_tab_venues.py` to `origin/main` with the test
in place — it fails with its own assertion message, not an environmental error.

`make determinism-check` now runs both modules. It previously ran only
`test_determinism.py`, which pins the seed for both of its runs and so was
structurally blind to the class it is named for.

Coverage is deliberately uneven, and the module docstring says so rather than
leaving the gap silent: the two traditions renderers need a Louvain partition
over a real citation graph before any label ties exist, which no cheap fixture
reproduces. They are fixed by inspection.

## Design notes

- **Sorting for edges, insertion order for `backbone_dois`.** Edge insertion
  order is pandas row order over a DVC-managed CSV — stable, but not
  *canonical*, where an explicit sort is a property of the data.
  `backbone_dois` keeps CSV row order instead: `tab_lineages.csv` is itself
  generated and its row order is now pinned upstream, and re-sorting would
  discard the lineage grouping a reader of that file sees.
- **Membership tests rebuild a local set** (`backbone = set(backbone_dois)`).
  The citation frame is scanned row by row, so an O(n) list lookup there would
  have been a real regression.
- **The ticket's "one shared helper if they can share" is declined.**
  `load_model` / `load_edges` are byte-identical across the two genealogy
  renderers and the codebase has the precedent (`_band_scheme.py`,
  `_community_registry.py`), so the extraction is warranted — but it is a
  different change, with its own Makefile-prerequisite blast radius, and
  bundling it here would bury a determinism fix inside a refactor diff.

## Gate

- `make check-fast` — clean (1399 passed)
- `make lint` — clean (330 passed)
- `make determinism-check` — clean (7 passed)
- `make check` — 2229 passed, **8 pre-existing failures**, all corpus-file
  *existence* assertions in `test_corpus_acceptance` / `test_corpus_flow`. This
  worktree holds DVC pointers but no `make data`; `data/catalogs/` contains only
  `*.dvc` stubs. Nothing in the diff touches a corpus file, and the count is
  identical to the pre-branch baseline.
- `/verify-adherence` — PASS, no mechanical failures. Its semantic phase is what
  surfaced the three sweep hits, now fixed in this branch.
- `/review-pr` — five-agent panel, no blockers, recommend merge. The panel
  independently replayed the defect against all four covered producers and ran a
  20-seed probe confirming the `1`/`12345` pair is not coincidentally passing.

## Not done — tracked in ticket 0610 (PR #1273)

Three **git-tracked** artifacts were generated by the old ordering and no longer
match what their producer emits. None can be rebuilt here: this worktree has
`.dvc` stubs, not the corpus.

- `fig_traditions_pre2008_citers.png` — cited to RDJ26561 reviewers at
  `revision-rdj26561/r1-14-network-response.md:38`. Highest stakes of the three.
- `tab_venues.md` — Œconomia manuscript.
- `tab_venues_fr.md` — Make-generated from the above, French variant.

`fig_genealogy.{png,html}` and `fig_traditions.png` also change; none is tracked
and no golden hash pins them, so nothing in the repo needs regenerating for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
