### PR TITLE
edit(rdj26561): fix stale claims in response letter; draft editor cover letter

### DIFF
--- a/deliverables/data-paper/revision-rdj26561/editor-letter.md
+++ b/deliverables/data-paper/revision-rdj26561/editor-letter.md
@@ -1,0 +1,64 @@
+# DRAFT — Cover letter to the editor, RDJ-26561 (author sign-off required before submission)
+
+Companion to `response-letter.md` (point-by-point reply) and
+`summary-of-revisions.md`. This letter carries the substance the editor
+needs before reading either: what changed in the dataset, what changed in
+the paper, and the choices that call for an editorial judgment.
+
+Dear Dr Chambru,
+
+Please find the revised version of manuscript RDJ-26561, "A Curated
+Multi-Source Corpus of Climate Finance Literature, 1990–2024," together
+with a summary of revisions and a point-by-point reply to your letter and
+to the referee report. Every point raised has been addressed; one is
+answered with a justified alternative rather than the requested change,
+flagged below. Three matters deserve your attention beyond the
+point-by-point reply.
+
+**The dataset itself changed, not only the paper.** Prompted by the
+referee's remark on institutional coverage (R1-06), the revision extends
+the corpus with a curated layer of UNFCCC and OECD DAC key documents —
+COP decisions on finance, Biennial Assessments, Rio-marker reporting
+directives — as a durable pipeline source with its own provenance flags.
+The corpus grows from 42,916 to 43,179 unified works (30,987 to 33,344
+after filtering), the source count from six to eight, and the deposit
+title drops "Six Sources" accordingly (same Zenodo concept DOI, new
+version). The Zenodo package is also restructured as you requested
+(ED-04): `code/`, `data/inputs/` (per-source catalogs as harvested), and
+`data/products/` (final corpus files with a machine-readable, executable
+data dictionary). Every statistic, table, and figure in the paper was
+regenerated from the v2 corpus by the deposited pipeline; no number is
+hand-typed.
+
+**The revision strengthens the paper partly by weakening its claims.**
+Rerun on the v2 corpus, the citation-link audit now reports 97.0%
+confirmed (previously 99.0%), and the paper states what that audit
+measures: agreement with Crossref, not ground truth, partly circular for
+links harvested from Crossref or OpenAlex deposits. The revision also
+quantifies a bias no one asked about: the relevance filter removes a
+larger share of non-English works, and rescoring against own-language
+queries shows the score partly reflects query language. Both statements
+trade headline polish for accuracy; I hope the journal reads them as the
+data paper's job.
+
+**One referee suggestion is declined with an alternative** (R1-19,
+restructuring the corpus CSV). The file layout stays: reshaping a
+published Zenodo artifact would break every downstream consumer for a
+viewer-ergonomics gain. Instead the revision documents the structure — a
+generated variables table in the paper and a Frictionless
+`datapackage.json` in the deposit that a reader can execute to verify the
+file against its own documentation.
+
+One placement choice is reversible at your preference: to hold the
+2,500-word budget, the three literature replications requested under
+ED-02 (growth break, pole disconnection, finance-journal share) are
+reported in the response letter, with only the growth break retained in
+the paper's Section 4. I will gladly reinstate them in the text if you
+prefer.
+
+Thank you and the referee for a report that made both the paper and the
+dataset better.
+
+Sincerely,
+
+Minh Ha-Duong

--- a/deliverables/data-paper/revision-rdj26561/editor-letter.md
+++ b/deliverables/data-paper/revision-rdj26561/editor-letter.md
@@ -23,10 +23,10 @@ directives — as a durable pipeline source with its own provenance flags.
 The corpus grows from 42,916 to 43,179 unified works (30,987 to 33,344
 after filtering), the source count from six to eight, and the deposit
 title drops "Six Sources" accordingly (same Zenodo concept DOI, new
-version). The Zenodo package is also restructured as you requested
-(ED-04): `code/`, `data/inputs/` (per-source catalogs as harvested), and
-`data/products/` (final corpus files with a machine-readable, executable
-data dictionary). Every statistic, table, and figure in the paper was
+version). The new Zenodo version, uploaded with this resubmission,
+restructures the package as you requested (ED-04): `code/`,
+`data/inputs/` (per-source catalogs as harvested), and `data/products/`
+(final corpus files with a machine-readable, executable data dictionary). Every statistic, table, and figure in the paper was
 regenerated from the v2 corpus by the deposited pipeline; no number is
 hand-typed.
 

