### PR TITLE
fix(0362): a corpus re-run refuses to publish dvc.lock instead of pushing to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,16 @@ all: manuscript papers
 # Padme is the data authority. Run the pipeline on padme, pull on doudou.
 #
 # On padme (pipeline run):
-#   make corpus                      # dvc repro + push + commit lock
+#   make corpus                      # dvc repro + dvc push (never commits)
 #
 # On doudou (sync only):
 #   make corpus-sync                 # git pull + dvc pull
 #   make figures && make manuscript  # Phase 2 + 3 (no DVC needed)
 
 # Full pipeline — run on padme only (GPU, API access).
-# After dvc repro + push, auto-commits dvc.lock if it's the only change.
+# After dvc repro + push, this target NEVER commits. If dvc.lock changed it
+# prints the diff and exits 1 — land the lock via branch + merge request
+# (ticket 0362).
 corpus:
 	bash scripts/run_corpus_pipeline.sh
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ uv run dvc cache dir /data/projets/dvc-cache/oeconomia
 **Padme is the data authority.** The corpus pipeline (Phase 1) runs on padme. Doudou only pulls data — never pushes.
 
 ```bash
-# On padme — build corpus (auto-pushes data, auto-commits dvc.lock):
+# On padme — build corpus (pushes data to the DVC remote; never commits.
+# A changed dvc.lock exits 1 — land it via branch + merge request):
 make corpus
 
 # On doudou — sync and build:

--- a/docs/revision-runbook.md
+++ b/docs/revision-runbook.md
@@ -75,7 +75,10 @@ Reviewer asks to include 2025 data or additional sources.
 
 1. Create ticket branch: `t{N}-corpus-expansion-{description}`
 2. Update `config/corpus_collect.yaml` (year_max, new queries)
-3. Run full pipeline: `make corpus` (on padme — GPU, API access)
+3. Run full pipeline: `make corpus` (on padme — GPU, API access). It exits 1
+   by design once `dvc.lock` changes — that refusal is the expected outcome of
+   a corpus-changing run, not a failure. Review the printed diff, then commit
+   `dvc.lock` onto the ticket branch yourself (ticket 0362).
 4. Verify: `make corpus-validate` (acceptance tests)
 5. Freeze new v2 config: `config/v2_*`
 6. Regenerate all figures: `make figures`

--- a/scripts/dvc_lock_gate.sh
+++ b/scripts/dvc_lock_gate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# dvc_lock_gate.sh — report what a corpus re-run changed; never publish it.
+#
+# Ticket 0362. This used to be the tail of run_corpus_pipeline.sh, where it
+# branched, committed dvc.lock, merged into main and `git push origin main`.
+# That bypassed the branch-and-PR gate every other change in this repo goes
+# through, and it removed the checkpoint a pending corpus change relies on:
+# a config or code edit that alters the corpus would be executed *and*
+# published by the next `make corpus`, with no human confirmation.
+#
+# The refusal lives in its own file so it can be driven directly by a test —
+# the pipeline script's own guards (padme, dvc, GROBID, main) make its tail
+# unreachable in a throwaway repo.
+#
+# Exit status: 0 when nothing changed or when files other than dvc.lock
+# changed (the pre-existing warning path, unchanged); 1 when dvc.lock changed,
+# so `make corpus` fails loudly and the operator commits it via branch + PR.
+#
+# Usage: bash scripts/dvc_lock_gate.sh   (run from the repository root)
+
+set -euo pipefail
+
+changed=$(git status --porcelain)
+
+if [ -z "$changed" ]; then
+    echo "dvc.lock unchanged, nothing to commit."
+elif [ "$(echo "$changed" | sed 's/^...//')" = "dvc.lock" ]; then
+    echo ""
+    echo "REFUSING to publish: the pipeline re-run changed dvc.lock."
+    echo ""
+    git --no-pager diff -- dvc.lock || true
+    echo ""
+    echo "dvc.lock is left uncommitted in the working tree. Publishing a corpus"
+    echo "change is a human decision (ticket 0362): review the diff above, then"
+    echo "land it on a branch and open a merge request —"
+    echo ""
+    echo "    git switch -c data-dvclock-\$(date +%Y%m%d)"
+    echo "    git add dvc.lock && git commit -m 'data: update dvc.lock after pipeline re-run'"
+    echo "    git push -u origin HEAD && gh pr create"
+    echo ""
+    exit 1
+else
+    echo ""
+    echo "WARNING: files other than dvc.lock changed:"
+    echo "$changed"
+    echo "Stage and commit manually."
+fi

--- a/scripts/dvc_lock_gate.sh
+++ b/scripts/dvc_lock_gate.sh
@@ -28,10 +28,19 @@ changed=$(git status --porcelain)
 
 if [ -z "$changed" ]; then
     echo "dvc.lock unchanged, nothing to commit."
-elif [ "$(echo "$changed" | sed 's/^...//')" = "dvc.lock" ]; then
+elif echo "$changed" | sed 's/^...//' | grep -qxF 'dvc.lock'; then
+    # Refuse when dvc.lock is *among* the changed files, not only when it is
+    # the sole one. A real `dvc repro` can leave a stray untracked file behind,
+    # and the old "is the only change" test then downgraded the refusal to the
+    # exit-0 warning path — the one case the checkpoint exists for.
     echo ""
     echo "REFUSING to publish: the pipeline re-run changed dvc.lock."
     echo ""
+    if [ "$(echo "$changed" | sed 's/^...//')" != "dvc.lock" ]; then
+        echo "Other files changed too — review them before committing anything:"
+        echo "$changed"
+        echo ""
+    fi
     # Against HEAD, not the index: an already-staged dvc.lock would otherwise
     # print an empty diff under "review the diff above".
     git --no-pager diff HEAD -- dvc.lock || true

--- a/scripts/dvc_lock_gate.sh
+++ b/scripts/dvc_lock_gate.sh
@@ -12,6 +12,10 @@
 # the pipeline script's own guards (padme, dvc, GROBID, main) make its tail
 # unreachable in a throwaway repo.
 #
+# There is deliberately no --publish opt-in flag (ticket 0362, action 3): an
+# opt-in is the same hole behind a flag, and the operator's next step is two
+# git commands the message spells out.
+#
 # Exit status: 0 when nothing changed or when files other than dvc.lock
 # changed (the pre-existing warning path, unchanged); 1 when dvc.lock changed,
 # so `make corpus` fails loudly and the operator commits it via branch + PR.
@@ -28,7 +32,9 @@ elif [ "$(echo "$changed" | sed 's/^...//')" = "dvc.lock" ]; then
     echo ""
     echo "REFUSING to publish: the pipeline re-run changed dvc.lock."
     echo ""
-    git --no-pager diff -- dvc.lock || true
+    # Against HEAD, not the index: an already-staged dvc.lock would otherwise
+    # print an empty diff under "review the diff above".
+    git --no-pager diff HEAD -- dvc.lock || true
     echo ""
     echo "dvc.lock is left uncommitted in the working tree. Publishing a corpus"
     echo "change is a human decision (ticket 0362): review the diff above, then"

--- a/scripts/run_corpus_pipeline.sh
+++ b/scripts/run_corpus_pipeline.sh
@@ -7,8 +7,9 @@
 # via BASH_ENV. Never via command-line KEY=value — that leaks to `ps`.
 #
 # Guards: hostname must be padme, dvc must be installed, branch must be main.
-# After dvc repro + push, auto-commits dvc.lock if it's the only changed file.
-# Otherwise warns the user to commit manually.
+# After dvc repro + push, scripts/dvc_lock_gate.sh reports what changed. It
+# never commits and never pushes: a dvc.lock change exits non-zero so the
+# operator lands it via branch + merge request (ticket 0362).
 #
 # Usage: bash scripts/run_corpus_pipeline.sh
 #   (or invoked via `make corpus`)
@@ -79,25 +80,7 @@ if [ "$ret" -ne 0 ]; then
     exit "$ret"
 fi
 
-# --- Auto-commit logic ---
-changed=$(git status --porcelain)
-
-if [ -z "$changed" ]; then
-    echo "dvc.lock unchanged, nothing to commit."
-elif [ "$(echo "$changed" | sed 's/^...//')" = "dvc.lock" ]; then
-    echo "Auto-committing dvc.lock..."
-    branch="housekeeping-dvclock-$(date +%Y%m%d-%H%M%S)"
-    git checkout -b "$branch"
-    git add dvc.lock
-    git commit -m "data: update dvc.lock after pipeline re-run"
-    git checkout main
-    git merge "$branch"
-    git branch -d "$branch"
-    git push origin main
-    echo "dvc.lock committed and pushed."
-else
-    echo ""
-    echo "WARNING: files other than dvc.lock changed:"
-    echo "$changed"
-    echo "Stage and commit manually."
-fi
+# --- Publication gate (ticket 0362) ---
+# Reports what changed; never commits or pushes. Exits non-zero when dvc.lock
+# changed, so publishing a corpus change stays a deliberate human step.
+bash "$PROJ_ROOT/scripts/dvc_lock_gate.sh"

--- a/tests/test_dvc_lock_gate.py
+++ b/tests/test_dvc_lock_gate.py
@@ -42,13 +42,15 @@ def throwaway_repo(tmp_path: Path) -> Path:
     (repo / "other.txt").write_text("hello\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-m", "initial")
-    shutil.copy(GATE, repo / "dvc_lock_gate.sh")
+    # The gate lives outside the repo: a copy inside it would show up as an
+    # untracked file and change the very `git status` the gate reads.
+    shutil.copy(GATE, tmp_path / "dvc_lock_gate.sh")
     return repo
 
 
 def _run_gate(repo: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", "./dvc_lock_gate.sh"],
+        ["bash", str(repo.parent / "dvc_lock_gate.sh")],
         cwd=repo,
         capture_output=True,
         text=True,

--- a/tests/test_dvc_lock_gate.py
+++ b/tests/test_dvc_lock_gate.py
@@ -1,0 +1,100 @@
+"""Ticket 0362 — a corpus re-run must never publish dvc.lock to main on its own.
+
+`scripts/run_corpus_pipeline.sh` used to branch, commit, merge into main and
+`git push origin main` whenever `dvc.lock` was the only changed file. The
+publish decision belongs to a human, behind the branch-and-PR gate.
+
+The refusal lives in `scripts/dvc_lock_gate.sh` so it can be driven directly:
+the tail of `run_corpus_pipeline.sh` is unreachable in a throwaway repo (the
+padme / dvc / GROBID guards fire first). Each test spawns a real subprocess —
+never source-in-shell — against a throwaway git repo.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "scripts" / "dvc_lock_gate.sh"
+
+pytestmark = pytest.mark.integration
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def throwaway_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "dvc.lock").write_text("schema: '2.0'\n")
+    (repo / "other.txt").write_text("hello\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "initial")
+    shutil.copy(GATE, repo / "dvc_lock_gate.sh")
+    return repo
+
+
+def _run_gate(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "./dvc_lock_gate.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_dvc_lock_change_is_refused_and_main_is_untouched(throwaway_repo: Path):
+    repo = throwaway_repo
+    before = _git(repo, "rev-parse", "main")
+
+    (repo / "dvc.lock").write_text("schema: '2.0'\nchanged: true\n")
+    result = _run_gate(repo)
+
+    assert result.returncode != 0, (
+        f"gate must exit non-zero when dvc.lock changed; got 0\n{result.stdout}"
+    )
+    assert _git(repo, "rev-parse", "main") == before, "main must not advance"
+    assert _git(repo, "status", "--porcelain") != "", (
+        "the change must be left in the working tree, not committed"
+    )
+    branches = _git(repo, "branch", "--format=%(refname:short)").split()
+    assert branches == ["main"], f"gate must create no branch; found {branches}"
+    assert "dvc.lock" in result.stdout, "the operator message must name dvc.lock"
+    assert "0362" in result.stdout, "the message must cite the ticket"
+
+
+def test_clean_tree_is_a_no_op(throwaway_repo: Path):
+    result = _run_gate(throwaway_repo)
+    assert result.returncode == 0, result.stderr
+    assert "unchanged" in result.stdout
+
+
+def test_other_files_changed_keeps_the_warning_path(throwaway_repo: Path):
+    repo = throwaway_repo
+    (repo / "other.txt").write_text("modified\n")
+    result = _run_gate(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "WARNING" in result.stdout
+    assert "other.txt" in result.stdout
+    assert _git(repo, "status", "--porcelain") != ""
+
+
+def test_pipeline_script_no_longer_pushes_to_main():
+    text = (REPO / "scripts" / "run_corpus_pipeline.sh").read_text()
+    assert "git push origin main" not in text, (
+        "run_corpus_pipeline.sh must not push to main (ticket 0362)"
+    )
+    assert "dvc_lock_gate.sh" in text, "the tail must delegate to the gate helper"

--- a/tests/test_dvc_lock_gate.py
+++ b/tests/test_dvc_lock_gate.py
@@ -106,22 +106,26 @@ def test_staged_dvc_lock_still_shows_its_diff(throwaway_repo: Path):
     assert "staged: true" in result.stdout, "the diff must be shown against HEAD"
 
 
-def test_dvc_lock_plus_another_file_takes_the_warning_path(throwaway_repo: Path):
-    """The mixed case is the warning path, not silence.
+@pytest.mark.parametrize("sibling", ["other.txt", "stray-untracked.tmp"])
+def test_dvc_lock_among_other_changes_is_still_refused(
+    throwaway_repo: Path, sibling: str
+):
+    """dvc.lock changed is a refusal even when it is not the only change.
 
-    Pins the boundary: a gate that dropped the refusal for every multi-file
-    change would pass the two single-case tests above.
+    The untracked variant is the one that matters: a real `dvc repro` can leave
+    a stray file behind, and an "is the only change" test would then downgrade
+    the refusal to the exit-0 warning path.
     """
     repo = throwaway_repo
     (repo / "dvc.lock").write_text("schema: '2.0'\nchanged: true\n")
-    (repo / "other.txt").write_text("modified\n")
+    (repo / sibling).write_text("modified\n")
 
     result = _run_gate(repo)
 
-    assert result.returncode == 0, result.stderr
-    assert "WARNING" in result.stdout
-    assert "dvc.lock" in result.stdout
-    assert "other.txt" in result.stdout
+    assert result.returncode != 0, f"a stray {sibling} must not downgrade the refusal"
+    assert "REFUSING" in result.stdout
+    assert sibling in result.stdout, "the other changed files must be listed too"
+    assert _git(repo, "rev-parse", "main") == _git(repo, "rev-parse", "HEAD")
 
 
 def test_pipeline_script_no_longer_pushes_to_main():

--- a/tests/test_dvc_lock_gate.py
+++ b/tests/test_dvc_lock_gate.py
@@ -94,6 +94,36 @@ def test_other_files_changed_keeps_the_warning_path(throwaway_repo: Path):
     assert _git(repo, "status", "--porcelain") != ""
 
 
+def test_staged_dvc_lock_still_shows_its_diff(throwaway_repo: Path):
+    """A gate diffing the index would print nothing under "review the diff"."""
+    repo = throwaway_repo
+    (repo / "dvc.lock").write_text("schema: '2.0'\nstaged: true\n")
+    _git(repo, "add", "dvc.lock")
+
+    result = _run_gate(repo)
+
+    assert result.returncode != 0
+    assert "staged: true" in result.stdout, "the diff must be shown against HEAD"
+
+
+def test_dvc_lock_plus_another_file_takes_the_warning_path(throwaway_repo: Path):
+    """The mixed case is the warning path, not silence.
+
+    Pins the boundary: a gate that dropped the refusal for every multi-file
+    change would pass the two single-case tests above.
+    """
+    repo = throwaway_repo
+    (repo / "dvc.lock").write_text("schema: '2.0'\nchanged: true\n")
+    (repo / "other.txt").write_text("modified\n")
+
+    result = _run_gate(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "WARNING" in result.stdout
+    assert "dvc.lock" in result.stdout
+    assert "other.txt" in result.stdout
+
+
 def test_pipeline_script_no_longer_pushes_to_main():
     text = (REPO / "scripts" / "run_corpus_pipeline.sh").read_text()
     assert "git push origin main" not in text, (

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -51,7 +51,7 @@ class TestTargetPresence:
     def test_corpus_target_delegates_to_script(self):
         """The 'corpus' meta-target must delegate to run_corpus_pipeline.sh.
 
-        The pipeline logic (guards, dvc repro, auto-commit) lives in a
+        The pipeline logic (guards, dvc repro, the publication gate) lives in a
         standalone bash script for testability and readability. The Makefile
         simply invokes it.
         """

--- a/tickets/closed/0362-run-corpus-pipeline-sh-auto-commits-and.erg
+++ b/tickets/closed/0362-run-corpus-pipeline-sh-auto-commits-and.erg
@@ -2,10 +2,12 @@
 Title: run_corpus_pipeline.sh auto-commits and pushes dvc.lock straight to main
 Created: 2026-07-27
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1287
 
 --- log ---
 2026-07-27T14:40Z HDMX-coding-agent created found while scoping 0336: the sign-off invariant Flag 5 depends on is not operationalized
 
+2026-07-28T20:31Z HDMX-coding-agent closed — autoclosed — PR #1287
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0362-run-corpus-pipeline-sh-auto-commits-and.erg

## What

`scripts/run_corpus_pipeline.sh` ended by branching, committing `dvc.lock`,
merging into `main` and running `git push origin main` whenever `dvc.lock` was
the only changed file. That bypassed the branch-and-PR gate every other change
in this repo goes through, and it removed the checkpoint pending corpus changes
rely on: a config or code edit that alters the corpus was executed *and*
published by the next `make corpus`, with no human confirmation.

The tail now delegates to the new `scripts/dvc_lock_gate.sh`, which prints the
`dvc.lock` diff, names the branch + merge-request recipe, cites ticket 0362,
and exits 1. The pre-existing "files other than dvc.lock changed" warning path
is carried over unchanged (still exit 0).

No `--publish` opt-in flag: the raid plan chose the conservative resolution,
and an opt-in is the same hole behind a flag.

## Why a separate file

`run_corpus_pipeline.sh`'s tail is unreachable in a throwaway repo — the
padme / dvc / GROBID / main guards fire first. Extracting the gate is what
makes the behaviour testable rather than only greppable.

## Test

`tests/test_dvc_lock_gate.py` (`@pytest.mark.integration`, 4 tests) drives the
gate as a **real subprocess** against a throwaway git repo, per the bash rules'
never-source-in-shell discipline. The dvc.lock case asserts the behaviour —
exit non-zero, `main` does not advance, no branch created, the change left in
the working tree, the message names `dvc.lock` and cites 0362 — and only
secondarily greps the pipeline script for `git push origin main`.

Red first (commit `test(0362)`), then green.

## Gate

- `make check-fast` — rc 0
- `make lint` — 330 passed, 12 skipped, rc 0
- `make check` (diff touches `scripts/`) — 2262 passed, 8 failed. All 8 are
  `test_corpus_acceptance` / `test_corpus_flow` missing-corpus failures: this
  worktree has not run `make data`. Environmental, unrelated to the diff.
- `/verify-adherence` — **PASS**, no mechanical or semantic findings. `/gaze`
  may skip the mechanical phase.

## Invariants respected

Corpus v2 is frozen: the pipeline was not run and no DVC state was touched.
The warning path was not weakened.

## Reported, not ticketed

The `sed 's/^...//'` single-file detection is carried over unchanged and would
misparse a rename entry (`R  old -> new`). Pre-existing, out of scope, and
below the tooling-lane severity floor — the failure mode is falling into the
WARNING path, which is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review rounds (3, all fixes applied)

**Round 1** — stale docs the behaviour change orphaned: `README.md:45`,
`Makefile:183,190`. Plus `git diff HEAD` (a staged `dvc.lock` printed an empty
diff), the no-`--publish` decision moved into the script header, and tests for
both.

**Round 2** — the refusal trigger **widened**, deliberately: from "`dvc.lock`
is the only changed file" to "`dvc.lock` is among the changed files". The
reviewers reproduced the hole — a modified `dvc.lock` plus any stray untracked
file, which a real `dvc repro` can leave behind, fell through to the exit-0
warning path, exactly the case the checkpoint exists for. The refusal now lists
the other changed files. This strengthens rather than weakens the warning path
the ticket protects: a change set without `dvc.lock` still takes it,
byte-identical. Also fixed a stale docstring in `test_makefile_contract.py`.

**Round 3** — verdict **approve**, 4/5 approve, no blockers. Red team ran 12
git states against throwaway repos and found no fail-open. Its one actionable
finding is applied: `docs/revision-runbook.md` scenario D now says the exit 1
is the expected outcome of a corpus-changing run, not a broken pipeline.

## Known gaps, disclosed not fixed

- A rename entry (`R  old -> dvc.lock`) is misparsed and routes to the WARNING
  path. Pre-existing parsing, commits nothing either way.
- `dvc push` still runs before the gate, so a refusal leaves the DVC remote
  ahead of `origin/main`'s lock until the human lands the PR. Pre-existing; the
  blobs are additive and unreferenced, so nothing reads a wrong value. Worth a
  follow-up ticket if the raid lead judges it above the severity floor.
