### PR TITLE
release(0283): archive render rule drops stale fig_bars prerequisite

### DIFF
--- a/build/templates/Makefile.datapaper
+++ b/build/templates/Makefile.datapaper
@@ -47,7 +47,6 @@ $(DATAPAPER): deliverables/data-paper/data-paper.qmd \
               deliverables/data-paper/data-paper-vars.yml \
               deliverables/data-paper/_quarto.yml \
               $(SHARED)/bibliography/main.bib \
-              $(SHARED)/figures/fig_bars.png \
               $(SHARED)/figures/fig_global_map_direct.png \
               $(SHARED)/tables/tab_corpus_flow.md \
               $(SHARED)/tables/tab_corpus_sources.md \


### PR DESCRIPTION
Clean-room RC1 verification caught it: make papers in the extracted archive fails on a figure the paper dropped in 0332. One-line fix; figure list now matches the paper's single embedded figure.

**Ticket-ref:** tickets/0283-response-letter-reconciliation.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)