### PR TITLE
ticket(0670,0671): file the two findings of the 0641 artifact audit

### DIFF
--- a/tickets/0670-recut-community-registry-off-unstable.erg
+++ b/tickets/0670-recut-community-registry-off-unstable.erg
@@ -41,6 +41,41 @@ rebuilt PNG rather than ship that string into a tracked artifact, so the
 committed figure is currently correct-looking but computed from a superseded
 corpus.
 
+## The measurement, recorded here because its source is gitignored
+
+The audit ran in a throwaway worktree and `data/derived/` is gitignored, so
+these numbers are unverifiable short of a full pipeline re-run once it is
+pruned. Recording them makes the diagnosis checkable.
+
+Registry ids for `fig_global_map_cocitation`: **13, 11, 25, 21, 10, 24, 8, 6, 9**
+(nine concepts). Community ids the pinned corpus actually produces, from
+`data/derived/tables/global_map_cocitation.json` (eight communities):
+
+| id | size | auto label (top two members) |
+|---|---|---|
+| 1 | 614 | `IPCC 2022 / nan nan` |
+| 8 | 517 | `Robert J. Zomer 2008 / IPCC 2018` |
+| 0 | 431 | `Stern 2007 / Philipp Krueger 2019` |
+| 4 | 416 | `nan nan / nan nan` |
+| 5 | 382 | `Karen Holm Olsen 2007 / Christoph Sutter 2007` |
+| 3 | 321 | `United Nations 1992 / Robert O. Keohane 2011` |
+| 7 | 223 | `Florian Weiler 2018 / nan nan` |
+| 6 | 148 | `Michael E. Porter 1995 / W. David Montgomery 1972` |
+
+The two id sets intersect at exactly **{8, 6}** — and those are precisely the
+two communities that kept a registry label in the rebuilt figure
+(`north-south`, `carbon-pricing`). The mechanism is therefore confirmed, not
+inferred: the other seven registry entries address ids the partition no longer
+contains, so `figure_communities` returns no match and every one of them falls
+through to `auto_label` and the grey default colour.
+
+Note also that id 8 is `Robert J. Zomer 2008 / IPCC 2018`, a land-use and
+climate-science pairing, while the registry labels id 8 "North-South climate
+finance allocation". So the surviving labels are not merely lucky — at least
+one of them is now **wrong**, applied to a community about something else. That
+is the worse half of the defect: an unmatched id degrades visibly to grey, a
+matched-but-reshuffled id lies silently.
+
 ## Relevant files
 
 - `config/community_registry.yml` — the id-keyed mapping

