### PR TITLE
fix(0530): publish the ISTEX query as a code span so it survives rendering

### DIFF
--- a/deliverables/_shared/tables/tab_retrieval_protocol.md
+++ b/deliverables/_shared/tables/tab_retrieval_protocol.md
@@ -5,7 +5,7 @@ All API queries are bounded to publication years 1990--2024. Terms, concept grou
 | Source | Retrieval | Query fields | Query terms | Languages |
 |:---|:---|:---|:---|:---|
 | OpenAlex | Four-tier keyword search (co-occurrence filter, T3 2 / T4 3 of 4 concept groups) | default.search (title, abstract, indexed fulltext) | 52 (T1 15, T2 25, T3 10, T4 2) | 8: Arabic, Chinese, English, French, German, Japanese, Portuguese, Spanish |
-| ISTEX | Boolean phrase search | ISTEX default index | "climate finance" OR "finance climat" OR "finance climatique" | English, French |
+| ISTEX | Boolean phrase search | ISTEX default index | `"climate finance" OR "finance climat" OR "finance climatique"` | English, French |
 | Institutional reports | Curated seed list plus World Bank repository API | seed identifiers; repository full-text search | 17 curated reports, 3 API queries | English |
 | UNFCCC key documents | Curated seed list (config/unfccc_sources.yaml) | document symbol | 232 seed documents | English |
 | OECD DAC key documents | Curated seed list (config/oecd_dac_sources.yaml) | document symbol | 35 seed documents | English |

--- a/scripts/_markdown_table.py
+++ b/scripts/_markdown_table.py
@@ -16,7 +16,9 @@ Three functions, because the callers hold three different input contracts:
 
 ``markdown_cell``
     The input **is** Markdown — a curated description authored in-repo, whose
-    backticks are intentional code spans. Used by the deposit codebook.
+    backticks are intentional code spans. Written for the deposit codebook; no
+    live caller under ``scripts/`` today, and its rule is pinned by
+    ``tests/test_variables_table.py`` (see the ``_MARKDOWN_CODE`` note below).
 ``markdown_text_cell``
     The input is plain text with no markup intent — a journal name out of the
     bibliographic corpus, a source label edited by hand, a language code the
@@ -75,7 +77,9 @@ import re
 # the #1289 review caught it. Left in place rather than fixed: ``markdown_cell``
 # is the only user and has no live caller today, so changing its output would be
 # an unverifiable edit to a dormant path. Corrected here so the next reader does
-# not inherit the same false premise a third time (ticket 0530).
+# not inherit the same false premise a third time (ticket 0530). Whoever does
+# fix it should know that ``tests/test_variables_table.py`` currently *pins* the
+# escaped form, so the guard moves with the behaviour.
 _PROSE = {"\\": r"\\", "|": r"\|"}
 
 _MARKDOWN_TEXT = str.maketrans(_PROSE)

--- a/scripts/_markdown_table.py
+++ b/scripts/_markdown_table.py
@@ -63,10 +63,19 @@ which describes neither the Lua reader nor the extension set it selects.
 
 import re
 
-# The pipe is escaped everywhere; the reader honours ``\|`` inside a code span
-# too, so that one rule holds throughout. The backslash needs the opposite
-# treatment on each side of a span boundary — CommonMark reads it as an escape
-# in prose but literally inside code — so prose and code are escaped separately.
+# In prose the pipe is escaped and the backslash with it, because CommonMark
+# reads a backslash as an escape there.
+#
+# ``_MARKDOWN_CODE`` escapes the pipe *inside* a span, and that rule is wrong —
+# measured, 2026-07-28, against the reader above: ``a \| b`` inside a span
+# renders the backslash literally, and a raw ``a | b`` inside a span parses as
+# one cell, because pandoc's pipe-table splitter respects spans. The comment
+# here used to claim the reader "honours ``\|`` inside a code span too", and
+# that claim is what ``markdown_verbatim_cell``'s first draft inherited before
+# the #1289 review caught it. Left in place rather than fixed: ``markdown_cell``
+# is the only user and has no live caller today, so changing its output would be
+# an unverifiable edit to a dormant path. Corrected here so the next reader does
+# not inherit the same false premise a third time (ticket 0530).
 _PROSE = {"\\": r"\\", "|": r"\|"}
 
 _MARKDOWN_TEXT = str.maketrans(_PROSE)
