### PR TITLE
paper(0274): keywords below the abstract + DOCX-surviving tables

### DIFF
--- a/deliverables/_shared/tables/tab_variables.md
+++ b/deliverables/_shared/tables/tab_variables.md
@@ -1,3 +1,4 @@
+::: {.content-visible when-format="pdf"}
 ::: {#tbl-variables tbl-pos="tbp"}
 ```{=latex}
 \begin{tabular}{@{}l p{10.4cm}@{}}
@@ -43,4 +44,43 @@ Variable & Description \\
 ```
 
 Variables of `climate_finance_corpus.csv`, in four groups: record identity, bibliographic metadata, provenance flags, curation metadata. Generated from the deposit column contract (`scripts/_deposit_variables.py`); storage types, allowed values, ranges and measured missingness are in the deposited `datapackage.json`.
+:::
+:::
+
+::: {.content-visible unless-format="pdf"}
+| Variable | Description |
+|:---------|:------------|
+| `source` | Primary source catalog for the record's metadata |
+| `source_id` | Identifier in the primary source (e.g. OpenAlex work ID) |
+| `doi` | Digital Object Identifier, when available |
+| `title` | Title of the work |
+| `first_author` | First author name |
+| `all_authors` | Full author list, separator-joined |
+| `year` | Publication year |
+| `journal` | Publication venue (journal, publisher, or repository) |
+| `language` | Language code (ISO 639-1), detected and normalised |
+| `keywords` | Keywords, semicolon-separated |
+| `categories` | Subject categories / concepts from the source catalog |
+| `cited_by_count` | Citation count (OpenAlex, as of the collection date) |
+| `affiliations` | Author affiliations, when available |
+| `from_openalex` | Provenance flag: found in OpenAlex |
+| `from_istex` | Provenance flag: found in ISTEX |
+| `from_bibcnrs` | Provenance flag: found in bibCNRS |
+| `from_scispace` | Provenance flag: found via SciSpace |
+| `from_grey` | Provenance flag: institutional reports (Section 2.1) |
+| `from_teaching` | Provenance flag: teaching canon (syllabi) |
+| `from_unfccc` | Provenance flag: curated UNFCCC key document |
+| `from_oecd` | Provenance flag: curated OECD key document |
+| `abstract_provenance` | Provenance of the abstract, for curated key documents only |
+| `keywords_provenance` | Provenance of the keywords, for curated key documents only |
+| `language_provenance` | How the language code was obtained (Section 2.4) |
+| `source_count` | Number of sources that contributed the record |
+| `abstract_status` | Fate of the undistributed abstract (Section 3) |
+| `near_duplicate_group` | Group id of near-identical content under several DOIs |
+| `is_flagged` | Any quality flag raised (refined-subset rule: Section 3) |
+| `flag_reason` | Comma-separated raised quality flags; empty when unflagged |
+| `is_protected` | Protection from removal (key papers kept despite flags) |
+| `protection_reason` | Why the work is protected (Section 2.2) |
+
+: Variables of `climate_finance_corpus.csv`, in four groups: record identity, bibliographic metadata, provenance flags, curation metadata. Generated from the deposit column contract (`scripts/_deposit_variables.py`); storage types, allowed values, ranges and measured missingness are in the deposited `datapackage.json`. {#tbl-variables}
 :::

--- a/deliverables/data-paper/data-paper.qmd
+++ b/deliverables/data-paper/data-paper.qmd
@@ -49,6 +49,8 @@ format:
 <!-- Format: Data Paper, max 2,500 words, diamond OA, IISG/Openjournals -->
 <!-- Structure follows Petram & Kruizinga (2024) exemplar: Introduction, Method, Data, Concluding Remarks -->
 
+**Keywords:** climate finance, bibliometric corpus, multilingual, sentence-transformer embeddings, scientometrics, history of economic thought
+
 - Related dataset: "A Curated Multi-Source Corpus of Climate Finance Literature, 1990--2024" with DOI [10.5281/zenodo.19236130](https://doi.org/10.5281/zenodo.19236130) in repository "Zenodo"
 
 ## 1. Introduction {#sec-introduction}
@@ -75,6 +77,7 @@ The dataset was constructed for a history-of-economic-thought study of how clima
 
 The corpus assembles academic literature and institutional documents from {{< meta corpus_sources >}} sources with complementary coverage profiles (@tbl-sources). Five are automated or semi-automated (reproducible from the scripts and an internet connection); three require manual export from restricted platforms.
 
+::: {.content-visible when-format="pdf"}
 ::: {#tbl-sources tbl-pos="tbp"}
 ```{=latex}
 \begin{tabular}{@{}p{0.17\linewidth} p{0.30\linewidth} p{0.42\linewidth}@{}}
@@ -94,6 +97,22 @@ OECD & Hand-harvested & Statistical guidelines \\
 ```
 
 Sources, automation level, and coverage scope.
+:::
+:::
+
+::: {.content-visible unless-format="pdf"}
+| Source | Automation | Coverage |
+|:-------|:-----------------|:---------------------------|
+| OpenAlex (Priem et al. 2022) | Automated (free API) | Primary academic source (indexes Crossref, DOAJ, PubMed, and more): tiered keyword search |
+| ISTEX | Automated (public metadata API; fulltext restricted to French research institutions) | CNRS national text-mining platform (multi-publisher) |
+| Institutional reports | Hybrid (curated seed + World Bank API) | 17 selected reports (e.g., Buchner et al. 2013) + World Bank repository grey-literature harvest |
+| Teaching canon | AI-assisted (scraping + LLM extraction) | Syllabus readings from university courses worldwide |
+| bibCNRS | Hand-harvested (CNRS credentials) | CNRS portal aggregating non-English news & discourse (Gale, Wanfang, NewsBank) in FR, ZH, JA, DE |
+| SciSpace | AI-collected, hand-exported | SciSpace systematic review tool exports |
+| UNFCCC | AI-collected | Negotiation documents |
+| OECD | Hand-harvested | Statistical guidelines |
+
+: Sources, automation level, and coverage scope. {#tbl-sources}
 :::
 
 The search strategy uses a four-tier keyword taxonomy reflecting the evolving vocabulary of climate finance: core terms in eight languages (Tier 1: English, French, German, Spanish, Portuguese, Arabic, Chinese, Japanese), English institutional and diplomatic vocabulary (Tier 2), and climate-adjacent terms retained only when the abstract mentions two (Tier 3) or three (Tier 4) of four concept groups (climate, finance, development, environment). Every term is issued against OpenAlex's `default.search` field, which matches title, abstract, and indexed fulltext. The taxonomy was informed by keyword mining of {{< meta corpus_core >}} core papers (cited $\geq$ {{< meta corpus_core_threshold >}} times).

--- a/scripts/_deposit_variables.py
+++ b/scripts/_deposit_variables.py
@@ -329,8 +329,15 @@ def render_markdown_table() -> str:
 
     Raw LaTeX means pandoc never sees these cells, so this function owns their
     escaping — see ``latex_inline``.
+
+    Raw LaTeX also means non-PDF formats (the journal's DOCX submission file)
+    would drop the table entirely, so the LaTeX div is wrapped in a
+    ``content-visible when-format="pdf"`` div and a pipe-table twin under
+    ``unless-format="pdf"`` carries the same rows for every other format.
+    Both carry the ``#tbl-variables`` label; only one survives a given render.
     """
     lines = [
+        '::: {.content-visible when-format="pdf"}',
         '::: {#tbl-variables tbl-pos="tbp"}',
         "```{=latex}",
         r"\begin{tabular}{@{}l p{10.4cm}@{}}",
@@ -349,17 +356,32 @@ def render_markdown_table() -> str:
         lines.append(
             rf"\texttt{{{v.name.translate(_LATEX_CODE)}}}"
             rf" & {latex_inline(describe(v))} \\")
-    lines += [
-        r"\bottomrule",
-        r"\end{tabular}",
-        "```",
-        "",
+    caption = (
         "Variables of `climate_finance_corpus.csv`, in four groups: "
         + ", ".join(groups) + ". "
         "Generated from the deposit column contract "
         "(`scripts/_deposit_variables.py`); storage types, allowed values, "
         "ranges and measured missingness are in the deposited "
-        "`datapackage.json`.",
+        "`datapackage.json`.")
+    lines += [
+        r"\bottomrule",
+        r"\end{tabular}",
+        "```",
+        "",
+        caption,
+        ":::",
+        ":::",
+        "",
+        '::: {.content-visible unless-format="pdf"}',
+        "| Variable | Description |",
+        "|:---------|:------------|",
+    ]
+    for v in DEPOSIT_VARIABLES:
+        desc = describe(v).replace("|", r"\|")
+        lines.append(f"| `{v.name}` | {desc} |")
+    lines += [
+        "",
+        f": {caption} {{#tbl-variables}}",
         ":::",
     ]
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
The RDJ4HSS submission format wants a Word file with 2-8 lowercase keywords below the abstract. The Quarto PDF template dropped the YAML `keywords` field, and both raw-LaTeX tables — Table 1 (sources) and Table 5 (variables, the editor-requested one) — vanished silently from any DOCX export.

- Visible **Keywords:** line after the abstract (renders in PDF and DOCX).
- Table 1: pipe-table twin behind `content-visible` divs; the tuned LaTeX tabular still owns the PDF.
- Table 5: `render_markdown_table()` now emits the LaTeX block under `when-format="pdf"` plus a pipe twin under `unless-format`, so the DOCX copy cannot drift from the deposit contract.

Verification: PDF text vs the frozen `rdj26561-revision1` release differs only in float/footnote reflow plus the keywords line; DOCX now carries all 5 tables, the figure, and the keywords. Full `make check`: 2277 passed; the 12 failures are pre-existing environmental (worktree without `make data`, doudou `.env` keystore migration, dvc `cache.type`) — none touch this diff. The rendered-fidelity probe and deliverable-artifact closure guards pass.

Produced for the revision-1 upload kit in `release/2026-07-29-RDJHSS-revision1/` (DataPaper.docx/pdf, Figure1.png, Table1-5.md, Acknowledgements.txt — outside the repo).

Ticket-ref: tickets/0274-rdj26561-rr-round-1-tracker.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)