### PR TITLE
chore(0274,0283): close R&R round-1 tickets — revision 1 resubmitted

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,18 +1,20 @@
 # State
 
-Last updated: 2026-07-29T14:41Z
+Last updated: 2026-07-29T16:20Z
 
 ## Current goal
 
-**RDJ-26561 revision 1 RELEASED (2026-07-29); handoff to doudou.**
-Zenodo v2.0.0 (DOI 10.5281/zenodo.21679237, concept .19236129); HAL
-hal-05570600v2 in moderation; tag rdj26561-revision1; frozen package in
-papiers/actif/RDJHSS_…/release/2026-07-29-RDJHSS-revision1 (padme).
-Doudou (author): rsync that dir to the nextcloud papiers tree; homepage
-Ha-Duong.bib (new title, concept DOI); platform upload (paper + cover +
-2 reply notes + Œconomia companion draft); actif → sent; close 0283/0274.
-If the platform asks: changes-highlighted manuscript (latexdiff).
-Œconomia: awaiting editor; 0671/0670 parked. Zoo + multilayer: later.
+**RDJ-26561 revision 1 RESUBMITTED (2026-07-29); awaiting decision.**
+Author uploaded the full kit on the journal platform (DataPaper.docx/pdf
+with keywords, Figure1, Table1-5, replies, Acknowledgements). Zenodo
+v2.0.0 (DOI 10.5281/zenodo.21679237, concept .19236129); HAL
+hal-05570600v2 in moderation; tag rdj26561-revision1; submission branch
+fast-forwarded to it; kit archived in
+papiers/sent/RDJ4HSS_…/release/2026-07-29-RDJHSS-revision1; 0283/0274
+closed. Remaining (author): homepage Ha-Duong.bib (new title, concept
+DOI). Œconomia: awaiting editor; 0671/0670 parked. Zoo + multilayer:
+later. Machine debt (doudou): .env keystore migration not applied;
+.dvc/config.local cache.type=symlink — 4 local test failures.
 
 ## Status
 <!-- generated 2026-07-29T14:41Z · as of 80c1563e -->

--- a/tickets/closed/0274-rdj26561-rr-round-1-tracker.erg
+++ b/tickets/closed/0274-rdj26561-rr-round-1-tracker.erg
@@ -2,6 +2,7 @@
 Title: RDJ-26561 data paper revise-and-resubmit round 1 — tracker
 Created: 2026-07-20
 Author: HDMX-coding-agent
+Closed: R&R round 1 complete: all children closed, revision 1 released (tag rdj26561-revision1, Zenodo v2.0.0) and uploaded 2026-07-29
 
 --- log ---
 2026-07-20T09:00Z HDMX-coding-agent created
@@ -18,6 +19,7 @@ Author: HDMX-coding-agent
 2026-07-27T11:59Z HDMX-coding-agent bump verify-reroll — round 1: ticket ID collision with origin/main (0330, 0331 duplicated already-merged IDs; renumbered to 0337/0338), tracker log order, §4/§1 misattribution in 0335 and 0332
 2026-07-27T19:33Z HDMX-coding-agent note 0372 named as a blocker (author): the AUC = 0.818 human-validation claim is not reproducible from either shipped table. It was filed 2026-07-27 citing this tracker but never listed as a child, so it was invisible to the children roll-up. Now carried as Blocked-by and listed below; [needs-human].
 2026-07-28T09:11Z HDMX-coding-agent note blocker 0372 closed — Blocked-by removed.
+2026-07-29T15:44Z HDMX-coding-agent closed — R&R round 1 complete: all children closed, revision 1 released (tag rdj26561-revision1, Zenodo v2.0.0) and uploaded 2026-07-29
 --- body ---
 ## Context
 

--- a/tickets/closed/0283-datapaper-response-letter-resubmission.erg
+++ b/tickets/closed/0283-datapaper-response-letter-resubmission.erg
@@ -2,6 +2,7 @@
 Title: Data paper: response letter, summary of revisions, resubmission package
 Created: 2026-07-20
 Author: HDMX-coding-agent
+Closed: revision 1 uploaded to the journal platform 2026-07-29 (author confirmation); release kit in papiers/sent/.../release/2026-07-29-RDJHSS-revision1
 
 --- log ---
 2026-07-20T09:00Z HDMX-coding-agent created
@@ -28,6 +29,7 @@ Author: HDMX-coding-agent
 2026-07-27T13:15Z HDMX-coding-agent note blocker 0288 closed — Blocked-by removed.
 2026-07-28T07:37Z HDMX-coding-agent note MATERIAL FOR THE REPLY LETTER (author, 2026-07-28): the 0337 removal ablation and a follow-up paired experiment produced findings that must appear in the response, not just in the paper. Three parts. (1) The panel's objection that the filter erases the layers the corpus claims to add is REFUTED with numbers on the axes they named: teaching, UNFCCC and OECD lose 0% of their records (protection catches every flagged one), bibCNRS 4.3%, SciSpace 4.1%, grey 23.8% against a corpus mean of 21.9%; and records WITHOUT a DOI are removed at 6.5% against 25.6% for records with one, the opposite of the predicted direction. (2) One stratum does lose disproportionately and it is language: non-English 41.8% vs English 19.9%. Not a metadata artifact — non-English abstract coverage is HIGHER (88.0% vs 85.7%), and restricted to works that have an abstract, flag 6 fires at 29.5% vs 14.4%. (3) The cause is measured, not conjectured: the cross-encoder BAAI/bge-reranker-v2-m3 is already multilingual, but the deployed query is a single English string. Scoring 1,589 non-English works against their own-language translation of that query lifts the pass rate 55.3% -> 66.8% (+11.5pp, Wilcoxon p=3.2e-104), and the symmetric control confirms the mechanism is query-document language match rather than better queries: 600 English works scored against a foreign-language query LOSE 6.5 to 48.7 points of pass rate. The filter therefore carries a measurable language bias, and the reply letter should disclose it rather than let a reader discover it. Remedy is a translated or multilingual query, which changes which works are removed and so re-opens the frozen corpus — a v3 decision, out of scope for this resubmission. Sequencing consequence for this ticket: the letter's filter-validation paragraph cannot be drafted from 0337 alone; it needs the ablation table as a deposited artifact, and it must be consistent with whatever 0372 restores as the validation evidence, since the 100-work sample was stratified by score and never by language and so has never measured the filter outside English.
 2026-07-29T13:33Z beta 1 closed by author 2026-07-29: paper, archive v2.0.0, cover + two reply notes all validated; tag rdj26561-resubmission-beta1; remaining: Zenodo upload + journal submission (author acts)
+2026-07-29T15:44Z HDMX-coding-agent closed — revision 1 uploaded to the journal platform 2026-07-29 (author confirmation); release kit in papiers/sent/.../release/2026-07-29-RDJHSS-revision1
 --- body ---
 ## Context
 


### PR DESCRIPTION
Revision 1 was uploaded on the journal platform by the author on 2026-07-29 (live confirmation in session). This PR records the wrap-up: both tickets closed and archived on-branch, STATE goal updated to awaiting-decision. The paper track moved actif → sent in the papiers tree (outside the repo).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)