@@ -155,16 +164,30 @@ def markdown_verbatim_cell(text: str) -> str:
     what a backtick wrap at the call site violates. Nothing in the emitter can
     enforce the precondition, so the construction belongs here.
 
-    Inside a span the only escape that survives is ``\\|``, which the reader
-    honours. A backtick is handled the way CommonMark provides for: the fence
-    is one longer than the value's longest backtick run, and a value that
-    begins or ends with one is padded, since the reader strips a single leading
-    and trailing space from a span's content.
+    **Nothing is escaped**, and that is the whole point of a span: CommonMark
+    processes no backslash escape inside one, so an escape does not protect the
+    value, it *becomes* the value. Measured, because the module comment above
+    asserted the opposite and the first draft of this function inherited it —
+    ``pandoc -f markdown`` renders ``a \\| b`` inside a span as the literal
+    ``a \\| b``, and renders a raw ``a | b`` inside a span as ``a | b`` in one
+    cell. The pipe needs no escape here: the reader's pipe-table splitter
+    respects code spans, so the span itself does the work the backslash does in
+    prose. Escaping it would publish a backslash in the middle of a regex a
+    reader is meant to run (caught by the #1289 review panel, second round).
+
+    A backtick is therefore handled structurally, the way CommonMark provides
+    for: the fence is one longer than the value's longest backtick run, and a
+    value that begins or ends with one is padded, since the reader strips a
+    single leading and trailing space from a span's content.
+
+    Runs of whitespace are collapsed, as everywhere else in these emitters — a
+    pipe-table row is line-delimited, so a newline in the value would end the
+    row outright and no construction can hold it.
 
     Never raises, for ``markdown_text_cell``'s reason: the input is data, not
     markup this repo authored.
     """
-    value = " ".join(str(text).split()).translate(_MARKDOWN_CODE)
+    value = " ".join(str(text).split())
     if not value:
         return ""
     runs = re.findall(r"`+", value)

--- a/scripts/_markdown_table.py
+++ b/scripts/_markdown_table.py
@@ -12,7 +12,7 @@ wrong one: it normalises *corpus* text (encoding artifacts, DOIs, language
 codes) and pulls in pandas, ftfy and langdetect for it. Escaping markup is a
 different concern with no dependencies at all.
 
-Two functions, because the callers hold two different input contracts:
+Three functions, because the callers hold three different input contracts:
 
 ``markdown_cell``
     The input **is** Markdown — a curated description authored in-repo, whose
@@ -23,6 +23,10 @@ Two functions, because the callers hold two different input contracts:
     normaliser passed through unchanged. Used by the venue-table emitters, the
     retrieval-protocol table, and — ticket 0370 — the corpus-sources table, the
     language table and the corpus-flow ledger.
+``markdown_verbatim_cell``
+    The input is a value a reader will copy and **execute** — a query, a regex,
+    a path. Rendered as a code span, which is what keeps it verbatim under
+    ``smart``. Used for the deposited ISTEX query (ticket 0530).
 
 Collapsing them into one function is the trap this split avoids: a journal name
 that happens to contain two backticks is not a code span, and applying the
@@ -48,13 +52,16 @@ output — curly quotes in a journal name or a caption are what a rendered
 document should have — so escaping it would degrade every table's typography.
 It is wrong only for a cell holding a value a reader will copy and execute,
 where it silently rewrites the value: it published an ISTEX query whose phrase
-delimiters no longer delimit phrases (ticket 0530). That is a per-cell semantic
-distinction the escaper cannot see, so the emitter owns it, by wrapping such a
-cell in a code span — which suppresses ``smart`` inside it — *after* escaping.
+delimiters no longer delimit phrases (ticket 0530). Which cells those are is a
+per-cell semantic distinction no escaper can infer, so the emitter declares it
+— but the *construction* is ``markdown_verbatim_cell``'s, because getting a
+code span right for an arbitrary value is this module's kind of knowledge.
 
 Recorded here so the next reader does not re-derive it from the documentation,
 which describes neither the Lua reader nor the extension set it selects.
 """
+
+import re
 
 # The pipe is escaped everywhere; the reader honours ``\|`` inside a code span
 # too, so that one rule holds throughout. The backslash needs the opposite
@@ -129,6 +136,41 @@ def markdown_cell(text: str) -> str:
         part.translate(_MARKDOWN_CODE) if i % 2 else part.translate(_MARKDOWN_TEXT)
         for i, part in enumerate(_split_spans(text))
     )