--- a/deliverables/data-paper/revision-rdj26561/response-letter.md
+++ b/deliverables/data-paper/revision-rdj26561/response-letter.md
@@ -19,11 +19,11 @@ point by point, first to your letter, then to the referee report.
 ## Reply to the editor
 
 **ED-01 (OpenAlex caveats, deduplication, regional databases).** I added
-Section 2.4, "OpenAlex limitations and pipeline responses," with a table
-(@tbl-openalex-limits) mapping each documented OpenAlex flaw — query false
-positives, duplicate records, missing abstracts, incorrect citation
-assignments, contaminated abstract fields, missing full-text — to the
-pipeline step that addresses it, or to an explicit "not mitigated" statement.
+Section 2.4, "Limitations and Potential Biases," which reviews each
+documented OpenAlex flaw — query false positives, duplicate records, missing
+abstracts, incorrect citation assignments, contaminated abstract fields,
+missing full-text — and pairs it with the pipeline step that addresses it,
+or with an explicit "not mitigated" statement.
 The section names deduplication's residual weak point (works sharing neither
 a DOI nor a normalised title+year pair, such as a preprint and its retitled
 published version) rather than claiming the merge passes catch everything.
@@ -176,10 +176,13 @@ title, first author, and year against corpus works. What I do not do — and
 the revised Section 3 states this explicitly — is full-text reference
 extraction from PDFs: I do not hold the full texts of the corpus's academic
 works, so parsing PDFs of the entire corpus is not feasible under current
-access conditions; the "Missing full-text" row of @tbl-openalex-limits keeps
-this limitation as explicitly not mitigated. On incorrect assignments
-generally, the existing 300-link audit against Crossref (99.0% confirmed,
-95% CI [97.1%, 99.7%]) addresses link accuracy; the new reference-count
+access conditions; Section 2.4 keeps this limitation as explicitly not
+mitigated. On incorrect assignments
+generally, the 300-link audit against Crossref (97.0% confirmed on the v2
+corpus, 95% CI [94.4%, 98.4%]) addresses link accuracy — the revised
+Section 2.3 also states what the audit measures: agreement with Crossref,
+not ground truth, partly circular for links harvested from Crossref or
+OpenAlex deposits; the new reference-count
 reporting addresses list completeness — the "empty or aberrant" failure mode
 the referee describes.
 

--- a/deliverables/data-paper/revision-rdj26561/response-letter.md
+++ b/deliverables/data-paper/revision-rdj26561/response-letter.md
@@ -1,8 +1,9 @@
 # DRAFT — Response letter, RDJ-26561 (author sign-off required before submission)
 
-Manuscript RDJ-26561, "A Curated Corpus of Climate Finance Literature,
-1990–2024" — point-by-point reply to the editor's letter and to the referee
-report. Assembled 2026-07-24 (ticket 0283); corpus numbers reflect the v2
+Manuscript RDJ-26561, submitted as "A Curated Corpus of Climate Finance
+Literature, 1990–2024" (retitled "A Curated Multi-Source Corpus of Climate
+Finance Literature, 1990–2024" in this revision) — point-by-point reply to
+the editor's letter and to the referee report. Assembled 2026-07-24 (ticket 0283); corpus numbers reflect the v2
 rebuild of 2026-07-24.
 
 Dear Dr Chambru,
@@ -83,8 +84,9 @@ the pipeline from the deposit's declared column contract, which the export
 script checks when writing the CSV, so the published table cannot drift from
 the deposited file.
 
