### PR TITLE
refactor: delete dormant markdown_cell and its wrong span-escape rule

### DIFF
--- a/scripts/_markdown_table.py
+++ b/scripts/_markdown_table.py
@@ -12,13 +12,8 @@ wrong one: it normalises *corpus* text (encoding artifacts, DOIs, language
 codes) and pulls in pandas, ftfy and langdetect for it. Escaping markup is a
 different concern with no dependencies at all.
 
-Three functions, because the callers hold three different input contracts:
+Two functions, because the callers hold two different input contracts:
 
-``markdown_cell``
-    The input **is** Markdown — a curated description authored in-repo, whose
-    backticks are intentional code spans. Written for the deposit codebook; no
-    live caller under ``scripts/`` today, and its rule is pinned by
-    ``tests/test_variables_table.py`` (see the ``_MARKDOWN_CODE`` note below).
 ``markdown_text_cell``
     The input is plain text with no markup intent — a journal name out of the
     bibliographic corpus, a source label edited by hand, a language code the
@@ -31,8 +26,15 @@ Three functions, because the callers hold three different input contracts:
     ``smart``. Used for the deposited ISTEX query (ticket 0530).
 
 Collapsing them into one function is the trap this split avoids: a journal name
-that happens to contain two backticks is not a code span, and applying the
-Markdown-aware rule to it would silently typeset half the name as code.
+is prose the reader should typeset (curly quotes and all), while a query set in
+a code span is a value the reader must receive byte-for-byte.
+
+A third sibling, ``markdown_cell``, took Markdown authored in-repo whose
+backticks were intentional code spans. It was written for the retired deposit
+codebook, never gained a live caller, and carried a measured-wrong rule (a
+backslash-pipe escape inside a span, which a span renders literally — the #1289/#1290
+lesson). Deleted 2026-07-29; git history keeps it, and any revival should build
+its span handling on ``markdown_verbatim_cell``'s fence construction instead.
 
 **Which reader these rules are calibrated to (ticket 0376).** Not GFM, though
 the tables look like GFM pipe tables. Quarto's ``from:`` is a custom Lua reader,
@@ -66,24 +68,10 @@ which describes neither the Lua reader nor the extension set it selects.
 import re
 
 # In prose the pipe is escaped and the backslash with it, because CommonMark
-# reads a backslash as an escape there.
-#
-# ``_MARKDOWN_CODE`` escapes the pipe *inside* a span, and that rule is wrong —
-# measured, 2026-07-28, against the reader above: ``a \| b`` inside a span
-# renders the backslash literally, and a raw ``a | b`` inside a span parses as
-# one cell, because pandoc's pipe-table splitter respects spans. The comment
-# here used to claim the reader "honours ``\|`` inside a code span too", and
-# that claim is what ``markdown_verbatim_cell``'s first draft inherited before
-# the #1289 review caught it. Left in place rather than fixed: ``markdown_cell``
-# is the only user and has no live caller today, so changing its output would be
-# an unverifiable edit to a dormant path. Corrected here so the next reader does
-# not inherit the same false premise a third time (ticket 0530). Whoever does
-# fix it should know that ``tests/test_variables_table.py`` currently *pins* the
-# escaped form, so the guard moves with the behaviour.
+# reads a backslash as an escape there. Inside a code span the opposite holds —
+# no escape is processed at all — which is why the span path below escapes
+# nothing (measured 2026-07-28 against the reader above; #1289 review).
 _PROSE = {"\\": r"\\", "|": r"\|"}
-
-_MARKDOWN_TEXT = str.maketrans(_PROSE)
-_MARKDOWN_CODE = str.maketrans({"|": r"\|"})
 
 # Plain text extends the prose rule rather than restating it: no character
 # carries markup intent, so the backtick is escaped rather than opening a span,