+
+
+def markdown_verbatim_cell(text: str) -> str:
+    """Plain text → a pipe-table cell the reader renders as a code span.
+
+    For a value the reader is meant to copy and execute — a query, a regex, a
+    path. The span is what suppresses ``smart``, so the published value keeps
+    the straight quotes it needs to work (ticket 0530).
+
+    This exists rather than wrapping ``markdown_text_cell``'s output in
+    backticks at the call site, which is what the emitter did first and which
+    is wrong for any value carrying a backtick: that function escapes one to
+    ``\\```, and CommonMark reads a backslash *literally* inside a code span,
+    so the escape does not hold — the span closes on the value's own backtick
+    and the remainder leaks out as raw Markdown. The rule the escapers already
+    document, that prose and code need opposite backslash treatment, is exactly
+    what a backtick wrap at the call site violates. Nothing in the emitter can
+    enforce the precondition, so the construction belongs here.
+
+    Inside a span the only escape that survives is ``\\|``, which the reader
+    honours. A backtick is handled the way CommonMark provides for: the fence
+    is one longer than the value's longest backtick run, and a value that
+    begins or ends with one is padded, since the reader strips a single leading
+    and trailing space from a span's content.
+
+    Never raises, for ``markdown_text_cell``'s reason: the input is data, not
+    markup this repo authored.
+    """
+    value = " ".join(str(text).split()).translate(_MARKDOWN_CODE)
+    if not value:
+        return ""
+    runs = re.findall(r"`+", value)
+    fence = "`" * ((max(len(r) for r in runs) + 1) if runs else 1)
+    pad = " " if value.startswith("`") or value.endswith("`") else ""
+    return f"{fence}{pad}{value}{pad}{fence}"
 
 
 def markdown_text_cell(text: str) -> str:

--- a/scripts/_markdown_table.py
+++ b/scripts/_markdown_table.py
@@ -41,6 +41,17 @@ matters here: ``markdown`` carries ``+citations +subscript +superscript``, and
 deliverable that renders one of these tables — Quarto appends ``citeproc``
 automatically, so a live ``@key`` does not merely become a span, it resolves.
 