-**ED-04 (Zenodo package structure).** I restructured the Zenodo package to
-separate raw data inputs from final data products. The new version of the
+**ED-04 (Zenodo package structure).** The Zenodo package is restructured to
+separate raw data inputs from final data products; the new version is
+uploaded with this resubmission. The new version of the
 deposit (same concept DOI) contains `data/inputs/` with the per-source
 catalogs as harvested, and `data/products/` with the paper's outputs
 (`climate_finance_corpus.csv`, `datapackage.json`,
@@ -222,7 +224,7 @@ annual totals do not depend on abstract length.
 **R1-16c (non-English coverage wording).** The referee is correct that
 OpenAlex includes non-English sources, so the earlier wording overstated.
 Section 2.3 now claims only the incremental coverage the smaller sources add:
-"the five smaller sources increase the corpus's non-English, institutional,
+"the seven smaller sources increase the corpus's non-English, institutional,
 and pedagogical coverage." The parallel exclusivity phrasing in the
 conclusion was removed in the same pass.
 

--- a/deliverables/data-paper/revision-rdj26561/summary-of-revisions.md
+++ b/deliverables/data-paper/revision-rdj26561/summary-of-revisions.md
@@ -10,9 +10,9 @@ Manuscript RDJ-26561, "A Curated Corpus of Climate Finance Literature,
    unified works (30,987 to 33,344 after filtering); all statistics, tables, and figures were regenerated from
    the v2 corpus by the deposited pipeline. (R1-06)
 
-2. **New Section 2.4, "OpenAlex limitations and pipeline responses."** A
-   table maps each documented OpenAlex flaw to the pipeline step that
-   addresses it, or to an explicit "not mitigated" statement; the section
+2. **New Section 2.4, "Limitations and Potential Biases."** The section
+   pairs each documented OpenAlex flaw with the pipeline step that
+   addresses it, or with an explicit "not mitigated" statement; it also
    names concrete regional databases (SciELO, Garuda) as complements.
    (ED-01, R1-07, R1-10, R1-11, R1-16b)
 
@@ -26,8 +26,9 @@ Manuscript RDJ-26561, "A Curated Corpus of Climate Finance Literature,
    per-document reference-count distribution, including the zero-reference
    share and its concentration in books, reviews, and grey literature;
    GROBID-based parsing of unresolved reference strings is now part of the
-   pipeline; the 300-link Crossref audit (99.0% confirmed) is retained.
-   (R1-13)
+   pipeline; the 300-link Crossref audit, rerun on the v2 corpus, confirms
+   97.0% of sampled links, and the paper now states what the audit measures:
+   agreement with Crossref, not ground truth. (R1-13)
 
 5. **Citation network demonstrated.** A new figure presents a global map of
    the corpus citation network (Louvain communities on the direct-citation
@@ -36,9 +37,11 @@ Manuscript RDJ-26561, "A Curated Corpus of Climate Finance Literature,
 
 6. **Added value made concrete.** The conclusion discusses the research
    directions the database enables and references the Œconomia companion
-   paper; the literature review re-tests six published results on the
-   corpus; a replication of prior mappings' published queries shows 89–91%
-   coverage of the climate finance populations they drew on. (ED-02, R1-18)
+   paper; three published results are re-tested on the corpus, each with one
+   explicit statistical test (reported in the response letter to hold the
+   word budget; the growth break stays in Section 4); a replication of prior
+   mappings' published queries shows 89–91% coverage of the climate finance
+   populations they drew on. (ED-02, R1-18)
 
 7. **Variables table and data dictionary.** Section 3 adds a generated table
    describing every variable of `climate_finance_corpus.csv`; the Zenodo

--- a/deliverables/data-paper/revision-rdj26561/summary-of-revisions.md
+++ b/deliverables/data-paper/revision-rdj26561/summary-of-revisions.md
@@ -1,7 +1,9 @@
 # DRAFT — Summary of revisions, RDJ-26561 (author sign-off required before submission)
 
-Manuscript RDJ-26561, "A Curated Corpus of Climate Finance Literature,
-1990–2024." Main revisions, 2026-07 round.
+Manuscript RDJ-26561, submitted as "A Curated Corpus of Climate Finance
+Literature, 1990–2024," retitled "A Curated Multi-Source Corpus of Climate
+Finance Literature, 1990–2024" in this revision. Main revisions, 2026-07
+round.
 
 1. **Corpus extended (v2).** A curated layer of UNFCCC and OECD DAC key
    documents (COP decisions on finance, Biennial Assessments, Rio-marker


### PR DESCRIPTION
**Ticket-ref:** tickets/0274-rdj26561-rr-round-1-tracker.erg

Prose-only PR on the RDJ-26561 revision correspondence (no code, no manuscript body).

## Corrections (response-letter.md, summary-of-revisions.md)
- Section 2.4 was described as carrying a table `@tbl-openalex-limits`; the cut plan turned it into prose. Wording now matches the paper ("Limitations and Potential Biases", flaw-by-flaw prose).
- Citation-audit numbers updated from v1 (99.0% [97.1, 99.7]) to v2 (97.0% [94.4, 98.4]), with the audit's stated scope (agreement with Crossref, not ground truth). Same staleness class as ticket 0625.
- Literature replications count corrected (three, reported in the response letter for word budget).

## New: editor-letter.md (DRAFT, author sign-off required)
Cover letter to the editor carrying the substance beyond the point-by-point reply: dataset v2 extension (UNFCCC/OECD layer, 6→8 sources, retitled deposit, same concept DOI), all numbers pipeline-regenerated, claims deliberately weakened for accuracy, the one declined referee point (R1-19) with its documented alternative, and the reversible placement of the ED-02 replications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)