@@ -122,35 +110,6 @@ _MARKDOWN_LITERAL = str.maketrans({
 # backslashes its own earlier substitutions introduced.
 
 
-def _split_spans(text: str) -> list[str]:
-    """Split Markdown on backticks; odd indices are code-span interiors."""
-    parts = text.split("`")
-    if len(parts) % 2 == 0:
-        raise ValueError(f"unbalanced backtick in description: {text!r}")
-    return parts
-
-
-def markdown_cell(text: str) -> str:
-    """Markdown description → a Markdown pipe-table cell.
-
-    A raw ``|`` ends the cell, so the codebook's reconstruction recipe used to
-    be published cut in half. Escaping both sides of a span boundary blindly
-    would corrupt any description documenting a regex or a path; escaping
-    neither reintroduces the cell split, one layer down, for a value that
-    already contains ``\\|``.
-
-    Raises ``ValueError`` on an unbalanced backtick, and deliberately keeps
-    doing so: the input is Markdown authored in this repo, where an odd
-    backtick is a typo whose intent is genuinely ambiguous — guessing would
-    either escape a real code span or typeset prose as code. Free text from the
-    corpus must not take this path; see ``markdown_text_cell``.
-    """
-    return "`".join(
-        part.translate(_MARKDOWN_CODE) if i % 2 else part.translate(_MARKDOWN_TEXT)
-        for i, part in enumerate(_split_spans(text))
-    )
-
-
 def markdown_verbatim_cell(text: str) -> str:
     """Plain text → a pipe-table cell the reader renders as a code span.
 
@@ -170,8 +129,8 @@ def markdown_verbatim_cell(text: str) -> str:
 
     **Nothing is escaped**, and that is the whole point of a span: CommonMark
     processes no backslash escape inside one, so an escape does not protect the
-    value, it *becomes* the value. Measured, because the module comment above
-    asserted the opposite and the first draft of this function inherited it —
+    value, it *becomes* the value. Measured, because this module once asserted
+    the opposite and the first draft of this function inherited it —
     ``pandoc -f markdown`` renders ``a \\| b`` inside a span as the literal
     ``a \\| b``, and renders a raw ``a | b`` inside a span as ``a | b`` in one
     cell. The pipe needs no escape here: the reader's pipe-table splitter
@@ -214,8 +173,8 @@ def markdown_text_cell(text: str) -> str:
     as the pipe, one level below the escaper.
 
     Never raises. These emitters feed a rendered manuscript, and a bibliographic
-    string is not a contract the build may reject: inheriting ``markdown_cell``'s
-    ValueError would turn one odd backtick in a corpus record — a character with
-    no meaning there — into a failed manuscript build.
+    string is not a contract the build may reject: raising on an odd backtick
+    would turn one such character in a corpus record — a character with no
+    meaning there — into a failed manuscript build.
     """
     return str(text).translate(_MARKDOWN_LITERAL)

--- a/scripts/figures/export_retrieval_protocol.py
+++ b/scripts/figures/export_retrieval_protocol.py
@@ -70,14 +70,10 @@ def _load(name):
 def _cell(value) -> str:
     """Make a value safe for a pipe-table cell.
 
-    ``markdown_text_cell``, not ``markdown_cell``: every value here is plain
-    text with no markup intent — YAML config strings and 17 bibliographic
-    titles from the institutional-reports seed list. ``markdown_cell`` is
-    reserved for Markdown
-    authored in this repo and raises on an unbalanced backtick, so a stray
-    backtick in a report title would abort the build, and a paired one would
-    typeset half a title as code. Neither is a contract a bibliographic
-    string should be held to (ticket 0339's escaper split).
+    ``markdown_text_cell``: every value here is plain text with no markup
+    intent — YAML config strings and 17 bibliographic titles from the
+    institutional-reports seed list — so every escapable character is escaped
+    and nothing is read as syntax (ticket 0339's escaper split).
     """
     return markdown_text_cell(" ".join(str(value).split()))
 

--- a/tests/test_markdown_table.py
+++ b/tests/test_markdown_table.py
@@ -4,10 +4,9 @@ The rendered-page oracles in `test_rendered_venue_table_fidelity.py` are the
 ones that prove the escaping *works*; they need pandoc and skip without it, so
 these fast-tier tests keep the rule itself covered on any machine.
 
-`markdown_cell`'s own rule is pinned in `test_variables_table.py`, next to the
-codebook contract it serves. What is pinned here is the plain-text sibling and,
-above all, the boundaries between them — the reason the module splits at all.
-Ticket 0530 adds the third sibling, `markdown_verbatim_cell`, at the bottom.
+What is pinned here is the plain-text escaper and, above all, the boundary with
+its sibling — the reason the module splits at all. Ticket 0530 adds the second
+sibling, `markdown_verbatim_cell`, at the bottom.
 
 Ticket 0376 adds one rendered class at the bottom of this module rather than in
 a fidelity suite: what it pins is the *character set* — a property of the
@@ -17,11 +16,7 @@ escaper itself — against the reader the build really uses.
 import os
 
 import pytest
-from _markdown_table import (
-    markdown_cell,
-    markdown_text_cell,
-    markdown_verbatim_cell,
-)
+from _markdown_table import markdown_text_cell, markdown_verbatim_cell
 
 TESTS_DIR = os.path.dirname(__file__)
 SCRIPTS_DIR = os.path.join(TESTS_DIR, "..", "scripts")
@@ -77,32 +72,19 @@ class TestPlainTextEscaping:
 
 
 class TestContractBoundary:
-    """The two functions differ by input contract, not by error policy."""
+    """Free text is data, not markup this repo authored."""
 
     def test_free_text_never_raises_on_an_odd_backtick(self):
         """A stray backtick in a bibliographic record is a character, not a typo.
 
-        Inheriting `markdown_cell`'s ValueError here would let one such
-        character fail a manuscript build.
+        Raising here would let one such character fail a manuscript build.
         """
         assert markdown_text_cell("Journal of ` Studies") == r"Journal of \` Studies"
 
-    def test_authored_markdown_still_rejects_an_odd_backtick(self):
-        """The raise is right where the input *is* Markdown: an unbalanced
-        backtick is an authoring typo whose intent cannot be guessed."""
-        with pytest.raises(ValueError, match="unbalanced backtick"):
-            markdown_cell("a `dangling span")
-
-    def test_balanced_backticks_are_a_code_span_only_for_authored_markdown(self):
-        """The case a mere non-raising variant would still get wrong.
-
-        Two backticks in a journal name are two characters; in a codebook
-        description they delimit a code span, which is escaped by the other
-        rule. One function cannot serve both.
-        """
-        payload = "a `b | c` d"
-        assert markdown_cell(payload) == r"a `b \| c` d"
-        assert markdown_text_cell(payload) == r"a \`b \| c\` d"
+    def test_balanced_backticks_are_characters_not_a_span(self):
+        """Two backticks in a journal name are two characters, never a code
+        span — the value carries no markup intent."""
+        assert markdown_text_cell("a `b | c` d") == r"a \`b \| c\` d"
 
 
 class TestLineBreaks:

--- a/tests/test_markdown_table_shape.py
+++ b/tests/test_markdown_table_shape.py
@@ -25,7 +25,7 @@ Adherence tier: the guard reads files and runs nothing.
 import re
 
 import pytest
-from _markdown_table import markdown_cell, markdown_text_cell
+from _markdown_table import markdown_text_cell
 from _mk_discovery import (
     REPO_ROOT,
     generated_markdown_targets,
@@ -158,9 +158,9 @@ def scan(text: str) -> tuple[list[tuple[int, list[str], list[tuple[int, list[str
 
     - **Orphans.** A raw newline inside a value ends the table at that line, so
       every row below it belongs to no table and would never be width-checked.
-      ``markdown_text_cell`` folds a newline to a space, but ``markdown_cell``
-      (the codebook path) does not, so the hole is reachable from a shipped
-      emitter. Any line outside a fence that carries an unescaped ``|`` and no
+      ``markdown_text_cell`` folds a newline to a space, but a hand-written
+      table has no escaper in front of it, so the hole stays reachable.
+      Any line outside a fence that carries an unescaped ``|`` and no
       table claimed is reported.
     - **Torn rows.** The orphan rule needs the remainder to still carry a pipe,
       and when the newline lands in the *last* column it does not: the row above
@@ -321,8 +321,8 @@ def test_parser_flags_a_delimiter_row_of_the_wrong_width():
 def test_parser_flags_rows_orphaned_by_a_raw_newline():
     """A newline inside a value ends the table; the break itself must be named.
 
-    `markdown_cell` — the codebook path — does not fold newlines, so this hole
-    is reachable from a shipped emitter. Both documents below carry the same
+    A newline can reach a hand-edited table even though every live emitter
+    folds them. Both documents below carry the same
     defect, and the short one is why this test asserts twice. It used to append
     the synthetic `| x | y | z |` row and assert only on that, so it passed for
     a reason unrelated to its name: strip the trailing row and the same broken
@@ -347,21 +347,21 @@ def test_parser_flags_rows_orphaned_by_a_raw_newline():
 
 
 def test_a_torn_last_cell_is_caught_across_a_blank_line():
-    """The shipped shape: `markdown_cell` passes a paragraph break straight through.
+    """A paragraph break in the last cell must be named, not read as clean.
 
-    `scripts/_deposit_variables.py:402` routes every codebook Description — free
-    Markdown prose, and the table's last column — through `markdown_cell`, which
-    folds nothing. A paragraph break in one description emits a blank line
+    A paragraph break inside a hand-written description emits a blank line
     mid-table: the row above it still counts its declared cells and passes, the
     table ends on the blank, and the tail of the description lands below as
     prose carrying the row's closing pipe. That remainder is a single cell,
-    which is precisely what a width check cannot see.
+    which is precisely what a width check cannot see. (The emitter that once
+    passed newlines through, `markdown_cell`, is deleted; the parser hole it
+    exposed stays covered.)
     """
     description = "first para\n\nsecond para"
     doc = (
         "| Variable | Description |\n"
         "|:--|:--|\n"
-        f"| `x` | {markdown_cell(description)} |\n"
+        f"| `x` | {description} |\n"
     )
     offenders = malformed_rows(doc)
     assert offenders, "a paragraph break inside the last cell read as clean"
@@ -454,13 +454,6 @@ def test_escaped_free_text_keeps_the_row_whole(payload):
     assert not malformed_rows(doc), payload
 
 
-def test_markdown_cell_output_keeps_the_row_whole():
-    """The codebook path: Markdown input whose code span carries a live pipe."""
-    recipe = "df[~df['is_flagged'] | df['is_protected']]"
-    doc = f"| Variable | Description |\n|:--|:--|\n| x | {markdown_cell(recipe)} |\n"
-    assert not malformed_rows(doc)
-
-
 def test_parser_reads_a_real_shipped_table():
     """Real-world positive: the parser reads a deposited table's true shape.
 
@@ -473,7 +466,7 @@ def test_parser_reads_a_real_shipped_table():
     escape path against a *deposited* artifact. That row now lives in a LaTeX
     longtable (tab_variables.md) and in datapackage.json, neither a pipe table,
     and no shipped Markdown table carries an escaped pipe any more. The escape
-    itself stays covered by the fixture tests on ``markdown_cell`` output; what
+    itself stays covered by the fixture tests on ``markdown_text_cell`` output; what
     is lost is the real-file half of that pair.
     """
     path = REPO_ROOT / CANONICAL
@@ -661,7 +654,7 @@ def test_generated_markdown_rows_match_their_header(artifact):
         f"{artifact} (built by {GENERATED[artifact]}) has rows whose cell count "
         "differs from their header — a raw `|` in an interpolated value splits "
         "the cell and the renderer drops the overflow. Route free text through "
-        "scripts/_markdown_table.py (markdown_text_cell / markdown_cell):\n  "
+        "scripts/_markdown_table.py (markdown_text_cell):\n  "
         + "\n  ".join(offenders)
     )
 

--- a/tests/test_variables_table.py
+++ b/tests/test_variables_table.py
@@ -24,7 +24,6 @@ from _deposit_variables import (
     render_markdown_table,
     transform,
 )
-from _markdown_table import markdown_cell
 from utils import FROM_COLS, WORKS_COLUMNS
 
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -292,30 +291,6 @@ class TestLatexEscaping:
         """A malformed contract description fails loudly, not silently."""
         with pytest.raises(ValueError, match="backtick"):
             latex_inline("a `dangling span")
-
-
-class TestMarkdownCellEscaping:
-    """A raw `|` ends a pipe-table cell, so payload text must escape it.
-
-    Same defect class as the LaTeX one — a delimiter inside payload — in the
-    other markup language the contract's descriptions render into. The retired
-    codebook published the recipe cut in half at the `|`; these rules are what
-    kept the remaining Markdown table emitters from repeating it.
-    """
-
-    def test_backslash_is_escaped_only_where_markdown_reads_it(self):
-        """Prose and code disagree on what a backslash means, so the cell
-        cannot use one rule for both. Escaping both blindly would corrupt a
-        description documenting a regex; escaping neither would let a value
-        already containing `\\|` split the cell — this ticket's defect, one
-        escape layer down."""
-        assert markdown_cell(r"a \ b") == r"a \\ b"
-        assert markdown_cell(r"a `\d{4}` b") == r"a `\d{4}` b"
-        assert markdown_cell(r"a \| b") == r"a \\\| b"
-
-    def test_pipe_is_escaped_on_both_sides_of_a_span(self):
-        assert markdown_cell("a | b") == r"a \| b"
-        assert markdown_cell("a `x | y` b") == r"a `x \| y` b"
 
 
 class TestDataPaperIntegration:


### PR DESCRIPTION
**Ticket:** none

Follow-up simplification from the #1289/#1290 verbatim-cell work, at the author's request ("simplify").

`markdown_cell` was dormant (no production caller — the codebook emitter it was written for renders LaTeX via `_deposit_variables.py`), and it carried the measured-wrong `_MARKDOWN_CODE` rule: a `\|` escape inside a code span, which pandoc renders literally. ~150 lines of tests pinned it, including pinning that wrong output.

Deleted: the function, `_split_spans`, `_MARKDOWN_CODE`, `_MARKDOWN_TEXT`, `TestMarkdownCellEscaping` (test_variables_table), two contract-boundary tests (test_markdown_table), one shape fixture (test_markdown_table_shape). Reworded the stale docstrings — one claimed a live caller at `_deposit_variables.py:402` that no longer exists. The module docstring records the deletion and points any revival at `markdown_verbatim_cell`'s fence construction.

Net −141/+46. Gate: `make check-fast` exit 0, `make lint` 333 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)