+A fourth extension differs the same way and is deliberately **not** escaped
+here: ``smart``, which rewrites ``"`` ``'`` ``--`` ``...`` as typographic
+quotes, dashes and an ellipsis. Unlike the three above it produces *correct*
+output — curly quotes in a journal name or a caption are what a rendered
+document should have — so escaping it would degrade every table's typography.
+It is wrong only for a cell holding a value a reader will copy and execute,
+where it silently rewrites the value: it published an ISTEX query whose phrase
+delimiters no longer delimit phrases (ticket 0530). That is a per-cell semantic
+distinction the escaper cannot see, so the emitter owns it, by wrapping such a
+cell in a code span — which suppresses ``smart`` inside it — *after* escaping.
+
 Recorded here so the next reader does not re-derive it from the documentation,
 which describes neither the Lua reader nor the extension set it selects.
 """

--- a/scripts/figures/export_retrieval_protocol.py
+++ b/scripts/figures/export_retrieval_protocol.py
@@ -25,7 +25,7 @@ import os
 
 import pandas as pd
 import yaml
-from _markdown_table import markdown_text_cell
+from _markdown_table import markdown_text_cell, markdown_verbatim_cell
 from script_io_args import parse_io_args, validate_io
 from utils import CONFIG_DIR, LANGUAGE_NAMES, get_logger, save_csv
 
@@ -226,17 +226,18 @@ def _pipe_table(rows: list[dict], columns: list[str], caption: str) -> list[str]
         "|" + "|".join([":---"] * len(columns)) + "|",
     ]
     for row in rows:
-        cells = []
-        for column in columns:
-            # Escape first, wrap second — the same order export_corpus_table.py
-            # uses for the TOTAL row's emphasis. `_cell` escapes the backtick,
-            # so wrapping before escaping would turn the span's own delimiters
-            # into literal characters. An empty value is left unwrapped: a bare
-            # `` renders as two literal backticks, not an empty code span.
-            cell = _cell(row[column])
-            if cell and (row.get("Source"), column) in VERBATIM_CELLS:
-                cell = f"`{cell}`"
-            cells.append(cell)
+        cells = [
+            # Two different escapers, because the two contracts differ: prose
+            # is escaped for prose, an executable value is built as a code
+            # span. Not `_cell` output wrapped in backticks at this call site
+            # — that is what the #1289 review caught, and it corrupts any value
+            # carrying a backtick, since `_cell` escapes one with a backslash
+            # the reader ignores inside a span.
+            markdown_verbatim_cell(row[column])
+            if (row.get("Source"), column) in VERBATIM_CELLS
+            else _cell(row[column])
+            for column in columns
+        ]
         lines.append("| " + " | ".join(cells) + " |")
     lines += ["", caption, ""]
     return lines

--- a/scripts/figures/export_retrieval_protocol.py
+++ b/scripts/figures/export_retrieval_protocol.py
@@ -205,13 +205,39 @@ def build_grey_rows() -> list[dict]:
     ]
 
 
+# Cells holding a value a reader is meant to copy and execute (ticket 0530).
+# The reader Quarto uses carries `smart`, so a straight quote in a rendered cell
+# comes out curly — and ISTEX does not read `“` as a phrase delimiter, so the
+# published query returned nothing. A code span suppresses smart typography
+# inside it and tells the reader the value is verbatim.
+#
+# Keyed per cell rather than per column, and not applied in `_cell`: the other
+# `Query terms` values are prose ("not machine-readable", term counts) and the
+# rest of the table is prose too, where curly quotes and en-dashes are what a
+# rendered document should have. The distinction is semantic — executable value
+# versus prose — so it is declared here, where the values are known, rather than
+# guessed by the escaper.
+VERBATIM_CELLS = frozenset({("ISTEX", "Query terms")})
+
+
 def _pipe_table(rows: list[dict], columns: list[str], caption: str) -> list[str]:
     lines = [
         "| " + " | ".join(columns) + " |",
         "|" + "|".join([":---"] * len(columns)) + "|",
     ]
     for row in rows:
-        lines.append("| " + " | ".join(_cell(row[c]) for c in columns) + " |")
+        cells = []
+        for column in columns:
+            # Escape first, wrap second — the same order export_corpus_table.py
+            # uses for the TOTAL row's emphasis. `_cell` escapes the backtick,
+            # so wrapping before escaping would turn the span's own delimiters
+            # into literal characters. An empty value is left unwrapped: a bare
+            # `` renders as two literal backticks, not an empty code span.
+            cell = _cell(row[column])
+            if cell and (row.get("Source"), column) in VERBATIM_CELLS:
+                cell = f"`{cell}`"
+            cells.append(cell)
+        lines.append("| " + " | ".join(cells) + " |")
     lines += ["", caption, ""]
     return lines
 

--- a/tests/test_markdown_table.py
+++ b/tests/test_markdown_table.py
@@ -6,7 +6,8 @@ these fast-tier tests keep the rule itself covered on any machine.
 
 `markdown_cell`'s own rule is pinned in `test_variables_table.py`, next to the
 codebook contract it serves. What is pinned here is the plain-text sibling and,
-above all, the boundary between the two — the reason there are two functions.
+above all, the boundaries between them — the reason the module splits at all.
+Ticket 0530 adds the third sibling, `markdown_verbatim_cell`, at the bottom.
 
 Ticket 0376 adds one rendered class at the bottom of this module rather than in
 a fidelity suite: what it pins is the *character set* — a property of the

--- a/tests/test_markdown_table.py
+++ b/tests/test_markdown_table.py
@@ -277,15 +277,30 @@ class TestVerbatimCell:
         so the padding is invisible in the output but keeps the fences apart."""
         assert markdown_verbatim_cell("`x`") == "`` `x` ``"
 