--- a/tickets/0670-recut-community-registry-off-unstable.erg
+++ b/tickets/0670-recut-community-registry-off-unstable.erg
@@ -1,0 +1,91 @@
+%erg 0.1
+Title: Re-key the community registry off unstable Louvain ids, and stop auto_label emitting "nan nan"
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T20:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 0641 artifact audit rebuilt `fig_global_map_cocitation.png` from the corpus
+`dvc.lock` pins and got a regression, not a data correction: 7 of the 9
+registered co-citation communities lost their name and their colour, and three
+of the fallback labels render the literal string `nan nan`.
+
+Cause: `config/community_registry.yml` maps hand-curated concepts onto Louvain
+community **ids**:
+
+```yaml
+figures:
+  fig_global_map_cocitation:
+    "13": climate-science
+    "11": climate-risk
+    ...
+```
+
+The file's own comment warns those ids are "stable only for that seed". They
+are also only stable for a fixed corpus — a corpus change repartitions the
+graph and renumbers the communities, so the mapping silently addresses the
+wrong communities or none at all. Nothing fails; the figure just comes out
+grey and mislabelled. `tests/test_global_map.py` checks the registry's
+*contents* (`"green-finance" in figs[...]`), which is true whatever the ids
+point at, so it cannot see this.
+
+The fallback then compounds it. `plot_fig_global_map.auto_label` builds a label
+from a community's top two members, and when the bibliographic metadata is
+missing the author-year string is the text `nan nan` — the same class as ticket
+0550 (`or ""` does not catch NaN). The audit deliberately did NOT commit the
+rebuilt PNG rather than ship that string into a tracked artifact, so the
+committed figure is currently correct-looking but computed from a superseded
+corpus.
+
+## Relevant files
+
+- `config/community_registry.yml` — the id-keyed mapping
+- `scripts/figures/_community_registry.py` — `figure_communities`, `surname_label`
+- `scripts/figures/plot_fig_global_map.py` — `auto_label`, `render`
+- `tests/test_global_map.py` — the guard that cannot see this
+- `deliverables/_shared/figures/fig_global_map_cocitation.png` — the artifact
+
+## Actions
+
+1. Key the registry on something stable across a repartition — the community's
+   anchor members (a few reference labels or DOIs that identify the concept),
+   matched at render time — rather than the Louvain id.
+2. Make `auto_label` refuse to emit a label built from missing metadata: no
+   `nan` in rendered text, ever. Prefer dropping the member and falling back
+   to the next one, then to `community <id>`.
+3. Re-derive the co-citation mapping against the pinned corpus and regenerate
+   `fig_global_map_cocitation.png`.
+
+## Test
+
+Red step first, and at the level where the defect lives (0402: a static guard
+is always one spelling behind):
+
+- A test that renders the label for a community whose top members carry NaN
+  author/year and asserts `nan` appears nowhere in the output text. This fails
+  today.
+- A test that permutes community ids in a synthetic summary and asserts the
+  same concepts keep their labels — the property the id-keyed registry lacks.
+
+## Verification
+
+- [ ] Renaming/renumbering communities does not change which concept gets which
+      label
+- [ ] No rendered label contains `nan`
+- [ ] `fig_global_map_cocitation.png` regenerated from the pinned corpus with
+      all major communities named and coloured
+
+## Invariants
+
+- One concept = one label = one colour across figures (the registry's purpose)
+- `fig_global_map_direct.png` is unaffected — it labels by top TF-IDF terms and
+  came back byte-identical in the 0641 audit
+
+## Exit criteria
+
+The co-citation map regenerates from the pinned corpus with its curated labels
+intact, and a corpus change can no longer silently unname a community.

--- a/tickets/0671-reconcile-manuscript-v1-provenance-with.erg
+++ b/tickets/0671-reconcile-manuscript-v1-provenance-with.erg
@@ -65,6 +65,36 @@ so a 2015 JS z of 1.53 is not fatal to the thesis, but it does need a reading
 rather than a silent republication. 0641 left the committed figure in place for
 that reason.
 
+**It is two window widths, not one.** The PR review re-derived the table and
+found 2015 above the threshold at w4 as well. Full z-scores from
+`data/derived/tables/tab_breakpoints.csv` on the pinned corpus, recorded here
+because that path is gitignored and the worktree is throwaway:
+
+| year | z_js_w2 | z_js_w3 | z_js_w4 | z_cos_w3 |
+|---|---|---|---|---|
+| 2007 | 0.112 | -0.197 | -0.598 | **1.855** |
+| 2013 | **2.208** | **1.659** | 1.286 | 1.103 |
+| 2015 | 1.186 | **1.528** | **1.594** | 0.070 |
+| 2021 | -0.078 | -0.458 | -0.703 | -1.117 |
+
+So 2015 clears z = 1.5 at two of the three window widths, and at w4 it clears
+by more than 2013 does at w3. The figure plots w3 only. Reading "marginal" onto
+this needs either a defence or a rewording; it is a stronger challenge than the
+single-window figure suggests.
+
+**Prior on the coverage table.** `tab_pre2007_coverage.csv` is 0641's fifth
+deferred artifact and comes with `tab_null_separation_pre2007.csv` as a pair:
+`separation.mk` declares `separation: $(SEP_COVERAGE) $(SEP_NULL)`, and
+`compute_pre2007_coverage.py`'s docstring says its numbers "decide the
+interpretive regime for the separation null model". On the pinned corpus the
+pre-2007 slice is markedly less thin than the committed table says — n_works
+1344 -> 1654, works with an outgoing edge 407 -> 667, share 30.3% -> 40.3%.
+A.5 currently reads "coverage of the early literature is sparse ... beyond what
+the corpus can settle"; that still holds at 40%, but the margin narrowed, and
+the two tables must be refreshed in one commit so the appendix does not end up
+citing two corpus snapshots. `docs/audit-manuscript-stat-provenance.md` handoff
+item 2 is an open instance of exactly that confusion on this same graph.
+
 Related: `docs/audit-manuscript-stat-provenance.md` handoff item 2 — reconcile
 the 84/369-vs-169/1,056 pre-2007 graph — is still open and now has a third
 number to account for.
@@ -90,10 +120,13 @@ Author decisions first; nothing here is the MOE's call.
 2. A.5: refresh the five transcribed values, and re-word the a-priori-anchor
    sentence against the 7-node/8-edge result. The CSV and the prose must move
    in the same commit — `test_a5_prose_matches_committed_csv` enforces it.
-3. `@fig-breaks`: read the 2015 z = 1.528 against the "not a rupture" claim,
-   then either regenerate the figure and adjust the marker semantics and the
-   prose together, or record why the committed figure stays.
-4. Decide whether these numbers should be Quarto variables rather than typed
+3. `@fig-breaks`: read 2015's z = 1.528 (w3) and 1.594 (w4) against the "not a
+   rupture" claim, then either regenerate the figure and adjust the marker
+   semantics and the prose together, or record why the committed figure stays.
+4. `tab_pre2007_coverage.csv` refreshes in the same commit as
+   `tab_null_separation_pre2007.csv` — they are one Make target and one
+   interpretive regime.
+5. Decide whether these numbers should be Quarto variables rather than typed
    prose, so the next corpus change moves them mechanically.
 
 ## Test
@@ -108,6 +141,7 @@ prose ticket gets no red step; verification is the recompiled PDF and
       `tab_null_separation_pre2007.csv`, and `make check` is green
 - [ ] A.2's freeze claim is true of both figures it names, or reworded
 - [ ] `@fig-breaks` and the Paris reading agree
+- [ ] The two pre-2007 tables land in one commit
 - [ ] `make manuscript` renders
 
 ## Invariants

--- a/tickets/0671-reconcile-manuscript-v1-provenance-with.erg
+++ b/tickets/0671-reconcile-manuscript-v1-provenance-with.erg
@@ -1,0 +1,123 @@
+%erg 0.1
+Title: Reconcile the manuscript's corpus-dependent claims with the pinned corpus (A.2 freeze, A.5 numbers, Paris marker)
+Created: 2026-07-28
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-07-28T20:45Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 0641 artifact audit rebuilt every tracked Phase-2 artifact from the corpus
+`dvc.lock` pins and turned up two things the manuscript asserts that the
+pipeline no longer supports. Both are manuscript prose, so the audit reported
+them rather than editing them (`rules/git.md`, prose workpackages: an
+autonomous pass produces a report, the author arbitrates).
+
+**A.2 — the frozen figure is not frozen.** `manuscript.qmd` A.2 states that
+"the growth of the literature (@fig-bars) and its thematic recomposition
+(@fig-composition) are frozen on the corpus as it stood at the first
+submission." `@fig-composition` genuinely is: `plot_fig2_composition.py` reads
+the frozen `config/v1_tab_alluvial.csv`, and it rebuilt byte-identical.
+`@fig-bars` is not: `plot_fig1_bars.py --v1-only` filters the live `in_v1`
+column of `refined_works.csv`, so it is recomputed from a mutable corpus. On
+the pinned corpus four year-bars move. The committed PNG is therefore the only
+record of the submitted figure, and re-running its documented command does not
+reproduce it.
+
+**A.5 — the quoted statistics have moved.** A.5 quotes five values inline from
+`tab_null_separation_pre2007.csv`. Regenerated from the pinned corpus (0641,
+PR for that ticket):
+
+| Quantity | A.5 prose | Pinned corpus |
+|---|---|---|
+| pre-2007 co-citation graph | 84 nodes, 369 edges | 109 nodes, 466 edges |
+| within-tradition co-citation share | 0.89 | 0.878 |
+| configuration-model null | 0.37 | 0.353 |
+| z | ≈ 25 | ≈ 28.1 |
+| a-priori anchor nodes matched | "about three" | 7 (8 edges) |
+
+A.2 explicitly licenses this drift — "the diagnostic statistics reported below
+are computed on the current working corpus" — so the direction of the fix is a
+transcription refresh, not a retraction. The qualitative claims survive: the
+separation is still strong and still circular, and the a-priori test still
+degenerates. But "only about three co-citation-core nodes match, all
+environmental economics" needs re-checking against the seven-node result before
+it is restated.
+
+**@fig-breaks — the Paris marker crosses its own threshold.**
+`scripts/figures/plot_fig2_breaks.py` draws a significance threshold at
+z = 1.5 and plots 2015 and 2021 as "not a break" markers; its docstring states
+the reading outright ("2007 is a cosine break, 2013 is a JS break. Paris and
+Glasgow are not breaks"). On the pinned corpus the window-3 Jensen-Shannon z
+for 2015 is **1.528** — above that line. The regenerated figure therefore shows
+the Paris marker sitting on the significance threshold, while `manuscript.qmd`
+L313 reads Paris as "a thematic diversification ... rather than a rupture" and
+`.claude/rules/writing.md` codifies "Paris (2015) shows only a marginal
+Jensen-Shannon rise, not a rupture."
+
+The periodization's two breaks survive and strengthen: 2007 cosine z 1.855,
+2013 JS z 1.659, both above threshold. What moves is the act II -> III boundary
+claim, which the writing rules describe as institutional rather than detected —
+so a 2015 JS z of 1.53 is not fatal to the thesis, but it does need a reading
+rather than a silent republication. 0641 left the committed figure in place for
+that reason.
+
+Related: `docs/audit-manuscript-stat-provenance.md` handoff item 2 — reconcile
+the 84/369-vs-169/1,056 pre-2007 graph — is still open and now has a third
+number to account for.
+
+## Relevant files
+
+- `deliverables/manuscript/manuscript.qmd` — A.2 disclosure (~L297), Paris
+  reading (~L313), A.5 bullet (~L323)
+- `deliverables/_shared/tables/tab_null_separation_pre2007.csv` — the A.5 source
+- `deliverables/_shared/figures/fig_breaks.png` — the figure whose marker moved
+- `scripts/figures/plot_fig1_bars.py` — the `--v1-only` filter
+- `scripts/figures/plot_fig2_breaks.py` — the hardcoded threshold and markers
+- `tests/test_separation_provenance.py` — the guard that couples CSV and prose
+- `docs/audit-manuscript-stat-provenance.md` — the Option C decision and its handoff list
+
+## Actions
+
+Author decisions first; nothing here is the MOE's call.
+
+1. `@fig-bars`: either freeze the v1 subset as a config artifact (the
+   `fig_composition` pattern — a committed `config/v1_*` snapshot the producer
+   reads), or amend A.2 to say the figure is archived rather than reproducible.
+2. A.5: refresh the five transcribed values, and re-word the a-priori-anchor
+   sentence against the 7-node/8-edge result. The CSV and the prose must move
+   in the same commit — `test_a5_prose_matches_committed_csv` enforces it.
+3. `@fig-breaks`: read the 2015 z = 1.528 against the "not a rupture" claim,
+   then either regenerate the figure and adjust the marker semantics and the
+   prose together, or record why the committed figure stays.
+4. Decide whether these numbers should be Quarto variables rather than typed
+   prose, so the next corpus change moves them mechanically.
+
+## Test
+
+None — pure prose plus an author decision. Per `.claude/rules/writing.md`, a
+prose ticket gets no red step; verification is the recompiled PDF and
+`/review-pr-prose`.
+
+## Verification
+
+- [ ] Every number A.5 quotes matches the committed
+      `tab_null_separation_pre2007.csv`, and `make check` is green
+- [ ] A.2's freeze claim is true of both figures it names, or reworded
+- [ ] `@fig-breaks` and the Paris reading agree
+- [ ] `make manuscript` renders
+
+## Invariants
+
+- The three-act periodization: 2007 cosine break, 2013 JS break, no further
+  structural break. Both survive on the pinned corpus and get stronger; nothing
+  here reopens them.
+
+## Exit criteria
+
+The manuscript's provenance claims, its quoted statistics, and its figures all
+hold against the corpus `dvc.lock` pins, under an explicit author decision on
+the freeze and on the Paris marker.


### PR DESCRIPTION
Ticket-ref: tickets/0670-recut-community-registry-off-unstable.erg
Ticket-ref: tickets/0671-reconcile-manuscript-v1-provenance-with.erg
Ticket: none

Tickets-only diff — the project's fast path (`erg check` + ID-collision scan,
no draft, no verify, no review request).

Both findings come out of the 0641 audit (PR #1282), which rebuilt all 63
tracked Phase-2 artifacts from the corpus `dvc.lock` pins. They are filed here
rather than on that branch so the audit PR stays one change.

**0670 — the community registry is keyed on unstable Louvain ids.**
`config/community_registry.yml` maps hand-curated concepts onto community
*ids*. Its own comment warns they are stable only for a fixed seed; they are
also only stable for a fixed corpus. On the pinned corpus 7 of 9 registered
co-citation communities lose their name and colour, and
`plot_fig_global_map.auto_label` renders three of them as the literal string
`nan nan` — the ticket 0550 NaN-formatting class. Nothing fails:
`tests/test_global_map.py` checks the registry's *contents*, which stay true
whatever the ids address. The audit deliberately did not commit the rebuilt
figure rather than ship that string.

**0671 — three manuscript claims the pipeline no longer supports.** Labelled
`needs-human`: every action is an author reading.

- A.2 calls `@fig-bars` frozen on the first-submission corpus, but
  `plot_fig1_bars.py --v1-only` filters the live `in_v1` column of
  `refined_works.csv`, so the figure is recomputed from a mutable corpus and
  four year-bars moved. Its documented command no longer reproduces it.
- A.5 quotes five values from `tab_null_separation_pre2007.csv`; all five have
  moved (84/369 nodes/edges → 109/466, z ≈ 25 → 28.1, and the a-priori anchor
  test from three nodes to seven). `test_a5_prose_matches_committed_csv`
  couples the CSV to the prose, so the pair must land in one commit.
- `@fig-breaks` now shows the Paris 2015 marker on the significance threshold
  `plot_fig2_breaks.py` itself draws — window-3 Jensen–Shannon z = 1.528
  against a 1.5 line — while that script's docstring, `manuscript.qmd` L313,
  and `.claude/rules/writing.md` all read Paris as a non-break. The
  periodization's two breaks survive and strengthen; it is the act II → III
  boundary claim that needs the reading.

IDs picked at 0670/0671, eighteen clear of the 0652 frontier, per the
renumber-clear-of-the-frontier rule. The collision scan looped `gh pr view`
over open PRs (never `gh pr list --json files`) and was validated with a
positive control: it correctly reports 0641 in PR #1282.