### PR TITLE
ticket(0361): log additional flag-5 prose surfaces

### DIFF
--- a/tickets/0361-flag-5-calibration-and-activation-sign-o.erg
+++ b/tickets/0361-flag-5-calibration-and-activation-sign-o.erg
@@ -10,6 +10,7 @@ Author: HDMX-coding-agent
 2026-07-27T17:40Z HDMX-coding-agent note author leans option B (retire): 'Flag 5 seems better suited to detect outliers and investigate, rather than filter'. Independent Fable-model defense round commissioned on the instrument, its implementation, state of the art, and redundancy with flags 1-4/6 before the call is fixed
 2026-07-27T17:57Z HDMX-coding-agent note blocker 0336 closed — Blocked-by removed.
 2026-07-28T21:50Z HDMX-coding-agent note author flagged the prose surfaces still describing an active flag 5 / six-flag pipeline while dvc.yaml holds it inert: data-paper.qmd section 2.2 (six-flag pipeline, flag 5 sentence), section 2.4 (six-flag filter), and export_corpus_table.py caption (six-flag quality filtering). Sweep them all when this decision lands.
+2026-07-29T09:30Z HDMX-coding-agent note roar sweep after PR #1285 found three more six-flag/flag-5 prose surfaces for the retirement sweep: deliverables/_shared/_includes/corpus-enrichment.md (flag 5 in §3), corpus-filtering.md (six flags), scripts/figures/export_filter_ablation.py (six-flag / Flag 5 comments); tab_corpus_sources.md caption regenerates from export_corpus_table.py, already listed
 --- body ---
 ## Context
 


### PR DESCRIPTION
Roar sweep after PR #1285: three more six-flag/flag-5 surfaces logged in ticket 0361 for the retirement sweep.

Ticket-ref: tickets/0361-flag-5-calibration-and-activation-sign-o.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)