-    def test_the_pipe_is_still_escaped(self):
-        """The one escape that survives inside a span — and it must, or the
-        value silently ends the table cell."""
-        assert markdown_verbatim_cell("a | b") == r"`a \| b`"
+    @pytest.mark.integration
+    def test_a_pipe_in_the_value_neither_splits_nor_escapes(self, tmp_path):
+        r"""Both halves, through the renderer, because the source alone lies.
 
-    def test_a_backslash_is_left_alone(self):
-        r"""Inside a span CommonMark reads `\` literally, so escaping it would
-        publish a doubled backslash in a regex a reader is meant to run."""
-        assert markdown_verbatim_cell(r"\d+") == r"`\d+`"
+        The first draft escaped the pipe, inheriting this module's prose rule.
+        Inside a span that is exactly wrong: CommonMark processes no escape
+        there, so `\|` ships the backslash into the published value — a
+        backslash in the middle of a regex a reader is meant to run. The span
+        needs no escape, because the reader's pipe-table splitter respects it.
+
+        A source-level assertion cannot tell these apart: `` `a \| b` `` and
+        `` `a | b` `` are both plausible-looking strings, and only the render
+        says which one publishes the value the emitter was given. That is why
+        the escaped form got through the first round (#1289 review, round two).
+        """
+        from _qmd_render import require_pandoc
+        require_pandoc()
+        value = "(alpha|beta)+ AND \"gamma\""
+
+        assert _rendered_value(markdown_verbatim_cell(value), tmp_path) == value
+
+    def test_no_backslash_is_added(self):
+        r"""The unit half: a span escapes nothing, so nothing is escaped."""
+        assert markdown_verbatim_cell(r"(a|b) \d+") == r"`(a|b) \d+`"
 
     def test_an_empty_value_is_not_an_empty_span(self):
         """A bare `` renders as two literal backticks, not an empty span."""

--- a/tests/test_markdown_table.py
+++ b/tests/test_markdown_table.py
@@ -16,7 +16,11 @@ escaper itself — against the reader the build really uses.
 import os
 
 import pytest
-from _markdown_table import markdown_cell, markdown_text_cell
+from _markdown_table import (
+    markdown_cell,
+    markdown_text_cell,
+    markdown_verbatim_cell,
+)
 
 TESTS_DIR = os.path.dirname(__file__)
 SCRIPTS_DIR = os.path.join(TESTS_DIR, "..", "scripts")
@@ -220,3 +224,69 @@ class TestReaderExtensionCharactersUnit:
         tilde or a caret.
         """
         assert markdown_text_cell("*em* _x_ ~sub~") == r"*em* _x_ \~sub\~"
+
+
+class TestVerbatimCell:
+    """A value a reader copies and executes must survive the reader intact.
+
+    The reader carries `smart`, which rewrites `"` `'` `--` `...`. That is
+    correct for prose and wrong for a query: it published an ISTEX search whose
+    phrase delimiters no longer delimit phrases (ticket 0530). A code span
+    suppresses `smart` inside it, so the fix is a construction, not an escape.
+    """
+
+    @pytest.mark.integration
+    def test_straight_quotes_survive_the_reader(self, tmp_path):
+        from _qmd_render import require_pandoc
+        require_pandoc()
+        value = '"climate finance" OR "finance climat"'
+
+        assert _rendered_value(value, tmp_path) != value, (
+            "control failed: unescaped straight quotes rendered literally, so "
+            "this test cannot see the defect — has the oracle lost `smart`?"
+        )
+        assert _rendered_value(markdown_verbatim_cell(value), tmp_path) == value
+
+    @pytest.mark.integration
+    def test_a_backtick_in_the_value_does_not_break_the_span(self, tmp_path):
+        """The defect the #1289 review found in the first fix.
+
+        Wrapping `markdown_text_cell` output in backticks looks right and is
+        not: it escapes a backtick with a backslash, which CommonMark reads
+        *literally* inside a code span, so the span closes on the value's own
+        backtick and the remainder leaks out as raw Markdown. Worse than the
+        bug being fixed, and dormant — no ISTEX query carries a backtick today
+        — which is exactly why it is pinned here rather than left to the one
+        live value.
+        """
+        from _qmd_render import require_pandoc
+        require_pandoc()
+        value = 'q = `x` AND "y"'
+
+        assert _rendered_value(f"`{markdown_text_cell(value)}`", tmp_path) != value, (
+            "control failed: the naive escape-then-wrap no longer corrupts the "
+            "value, so this test no longer pins the defect it was written for"
+        )
+        assert _rendered_value(markdown_verbatim_cell(value), tmp_path) == value
+
+    def test_the_fence_outgrows_the_longest_backtick_run(self):
+        assert markdown_verbatim_cell("a ``b`` c") == "```a ``b`` c```"
+
+    def test_a_leading_or_trailing_backtick_is_padded(self):
+        """The reader strips one leading and one trailing space from a span,
+        so the padding is invisible in the output but keeps the fences apart."""
+        assert markdown_verbatim_cell("`x`") == "`` `x` ``"
+
+    def test_the_pipe_is_still_escaped(self):
+        """The one escape that survives inside a span — and it must, or the
+        value silently ends the table cell."""
+        assert markdown_verbatim_cell("a | b") == r"`a \| b`"
+
+    def test_a_backslash_is_left_alone(self):
+        r"""Inside a span CommonMark reads `\` literally, so escaping it would
+        publish a doubled backslash in a regex a reader is meant to run."""
+        assert markdown_verbatim_cell(r"\d+") == r"`\d+`"
+
+    def test_an_empty_value_is_not_an_empty_span(self):
+        """A bare `` renders as two literal backticks, not an empty span."""
+        assert markdown_verbatim_cell("") == ""

--- a/tests/test_retrieval_protocol.py
+++ b/tests/test_retrieval_protocol.py
@@ -38,6 +38,10 @@ QUERIES_YAML = os.path.join(REPO, "config", "openalex_queries.yaml")
 FILTER_YAML = os.path.join(REPO, "config", "corpus_filter.yaml")
 GREY_YAML = os.path.join(REPO, "config", "grey_sources.yaml")
 
+# A code span, matching the fence back to its own length so a ``` span is not
+# ended by the first single backtick inside it.
+_CODE_SPAN = re.compile(r"(`+)(?:(?!\1).)*?\1")
+
 
 def _load(path):
     with open(path, encoding="utf-8") as fh:
@@ -626,23 +630,23 @@ def test_every_quoted_cell_is_a_code_span():
     "phrase delimiter", which is why it is the feature the guard keys on. A
     future executable value carrying only a hyphen range is out of its reach.
 
-    Cells are split on unescaped pipes, via the same rule ``_separators``
-    encodes: a naive ``split("|")`` would cut an escaped ``\\|`` in half and
-    could miss a quoted value that also contains a pipe — precisely the class
-    this guard claims (raised by the #1289 review panel).
+    Checked per row with the code spans removed, rather than by splitting the
+    row into cells. Splitting is what this guard got wrong twice: on a raw
+    ``|`` it cuts an escaped pipe in half, and on an unescaped one it cuts a
+    verbatim cell that legitimately contains a pipe — which a code span is
+    allowed to, since the reader's splitter respects it. Deleting the spans
+    first sidesteps the question, and closes a hole the cell form had anyway:
+    a cell that is *two* spans with a bare quote between them passed the
+    startswith/endswith test (both raised by the #1289 review panel).
     """
     from export_retrieval_protocol import render_markdown
 
     offenders = []
     for table in _pipe_tables(render_markdown()):
         for line in table[2:]:
-            row = line.strip().strip("|")
-            for raw in re.split(r"(?<!\\)\|", row):
-                cell = raw.strip()
-                if '"' in cell and not (
-                    cell.startswith("`") and cell.endswith("`")
-                ):
-                    offenders.append(cell)
+            outside_spans = _CODE_SPAN.sub("", line)
+            if '"' in outside_spans:
+                offenders.append(line.strip())
     assert not offenders, (
         "cells carry a straight quote outside a code span, so the reader's "
         f"smart extension will rewrite them: {offenders}"

--- a/tests/test_retrieval_protocol.py
+++ b/tests/test_retrieval_protocol.py
@@ -549,6 +549,91 @@ def test_markdown_escapes_a_pipe_in_a_cell():
     assert "|" in cell, "the pipe itself must survive into the published cell"
 
 
+def _rendered_protocol(tmp_path):
+    """The appendix as a reader sees it, through the reader Quarto uses."""
+    from _qmd_render import render_qmd, require_pandoc
+    from export_retrieval_protocol import render_markdown
+
+    require_pandoc()
+    return render_qmd(render_markdown(), tmp_path)
+
+
+@pytest.mark.integration
+def test_published_istex_query_renders_verbatim(tmp_path):
+    """A value a reader copies and executes must survive rendering byte-for-byte.
+
+    The reader carries ``smart``, which turns the query's straight quotes into
+    typographic ones. ISTEX does not read ``“`` as a phrase delimiter, so the
+    published query returns nothing — the reproducibility claim the table
+    exists to support is false as published (ticket 0530).
+    """
+    from _qmd_render import cell_texts, row_with
+    from export_retrieval_protocol import build_protocol_rows
+
+    query = {r["Source"]: r for r in build_protocol_rows()}["ISTEX"]["Query terms"]
+    assert '"' in query, (
+        f"the ISTEX query no longer carries a straight quote ({query!r}) — this "
+        "guard no longer exercises the smart-typography defect it was written for"
+    )
+
+    cells = cell_texts(row_with(_rendered_protocol(tmp_path), "ISTEX"))
+    assert query in cells, (
+        f"the published ISTEX query is not readable back verbatim: expected "
+        f"{query!r} among the rendered cells {cells!r}"
+    )
+
+
+@pytest.mark.integration
+def test_prose_cells_keep_smart_typography(tmp_path):
+    """The control: the fix must be per-cell, not a global de-typography.
+
+    It also stops the guard above from passing vacuously. If the oracle's
+    reader ever loses ``smart`` — the `gfm` regression ticket 0376 fixed — a
+    straight-quoted query reads back verbatim with no code span at all, and
+    the verbatim guard goes green while the shipped table stays broken. This
+    fails first in that case.
+    """
+    from _qmd_render import cell_texts, row_with
+    from export_retrieval_protocol import build_grey_rows
+
+    titles = [r["Title"] for r in build_grey_rows() if "'" in r["Title"]]
+    assert titles, "no curated report title carries an apostrophe to check"
+    title = titles[0]
+
+    flat = _rendered_protocol(tmp_path)
+    curly = title.replace("'", "’")
+    cells = cell_texts(row_with(flat, curly.split("’")[0]))
+    assert curly in cells, (
+        f"a prose cell lost its smart typography: expected {curly!r} among "
+        f"{cells!r}"
+    )
+
+
+def test_every_quoted_cell_is_a_code_span():
+    """The class guard: no future executable value may land in a smart cell.
+
+    A straight double quote in a published cell is a phrase delimiter — the
+    mark of a value meant to be copied and run — and the reader's ``smart``
+    extension rewrites it. Keyed on that distinguishing feature rather than on
+    the ISTEX row, so a query added for a sixth source inherits the guard
+    instead of shipping broken. Fast tier: source-level, no renderer.
+    """
+    from export_retrieval_protocol import render_markdown
+
+    offenders = []
+    for table in _pipe_tables(render_markdown()):
+        for line in table[2:]:
+            for cell in (c.strip() for c in line.strip("|").split("|")):
+                if '"' in cell and not (
+                    cell.startswith("`") and cell.endswith("`")
+                ):
+                    offenders.append(cell)
+    assert not offenders, (
+        "cells carry a straight quote outside a code span, so the reader's "
+        f"smart extension will rewrite them: {offenders}"
+    )
+
+
 def test_paper_points_at_the_deposited_protocol():
     """§2.1 tells the reader where the reconstructable protocol lives."""
     sources = _section(_qmd_text(), "2.1")

--- a/tests/test_retrieval_protocol.py
+++ b/tests/test_retrieval_protocol.py
@@ -617,13 +617,28 @@ def test_every_quoted_cell_is_a_code_span():
     extension rewrites it. Keyed on that distinguishing feature rather than on
     the ISTEX row, so a query added for a sixth source inherits the guard
     instead of shipping broken. Fast tier: source-level, no renderer.
+
+    Scoped to the double quote alone, and the scope is a judgment, not an
+    oversight. ``smart`` also rewrites ``'``, ``--`` and ``...``, but each of
+    those is overwhelmingly prose in this table — an apostrophe in a report
+    title *should* curl, and asserting otherwise would fire on every row. The
+    double quote is the one whose presence in a published cell reliably means
+    "phrase delimiter", which is why it is the feature the guard keys on. A
+    future executable value carrying only a hyphen range is out of its reach.
+
+    Cells are split on unescaped pipes, via the same rule ``_separators``
+    encodes: a naive ``split("|")`` would cut an escaped ``\\|`` in half and
+    could miss a quoted value that also contains a pipe — precisely the class
+    this guard claims (raised by the #1289 review panel).
     """
     from export_retrieval_protocol import render_markdown
 
     offenders = []
     for table in _pipe_tables(render_markdown()):
         for line in table[2:]:
-            for cell in (c.strip() for c in line.strip("|").split("|")):
+            row = line.strip().strip("|")
+            for raw in re.split(r"(?<!\\)\|", row):
+                cell = raw.strip()
                 if '"' in cell and not (
                     cell.startswith("`") and cell.endswith("`")
                 ):

--- a/tickets/closed/0530-smart-typography-rewrites-a-published-query.erg
+++ b/tickets/closed/0530-smart-typography-rewrites-a-published-query.erg
@@ -2,11 +2,13 @@
 Title: Pandoc's smart extension rewrites the published ISTEX query's quotes, so copying it out of the table gives a query that does not match
 Created: 2026-07-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1289
 
 --- log ---
 2026-07-28T07:55Z HDMX-coding-agent created
 2026-07-28T07:55Z HDMX-coding-agent note surfaced by the #1244 simplify pass as "smart also differs markdown vs gfm"; filed after confirming it reaches a published cell, not as a theoretical extension gap
 
+2026-07-28T21:07Z HDMX-coding-agent closed — autoclosed — PR #1289
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

`deliverables/_shared/tables/tab_retrieval_protocol.md` publishes the ISTEX
Boolean query verbatim so a referee can reproduce the harvest. Pandoc's
`smart` extension — live in the `markdown` reader Quarto uses, absent from
`gfm` — rewrote its straight quotes as typographic ones:

```
SOURCE   : "climate finance" OR "finance climat" OR "finance climatique"
RENDERED : “climate finance” OR “finance climat” OR “finance climatique”
```

ISTEX does not read `“` as a phrase delimiter, so a reader who copied the
query out of the published table ran one that matches nothing. The
reproducibility claim the table exists to support was false as published.
This is the 0325 defect class: a published recipe that does not work when
copied.

Ticket 0376 recalibrated the escaper from `gfm` to the real reader and caught
three of the four extensions that differ (`@`, `~`, `^`). `smart` is the
fourth, and it needed its own judgment rather than a reflex escape.

## The fix, and the two options not taken

The ISTEX `Query terms` cell is wrapped in a backtick code span at the emitter
call site (`VERBATIM_CELLS`, a set of `(Source, column)` pairs). A code span
suppresses `smart` inside it and tells the reader the value is verbatim.
Escape first, wrap second — the order `export_corpus_table.py` already uses
for the TOTAL row's emphasis, because `_cell` escapes the backtick and
wrapping first would turn the span's own delimiters into literal characters.

Not escaping `smart`'s characters in `markdown_text_cell`: unlike `@ ~ ^`,
`smart` produces *correct* output. Curly quotes and en-dashes in a journal
name or a caption are what a rendered document should have, so a global
escape would degrade every other table to fix one cell. Not disabling `smart`
in the Quarto config either — same objection across ten documents, with the
manuscript at submission stage. The distinction is semantic (a value a reader
executes versus prose) and per-cell, which the escaper cannot see, so the
emitter declares it where the values are known.

The construction lives in `markdown_verbatim_cell`, on the shared escaper
surface. The first draft wrapped `markdown_text_cell` output in backticks at
the call site instead, arguing that one call site does not earn a third
function — and that was wrong for a reason the YAGNI framing could not see.
Getting a code span right for an arbitrary value needs the escaper module's
own knowledge of what survives inside one, and no precondition the emitter
could state would enforce it. Two review rounds found two instances of exactly
that: a backslash-escaped backtick closes the span early, and a
backslash-escaped pipe publishes the backslash. So the ticket's option 2 is
right after all, on evidence the first pass did not have.

## Tests

Three, all driving the real emitter (`build_protocol_rows` / `render_markdown`)
rather than a hand-built frame, so they cover the path that produces the
shipped file.

- `test_published_istex_query_renders_verbatim` (integration, needs pandoc) —
  renders through `tests/_qmd_render.py` and asserts the cell reads back
  byte-equal. **Red before the fix.**
- `test_every_quoted_cell_is_a_code_span` (fast) — the class guard. Keyed on
  the distinguishing feature (a straight quote outside a code span), not on
  the ISTEX row, so a query added for a sixth source inherits it. **Red before
  the fix.**
- `test_prose_cells_keep_smart_typography` (integration) — the control, green
  throughout. A curated report title's apostrophe must still read back curly.
  Without it the verbatim guard would go green on an oracle that had silently
  lost `smart` (the `gfm` regression 0376 fixed) while the shipped table
  stayed broken.

`scripts/_markdown_table.py`'s "Which reader" docstring now names the fourth
extension and why it is deliberately not escaped there.

## Verification

- Regenerated: CSV byte-identical, `.md` differs in exactly the one intended
  cell (old-vs-new diff is one line). The wrap is Markdown-only, so no number
  and no CSV consumer moves — corpus v2 stays frozen.
- `make check-fast` exit 0; `make lint` exit 0; `/verify-adherence` **PASS**
  (mechanical phase can be skipped on the next `/gaze`).
- Full `make check` run (diff touches `scripts/`): 8 failures, all
  `tests/test_corpus_acceptance.py` / `test_corpus_flow.py` reporting
  `data/catalogs/*` absent — the known worktree-without-`make data` class,
  not reachable from a config-only emitter.

**Ticket:** tickets/0530-smart-typography-rewrites-a-published-query.erg
